### PR TITLE
chore: make ReplicaManager inherit SynapseBase

### DIFF
--- a/packages/contracts/contracts/Home.sol
+++ b/packages/contracts/contracts/Home.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.13;
 
 // ============ Internal Imports ============
 import { Version0 } from "./Version0.sol";
-import { SynapseBase } from "./SynapseBase.sol";
+import { UpdaterStorage } from "./UpdaterStorage.sol";
 import { QueueLib } from "./libs/Queue.sol";
 import { MerkleLib } from "./libs/Merkle.sol";
 import { Message } from "./libs/Message.sol";
@@ -23,7 +23,7 @@ import { Address } from "@openzeppelin/contracts/utils/Address.sol";
  * Accepts submissions of fraudulent signatures
  * by the Updater and slashes the Updater in this case.
  */
-contract Home is Version0, QueueManager, MerkleTreeManager, SynapseBase {
+contract Home is Version0, QueueManager, MerkleTreeManager, UpdaterStorage {
     // ============ Libraries ============
 
     using QueueLib for QueueLib.Queue;
@@ -121,7 +121,7 @@ contract Home is Version0, QueueManager, MerkleTreeManager, SynapseBase {
 
     // ============ Constructor ============
 
-    constructor(uint32 _localDomain) SynapseBase(_localDomain) {} // solhint-disable-line no-empty-blocks
+    constructor(uint32 _localDomain) UpdaterStorage(_localDomain) {} // solhint-disable-line no-empty-blocks
 
     // ============ Initializer ============
 

--- a/packages/contracts/contracts/ReplicaManager.sol
+++ b/packages/contracts/contracts/ReplicaManager.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.13;
 
 // ============ Internal Imports ============
-import { SynapseBase } from "./SynapseBase.sol";
+import { UpdaterStorage } from "./UpdaterStorage.sol";
 import { Version0 } from "./Version0.sol";
 import { ReplicaLib } from "./libs/Replica.sol";
 import { MerkleLib } from "./libs/Merkle.sol";
@@ -16,7 +16,7 @@ import { TypedMemView } from "./libs/TypedMemView.sol";
  * @notice Track root updates on Home,
  * prove and dispatch messages to end recipients.
  */
-contract ReplicaManager is Version0, SynapseBase {
+contract ReplicaManager is Version0, UpdaterStorage {
     // ============ Libraries ============
 
     using ReplicaLib for ReplicaLib.Replica;
@@ -89,7 +89,7 @@ contract ReplicaManager is Version0, SynapseBase {
         uint32 _localDomain,
         uint256 _processGas,
         uint256 _reserveGas
-    ) SynapseBase(_localDomain) {
+    ) UpdaterStorage(_localDomain) {
         require(_processGas >= 850_000, "!process gas");
         require(_reserveGas >= 15_000, "!reserve gas");
         PROCESS_GAS = _processGas;
@@ -178,7 +178,7 @@ contract ReplicaManager is Version0, SynapseBase {
      * `message`. If the message is successfully proven, then tries to process
      * message.
      * @dev Reverts if `prove` call returns false
-     * @param _message Formatted message (refer to SynapseBase.sol Message library)
+     * @param _message Formatted message (refer to UpdaterStorage.sol Message library)
      * @param _proof Merkle proof of inclusion for message's leaf
      * @param _index Index of leaf in home's merkle tree
      */

--- a/packages/contracts/contracts/UpdaterStorage.sol
+++ b/packages/contracts/contracts/UpdaterStorage.sol
@@ -11,11 +11,11 @@ import {
 } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 /**
- * @title SynapseBase
+ * @title UpdaterStorage
  * @author Illusory Systems Inc.
  * @notice Shared utilities between Home and Replica.
  */
-abstract contract SynapseBase is Initializable, OwnableUpgradeable {
+abstract contract UpdaterStorage is Initializable, OwnableUpgradeable {
     // ============ Immutable Variables ============
 
     // Domain of chain on which the contract is deployed


### PR DESCRIPTION
**Description**

Restructured `Home` and `ReplicaManager` contracts to move updater/signatures logic in ~~`SynapseBase`~~`UpdaterStorage`.