### PR TITLE
Speed up Merkle Tree: `root()`

### DIFF
--- a/packages/contracts/contracts/libs/Merkle.sol
+++ b/packages/contracts/contracts/libs/Merkle.sol
@@ -65,9 +65,8 @@ library MerkleLib {
 
         for (uint256 i = 0; i < TREE_DEPTH; ) {
             uint256 _ithBit = (_index >> i) & 0x01;
-            bytes32 _next = _tree.branch[i];
             if (_ithBit == 1) {
-                _current = keccak256(abi.encodePacked(_next, _current));
+                _current = keccak256(abi.encodePacked(_tree.branch[i], _current));
             } else {
                 _current = keccak256(abi.encodePacked(_current, _zeroes[i]));
             }


### PR DESCRIPTION
**Description**
Apparently, in the old implementation an array element was accessed regardless of it being used later. It's only used when `bit = 1` in the binary representation of amount of leaves in the tree. So this easy fix actually saves a lot of gas, especially when amount of leaves is low.

**Additional context**

`forge test --match-contract GasGolf --gas-report`

Gas benchmark before the fix:
![Before](https://user-images.githubusercontent.com/88190723/177980403-8b511e03-1b94-4da5-a765-9c892428db23.png)

Gas benchmark after the fix:
![After](https://user-images.githubusercontent.com/88190723/177980533-1f5cb336-7723-4c29-8c9c-41ce9cebdc22.png)

`Merkle.root()` median gas usage is 4100 gas lower.