### PR TITLE
fix two flaky tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -170,7 +170,7 @@ jobs:
           # Path to your GolangCI-Lint config within the repo (optional)
           config: ${{ env.GITHUB_WORKSPACE }}/.golangci.yml
           # see: https://github.com/golangci/golangci-lint/issues/2654
-          args: --timeout=5m
+          args: --timeout=10m
         env:
           # GitHub token for annotations (optional)
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/core/agents/updater/updater_test.go
+++ b/core/agents/updater/updater_test.go
@@ -35,8 +35,8 @@ func (u UpdaterSuite) TestUpdaterE2E() {
 	u.testBackend.WaitForConfirmation(u.GetTestContext(), tx)
 
 	go func() {
-		err = ud.Start(u.GetTestContext())
-		Nil(u.T(), err)
+		// we don't check errors here since this will error on cancellation at the end of the test
+		_ = ud.Start(u.GetTestContext())
 	}()
 
 	u.Eventually(func() bool {


### PR DESCRIPTION
**Description**

Fixes two flakes:
 - lint timeout when cache is not present affecting  (#60, #61, #62, #63) 
 - Error after context cancellation (affecting #59)
