### PR TITLE
Messaging nonce semantic changes

### DIFF
--- a/packages/contracts/contracts/Home.sol
+++ b/packages/contracts/contracts/Home.sol
@@ -60,7 +60,7 @@ contract Home is Version0, MerkleTreeManager, UpdaterStorage, AuthManager {
     // ============ Public Storage Variables ============
 
     // domain => next available nonce for the domain
-    mapping(uint32 => uint32) public nonces;
+    uint32 public nonce;
     // contract responsible for Updater bonding, slashing and rotation
     IUpdaterManager public updaterManager;
     // Current state of contract
@@ -189,14 +189,13 @@ contract Home is Version0, MerkleTreeManager, UpdaterStorage, AuthManager {
         require(_messageBody.length <= MAX_MESSAGE_BODY_BYTES, "msg too long");
         require(_tips.tipsView().totalTips() == msg.value, "!tips");
         // get the next nonce for the destination domain, then increment it
-        uint32 _nonce = nonces[_destinationDomain];
-        nonces[_destinationDomain] = _nonce + 1;
+        nonce = nonce + 1;
         bytes32 _sender = _checkForSystemMessage(_recipientAddress);
         // format the message into packed bytes
         bytes memory _header = Header.formatHeader(
             localDomain,
             _sender,
-            _nonce,
+            nonce,
             _destinationDomain,
             _recipientAddress,
             _optimisticSeconds
@@ -212,7 +211,7 @@ contract Home is Version0, MerkleTreeManager, UpdaterStorage, AuthManager {
         emit Dispatch(
             _messageHash,
             count() - 1,
-            _destinationAndNonce(_destinationDomain, _nonce),
+            _destinationAndNonce(_destinationDomain, nonce),
             _tips,
             _message
         );

--- a/packages/contracts/test/Home.t.sol
+++ b/packages/contracts/test/Home.t.sol
@@ -100,7 +100,7 @@ contract HomeTest is SynapseTestWithUpdaterManager {
         bytes32 recipient = addressToBytes32(vm.addr(1337));
         address sender = vm.addr(1555);
         bytes memory messageBody = bytes("message");
-        uint32 nonce = home.nonces(remoteDomain);
+        uint32 nonce = home.nonce() + 1;
         bytes memory _header = Header.formatHeader(
             localDomain,
             addressToBytes32(sender),

--- a/packages/contracts/test/HomeGasGolf.t.sol
+++ b/packages/contracts/test/HomeGasGolf.t.sol
@@ -30,7 +30,7 @@ contract HomeGasGolfTest is SynapseTestWithUpdaterManager {
         bytes32 recipient = addressToBytes32(vm.addr(1337));
         address sender = vm.addr(1555);
         bytes memory messageBody = bytes("message");
-        uint32 nonce = home.nonces(remoteDomain);
+        uint32 nonce = home.nonce() + 1;
         bytes memory _header = Header.formatHeader(
             localDomain,
             addressToBytes32(sender),

--- a/packages/contracts/test/SynapseClient.t.sol
+++ b/packages/contracts/test/SynapseClient.t.sol
@@ -167,7 +167,7 @@ contract SynapseClientTest is SynapseTestWithUpdaterManager {
         bytes memory _header = Header.formatHeader(
             localDomain,
             bytes32(uint256(uint160(address(client)))),
-            0,
+            1,
             remoteDomain,
             trustedSender,
             0
@@ -175,7 +175,7 @@ contract SynapseClientTest is SynapseTestWithUpdaterManager {
         bytes memory _tips = getDefaultTips();
         bytes memory message = Message.formatMessage(_header, _tips, messageBody);
         vm.expectEmit(true, true, true, true);
-        emit Dispatch(keccak256(message), 0, uint64(remoteDomain) << 32, _tips, message);
+        emit Dispatch(keccak256(message), 0, uint64(remoteDomain) << 32 | 1, _tips, message);
         deal(address(this), TOTAL_TIPS);
         client.send{ value: TOTAL_TIPS }(remoteDomain, _tips, messageBody);
     }

--- a/packages/contracts/test/SynapseClientUpgradeable.t.sol
+++ b/packages/contracts/test/SynapseClientUpgradeable.t.sol
@@ -100,6 +100,7 @@ contract SynapseClientTest is SynapseTestWithUpdaterManager {
         }
     }
 
+
     function test_setTrustedSendersAsNotOwner(address _notOwner) public {
         vm.assume(_notOwner != owner);
         uint32[] memory domains = new uint32[](1);
@@ -187,7 +188,7 @@ contract SynapseClientTest is SynapseTestWithUpdaterManager {
         bytes memory _header = Header.formatHeader(
             localDomain,
             bytes32(uint256(uint160(address(client)))),
-            0,
+            1,
             remoteDomain,
             trustedSender,
             0
@@ -195,7 +196,7 @@ contract SynapseClientTest is SynapseTestWithUpdaterManager {
         bytes memory _tips = getDefaultTips();
         bytes memory message = Message.formatMessage(_header, _tips, messageBody);
         vm.expectEmit(true, true, true, true);
-        emit Dispatch(keccak256(message), 0, uint64(remoteDomain) << 32, _tips, message);
+        emit Dispatch(keccak256(message), 0, uint64(remoteDomain) << 32 | 1, _tips, message);
         deal(address(this), TOTAL_TIPS);
         client.send{ value: TOTAL_TIPS }(remoteDomain, _tips, messageBody);
     }

--- a/packages/contracts/test/SystemMessenger.t.sol
+++ b/packages/contracts/test/SystemMessenger.t.sol
@@ -152,13 +152,14 @@ contract SystemMessengerTest is SynapseTestWithUpdaterManager {
 
     function _testSendSystemMessage(address _sender) internal {
         for (uint8 t = 0; t <= 1; ++t) {
-            bytes memory message = _createSentSystemMessage(t, t);
+            bytes memory message = _createSentSystemMessage(t+1, t);
             bytes32 messageHash = keccak256(message);
+
             vm.expectEmit(true, true, true, true);
             emit Dispatch(
                 messageHash,
                 t,
-                (uint64(remoteDomain) << 32) | t,
+                (uint64(remoteDomain) << 32) | t+1,
                 Tips.emptyTips(),
                 message
             );


### PR DESCRIPTION
**Description**

In the original implementation, message nonces were specific to each destination. With the introduction of #55 this is no longer needed so we use a global nonce on each `Home`. 

This also starts message nonces at 1 to more easily differentiate between 0 messages dispatched and 1 message dispatched in consuming clients 

** Note **:

Like #72 this is waiting on #71 for a abi regeneration in #71 because of the number of breaking changes in the home contract introduced by #53 