### PR TITLE
Add foundry coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,14 @@
+codecov:
+  require_ci_to_pass: false
+# Team Yaml
+coverage:
+  round: down
+  precision: 5
+
+ignore:
+  - "*_generated.go"  # ignore folders and all its contents
+  - "*.abigen.go"       # wildcards accepted
+  - "*_string.go"         # glob accepted
+  - "*_string.go"         # glob accepted
+# solidity test files
+  - 'packages/contracts/test/*'

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -1,7 +1,9 @@
 ---
 name: Changeset integrity checker
 on:
-  - pull_request_target
+  pull_request_target:
+    branches:
+      - master
 
 jobs:
   changesets-integrity-checker:
@@ -10,8 +12,30 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install Dependencies
-        run: yarn
+      - name: Read .nvmrc
+        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
+        id: nvmrc
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: "Use NodeJS by nvmrc"
+        uses: actions/setup-node@v2
+        with:
+          node-version: '${{steps.nvmrc.outputs.NVMRC}}'
+
+      - name: Initialize Yarn cache
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install Node Dependencies
+        run: yarn install --frozen-lockfile --check-files
 
       - name: Changeset Status
         run: npx changeset status

--- a/.github/workflows/foundry-tests.yml
+++ b/.github/workflows/foundry-tests.yml
@@ -1,29 +1,69 @@
-on: [push]
+on: [push,pull_request]
 
 name: Foundry Tests
 
 jobs:
   check:
-    name: Packages/contracts
+    name: Foundry Coverage
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
 
+
+      - name: Read .nvmrc
+        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
+        id: nvmrc
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: "Use NodeJS by nvmrc"
+        uses: actions/setup-node@v2
+        with:
+          node-version: '${{steps.nvmrc.outputs.NVMRC}}'
+
+      - name: Initialize Yarn cache
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
       - name: Installing dependencies
         working-directory: ./packages/contracts
-        run: yarn install
+        run: yarn install --frozen-lockfile --check-files
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: nightly
 
-      - name: Run tests
+      - name: Run Foundry Tests
         working-directory: ./packages/contracts
-        run: forge test -vvv
+        run: forge coverage -vvv --report=lcov
 
       - name: Run snapshot
         working-directory: ./packages/contracts
         run: forge snapshot >> $GITHUB_STEP_SUMMARY
+
+      - uses: codecov/codecov-action@v3
+        name: Send Coverage (Codecov)
+        with:
+          token: ${{ secrets.CODECOV }}
+          fail_ci_if_error: true # optional (default = false)
+          verbose: true # optional (default = false)
+          working-directory: ./packages/contracts/
+
+
+      - name: Send Coverage (Coveralls)
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.github_token }}
+          path-to-lcov: ./packages/contracts/lcov.info
+          base-path: ./packages/contracts/
+          flag-name: foundry

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    name: Test
+    name: Go Coverage
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
@@ -66,7 +66,11 @@ jobs:
           done
 
       - name: Test
-        run:  go test $(go work edit -json | jq -c -r '[.Use[].DiskPath] | map_values(. + "/...")[]')  -coverprofile=profile.cov
+        uses: nick-fields/retry@v2
+        with:
+          command: go test $(go work edit -json | jq -c -r '[.Use[].DiskPath] | map_values(. + "/...")[]')  -coverprofile=profile.cov
+          max_attempts: 4
+          timeout_minutes: 20
         env:
           ENABLE_MYSQL_TEST: true
           MYSQL_HOST: 0.0.0.0
@@ -82,15 +86,24 @@ jobs:
         run: |
           echo "IGNORED=$(find . \( -name "*_generated.go" -o -name "*.abigen.go"  -o -name "*_string.go"   \) -print0 | xargs -0 ls | sed 's/.\/*//' | tr '\n' ',' |  sed 's/,*\r*$//')" >> $GITHUB_ENV
 
+      - uses: codecov/codecov-action@v3
+        name: Send Coverage (Codecov)
+        with:
+          token: ${{ secrets.CODECOV }}
+          files: profile.cov
+          fail_ci_if_error: true # optional (default = false)
+          verbose: true # optional (default = false)
+
       # We customize the build step because by default
       # We can not use ** because goveralls uses filepath.Match
       # to match ignore files and it does not support it.
-      - name: Send coverage
+      - name: Send coverage (Coveralls)
         uses: shogo82148/actions-goveralls@v1
         with:
           github-token: ${{ secrets.github_token }}
           path-to-profile: profile.cov
           ignore: ${{ env.IGNORED }}
+          flag-name: Go-${{ matrix.go-version }}
 
   # changes allows us to only run a job on changed packages
   changes:

--- a/.github/workflows/label-requires-reviews.yml
+++ b/.github/workflows/label-requires-reviews.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: develop
+          ref: master
 
       - name: Require-reviewers
         uses: travelperk/label-requires-reviews-action@v0.1

--- a/packages/contracts/.gitignore
+++ b/packages/contracts/.gitignore
@@ -1,3 +1,6 @@
 types
 flattened/
 build/
+
+# generated foundry coverage info
+lcov.info

--- a/packages/contracts/foundry.toml
+++ b/packages/contracts/foundry.toml
@@ -8,5 +8,6 @@ libs = ["../../node_modules", "node_modules", "lib"]
 
 [profile.ci]
 verbosity = 4
+fuzz_runs = 1000
 
 # See more config options https://github.com/gakonst/foundry/tree/master/config


### PR DESCRIPTION
**Description**

Replaces #89

- Add yarn cache for foundry tests (needed for solidity dependencies)
- Add coveralls for foundry
- Handles flakes on go tests

Right now, coveralls is being kept around because of an issue with codecov where `codecov.yml` is being ignored (see codecov/codecov#430 and codecov/codecov#554). It's possible this gets fixed by merging codecov to master. Support has been contacted.



**Additional context**

To implement combined coverage, we had three options:

- `workflow_run`: We can't use workflow run here because of [this limitation](https://github.com/orgs/community/discussions/25288). Manual dispatching also does not work.
- `long_polling`: slower, hits rate limits and not workable because if the coverage is on different workflows, nothing gets combined since we use coveralls uses `github_run_id` (see: https://github.com/coverallsapp/github-action/blob/master/src/run.ts#L58)
- `combine coverage into a single workflow`: not clean.
- `codecov`: should fix this issue by auto-reconciling reports

