### PR TITLE
chore: purge old contracts on regeneration

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "scripts": {
     "build": "yarn build:contracts && yarn build:typescript && yarn build:go",
-    "build:go": "yarn sol-merger \"./contracts/**.sol\" ./flattened --export-plugin SPDXLicenseRemovePlugin & yarn sol-merger \"./test/harnesses/**.sol\" ./flattened --export-plugin SPDXLicenseRemovePlugin",
+    "build:go": "rm ./flattened/* && yarn sol-merger \"./contracts/**.sol\" ./flattened --export-plugin SPDXLicenseRemovePlugin & yarn sol-merger \"./test/harnesses/**.sol\" ./flattened --export-plugin SPDXLicenseRemovePlugin",
     "build:contracts": "forge build",
     "build:slither": "hardhat compile",
     "build:typescript": "typechain --target ethers-v5 'artifacts/**/*json'",


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**

When dealing with PRs like #94 and #76 where contracts are regenerated after being potentially renamed, it is useful to remove old contracts so abigen will throw errors when the old contract is not present.

Rather then everything passing since the contract is there, the user receives an error message from abigen like so (when ReplicaManager was renamed in #94):

<img width="366" alt="image" src="https://user-images.githubusercontent.com/83933037/184636073-2f9851a1-79ee-40ec-960d-a0c2305a7b00.png">

