### PR TITLE
reduce renovate pr count

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,20 +3,19 @@
     "config:base"
   ],
   "assignees": [],
-  "enabledManagers": ["gomod"],
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "excludePackagePrefixes": [],
       "matchManagers": ["gomod"],
-      "automerge": true,
+      "automerge": false,
       "postUpdateOptions": [
         "gomodTidy"
       ]
     }
   ],
-  "branchConcurrentLimit": 10,
-  "prConcurrentLimit": 10,
+  "branchConcurrentLimit": 1,
+  "prConcurrentLimit": 1,
   "git-submodules": {
     "enabled": true
   }


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**

Until we remove the dependency on synapse-node (private gh repo), these will fail and just clutter up the pr count.

Automerge was also removed because of security concerns

