### PR TITLE
Proof generation in tests

### DIFF
--- a/packages/contracts/test/ProofGenerator.t.sol
+++ b/packages/contracts/test/ProofGenerator.t.sol
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.13;
+
+import "forge-std/Test.sol";
+
+import { MerkleLib } from "../contracts/libs/Merkle.sol";
+import { ProofGenerator } from "./utils/ProofGenerator.sol";
+
+// solhint-disable func-name-mixedcase
+contract ProofGeneratorTest is Test {
+    using MerkleLib for MerkleLib.Tree;
+
+    uint256 internal constant MAX_COUNT = 10;
+
+    MerkleLib.Tree internal tree;
+    ProofGenerator internal gen;
+    uint256 internal length;
+    bytes32[] internal leafs;
+
+    function setUp() public {
+        gen = new ProofGenerator();
+    }
+
+    function test_createTree() public {
+        length = MAX_COUNT;
+        _checkCreateTree();
+    }
+
+    function test_generateProofs() public {
+        test_createTree();
+        _checkGenerateProofs();
+    }
+
+    function test_recreateTree_biggerSize() public {
+        test_createTree();
+        length = MAX_COUNT * 2;
+        _checkCreateTree();
+        _checkGenerateProofs();
+    }
+
+    function test_recreateTree_smallerSize() public {
+        test_createTree();
+        length = MAX_COUNT / 2;
+        _checkCreateTree();
+        _checkGenerateProofs();
+    }
+
+    function _createTestData() internal {
+        delete tree;
+        leafs = new bytes32[](length);
+        for (uint256 i = 0; i < length; ++i) {
+            bytes32 node = keccak256(abi.encode(length, i));
+            leafs[i] = node;
+            tree.insert(node);
+        }
+    }
+
+    function _checkCreateTree() internal {
+        _createTestData();
+        gen.createTree(leafs);
+        // Leafs should match the lowest depth level
+        for (uint256 i = 0; i < length; ++i) {
+            assertEq(gen.getNode(0, i), leafs[i], "!leaf");
+        }
+        // Non-existing leaf should be zero
+        assertEq(gen.getNode(0, length), bytes32(0), "!zero");
+        // Merkle root should match
+        assertEq(gen.getRoot(), tree.root(), "!root");
+    }
+
+    function _checkGenerateProofs() internal {
+        bytes32 root = tree.root();
+        // Should be able to generate a valid proof for any existing leafs
+        for (uint256 i = 0; i < length; ++i) {
+            bytes32[32] memory proof = gen.getProof(i);
+            assertEq(MerkleLib.branchRoot(leafs[i], proof, i), root, "!proof");
+        }
+        // Cool side effect: could prove message non-inclusion at next index
+        {
+            uint256 index = length;
+            // Should be able to generate a valid proof for a null leaf
+            bytes32[32] memory proof = gen.getProof(index);
+            assertEq(MerkleLib.branchRoot(bytes32(0), proof, index), root, "!proof");
+        }
+        // Cool side effect: could prove message non-inclusion at index from a distant future
+        {
+            uint256 index = length + 42069;
+            // Should be able to generate a valid proof for a null leaf
+            bytes32[32] memory proof = gen.getProof(index);
+            assertEq(MerkleLib.branchRoot(bytes32(0), proof, index), root, "!proof");
+        }
+    }
+}

--- a/packages/contracts/test/utils/ProofGenerator.sol
+++ b/packages/contracts/test/utils/ProofGenerator.sol
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.13;
+
+import { MerkleLib } from "../../contracts/libs/Merkle.sol";
+
+contract ProofGenerator {
+    uint256 public constant TREE_DEPTH = 32;
+
+    /**
+     * @notice Store only non-"zero" values of the merkle tree
+     * merkleTree[0] are the leafs
+     * merkleTree[1] are keccak256(A, B) where A and B are leafs
+     * ...
+     * merkleTree[TREE_DEPTH][0] is the merkle root
+     */
+    bytes32[][] internal merkleTree;
+
+    bytes32[] internal zeroHashes;
+
+    constructor() {
+        zeroHashes = MerkleLib.zeroHashes();
+        merkleTree = new bytes32[][](TREE_DEPTH + 1);
+    }
+
+    /**
+     * @notice Creates a Merkle Tree from an array of leafs.
+     */
+    function createTree(bytes32[] memory _leafs) external {
+        _clearTree();
+        // Copy the leafs into the tree
+        uint256 size = _copyLeafs(_leafs);
+        // Go upwards the tree and construct parent layers one by one
+        for (uint256 d = 1; d <= TREE_DEPTH; ++d) {
+            size = (size + 1) / 2;
+            _createLayer(d, size);
+        }
+    }
+
+    /**
+     * @notice Returns a merkle proof for leaf with a given index.
+     */
+    function getProof(uint256 _index) external view returns (bytes32[TREE_DEPTH] memory proof) {
+        for (uint256 d = 0; d < TREE_DEPTH; ++d) {
+            // Get node's neighbor
+            if (_index % 2 == 0) {
+                ++_index;
+            } else {
+                --_index;
+            }
+            proof[d] = getNode(d, _index);
+            // We need to go deeper
+            _index = _index / 2;
+        }
+    }
+
+    /**
+     * @notice Returns merkle root of the tree.
+     */
+    function getRoot() external view returns (bytes32) {
+        return merkleTree[TREE_DEPTH][0];
+    }
+
+    /**
+     * @notice Returns node of the Merkle Tree given its depth and index.
+     */
+    function getNode(uint256 _depth, uint256 _index) public view returns (bytes32 node) {
+        if (_index < merkleTree[_depth].length) {
+            node = merkleTree[_depth][_index];
+        } else {
+            node = zeroHashes[_depth];
+        }
+    }
+
+    /**
+     * @notice Clears the merkle tree.
+     */
+    function _clearTree() internal {
+        if (merkleTree[0].length != 0) {
+            for (uint256 d = 0; d <= TREE_DEPTH; ++d) {
+                delete merkleTree[d];
+            }
+        }
+    }
+
+    /**
+     * @notice Copies the leafs into the leaf layer of the tree.
+     */
+    function _copyLeafs(bytes32[] memory _leafs) internal returns (uint256 size) {
+        size = _leafs.length;
+        merkleTree[0] = new bytes32[](size);
+        for (uint256 i = 0; i < size; ++i) {
+            merkleTree[0][i] = _leafs[i];
+        }
+    }
+
+    /**
+     * @notice Creates a layer of the tree using its child layer.
+     */
+    function _createLayer(uint256 _depth, uint256 _size) internal {
+        merkleTree[_depth] = new bytes32[](_size);
+        for (uint256 i = 0; i < _size; ++i) {
+            merkleTree[_depth][i] = keccak256(
+                abi.encodePacked(getNode(_depth - 1, 2 * i), getNode(_depth - 1, 2 * i + 1))
+            );
+        }
+    }
+}


### PR DESCRIPTION
# Description
Adds a `ProofGenerator` utility contract, that is able to:
- Construct a merkle tree out of an array of leafs
- Produce merkle proofs for any of the leafs

Proving that an element with a given index doesn't exist in the tree yet is also possible.
