### PR TITLE
Adding Clickhouse to workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,6 +31,9 @@ jobs:
         with:
           fetch-depth: 0
           submodules: 'recursive'
+          
+      - name: Init clickhouse
+        run: docker run --name clickhouse -p 9000:9000 -p 8123:8123 -d yandex/clickhouse-server
 
       # todo: consider making this a service. You'd need another way to expose the private keys for the test
       - name: Run rinkeby


### PR DESCRIPTION
**Description**
Simple spin up of a [clickhouse docker container](https://hub.docker.com/r/yandex/clickhouse-server) in the CI and GitHub action workflow

**Additional context**
Current storage solutions have trouble with int256s. Clickhouse solves this and is very performant.

**Metadata**
Because I am not the most experienced with workflows I did a couple tests 
First I used https://github.com/nektos/act to test workflow compilation locally and get a successful run (some logs below)
`[Go Workflows/Go Coverage      ] ⭐ Run Main Init clickhouse
| Unable to find image 'yandex/clickhouse-server:latest' locally
| latest: Pulling from yandex/clickhouse-server
ea362f368469: Pulling fs layer 
38ba82a23e2b: Pulling fs layer 
9b17d04b6c62: Pulling fs layer 
5658714e4e8b: Pulling fs layer 
6bde977a0bf8: Pulling fs layer 
39053b27290b: Pulling fs layer 
| Digest: sha256:1cbf75aabe1e2cc9f62d1d9929c318a59ae552e2700e201db985b92a9bcabc6e
| Status: Downloaded newer image for yandex/clickhouse-server:latest
| 2383c6d1c152e67a420d85d51b4c91324578c2ea7cf0752efa78b5ebd6f83fb9
[Go Workflows/Go Coverage      ]   ✅  Success - Main Init clickhouse`


then using this I used some examples from clickhouse/clickhouse-go to test a batch insert and query. Here is that [file](https://gist.github.com/simonmahns/68d7364c22687efa6c7d898146ae6c9e).


Feedback and requests for more tests appreciated, still a bit new to GitHub actions so possible I overlooked something.





