### PR TITLE
Panic on startup fix

### DIFF
--- a/services/scribe/backfill/chain_test.go
+++ b/services/scribe/backfill/chain_test.go
@@ -80,9 +80,7 @@ func (b BackfillSuite) EmitEventsForAChain(contracts []contracts.DeployedContrac
 
 	if backfill {
 		// Backfill the chain.
-		lastBlock, err := simulatedChain.BlockNumber(b.GetTestContext())
-		Nil(b.T(), err)
-		err = chainBackfiller.Backfill(b.GetTestContext(), lastBlock, false)
+		err := chainBackfiller.Backfill(b.GetTestContext(), false)
 		Nil(b.T(), err)
 
 		// Check that the events were written to the database.

--- a/services/scribe/backfill/scribe.go
+++ b/services/scribe/backfill/scribe.go
@@ -3,15 +3,14 @@ package backfill
 import (
 	"context"
 	"fmt"
-	"github.com/synapsecns/sanguine/ethergo/backends/simulated"
-	"math/big"
-
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/synapsecns/sanguine/ethergo/backends/simulated"
 	"github.com/synapsecns/sanguine/services/scribe/config"
 	"github.com/synapsecns/sanguine/services/scribe/db"
 	"golang.org/x/sync/errgroup"
+	"math/big"
 )
 
 // ScribeBackfiller is a backfiller that aggregates all backfilling from ChainBackfillers.
@@ -56,14 +55,9 @@ func (s ScribeBackfiller) Backfill(ctx context.Context) error {
 	for _, chainBackfiller := range s.ChainBackfillers {
 		// capture func literal
 		chainBackfiller := chainBackfiller
-		// get the end height for the backfill
-		currentBlock, err := s.clients[chainBackfiller.chainID].BlockNumber(groupCtx)
-		if err != nil {
-			return fmt.Errorf("could not get current block number: %w", err)
-		}
 		// call Backfill concurrently
 		g.Go(func() error {
-			err := chainBackfiller.Backfill(groupCtx, currentBlock, false)
+			err := chainBackfiller.Backfill(groupCtx, false)
 			if err != nil {
 				return fmt.Errorf("could not backfill chain: %w", err)
 			}

--- a/services/scribe/node/scribe.go
+++ b/services/scribe/node/scribe.go
@@ -98,7 +98,7 @@ func (s Scribe) processRange(ctx context.Context, chainID uint32, requiredConfir
 		return fmt.Errorf("could not get current block number: %w", err)
 	}
 
-	err = s.scribeBackfiller.ChainBackfillers[chainID].Backfill(ctx, newBlock, false)
+	err = s.scribeBackfiller.ChainBackfillers[chainID].Backfill(ctx, false)
 	if err != nil {
 		return fmt.Errorf("could not backfill: %w", err)
 	}
@@ -172,7 +172,7 @@ func (s Scribe) processRange(ctx context.Context, chainID uint32, requiredConfir
 			}
 
 			// get the data for the block and backfill
-			err = s.scribeBackfiller.ChainBackfillers[chainID].Backfill(ctx, i, true)
+			err = s.scribeBackfiller.ChainBackfillers[chainID].Backfill(ctx, true)
 			if err != nil {
 				return fmt.Errorf("could not backfill: %w", err)
 			}


### PR DESCRIPTION
**Description**
Currently the entire scribe backfill process will be killed if there's a single invalid url. This PR adds simple error handling to prevent this.

**Metadata**
- Fixes #236 
