### PR TITLE
Adding Indexes to LastIndexedInfo

### DIFF
--- a/services/scribe/db/datastore/sql/base/model.go
+++ b/services/scribe/db/datastore/sql/base/model.go
@@ -127,9 +127,9 @@ type EthTx struct {
 type LastIndexedInfo struct {
 	gorm.Model
 	// ContractAddress is the contract address
-	ContractAddress string `gorm:"column:contract_address;index"`
+	ContractAddress string `gorm:"column:contract_address;index:idx_last_indexed,priority:1"`
 	// BlockNumber is the last block number indexed
-	BlockNumber uint64 `gorm:"column:block_number;auto_increment:false;index'"`
+	BlockNumber uint64 `gorm:"column:block_number;auto_increment:false;index:idx_last_indexed,priority:2"`
 	// ChainID is the chain id of the contract
 	ChainID uint32 `gorm:"column:chain_id"`
 }


### PR DESCRIPTION
**Description**
Currently storing LastIndexedInfo is inefficient. adding [database indexes with gorm](https://gorm.io/docs/indexes.html) will fix this.
