### PR TITLE
Historical proofs generation

### DIFF
--- a/packages/contracts-core/test/HistoricalProofGenerator.t.sol
+++ b/packages/contracts-core/test/HistoricalProofGenerator.t.sol
@@ -1,0 +1,77 @@
+//  SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import "forge-std/Test.sol";
+
+import { MerkleLib } from "../contracts/libs/Merkle.sol";
+import { HistoricalProofGenerator } from "./utils/HistoricalProofGenerator.sol";
+
+// solhint-disable func-name-mixedcase
+contract HistoricalProofGeneratorTest is Test {
+    using MerkleLib for MerkleLib.Tree;
+
+    MerkleLib.Tree internal tree;
+    HistoricalProofGenerator internal proofGen;
+
+    uint256 internal constant TREE_DEPTH = 32;
+    uint256 internal constant AMOUNT = 10;
+    bytes32[] internal leafs;
+
+    function setUp() public {
+        proofGen = new HistoricalProofGenerator();
+        leafs = new bytes32[](AMOUNT);
+        for (uint256 i = 0; i < AMOUNT; ++i) {
+            leafs[i] = keccak256(abi.encode("test", i));
+        }
+    }
+
+    function test_insert() public {
+        // Just to get an idea of how much gas this could've wasted if implemented on-chain
+        for (uint256 index = 0; index < AMOUNT; ++index) {
+            proofGen.insert(leafs[index]);
+        }
+    }
+
+    function test_getRoot() public {
+        bytes32[] memory roots = new bytes32[](AMOUNT + 1);
+        roots[0] = tree.root(0);
+        // Sanity check against precomputed root for an empty Merkle tree
+        assertEq(
+            roots[0],
+            hex"27ae5ba08d7291c96c8cbddcc148bf48a6d68c7974b94356f53754ef6171d757",
+            "!root(empty tree)"
+        );
+        for (uint256 count = 1; count <= AMOUNT; ++count) {
+            proofGen.insert(leafs[count - 1]);
+            tree.insert(count, leafs[count - 1]);
+            // Save merkle root after inserting `count` leafs
+            roots[count] = tree.root(count);
+        }
+        for (uint256 count = 0; count <= AMOUNT; ++count) {
+            assertEq(proofGen.getRoot(count), roots[count]);
+        }
+    }
+
+    function test_generateProof() public {
+        test_getRoot();
+        for (uint256 count = 1; count <= AMOUNT; ++count) {
+            // Use a "historical root" for proving
+            // root is already tested against the MerkleLib implementation
+            bytes32 root = proofGen.getRoot(count);
+            // Check generated proofs for every leaf that precedes the "historical root"
+            for (uint256 index = 0; index < count; ++index) {
+                bytes32[TREE_DEPTH] memory proof = proofGen.getProof(index, count);
+                assertEq(MerkleLib.branchRoot(leafs[index], proof, index), root, "Invalid proof");
+            }
+        }
+    }
+
+    function test_allElementsEqual() public {
+        // Weird scenario where all leafs are equal.
+        // Everything should be working though.
+        for (uint256 i = 0; i < AMOUNT; ++i) {
+            leafs[i] = keccak256(abi.encode("test"));
+        }
+        test_generateProof();
+    }
+}

--- a/packages/contracts-core/test/utils/HistoricalProofGenerator.sol
+++ b/packages/contracts-core/test/utils/HistoricalProofGenerator.sol
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+contract HistoricalProofGenerator {
+    uint256 public constant TREE_DEPTH = 32;
+
+    /**
+     * @notice Store historical non-"zero" values of the FULL merkle tree.
+     * Full merkle tree consists of 2**TREE_DEPTH "zero" leafs, which are
+     * getting populated throughout time. Once a new leaf is added, all elements
+     * in the merkle tree on the path from root to the leaf are updated.
+     * The goal of this contract is to store only the significant values.
+     *
+     * merkleTree[H][X][N] is the value for the tree element:
+     * - With [height = H] (increasing from leafs to root)
+     * - With [x-coord = X] (increasing from older leafs to newer)
+     * - When N leafs were inserted in the merkle tree
+     *
+     * 1. Height (H):
+     * merkleTree[0] are the leafs
+     * merkleTree[1] are keccak256(A, B) where A and B are leafs
+     * ...
+     * merkleTree[TREE_DEPTH] is the merkle root level
+     *
+     * 2. Coordinate (X):
+     * A merkle tree can have up to 2**(32-H) elements on a level with height=H
+     * Therefore:
+     * merkleTree[0][0] is the first leaf
+     * merkleTree[0][1] is the second leaf
+     * merkleTree[1][0] is their parent
+     * merkleTree[1][1] is parent of merkleTree[0][2] and merkleTree[0][3]
+     * merkleTree[2][0] is parent of merkleTree[1][0] and merkleTree[1][1]
+     * ...
+     * merkleTree[TREE_DEPTH][0] is the merkle root
+     *
+     * 3. Historical state (N).
+     * Every element of the full merkle tree has three chronological "stages".
+     * a. Element value did not change after the latest leaf insertion. Meaning that
+     *    all element's children are "zero" elements, and element itself is "zero".
+     *    Requires: 0 <= N <= X*(2**H)
+     * b. Element value changed after the latest leaf insertion. Meaning that
+     *    at least one of the children is non-zero.
+     *    Requires: X*(2**H) < N <= (X+1)*(2**H)
+     * c. Element value stopped changing after the latest leaf insertion. Meaning that
+     *    all element children are already non-zero.
+     *    Requires: (X+1)*(2**H) < N
+     *
+     * Thus we actually need to store tree element value for N in range (X*(2**H), (X+1)*(2**H)]
+     * The amount of "significant" values (stage b) is 2**H.
+     *
+     * We're using mapping to avoid dealing with dynamic arrays in Solidity.
+     */
+    mapping(uint256 => mapping(uint256 => mapping(uint256 => bytes32))) internal merkleTree;
+    // Default ("zero") element values for given height
+    bytes32[] internal zeroHashes;
+    // Amount of inserted leaves in the tree
+    uint256 internal treeCount;
+
+    constructor() {
+        zeroHashes = new bytes32[](TREE_DEPTH + 1);
+        // zeroHashes[0] is bytes32(0)
+        // Calculate "zero" element values for other heights. These are the
+        // value for an element in the merkle tree, when all their children are "zero".
+        for (uint256 h = 0; h < TREE_DEPTH; ++h) {
+            zeroHashes[h + 1] = keccak256(abi.encodePacked(zeroHashes[h], zeroHashes[h]));
+        }
+    }
+
+    /**
+     * @notice Insert a new leaf into the tree and update the historical
+     * merkle tree. O(1)
+     */
+    function insert(bytes32 leaf) external {
+        uint256 x = treeCount;
+        uint256 newCount = x + 1;
+        merkleTree[0][x][newCount] = leaf;
+        for (uint256 h = 1; h <= TREE_DEPTH; ++h) {
+            // Traverse to parent
+            x = x >> 1;
+            // Children have [height = h - 1]
+            // And X-coordinates [2 * x] and [2 * x + 1]
+            merkleTree[h][x][newCount] = keccak256(
+                abi.encodePacked(
+                    _fetchSavedTreeElement(h - 1, (x << 1), newCount),
+                    _fetchSavedTreeElement(h - 1, (x << 1) + 1, newCount)
+                )
+            );
+        }
+        ++treeCount;
+    }
+
+    /**
+     * @notice Calculate root of merkle tree at the time when
+     * `count` leafs have been inserted. O(1)
+     */
+    function getRoot(uint256 count) external view returns (bytes32) {
+        require(count <= treeCount, "Not enough leafs inserted");
+        return _fetchSavedTreeElement({ h: TREE_DEPTH, x: 0, count: count });
+    }
+
+    /**
+     * @notice Generate proof of inclusion for leaf with given `index`,
+     * at the time when `count` leafs have been inserted. O(1)
+     */
+    function getProof(uint256 index, uint256 count)
+        external
+        view
+        returns (bytes32[TREE_DEPTH] memory proof)
+    {
+        require(index < count, "Out of range");
+        require(count <= treeCount, "Not enough leafs inserted");
+        for (uint256 h = 0; h < TREE_DEPTH; ++h) {
+            // First, determine X-axis of the element's sibling
+            uint256 siblingX = (index & 1 == 0) ? index + 1 : index - 1;
+            // Get sibling state at the time when `nonce` leafs were added
+            proof[h] = _fetchSavedTreeElement(h, siblingX, count);
+            // Traverse to parent
+            index = index >> 1;
+        }
+    }
+
+    /**
+     * @notice Return tree element with height `h`, x-coordinate `x`, after
+     * `count` leafs have been inserted. O(1)
+     */
+    function _fetchSavedTreeElement(
+        uint256 h,
+        uint256 x,
+        uint256 count
+    ) internal view returns (bytes32 savedValue) {
+        // Should be probably named greatgreat...grandchild, as this
+        // references the children in the very bottom (leafs)
+        uint256 firstChildLeafIndex = x << h; // x * (2**H)
+        uint256 childLeafsAmount = 1 << h; // 2**H
+        if (count <= firstChildLeafIndex) {
+            // Stage A: not enough leafs were inserted, element is still zero
+            savedValue = zeroHashes[h];
+        } else if (count <= firstChildLeafIndex + childLeafsAmount) {
+            // Stage B: tree element was updated after last leaf insertion
+            savedValue = merkleTree[h][x][count];
+            // Sanity check, can't be zero at this point
+            require(savedValue != bytes32(0), "Stage B");
+        } else {
+            // Stage C: tree element was not updated after last leaf insertion
+            // Use last saved value
+            savedValue = merkleTree[h][x][firstChildLeafIndex + childLeafsAmount];
+            // Sanity check, can't be zero at this point
+            require(savedValue != bytes32(0), "Stage C");
+        }
+    }
+}


### PR DESCRIPTION
# Description

Proof-of-concept implementation for generating historical merkle proofs for the sparse merkle tree we are using in `Origin`. Keeps track of the current Merkle tree, allowing to generate proofs against "historical root", i.e. a merkle root for the same tree without last `X` leafs inserted.

Without a doubt, this should be implemented off-chain. Could be used for advanced Foundry tests. Benchmarks for operations:
- New leaf insertion requires 32 storage writes.
- Calculating merkle root at given time requires 1 storage read.
- Generating merkle proof at given time requires 32 storage reads.

Or, in terms of gas usage. There's no world where spending ~800k gas on origin chain to dispatch a message is worth it.

![image](https://user-images.githubusercontent.com/88190723/200118675-83cf4157-34cd-47e5-97c0-9dc55297f0e0.png)
