### PR TITLE
fix gorm filter leak

### DIFF
--- a/services/scribe/db/datastore/sql/mysql/store.go
+++ b/services/scribe/db/datastore/sql/mysql/store.go
@@ -3,12 +3,12 @@ package mysql
 import (
 	"context"
 	"fmt"
-	"github.com/synapsecns/sanguine/core/dbcommon"
 	"time"
 
 	"github.com/synapsecns/sanguine/services/scribe/db/datastore/sql/base"
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
+	gormLogger "gorm.io/gorm/logger"
 	"gorm.io/gorm/schema"
 )
 
@@ -30,7 +30,7 @@ func NewMysqlStore(ctx context.Context, dbURL string) (*Store, error) {
 	logger.Debug("creating mysql store")
 
 	gdb, err := gorm.Open(mysql.Open(dbURL), &gorm.Config{
-		Logger:               dbcommon.GetGormLogger(logger),
+		Logger:               gormLogger.Default.LogMode(gormLogger.Silent),
 		FullSaveAssociations: true,
 		NamingStrategy:       NamingStrategy,
 		NowFunc:              time.Now,


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**

Fixes a context leak where scribe leaks data if context is cancelled:

![image](https://user-images.githubusercontent.com/83933037/206617937-19aafae2-68cd-4d2d-b444-26a6777efebd.png)



Before, this resulted in the for loop continuing forever and garbage associated with the range filter not being collected