### PR TITLE
Fix attestation formatting in go tests

### DIFF
--- a/agents/contracts/attestationcollector/attestationcollector_test.go
+++ b/agents/contracts/attestationcollector/attestationcollector_test.go
@@ -64,17 +64,11 @@ func (a AttestationCollectorSuite) TestAttestationCollectorSuite() {
 	guardEncodedSig, err := types.EncodeSignature(guardSignedAttestation.Signature())
 	Nil(a.T(), err)
 
-	guardSignatures := [][]byte{}
-	notarySignatures := [][]byte{}
-
-	guardSignatures = append(guardSignatures, guardEncodedSig)
-	notarySignatures = append(notarySignatures, notaryEncodedSig)
-
 	attestation, err := a.attestationHarness.FormatAttestation(
 		&bind.CallOpts{Context: a.GetTestContext()},
 		encodedAttestation,
-		guardSignatures,
-		notarySignatures,
+		guardEncodedSig,
+		notaryEncodedSig,
 	)
 	Nil(a.T(), err)
 

--- a/agents/contracts/destination/destination_test.go
+++ b/agents/contracts/destination/destination_test.go
@@ -58,19 +58,14 @@ func (d DestinationSuite) TestDestinationSuite() {
 	encodedSig, err := types.EncodeSignature(signedAttestation.Signature())
 	Nil(d.T(), err)
 
-	guardSignatures := [][]byte{}
-	notarySignatures := [][]byte{}
-
-	notarySignatures = append(notarySignatures, encodedSig)
-
 	encodedAttestation, err := types.EncodeAttestation(unsignedAttestation)
 	Nil(d.T(), err)
 
 	attestation, err := d.attestationHarness.FormatAttestation(
 		&bind.CallOpts{Context: d.GetTestContext()},
 		encodedAttestation,
-		guardSignatures,
-		notarySignatures,
+		[]byte{},
+		encodedSig,
 	)
 	Nil(d.T(), err)
 

--- a/agents/types/parity_test.go
+++ b/agents/types/parity_test.go
@@ -136,18 +136,13 @@ func TestEncodeSignedAttestationParity(t *testing.T) {
 	encodedAttestation, err := types.EncodeAttestation(signedAttestation.Attestation())
 	Nil(t, err)
 
-	guardSignatures := [][]byte{}
-	notarySignatures := [][]byte{}
-
-	guardSignatures = append(guardSignatures, encodedSignature)
-
 	// TODO (joe): This isn't working because we are leaving out the number of signatures for notaries and guards. Fix this.
 	/*signedContractAttestation*/
 	_, err = attesationContract.FormatAttestation(
 		&bind.CallOpts{Context: ctx},
 		encodedAttestation,
-		guardSignatures,
-		notarySignatures,
+		[]byte{},
+		encodedSignature,
 	)
 	Nil(t, err)
 


### PR DESCRIPTION
# Description

Fixes attestation formatting in Go tests that was broken in #410 