### PR TITLE
Replace uses of HashAttestation with types.Hash

### DIFF
--- a/agents/agents/notary/producer.go
+++ b/agents/agents/notary/producer.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/synapsecns/sanguine/agents/db"
 	"github.com/synapsecns/sanguine/agents/domains"
 	"github.com/synapsecns/sanguine/agents/types"
@@ -102,7 +101,7 @@ func (a AttestationProducer) update(ctx context.Context) error {
 	}
 
 	// get the update to sign
-	hashedAttestation, err := HashAttestation(suggestedAttestation)
+	hashedAttestation, err := types.Hash(suggestedAttestation)
 	if err != nil {
 		return fmt.Errorf("could not hash update: %w", err)
 	}
@@ -117,17 +116,4 @@ func (a AttestationProducer) update(ctx context.Context) error {
 		return fmt.Errorf("could not store signed attestations: %w", err)
 	}
 	return nil
-}
-
-// HashAttestation hashes an attestation.
-func HashAttestation(attestation types.Attestation) ([32]byte, error) {
-	encodedAttestation, err := types.EncodeAttestation(attestation)
-	if err != nil {
-		return [32]byte{}, fmt.Errorf("could not encode attestation: %w", err)
-	}
-
-	hashedDigest := crypto.Keccak256Hash(encodedAttestation)
-
-	signedHash := crypto.Keccak256Hash([]byte("\x19Ethereum Signed Message:\n32"), hashedDigest.Bytes())
-	return signedHash, nil
 }

--- a/agents/contracts/attestationcollector/attestationcollector_test.go
+++ b/agents/contracts/attestationcollector/attestationcollector_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	. "github.com/stretchr/testify/assert"
-	"github.com/synapsecns/sanguine/agents/agents/notary"
 	"github.com/synapsecns/sanguine/agents/contracts/attestationcollector"
 	"github.com/synapsecns/sanguine/agents/types"
 )
@@ -41,7 +40,7 @@ func (a AttestationCollectorSuite) launchTest(amountGuards, amountNotaries int) 
 		Nonce:       nonce,
 	}
 	unsignedAttestation := types.NewAttestation(attestKey.GetRawKey(), root)
-	hashedAttestation, err := notary.HashAttestation(unsignedAttestation)
+	hashedAttestation, err := types.Hash(unsignedAttestation)
 	Nil(a.T(), err)
 
 	encodedAttestation, err := types.EncodeAttestation(unsignedAttestation)

--- a/agents/contracts/destination/destination_test.go
+++ b/agents/contracts/destination/destination_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	. "github.com/stretchr/testify/assert"
-	"github.com/synapsecns/sanguine/agents/agents/notary"
 	"github.com/synapsecns/sanguine/agents/types"
 	"github.com/synapsecns/sanguine/core"
 )
@@ -48,7 +47,7 @@ func (d DestinationSuite) TestDestinationSuite() {
 
 	root := common.BigToHash(new(big.Int).SetUint64(gofakeit.Uint64()))
 	unsignedAttestation := types.NewAttestation(attestationKey.GetRawKey(), root)
-	hashedAttestation, err := notary.HashAttestation(unsignedAttestation)
+	hashedAttestation, err := types.Hash(unsignedAttestation)
 	Nil(d.T(), err)
 
 	signature, err := d.signer.SignMessage(d.GetTestContext(), core.BytesToSlice(hashedAttestation), false)

--- a/agents/domains/evm/collector_test.go
+++ b/agents/domains/evm/collector_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	. "github.com/stretchr/testify/assert"
-	"github.com/synapsecns/sanguine/agents/agents/notary"
 	"github.com/synapsecns/sanguine/agents/domains/evm"
 	"github.com/synapsecns/sanguine/agents/types"
 	"github.com/synapsecns/sanguine/core"
@@ -40,7 +39,7 @@ func (i ContractSuite) TestSubmitAttestation() {
 		Nonce:       nonce,
 	}
 	unsignedAttestation := types.NewAttestation(attestKey.GetRawKey(), root)
-	hashedAttestation, err := notary.HashAttestation(unsignedAttestation)
+	hashedAttestation, err := types.Hash(unsignedAttestation)
 	Nil(i.T(), err)
 
 	signature, err := i.signer.SignMessage(i.GetTestContext(), core.BytesToSlice(hashedAttestation), false)


### PR DESCRIPTION
HashAttestation was moved to be types.Hash since we use it in many places.