### PR TITLE
Adding GetRoot and GetAttestation to the AttestationCollector domain interface

### DIFF
--- a/agents/domains/domain.go
+++ b/agents/domains/domain.go
@@ -49,6 +49,10 @@ type AttestationCollectorContract interface {
 	SubmitAttestation(ctx context.Context, signer signer.Signer, attestation types.SignedAttestation) error
 	// GetLatestNonce gets the latest nonce signed by the bondedAgentSigner for the domain on the attestation collector
 	GetLatestNonce(ctx context.Context, origin uint32, destination uint32, bondedAgentSigner signer.Signer) (nonce uint32, err error)
+	// GetAttestation gets the attestation if any for the given origin, destination and nonce
+	GetAttestation(ctx context.Context, origin, destination, nonce uint32) (types.SignedAttestation, error)
+	// GetRoot gets the root if any for the given origin, destination and nonce
+	GetRoot(ctx context.Context, origin, destination, nonce uint32) ([32]byte, error)
 }
 
 // DestinationContract contains the interface for the destination.

--- a/agents/domains/evm/collector.go
+++ b/agents/domains/evm/collector.go
@@ -83,3 +83,26 @@ func (a attestationCollectorContract) GetLatestNonce(ctx context.Context, origin
 
 	return latestNonce, nil
 }
+
+func (a attestationCollectorContract) GetAttestation(ctx context.Context, origin, destination, nonce uint32) (types.SignedAttestation, error) {
+	rawAttestation, err := a.contract.GetAttestation(&bind.CallOpts{Context: ctx}, origin, destination, nonce)
+	if err != nil {
+		return nil, fmt.Errorf("could not retrieve attestation: %w", err)
+	}
+
+	signedAttesation, err := types.DecodeSignedAttestation(rawAttestation)
+	if err != nil {
+		return nil, fmt.Errorf("could not decode attestation: %w", err)
+	}
+
+	return signedAttesation, nil
+}
+
+func (a attestationCollectorContract) GetRoot(ctx context.Context, origin, destination, nonce uint32) ([32]byte, error) {
+	root, err := a.contract.GetRoot(&bind.CallOpts{Context: ctx}, origin, destination, nonce)
+	if err != nil {
+		return [32]byte{}, fmt.Errorf("could not retrieve root: %w", err)
+	}
+
+	return root, nil
+}

--- a/agents/domains/evm/collector_test.go
+++ b/agents/domains/evm/collector_test.go
@@ -43,4 +43,17 @@ func (i ContractSuite) TestSubmitAttestation() {
 	latestNonce, err := i.AttestationContract.GetLatestNonce(&bind.CallOpts{Context: i.GetTestContext()}, originDomain, destinationDomain, i.NotarySigner.Address())
 	Nil(i.T(), err)
 	Equal(i.T(), nonce, latestNonce)
+
+	retrievedRawSignedAttestation, err := i.AttestationContract.GetAttestation(&bind.CallOpts{Context: i.GetTestContext()}, originDomain, destinationDomain, nonce)
+	Nil(i.T(), err)
+	retrievedSignedAttestation, err := types.DecodeSignedAttestation(retrievedRawSignedAttestation)
+	Nil(i.T(), err)
+	Equal(i.T(), signedAttestation.Attestation().Origin(), retrievedSignedAttestation.Attestation().Origin())
+	Equal(i.T(), signedAttestation.Attestation().Destination(), retrievedSignedAttestation.Attestation().Destination())
+	Equal(i.T(), signedAttestation.Attestation().Root(), retrievedSignedAttestation.Attestation().Root())
+	Equal(i.T(), signedAttestation.Attestation().Nonce(), retrievedSignedAttestation.Attestation().Nonce())
+
+	retrievedRoot, err := i.AttestationContract.GetRoot(&bind.CallOpts{Context: i.GetTestContext()}, originDomain, destinationDomain, nonce)
+	Nil(i.T(), err)
+	Equal(i.T(), signedAttestation.Attestation().Root(), retrievedRoot)
 }


### PR DESCRIPTION
I am adding a couple functions to the domain interface for the AttestationCollector contract which will be used by the GuardMVP. 