### PR TITLE
Fix Channel Drain Issue

### DIFF
--- a/ethergo/chain/chainwatcher/block_broadcaster.go
+++ b/ethergo/chain/chainwatcher/block_broadcaster.go
@@ -82,7 +82,7 @@ func (b *BlockBroadcaster) Subscribe() <-chan uint64 {
 	b.blockListenersMux.Lock()
 	listener := blockListener{
 		producerChan:         make(chan uint64),
-		listenerChan:         make(chan uint64),
+		listenerChan:         make(chan uint64, 2048),
 		hasNewHeightChan:     make(chan bool),
 		blockNotifierIsReady: make(chan bool),
 		lastHeight:           b.lastHeight,


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**

There's currently a bug that makes logs proceed one at a time no matter what, getFilterEndHeight is called on an unbuffered channel so the go func that adds heights to the channel is blocked until the channel is read before that can happen (most of the time) the default case is hit. This is a test to verify this is the case. The test will be amended to pass once the bug is fixed.

