### PR TITLE
Fix for executor CLI

### DIFF
--- a/agents/agents/executor/README.md
+++ b/agents/agents/executor/README.md
@@ -25,7 +25,7 @@ $ go run main.go
 ```
 Then the Executor command line will be exposed. The Executor requires a gRPC connection to a Scribe instance to stream logs. This can be done with either a remote Scribe or an embedded Scribe.
 
-From the CLI, you specify whether you want to use a `remote` or `embedded` scribe by using either the `run-remote` or `run-embedded` functions respectively. If using `remote`, you need to use the `--scribe-port`, `--scribe-grpc-port` and `--scribe-url` flags. If using `embedded`, you need to use the `--scribe-db` and `--scribe-path` flags.
+From the CLI, you specify whether you want to use a `remote` or `embedded` scribe via the `--scribe-type` flag. If using `remote`, you need to use the `--scribe-port`, `--scribe-grpc-port` and `--scribe-url` flags. If using `embedded`, you need to use the `--scribe-db` and `--scribe-path` flags.
 
 ### Remote Scribe
 
@@ -33,8 +33,8 @@ Run the following command to start the Executor with a remote Scribe:
 
 ```bash
 # Start the Executor
-$ run-remote --config </Users/synapsecns/config.yaml> --db <sqlite> or <mysql>\
- --path <path/to/database> or <database url>\
+$ run --config </Users/synapsecns/config.yaml> --db <sqlite> or <mysql>\
+ --path <path/to/database> or <database url> --scribe-type remote\
  --scribe-port <port> --scribe-grpc-port <port> --scribe-url <url>
 ```
 
@@ -46,10 +46,11 @@ Run the following command to start the Executor with an embedded Scribe:
 
 ```bash
 # Start the Executor and an embedded Scribe
-$ run-embedded --config </Users/synapsecns/config.yaml> --db <sqlite> or <mysql>\
- --path <path/to/database> or <database url>\
+$ run --config </Users/synapsecns/config.yaml> --db <sqlite> or <mysql>\
+ --path <path/to/database> or <database url> --scribe-type embedded\
  --scribe-db <sqlite> or <mysql> --scribe-path <path/to/database> or <database url>
 ```
+
 
 
 ## Directory Structure

--- a/agents/agents/executor/cmd/cmd.go
+++ b/agents/agents/executor/cmd/cmd.go
@@ -18,7 +18,7 @@ func Start(args []string, buildInfo config.BuildInfo) {
 	app.EnableBashCompletion = true
 
 	// commands
-	app.Commands = cli.Commands{infoCommand, runRemoteCommand, runEmbeddedCommand}
+	app.Commands = cli.Commands{infoCommand, runCommand}
 	shellCommand := commandline.GenerateShellCommand(app.Commands)
 	app.Commands = append(app.Commands, shellCommand)
 	app.Action = shellCommand.Action

--- a/agents/agents/executor/cmd/cmd.md
+++ b/agents/agents/executor/cmd/cmd.md
@@ -4,14 +4,14 @@ The Executor is an agent that verifies messages and executes them on the destina
 
 ## Usage
 
-Run the following command to start the Executor:
+Navigate to `sanguine/agents/agents/executor/main` and run the following command to start the Executor:
 
 ```bash
 $ go run main.go
 ```
 Then the Executor command line will be exposed. The Executor requires a gRPC connection to a Scribe instance to stream logs. This can be done with either a remote Scribe or an embedded Scribe.
 
-From the CLI, you specify whether you want to use a `remote` or `embedded` scribe by using either the `run-remote` or `run-embedded` functions respectively. If using `remote`, you need to use the `--scribe-port`, `--scribe-grpc-port` and `--scribe-url` flags. If using `embedded`, you need to use the `--scribe-db` and `--scribe-path` flags.
+From the CLI, you specify whether you want to use a `remote` or `embedded` scribe via the `--scribe-type` flag. If using `remote`, you need to use the `--scribe-port`, `--scribe-grpc-port` and `--scribe-url` flags. If using `embedded`, you need to use the `--scribe-db` and `--scribe-path` flags.
 
 ### Remote Scribe
 
@@ -19,8 +19,8 @@ Run the following command to start the Executor with a remote Scribe:
 
 ```bash
 # Start the Executor
-$ run-remote --config </Users/synapsecns/config.yaml> --db <sqlite> or <mysql>\
- --path <path/to/database> or <database url>\
+$ run --config </Users/synapsecns/config.yaml> --db <sqlite> or <mysql>\
+ --path <path/to/database> or <database url> --scribe-type remote\
  --scribe-port <port> --scribe-grpc-port <port> --scribe-url <url>
 ```
 
@@ -32,7 +32,7 @@ Run the following command to start the Executor with an embedded Scribe:
 
 ```bash
 # Start the Executor and an embedded Scribe
-$ run-embedded --config </Users/synapsecns/config.yaml> --db <sqlite> or <mysql>\
- --path <path/to/database> or <database url>\
+$ run --config </Users/synapsecns/config.yaml> --db <sqlite> or <mysql>\
+ --path <path/to/database> or <database url> --scribe-type embedded\
  --scribe-db <sqlite> or <mysql> --scribe-path <path/to/database> or <database url>
 ```


### PR DESCRIPTION
**Description**
In the previous executor CLI PR, there were two CLI commands that would be used for either remote scribe or embedded scribe. This is to revert them into one command in order to make it easier to use with helm, and have the differentiation of spinning up a scribe or using a remote one in the helm chart instead.