### PR TITLE
Update `TestClient`to 0.0.2

### DIFF
--- a/packages/contracts-core/contracts/client/TestClient.sol
+++ b/packages/contracts-core/contracts/client/TestClient.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.17;
 import { IMessageRecipient } from "../interfaces/IMessageRecipient.sol";
 import { Origin } from "../Origin.sol";
 
-import { Tips } from "../libs/Tips.sol";
+import { TipsLib } from "../libs/Tips.sol";
 import { TypeCasts } from "../libs/TypeCasts.sol";
 
 contract TestClient is IMessageRecipient {
@@ -73,7 +73,7 @@ contract TestClient is IMessageRecipient {
         bytes memory _message
     ) external {
         bytes32 recipient = TypeCasts.addressToBytes32(_recipient);
-        bytes memory tips = Tips.emptyTips();
+        bytes memory tips = TipsLib.emptyTips();
         (uint32 nonce, ) = Origin(origin).dispatch(
             _destination,
             recipient,


### PR DESCRIPTION
**Description**
Libraries naming was updated in `messaging-0.0.2` branch, causing compile errors after `master` was merged in the last time. This PR fixes that.