### PR TITLE
Fixing Notary to not scan its own origin

### DIFF
--- a/agents/agents/notary/notary.go
+++ b/agents/agents/notary/notary.go
@@ -82,6 +82,10 @@ func NewNotary(ctx context.Context, cfg config.NotaryConfig) (_ Notary, err erro
 	}
 
 	for name, originDomain := range cfg.OriginDomains {
+		if originDomain.DomainID == cfg.DestinationDomain.DomainID {
+			continue
+		}
+
 		originClient, err := evm.NewEVM(ctx, name, originDomain)
 		if err != nil {
 			return Notary{}, fmt.Errorf("error with originClient, could not create notary for: %w", err)

--- a/agents/agents/notary/origin_attestation_scanner.go
+++ b/agents/agents/notary/origin_attestation_scanner.go
@@ -98,6 +98,10 @@ func (a OriginAttestationScanner) update(ctx context.Context) error {
 		return fmt.Errorf("could not get suggested attestation: %w", err)
 	}
 
+	if attestation.Nonce() == 0 {
+		return nil
+	}
+
 	if latestNonce > uint32(0) && attestation.Nonce() <= latestNonce {
 		// We already have seen this nonce
 		return nil

--- a/agents/types/encoder_test.go
+++ b/agents/types/encoder_test.go
@@ -1,6 +1,7 @@
 package types_test
 
 import (
+	"encoding/hex"
 	"math/big"
 	"testing"
 
@@ -200,4 +201,18 @@ func TestHeaderEncodeDecode(t *testing.T) {
 	Equal(t, decodedHeader.DestinationDomain(), destination)
 	Equal(t, decodedHeader.Recipient(), recipient)
 	Equal(t, decodedHeader.OptimisticSeconds(), optimisticSeconds)
+}
+
+func TestDecodeAttestation(t *testing.T) {
+	rawAttestation, err := hex.DecodeString("00000089000000890000000027ae5ba08d7291c96c8cbddcc148bf48a6d68c7974b94356f53754ef6171d757")
+	Nil(t, err)
+
+	decodedAttestation, err := types.DecodeAttestation(rawAttestation)
+	Nil(t, err)
+	NotNil(t, decodedAttestation)
+
+	/*rootBytes32 := decodedAttestation.Root()
+	rootStr := hex.EncodeToString(rootBytes32[:])
+	fmt.Printf("\nCRONIN\n origin: %d,\n destination: %d,\n nonce: %d,\n root: %s\n \nCRONIN\n",
+		decodedAttestation.Origin(), decodedAttestation.Destination(), decodedAttestation.Nonce(), rootStr)*/
 }


### PR DESCRIPTION
I have a bug in my Notary where it scans its own origin if the same origin as the destination appears in the list of origins.
