### PR TITLE
add omnirpc testhelper

### DIFF
--- a/core/mocktesting/doc.go
+++ b/core/mocktesting/doc.go
@@ -1,0 +1,2 @@
+// Package mocktesting is used for mocking out the testing.T interface.
+package mocktesting

--- a/core/mocktesting/mocktester.go
+++ b/core/mocktesting/mocktester.go
@@ -1,0 +1,166 @@
+package mocktesting
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"sync"
+	"testing"
+)
+
+// MockTester is a mock tester. This is used for making sure a test fails
+// using the testing.TB interface and is useful for testing error cases in other test helpers.
+type MockTester struct {
+	name            string
+	mu              sync.RWMutex
+	output          []string
+	skipped, failed bool
+	// print errors is whether or not to print errors
+	printErrors bool
+	// whether or not to print logs
+	printLogs bool
+	// outputHandler specifies how to tread output
+	outputHandler func(...interface{})
+	// The testing.TB interface has an unexported method "to prevent users implementing the
+	// interface and so future additions to it will not violate Go 1 compatibility."
+	//
+	// This may cause problems across Go versions, but let's ignore them and
+	// work around that restriction by embedding a T so we satisfy the unexported methods of the interface.
+	*testing.T
+}
+
+// NewMockTester creates a new process tester.
+func NewMockTester(name string) *MockTester {
+	return &MockTester{
+		name:          name,
+		mu:            sync.RWMutex{},
+		output:        nil,
+		skipped:       false,
+		printErrors:   true,
+		printLogs:     true,
+		outputHandler: log.New(os.Stderr, "", 0).Println,
+		failed:        false,
+		T:             nil,
+	}
+}
+
+// SetOutputHandler sets the output handler for the test output.
+func (t *MockTester) SetOutputHandler(handler func(...interface{})) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.outputHandler = handler
+}
+
+var _ testing.TB = (*MockTester)(nil)
+
+// Error registers an error.
+func (t *MockTester) Error(args ...interface{}) {
+	t.Log(args...)
+	t.Fail()
+}
+
+// Errorf formats the error.
+func (t *MockTester) Errorf(format string, args ...interface{}) {
+	t.Logf(format, args...)
+	t.Fail()
+}
+
+// Fail fails the process.
+func (t *MockTester) Fail() {
+	t.mu.Lock()
+	t.failed = true
+	t.mu.Unlock()
+}
+
+// FailNow immediately fails the process.
+func (t *MockTester) FailNow() {
+	t.Fail()
+}
+
+// Failed indicates whether or not the process failed.
+func (t *MockTester) Failed() bool {
+	t.mu.RLock()
+	failed := t.failed
+	t.mu.RUnlock()
+	return failed
+}
+
+// Fatal fails instantly.
+func (t *MockTester) Fatal(args ...interface{}) {
+	t.Log(args...)
+	t.FailNow()
+}
+
+// Fatalf formats a fail.
+func (t *MockTester) Fatalf(format string, args ...interface{}) {
+	t.Logf(format, args...)
+	t.FailNow()
+}
+
+// Log logs the process.
+func (t *MockTester) Log(args ...interface{}) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	formattedOut := fmt.Sprintln(args...)
+	t.output = append(t.output, formattedOut)
+	if t.printErrors {
+		t.outputHandler(fmt.Sprintln(args...))
+	}
+}
+
+// Logf format logs.
+func (t *MockTester) Logf(format string, args ...interface{}) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	// Ensure message ends with newline.
+	if len(format) > 0 && format[len(format)-1] != '\n' {
+		format += "\n"
+	}
+	formattedOut := fmt.Sprintf(format, args...)
+	t.output = append(t.output, formattedOut)
+	if t.printLogs {
+		t.outputHandler(fmt.Sprintln(args...))
+	}
+}
+
+// Name gets the test name.
+func (t *MockTester) Name() string {
+	return t.name
+}
+
+// Skip skips the test.
+func (t *MockTester) Skip(args ...interface{}) {
+	t.Log(args...)
+	t.SkipNow()
+}
+
+// SkipNow skips the test immediately.
+func (t *MockTester) SkipNow() {
+	t.mu.Lock()
+	t.skipped = true
+	t.mu.Unlock()
+}
+
+// Skipf skips the test with formaatting.
+func (t *MockTester) Skipf(format string, args ...interface{}) {
+	t.Logf(format, args...)
+	t.SkipNow()
+}
+
+// Skipped gets whether or not a process was skipped.
+func (t *MockTester) Skipped() bool {
+	t.mu.Lock()
+	skipped := t.skipped
+	t.mu.Unlock()
+	return skipped
+}
+
+// Helper is used to implement the test helper.
+func (t *MockTester) Helper() {}
+
+// Output gets the output of the test.
+func (t *MockTester) Output() []string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.output
+}

--- a/core/mocktesting/mocktester_test.go
+++ b/core/mocktesting/mocktester_test.go
@@ -1,0 +1,68 @@
+package mocktesting_test
+
+import (
+	"github.com/synapsecns/sanguine/core/mocktesting"
+	"testing"
+)
+
+func TestMockTester(t *testing.T) {
+	mockTester := mocktesting.NewMockTester("TestMockTester")
+
+	// Test Log and Logf
+	mockTester.Log("Test Log")
+	mockTester.Logf("Test Logf with argument %d", 42)
+
+	// Test Error and Errorf
+	mockTester.Error("Test Error")
+	mockTester.Errorf("Test Errorf with argument %s", "hello")
+
+	// Test Fail and FailNow
+	mockTester.Fail()
+	if !mockTester.Failed() {
+		t.Errorf("Expected MockTester to have failed, but it didn't")
+	}
+	mockTester.FailNow()
+
+	// Test Failed
+	mockTester2 := mocktesting.NewMockTester("TestFailed")
+	if mockTester2.Failed() {
+		t.Errorf("Expected MockTester2 to not have failed, but it did")
+	}
+
+	// Test Skip and Skipf
+	mockTester.Skip("Test Skip")
+	mockTester.Skipf("Test Skipf with argument %d", 42)
+
+	// Test Skipped
+	mockTester3 := mocktesting.NewMockTester("TestSkipped")
+	if mockTester3.Skipped() {
+		t.Errorf("Expected MockTester3 to not have been skipped, but it did")
+	}
+	mockTester3.SkipNow()
+	if !mockTester3.Skipped() {
+		t.Errorf("Expected MockTester3 to have been skipped, but it wasn't")
+	}
+
+	// Test Name
+	if mockTester.Name() != "TestMockTester" {
+		t.Errorf("Expected MockTester name to be %q, but got %q", "TestMockTester", mockTester.Name())
+	}
+
+	// Test Helper
+	mockTester.Helper()
+
+	// Test output
+	expectedOutput := []string{
+		"Test Log\n",
+		"Test Logf with argument 42\n",
+		"Test Error\n",
+		"Test Errorf with argument hello\n",
+		"Test Skip\n",
+		"Test Skipf with argument 42\n",
+	}
+	for i, expectedLine := range expectedOutput {
+		if mockTester.Output()[i] != expectedLine {
+			t.Errorf("Expected output line %d to be %q but got %q", i, expectedLine, mockTester.Output())
+		}
+	}
+}

--- a/core/testsuite/util.go
+++ b/core/testsuite/util.go
@@ -1,0 +1,42 @@
+package testsuite
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"testing"
+	"time"
+)
+
+// Here, we separate out some functions that may be useful even outside of the test suite context
+// for example, in utility functions.
+
+// MustMarshall is a helper method that attempts to marshall, otherwise it
+// fails the test.
+func MustMarshall(tb testing.TB, v any) []byte {
+	tb.Helper()
+
+	res, err := json.Marshal(v)
+	assert.Nil(tb, err)
+	return res
+}
+
+// Eventually asserts willBeTrue is true before the test context times out.
+func Eventually(ctx context.Context, tb testing.TB, willBeTrue func() bool) {
+	tb.Helper()
+
+	ctx, cancel := context.WithCancel(ctx)
+	isTrue := false
+	wait.UntilWithContext(ctx, func(ctx context.Context) {
+		if willBeTrue() {
+			isTrue = true
+			cancel()
+		}
+	}, time.Millisecond)
+
+	// make sure the context just didn't cancel
+	if !isTrue {
+		tb.Errorf("expected %T to be true before test context timed out", willBeTrue)
+	}
+}

--- a/core/testsuite/util_test.go
+++ b/core/testsuite/util_test.go
@@ -1,0 +1,60 @@
+package testsuite_test
+
+import (
+	"context"
+	. "github.com/stretchr/testify/assert"
+	"github.com/synapsecns/sanguine/core/mocktesting"
+	"github.com/synapsecns/sanguine/core/testsuite"
+	"testing"
+	"time"
+)
+
+func TestMustMarshall(t *testing.T) {
+	type Person struct {
+		Name string `json:"name"`
+		Age  int    `json:"age"`
+	}
+	p := Person{Name: "John Doe", Age: 30}
+
+	// Test that MustMarshall successfully marshalls the struct to JSON
+	result := testsuite.MustMarshall(t, p)
+	expectedResult := `{"name":"John Doe","age":30}`
+	if string(result) != expectedResult {
+		t.Errorf("Expected %q but got %q", expectedResult, result)
+	}
+
+	// Test that MustMarshall fails when given an unmarshallable input
+	invalidInput := make(chan int)
+	mockTester := mocktesting.NewMockTester("mock tester")
+	mockTester.SetOutputHandler(func(i ...interface{}) {
+		// do nothing
+	})
+	testsuite.MustMarshall(mockTester, invalidInput)
+	True(t, mockTester.Failed())
+}
+
+func TestEventually(t *testing.T) {
+	// Test that Eventually returns without error when the condition is true before the context times out
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	count := 0
+	testFunc := func() bool {
+		count++
+		return count >= 5
+	}
+	testsuite.Eventually(ctx, t, testFunc)
+	if count != 5 {
+		t.Errorf("Expected testFunc to be called 5 times but got %d", count)
+	}
+
+	// Test that Eventually returns an error when the context times out before the condition is true
+	ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	testFunc = func() bool {
+		return false
+	}
+
+	mockTester := mocktesting.NewMockTester("mock tester")
+	testsuite.Eventually(ctx, mockTester, testFunc)
+	True(t, mockTester.Failed())
+}

--- a/make/go.Makefile
+++ b/make/go.Makefile
@@ -27,5 +27,6 @@ lint: ## Run golangci-lint and go fmt ./...
 	cd $(GIT_ROOT)
 	go work sync
 	cd $(CURRENT_PATH)
-	## Note: when we upgrade, we can use either the brew version (needs to stay at latest). If we decide to stay with docker, we can use gomemlimit instead of a constant heap size
+	# Note: when we upgrade, we can use either the brew version (needs to stay at latest). If we decide to stay with docker, we can use gomemlimit instead of a constant heap size.
+	# TODO: investigate why this is so much slower than local install
 	docker run -t --rm -v $(go env GOCACHE):/cache/go -v ${GOPATH}/pkg:/go/pkg -e GOGC=2000  -e GOCACHE=/cache/go -v ~/.cache/golangci-lint/:/root/.cache -v "$(GIT_ROOT)":/app -w "/app/$(RELPATH)" golangci/golangci-lint:v1.48.0 golangci-lint run -v --fix

--- a/services/omnirpc/cmd/commands.go
+++ b/services/omnirpc/cmd/commands.go
@@ -9,7 +9,6 @@ import (
 	"github.com/synapsecns/sanguine/core"
 	rpcConfig "github.com/synapsecns/sanguine/services/omnirpc/config"
 	"github.com/synapsecns/sanguine/services/omnirpc/debug"
-	omniHTTP "github.com/synapsecns/sanguine/services/omnirpc/http"
 	"github.com/synapsecns/sanguine/services/omnirpc/proxy"
 	"github.com/synapsecns/sanguine/services/omnirpc/rpcinfo"
 	"github.com/urfave/cli/v2"
@@ -59,7 +58,7 @@ var chainListCommand = &cli.Command{
 			rConfig.Port = uint16(freeport.GetPort())
 		}
 
-		server := proxy.NewProxy(rConfig, omniHTTP.ClientTypeFromString(rConfig.ClientType))
+		server := proxy.NewProxy(rConfig)
 
 		server.Run(c.Context)
 
@@ -130,7 +129,7 @@ var serverCommand = &cli.Command{
 			rConfig.Port = uint16(freeport.GetPort())
 		}
 
-		server := proxy.NewProxy(rConfig, omniHTTP.ClientTypeFromString(rConfig.ClientType))
+		server := proxy.NewProxy(rConfig)
 
 		server.Run(c.Context)
 

--- a/services/omnirpc/proxy/forward_test.go
+++ b/services/omnirpc/proxy/forward_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func (p *ProxySuite) TestServeRequestNoChain() {
-	prxy := proxy.NewProxy(config.Config{}, omniHTTP.FastHTTP)
+	prxy := proxy.NewProxy(config.Config{})
 
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
@@ -32,7 +32,7 @@ func (p *ProxySuite) TestServeRequestNoChain() {
 }
 
 func (p *ProxySuite) TestCannotReadBody() {
-	prxy := proxy.NewProxy(config.Config{}, omniHTTP.FastHTTP)
+	prxy := proxy.NewProxy(config.Config{})
 
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
@@ -63,7 +63,7 @@ func (p *ProxySuite) generateFakeJSON() []byte {
 }
 
 func (p *ProxySuite) TestMalformedRequestBody() {
-	prxy := proxy.NewProxy(config.Config{}, omniHTTP.FastHTTP)
+	prxy := proxy.NewProxy(config.Config{})
 
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
@@ -76,7 +76,7 @@ func (p *ProxySuite) TestMalformedRequestBody() {
 
 // TestAcquireReleaseForwarder makes sure the forwarder is cleared afte r being released.
 func (p *ProxySuite) TestAcquireReleaseForwarder() {
-	prxy := proxy.NewProxy(config.Config{}, omniHTTP.FastHTTP)
+	prxy := proxy.NewProxy(config.Config{})
 
 	forwarder := prxy.AcquireForwarder()
 	forwarder.SetChain(new(chainManagerMocks.Chain))
@@ -107,7 +107,7 @@ func (p *ProxySuite) TestAcquireReleaseForwarder() {
 }
 
 func (p *ProxySuite) TestForwardRequestDisallowWS() {
-	prxy := proxy.NewProxy(config.Config{}, omniHTTP.FastHTTP)
+	prxy := proxy.NewProxy(config.Config{})
 
 	invalidSchemes := []string{"wss", "ws"}
 	for _, scheme := range invalidSchemes {
@@ -130,7 +130,7 @@ func (p *ProxySuite) TestForwardRequestDisallowWS() {
 }
 
 func (p *ProxySuite) TestForwardRequest() {
-	prxy := proxy.NewProxy(config.Config{}, omniHTTP.FastHTTP)
+	prxy := proxy.NewProxy(config.Config{})
 
 	methodName := "test"
 	testRes := p.MustMarshall(proxy.JSONRPCMessage{
@@ -174,7 +174,7 @@ func (p *ProxySuite) TestForwardRequest() {
 }
 
 func (p *ProxySuite) TestOverrideConfirmability() {
-	prxy := proxy.NewProxy(config.Config{}, omniHTTP.FastHTTP)
+	prxy := proxy.NewProxy(config.Config{})
 	forwarder := prxy.AcquireForwarder()
 
 	const chainConfirmations = uint16(10)

--- a/services/omnirpc/proxy/server.go
+++ b/services/omnirpc/proxy/server.go
@@ -31,13 +31,20 @@ type RPCProxy struct {
 	client omniHTTP.Client
 }
 
+// defaultInterval is the default refresh interval.
+const defaultInterval = 30
+
 // NewProxy creates a new rpc proxy.
-func NewProxy(config config.Config, clientType omniHTTP.ClientType) *RPCProxy {
+func NewProxy(config config.Config) *RPCProxy {
+	if config.RefreshInterval == 0 {
+		logger.Warn("no refresh interval set (or interval is 0), using default of %d seconds", defaultInterval)
+	}
+
 	return &RPCProxy{
 		chainManager:    chainmanager.NewChainManagerFromConfig(config),
 		refreshInterval: time.Second * time.Duration(config.RefreshInterval),
 		port:            config.Port,
-		client:          omniHTTP.NewClient(clientType),
+		client:          omniHTTP.NewClient(omniHTTP.ClientTypeFromString(config.ClientType)),
 	}
 }
 

--- a/services/omnirpc/testhelper/doc.go
+++ b/services/omnirpc/testhelper/doc.go
@@ -1,0 +1,3 @@
+// Package testhelper is used for setting up ominrpc instances for any number of backends.
+// this is purely a helper package and should be used solely for testing.
+package testhelper

--- a/services/omnirpc/testhelper/server.go
+++ b/services/omnirpc/testhelper/server.go
@@ -1,0 +1,82 @@
+package testhelper
+
+import (
+	"context"
+	"fmt"
+	"github.com/phayes/freeport"
+	"github.com/stretchr/testify/assert"
+	"github.com/synapsecns/sanguine/core/ginhelper"
+	"github.com/synapsecns/sanguine/core/testsuite"
+	"github.com/synapsecns/sanguine/ethergo/backends"
+	"github.com/synapsecns/sanguine/services/omnirpc/config"
+	omniHTTP "github.com/synapsecns/sanguine/services/omnirpc/http"
+	"github.com/synapsecns/sanguine/services/omnirpc/proxy"
+	"net/http"
+	"testing"
+)
+
+func makeConfig(backends []backends.SimulatedTestBackend, clientType omniHTTP.ClientType) config.Config {
+	chains := make(map[uint32]config.ChainConfig)
+
+	for _, backend := range backends {
+		chains[uint32(backend.GetChainID())] = config.ChainConfig{
+			RPCs:   []string{backend.RPCAddress()},
+			Checks: 1,
+		}
+	}
+
+	return config.Config{
+		Chains:          chains,
+		Port:            uint16(freeport.GetPort()),
+		RefreshInterval: 0,
+		ClientType:      clientType.String(),
+	}
+}
+
+// NewOmnirpcServer creates a new omnirpc server with all the test backends passed in.
+// since these are all mocked geth instances, these are single confirmation instances only.
+// a string is returned with the base url for the omnirpc server.
+//
+// context is respected and the server will be killed when the context is done.
+func NewOmnirpcServer(ctx context.Context, tb testing.TB, backends ...backends.SimulatedTestBackend) string {
+	tb.Helper()
+
+	server := proxy.NewProxy(makeConfig(backends, omniHTTP.FastHTTP))
+
+	go func() {
+		server.Run(ctx)
+	}()
+
+	baseHost := fmt.Sprintf("http://0.0.0.0:%d", server.Port())
+	healthCheck := fmt.Sprintf("%s%s", baseHost, ginhelper.HealthCheck)
+
+	// wait for server to start
+	testsuite.Eventually(ctx, tb, func() bool {
+		select {
+		case <-ctx.Done():
+			tb.Error(ctx.Err())
+		default:
+			// see below
+		}
+
+		request, err := http.NewRequestWithContext(ctx, http.MethodGet, healthCheck, nil)
+		assert.Nil(tb, err)
+
+		res, err := http.DefaultClient.Do(request)
+		if err == nil {
+			defer func() {
+				_ = res.Body.Close()
+			}()
+			return true
+		}
+
+		return false
+	})
+
+	return baseHost
+}
+
+// GetURL gets the url for a given backend given the base host.
+func GetURL(baseHost string, backend backends.SimulatedTestBackend) string {
+	return fmt.Sprintf("%s/rpc/%d", baseHost, backend.GetChainID())
+}

--- a/services/omnirpc/testhelper/server_test.go
+++ b/services/omnirpc/testhelper/server_test.go
@@ -1,0 +1,26 @@
+package testhelper_test
+
+import (
+	"github.com/ethereum/go-ethereum/ethclient"
+	. "github.com/stretchr/testify/assert"
+	"github.com/synapsecns/sanguine/services/omnirpc/testhelper"
+	"math/big"
+)
+
+func (s *TestHelperSuite) TestOminrpcServer() {
+	omnirpcServer := testhelper.NewOmnirpcServer(s.GetTestContext(), s.T(), s.testBackends...)
+
+	for _, testBackend := range s.testBackends {
+		ogBlock, err := testBackend.BlockByNumber(s.GetTestContext(), big.NewInt(1))
+		Nil(s.T(), err)
+
+		omnirpcURL := testhelper.GetURL(omnirpcServer, testBackend)
+		omnirpcEthClient, err := ethclient.DialContext(s.GetTestContext(), omnirpcURL)
+		Nil(s.T(), err)
+
+		omniBlock, err := omnirpcEthClient.BlockByNumber(s.GetTestContext(), big.NewInt(1))
+		Nil(s.T(), err)
+
+		Equal(s.T(), ogBlock.Hash(), omniBlock.Hash())
+	}
+}

--- a/services/omnirpc/testhelper/suite_test.go
+++ b/services/omnirpc/testhelper/suite_test.go
@@ -1,0 +1,70 @@
+package testhelper_test
+
+import (
+	"context"
+	"github.com/stretchr/testify/suite"
+	"github.com/synapsecns/sanguine/core/testsuite"
+	"github.com/synapsecns/sanguine/ethergo/backends"
+	"github.com/synapsecns/sanguine/ethergo/backends/geth"
+	"golang.org/x/sync/errgroup"
+	"math/big"
+	"testing"
+)
+
+type TestHelperSuite struct {
+	*testsuite.TestSuite
+	// testBackends contins a list of all test backends
+	testBackends []backends.SimulatedTestBackend
+}
+
+func NewTestHelperSuite(tb testing.TB) *TestHelperSuite {
+	tb.Helper()
+	return &TestHelperSuite{
+		TestSuite: testsuite.NewTestSuite(tb),
+	}
+}
+
+func TestTestHelperSuite(t *testing.T) {
+	suite.Run(t, NewTestHelperSuite(t))
+}
+
+func (s *TestHelperSuite) SetupSuite() {
+	s.TestSuite.SetupSuite()
+
+	s.SetupBackends(s.GetSuiteContext())
+}
+
+// SetupBackends sets up the test backends that are used for the tests. These need to be setup as embedded backends since
+// scribe requires rpc addresses, so we employ some paraellism to speed up the test process.
+//
+// This can either be done per suite or per test. This is done per suite do to the cost of spinning up fake geth nodes.
+func (s *TestHelperSuite) SetupBackends(ctx context.Context) {
+	// let's create 3 mock chains
+	chainIDs := []uint64{1, 2, 3}
+
+	// preallocate a slice for testbackends to the size of chainIDs
+	// this way we can avoid non-deterministic order + needing to acquire/release a lock
+	s.testBackends = make([]backends.SimulatedTestBackend, len(chainIDs))
+
+	// TODO: can we use a waitgroup here instead?
+	g, gCtx := errgroup.WithContext(ctx)
+	for i, chainID := range chainIDs {
+		pos := i           // get position of chain id in array
+		chainID := chainID // capture func literal
+		g.Go(func() error {
+			// we need to use the embedded backend here, because the simulated backend doesn't support rpcs required by scribe
+			backend := geth.NewEmbeddedBackendForChainID(ctx, s.T(), new(big.Int).SetUint64(chainID))
+
+			// make sure we mine at least 1 block
+			backend.GetFundedAccount(gCtx, big.NewInt(1000000000000000000))
+			// add the backend to the list of backends
+			s.testBackends[pos] = backend
+			return nil
+		})
+	}
+
+	// wait for all backends to be ready
+	if err := g.Wait(); err != nil {
+		s.T().Fatal(err)
+	}
+}


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**

 - Adds a test helper to omnirpc to speed up the use of multiple backends
 - add a mocktester for mocking out test failure 
 - seperate out some core/testsuite functions into utils that can be used outside of the core
 - refactor scribe to use omnirpc test helper