### PR TITLE
update renovate to reflect renovatebot/renovate#20759

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,7 +14,7 @@
   "fetchReleaseNotes": true,
   "draftPR": true,
   "cloneSubmodules": true,
-  "forkProcessing": true,
+  "forkProcessing": "enabled",
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**

The generic-linters github action was previously broken since`includeForks` was renamed to `forkProcessing` and the value was changed from a `bool` to a string in renovatebot/renovate#20759

This makes our config compatible w/ the updated version