### PR TITLE
Mark previously executed messages as executed in the database.

### DIFF
--- a/agents/agents/executor/executor.go
+++ b/agents/agents/executor/executor.go
@@ -700,6 +700,12 @@ func (e Executor) executeExecutable(ctx context.Context, chainID uint32) error {
 					}
 
 					destinationDomain := message.DestinationDomain()
+					nonce := message.Nonce()
+					executedMessageMask := execTypes.DBMessage{
+						ChainID:     &chainID,
+						Destination: &destinationDomain,
+						Nonce:       &nonce,
+					}
 
 					if !e.chainExecutors[destinationDomain].executed[leaf] {
 						executed, err := e.Execute(ctx, message)
@@ -711,14 +717,15 @@ func (e Executor) executeExecutable(ctx context.Context, chainID uint32) error {
 						if !executed {
 							continue
 						}
+					} else {
+						err = e.executorDB.ExecuteMessage(ctx, executedMessageMask)
+						if err != nil {
+							logger.Errorf("could not mark previously executed message as executed")
+						}
+
+						e.chainExecutors[destinationDomain].executed[leaf] = false
 					}
 
-					nonce := message.Nonce()
-					executedMessageMask := execTypes.DBMessage{
-						ChainID:     &chainID,
-						Destination: &destinationDomain,
-						Nonce:       &nonce,
-					}
 					err = e.executorDB.ExecuteMessage(ctx, executedMessageMask)
 					if err != nil {
 						return fmt.Errorf("could not execute message: %w", err)


### PR DESCRIPTION
**Description**
Right now, the executor will go to the destination before it starts running and store messages that have been executed in a mapping. Right now, it only uses a mapping. This PR will make it that after a message is added into the database and it has been executed, we will mark it as executed in the database, rather than relying on the mapping. This makes the database easier to carry forward.