### PR TITLE
Revert "prev messages as executed in db (#673)"

### DIFF
--- a/agents/agents/executor/executor.go
+++ b/agents/agents/executor/executor.go
@@ -700,12 +700,6 @@ func (e Executor) executeExecutable(ctx context.Context, chainID uint32) error {
 					}
 
 					destinationDomain := message.DestinationDomain()
-					nonce := message.Nonce()
-					executedMessageMask := execTypes.DBMessage{
-						ChainID:     &chainID,
-						Destination: &destinationDomain,
-						Nonce:       &nonce,
-					}
 
 					if !e.chainExecutors[destinationDomain].executed[leaf] {
 						executed, err := e.Execute(ctx, message)
@@ -717,15 +711,14 @@ func (e Executor) executeExecutable(ctx context.Context, chainID uint32) error {
 						if !executed {
 							continue
 						}
-					} else {
-						err = e.executorDB.ExecuteMessage(ctx, executedMessageMask)
-						if err != nil {
-							logger.Errorf("could not mark previously executed message as executed")
-						}
-
-						e.chainExecutors[destinationDomain].executed[leaf] = false
 					}
 
+					nonce := message.Nonce()
+					executedMessageMask := execTypes.DBMessage{
+						ChainID:     &chainID,
+						Destination: &destinationDomain,
+						Nonce:       &nonce,
+					}
 					err = e.executorDB.ExecuteMessage(ctx, executedMessageMask)
 					if err != nil {
 						return fmt.Errorf("could not execute message: %w", err)


### PR DESCRIPTION
This reverts commit ddd29e757a7759dc5d1bb28182c8c59a7d28c9b2.

**Description**
Messed up. Didn't work in real mainnet test. To figure out later.