### PR TITLE
Chore: follow v1 branch in forge-std 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "packages/contracts-core/lib/forge-std"]
 	path = packages/contracts-core/lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
+	branch = v1
 [submodule "ethergo/internal/test-data"]
 	path = ethergo/internal/test-data
 	url = https://github.com/synapsecns/synapse-contracts


### PR DESCRIPTION
**Description**
To avoid committing submodule changes:
- `git submodule update --init --recursive` after switching from branch to branch branches
- or `git checkout feat/branch-name --recurse-submodules`

A nice read as well:
https://git-scm.com/book/en/v2/Git-Tools-Submodules