### PR TITLE
don't keep containers in agents backend

### DIFF
--- a/agents/testutil/simulated_backends_suite.go
+++ b/agents/testutil/simulated_backends_suite.go
@@ -105,7 +105,7 @@ func NewSimulatedBackendsTestSuite(tb testing.TB) *SimulatedBackendsTestSuite {
 // SetupSuite sets up the test suite.
 func (a *SimulatedBackendsTestSuite) SetupSuite() {
 	a.TestSuite.SetupSuite()
-	localmetrics.SetupTestJaeger(a.GetSuiteContext(), a.T(), localmetrics.WithKeepContainers(true))
+	localmetrics.SetupTestJaeger(a.GetSuiteContext(), a.T())
 
 	var err error
 	a.ScribeMetrics, err = metrics.NewByType(a.GetSuiteContext(), scribeMetadata.BuildInfo(), metrics.Jaeger)


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**

Removes the keep containers directive in `simulated_backends_suite`, this was added in #695 for debugging
