### PR TITLE
Fixing executor tests and parity tests for messaging003

### DIFF
--- a/packages/contracts-core/contracts/events/AgentManagerEvents.sol
+++ b/packages/contracts-core/contracts/events/AgentManagerEvents.sol
@@ -4,6 +4,19 @@ pragma solidity 0.8.17;
 import {AgentFlag, Dispute} from "../libs/Structures.sol";
 
 abstract contract AgentManagerEvents {
+    // ════════════════════════════════════════════ STATEMENT ACCEPTED ═════════════════════════════════════════════════
+
+    /**
+     * @notice Emitted when a snapshot is accepted by the Destination contract.
+     * @param domain        Domain where the signed Notary is active
+     * @param notary        Notary who signed the attestation
+     * @param attPayload    Raw payload with attestation data
+     * @param attSignature  Notary signature for the attestation
+     */
+    event AttestationAccepted(uint32 domain, address notary, bytes attPayload, bytes attSignature);
+
+    // ═════════════════════════════════════════ INVALID STATEMENT PROVED ══════════════════════════════════════════════
+
     /**
      * @notice Emitted when a proof of invalid receipt statement is submitted.
      * @param rcptPayload   Raw payload with the receipt statement
@@ -34,6 +47,8 @@ abstract contract AgentManagerEvents {
      * @param srSignature   Guard signature for the report
      */
     event InvalidStateReport(bytes srPayload, bytes srSignature);
+
+    // ═══════════════════════════════════════════════ DATA UPDATED ════════════════════════════════════════════════════
 
     /**
      * @notice Emitted whenever the root of the Agent Merkle Tree is updated.

--- a/packages/contracts-core/contracts/events/BondingManagerEvents.sol
+++ b/packages/contracts-core/contracts/events/BondingManagerEvents.sol
@@ -3,6 +3,24 @@ pragma solidity 0.8.17;
 
 abstract contract BondingManagerEvents {
     /**
+     * @notice Emitted when a snapshot is accepted by the Summit contract.
+     * @param domain        Domain where the signed Agent is active (ZERO for Guards)
+     * @param agent         Agent who signed the snapshot
+     * @param snapPayload   Raw payload with snapshot data
+     * @param snapSignature Agent signature for the snapshot
+     */
+    event SnapshotAccepted(uint32 indexed domain, address indexed agent, bytes snapPayload, bytes snapSignature);
+
+    /**
+     * @notice Emitted when a snapshot is accepted by the Summit contract.
+     * @param domain        Domain where the signed Notary is active
+     * @param notary        Notary who signed the attestation
+     * @param rcptPayload   Raw payload with receipt data
+     * @param rcptSignature Notary signature for the receipt
+     */
+    event ReceiptAccepted(uint32 domain, address notary, bytes rcptPayload, bytes rcptSignature);
+
+    /**
      * @notice Emitted when a proof of invalid attestation is submitted.
      * @param attPayload    Raw payload with Attestation data
      * @param attSignature  Notary signature for the attestation

--- a/packages/contracts-core/contracts/events/DestinationEvents.sol
+++ b/packages/contracts-core/contracts/events/DestinationEvents.sol
@@ -3,14 +3,5 @@ pragma solidity 0.8.17;
 
 /// @notice A collection of events emitted by the Destination contract
 abstract contract DestinationEvents {
-    /**
-     * @notice Emitted when a snapshot is accepted by the Destination contract.
-     * @param domain        Domain where the signed Notary is active
-     * @param notary        Notary who signed the attestation
-     * @param attestation   Raw payload with attestation data
-     * @param attSignature  Notary signature for the attestation
-     */
-    event AttestationAccepted(uint32 domain, address notary, bytes attestation, bytes attSignature);
-
     event AgentRootAccepted(bytes32 agentRoot);
 }

--- a/packages/contracts-core/contracts/events/SummitEvents.sol
+++ b/packages/contracts-core/contracts/events/SummitEvents.sol
@@ -4,24 +4,6 @@ pragma solidity 0.8.17;
 /// @notice A collection of events emitted by the Summit contract
 abstract contract SummitEvents {
     /**
-     * @notice Emitted when a snapshot is accepted by the Summit contract.
-     * @param domain        Domain where the signed Notary is active
-     * @param notary        Notary who signed the attestation
-     * @param rcptPayload   Raw payload with receipt data
-     * @param rcptSignature Notary signature for the receipt
-     */
-    event ReceiptAccepted(uint32 domain, address notary, bytes rcptPayload, bytes rcptSignature);
-
-    /**
-     * @notice Emitted when a snapshot is accepted by the Summit contract.
-     * @param domain        Domain where the signed Agent is active (ZERO for Guards)
-     * @param agent         Agent who signed the snapshot
-     * @param snapshot      Raw payload with snapshot data
-     * @param snapSignature Agent signature for the snapshot
-     */
-    event SnapshotAccepted(uint32 indexed domain, address indexed agent, bytes snapshot, bytes snapSignature);
-
-    /**
      * @notice Emitted when a tip is awarded to the actor, whether they are bonded or unbonded actor.
      * @param actor     Actor address
      * @param origin    Domain where tips were originally paid

--- a/packages/contracts-core/contracts/hubs/SnapshotHub.sol
+++ b/packages/contracts-core/contracts/hubs/SnapshotHub.sol
@@ -7,13 +7,15 @@ import {MerkleMath} from "../libs/MerkleMath.sol";
 import {Snapshot, SnapshotLib} from "../libs/Snapshot.sol";
 import {State, StateLib} from "../libs/State.sol";
 // ═════════════════════════════ INTERNAL IMPORTS ══════════════════════════════
+import {AgentSecured} from "../base/AgentSecured.sol";
 import {SnapshotHubEvents} from "../events/SnapshotHubEvents.sol";
+import {IAgentManager} from "../interfaces/IAgentManager.sol";
 import {ISnapshotHub} from "../interfaces/ISnapshotHub.sol";
 
 /**
  * @notice Hub to accept and save snapshots, as well as verify _attestations.
  */
-abstract contract SnapshotHub is SnapshotHubEvents, ISnapshotHub {
+abstract contract SnapshotHub is AgentSecured, SnapshotHubEvents, ISnapshotHub {
     using AttestationLib for bytes;
     using StateLib for bytes;
 
@@ -34,6 +36,7 @@ abstract contract SnapshotHub is SnapshotHubEvents, ISnapshotHub {
     struct SummitSnapshot {
         // TODO: compress this - indexes might as well be uint32/uint64
         uint256[] statePtrs;
+        uint256 sigIndex;
     }
 
     struct SummitAttestation {
@@ -65,11 +68,12 @@ abstract contract SnapshotHub is SnapshotHubEvents, ISnapshotHub {
 
     /// @dev Pointer for the latest Agent State of a given origin
     /// with ZERO as a sentinel value for "no states submitted yet".
-    // (origin => (agent => {latest state index in _states PLUS 1}))
-    mapping(uint32 => mapping(address => uint256)) private _latestStatePtr;
+    // (origin => (agent index => {latest state index in _states PLUS 1}))
+    mapping(uint32 => mapping(uint32 => uint256)) private _latestStatePtr;
 
     /// @dev Latest nonce that a Notary created
-    mapping(address => uint32) private _latestAttNonce;
+    // (notary index => latest nonce)
+    mapping(uint32 => uint32) private _latestAttNonce;
 
     /// @dev gap for upgrade safety
     uint256[43] private __GAP; // solhint-disable-line var-name-mixedcase
@@ -84,40 +88,53 @@ abstract contract SnapshotHub is SnapshotHubEvents, ISnapshotHub {
     }
 
     /// @inheritdoc ISnapshotHub
-    function getAttestation(uint32 nonce) external view returns (bytes memory attPayload) {
-        require(nonce < _attestations.length, "Nonce out of range");
-        return _formatSummitAttestation(_attestations[nonce], nonce);
+    function getAttestation(uint32 attNonce) external view returns (bytes memory attPayload) {
+        require(attNonce < _attestations.length, "Nonce out of range");
+        return _formatSummitAttestation(_attestations[attNonce], attNonce);
     }
 
     /// @inheritdoc ISnapshotHub
     function getLatestAgentState(uint32 origin, address agent) external view returns (bytes memory stateData) {
-        SummitState memory latestState = _latestState(origin, agent);
+        SummitState memory latestState = _latestState(origin, _agentStatus(agent).index);
         if (latestState.nonce == 0) return bytes("");
         return _formatSummitState(latestState);
     }
 
     /// @inheritdoc ISnapshotHub
     function getLatestNotaryAttestation(address notary) external view returns (bytes memory attPayload) {
-        uint32 latestAttNonce = _latestAttNonce[notary];
+        uint32 latestAttNonce = _latestAttNonce[_agentStatus(notary).index];
         if (latestAttNonce == 0) return bytes("");
         return _formatSummitAttestation(_attestations[latestAttNonce], latestAttNonce);
     }
 
     /// @inheritdoc ISnapshotHub
-    function getGuardSnapshot(uint256 index) external view returns (bytes memory snapshotPayload) {
+    function getGuardSnapshot(uint256 index)
+        external
+        view
+        returns (bytes memory snapPayload, bytes memory snapSignature)
+    {
         require(index < _guardSnapshots.length, "Index out of range");
         return _restoreSnapshot(_guardSnapshots[index]);
     }
 
     /// @inheritdoc ISnapshotHub
-    function getNotarySnapshot(uint256 nonce) public view returns (bytes memory snapshotPayload) {
-        require(nonce != 0 && nonce < _notarySnapshots.length, "Nonce out of range");
+    function getNotarySnapshot(uint256 index)
+        public
+        view
+        returns (bytes memory snapPayload, bytes memory snapSignature)
+    {
+        uint256 nonce = index + 1;
+        require(nonce < _notarySnapshots.length, "Nonce out of range");
         return _restoreSnapshot(_notarySnapshots[nonce]);
     }
 
     /// @inheritdoc ISnapshotHub
     // solhint-disable-next-line ordering
-    function getNotarySnapshot(bytes memory attPayload) external view returns (bytes memory snapshotPayload) {
+    function getNotarySnapshot(bytes memory attPayload)
+        external
+        view
+        returns (bytes memory snapPayload, bytes memory snapSignature)
+    {
         // This will revert if payload is not a formatted attestation
         Attestation attestation = attPayload.castToAttestation();
         require(_isValidAttestation(attestation), "Invalid attestation");
@@ -127,9 +144,9 @@ abstract contract SnapshotHub is SnapshotHubEvents, ISnapshotHub {
     }
 
     /// @inheritdoc ISnapshotHub
-    function getSnapshotProof(uint256 nonce, uint256 stateIndex) external view returns (bytes32[] memory snapProof) {
-        require(nonce != 0 && nonce < _notarySnapshots.length, "Nonce out of range");
-        SummitSnapshot memory snap = _notarySnapshots[nonce];
+    function getSnapshotProof(uint32 attNonce, uint256 stateIndex) external view returns (bytes32[] memory snapProof) {
+        require(attNonce != 0 && attNonce < _notarySnapshots.length, "Nonce out of range");
+        SummitSnapshot memory snap = _notarySnapshots[attNonce];
         uint256 statesAmount = snap.statePtrs.length;
         require(stateIndex < statesAmount, "Index out of range");
         // Reconstruct the leafs of Snapshot Merkle Tree: two for each state
@@ -150,24 +167,24 @@ abstract contract SnapshotHub is SnapshotHubEvents, ISnapshotHub {
 
     /// @dev Accepts a Snapshot signed by a Guard.
     /// It is assumed that the Guard signature has been checked outside of this contract.
-    function _acceptGuardSnapshot(Snapshot snapshot, address guard, uint32 guardIndex) internal {
+    function _acceptGuardSnapshot(Snapshot snapshot, uint32 guardIndex, uint256 sigIndex) internal {
         // Snapshot Signer is a Guard: save the states for later use.
         uint256 statesAmount = snapshot.statesAmount();
         uint256[] memory statePtrs = new uint256[](statesAmount);
         for (uint256 i = 0; i < statesAmount; ++i) {
-            statePtrs[i] = _saveState(snapshot.state(i), guard, guardIndex);
+            statePtrs[i] = _saveState(snapshot.state(i), guardIndex);
             // Guard either submitted a fresh state, or reused state submitted by another Guard
             // In any case, the "state pointer" would never be zero
             assert(statePtrs[i] != 0);
         }
         // Save Guard snapshot for later retrieval
-        _saveGuardSnapshot(statePtrs);
+        _saveGuardSnapshot(statePtrs, sigIndex);
     }
 
     /// @dev Accepts a Snapshot signed by a Notary.
     /// It is assumed that the Notary signature has been checked outside of this contract.
     /// Returns the attestation created from the Notary snapshot.
-    function _acceptNotarySnapshot(Snapshot snapshot, bytes32 agentRoot, address notary, uint32 notaryIndex)
+    function _acceptNotarySnapshot(Snapshot snapshot, bytes32 agentRoot, uint32 notaryIndex, uint256 sigIndex)
         internal
         returns (bytes memory attPayload)
     {
@@ -183,15 +200,15 @@ abstract contract SnapshotHub is SnapshotHubEvents, ISnapshotHub {
             statePtrs[i] = statePtr;
             // Check that Notary hasn't used a fresher state for this origin before
             uint32 origin = state.origin();
-            require(state.nonce() > _latestState(origin, notary).nonce, "Outdated nonce");
+            require(state.nonce() > _latestState(origin, notaryIndex).nonce, "Outdated nonce");
             // Save Notary if they are the first to use this state
             if (_states[statePtr - 1].notaryIndex == 0) _states[statePtr - 1].notaryIndex = notaryIndex;
             // Update Notary latest state for origin
-            _latestStatePtr[origin][notary] = statePtrs[i];
+            _latestStatePtr[origin][notaryIndex] = statePtrs[i];
         }
         // Derive the snapshot merkle root and save it for a Notary attestation.
         // Save Notary snapshot for later retrieval
-        return _saveNotarySnapshot(snapshot, statePtrs, agentRoot, notary);
+        return _saveNotarySnapshot(snapshot, statePtrs, agentRoot, notaryIndex, sigIndex);
     }
 
     // ════════════════════════════════════ INTERNAL LOGIC: SAVE STATEMENT DATA ════════════════════════════════════════
@@ -202,38 +219,41 @@ abstract contract SnapshotHub is SnapshotHubEvents, ISnapshotHub {
         assert(_attestations.length == 0);
         // Insert empty non-meaningful values, that can't be used to prove anything
         _attestations.push(_toSummitAttestation(bytes32(0), bytes32(0)));
-        _notarySnapshots.push(SummitSnapshot(new uint256[](0)));
+        _notarySnapshots.push(SummitSnapshot(new uint256[](0), 0));
     }
 
     /// @dev Saves the Guard snapshot.
-    function _saveGuardSnapshot(uint256[] memory statePtrs) internal {
-        _guardSnapshots.push(SummitSnapshot(statePtrs));
+    function _saveGuardSnapshot(uint256[] memory statePtrs, uint256 sigIndex) internal {
+        _guardSnapshots.push(SummitSnapshot(statePtrs, sigIndex));
     }
 
     /// @dev Saves the Notary snapshot and the attestation created from it.
     /// Returns the created attestation.
-    function _saveNotarySnapshot(Snapshot snapshot, uint256[] memory statePtrs, bytes32 agentRoot, address notary)
-        internal
-        returns (bytes memory attPayload)
-    {
+    function _saveNotarySnapshot(
+        Snapshot snapshot,
+        uint256[] memory statePtrs,
+        bytes32 agentRoot,
+        uint32 notaryIndex,
+        uint256 sigIndex
+    ) internal returns (bytes memory attPayload) {
         // Attestation nonce is its index in `_attestations` array
         uint32 attNonce = uint32(_attestations.length);
         SummitAttestation memory summitAtt = _toSummitAttestation(snapshot.calculateRoot(), agentRoot);
         attPayload = _formatSummitAttestation(summitAtt, attNonce);
-        _latestAttNonce[notary] = attNonce;
+        _latestAttNonce[notaryIndex] = attNonce;
         /// @dev Add a single element to both `_attestations` and `_notarySnapshots`,
         /// enforcing the (_attestations.length == _notarySnapshots.length) invariant.
         _attestations.push(summitAtt);
-        _notarySnapshots.push(SummitSnapshot(statePtrs));
+        _notarySnapshots.push(SummitSnapshot(statePtrs, sigIndex));
         // Emit event with raw attestation data
         emit AttestationSaved(attPayload);
     }
 
     /// @dev Saves the state signed by a Guard.
-    function _saveState(State state, address guard, uint32 guardIndex) internal returns (uint256 statePtr) {
+    function _saveState(State state, uint32 guardIndex) internal returns (uint256 statePtr) {
         uint32 origin = state.origin();
         // Check that Guard hasn't submitted a fresher State before
-        require(state.nonce() > _latestState(origin, guard).nonce, "Outdated nonce");
+        require(state.nonce() > _latestState(origin, guardIndex).nonce, "Outdated nonce");
         bytes32 stateHash = state.leaf();
         statePtr = _leafPtr[origin][stateHash];
         // Save state only if it wasn't previously submitted
@@ -248,7 +268,7 @@ abstract contract SnapshotHub is SnapshotHubEvents, ISnapshotHub {
             emit StateSaved(state.unwrap().clone());
         }
         // Update latest guard state for origin
-        _latestStatePtr[origin][guard] = statePtr;
+        _latestStatePtr[origin][guardIndex] = statePtr;
     }
 
     // ══════════════════════════════════════════════ INTERNAL VIEWS ═══════════════════════════════════════════════════
@@ -268,7 +288,11 @@ abstract contract SnapshotHub is SnapshotHubEvents, ISnapshotHub {
     }
 
     /// @dev Restores Snapshot payload from a list of state pointers used for the snapshot.
-    function _restoreSnapshot(SummitSnapshot memory snapshot) internal view returns (bytes memory) {
+    function _restoreSnapshot(SummitSnapshot memory snapshot)
+        internal
+        view
+        returns (bytes memory snapPayload, bytes memory snapSignature)
+    {
         uint256 statesAmount = snapshot.statePtrs.length;
         State[] memory states = new State[](statesAmount);
         for (uint256 i = 0; i < statesAmount; ++i) {
@@ -279,7 +303,8 @@ abstract contract SnapshotHub is SnapshotHubEvents, ISnapshotHub {
             // Get the state that Agent used for the snapshot
             states[i] = _formatSummitState(_states[statePtr - 1]).castToState();
         }
-        return SnapshotLib.formatSnapshot(states);
+        snapPayload = SnapshotLib.formatSnapshot(states);
+        snapSignature = IAgentManager(agentManager).getStoredSignature(snapshot.sigIndex);
     }
 
     /// @dev Returns indexes of agents who provided state data for the Notary snapshot with the given nonce.
@@ -299,9 +324,9 @@ abstract contract SnapshotHub is SnapshotHubEvents, ISnapshotHub {
 
     /// @dev Returns the latest state submitted by the Agent for the origin.
     /// Will return an empty struct, if the Agent hasn't submitted a single origin State yet.
-    function _latestState(uint32 origin, address agent) internal view returns (SummitState memory state) {
+    function _latestState(uint32 origin, uint32 agentIndex) internal view returns (SummitState memory state) {
         // Get value for "index in _states PLUS 1"
-        uint256 latestPtr = _latestStatePtr[origin][agent];
+        uint256 latestPtr = _latestStatePtr[origin][agentIndex];
         // Check if the Agent has submitted at least one State for origin
         if (latestPtr != 0) {
             state = _states[latestPtr - 1];

--- a/packages/contracts-core/contracts/interfaces/IAgentManager.sol
+++ b/packages/contracts-core/contracts/interfaces/IAgentManager.sol
@@ -244,4 +244,12 @@ interface IAgentManager {
      * @return          Status for the given agent: (flag, rivalIndex, fraudProver).
      */
     function disputeStatus(address agent) external view returns (Dispute memory);
+
+    /**
+     * @notice Returns the signature with the given index stored in AgentManager.
+     * @dev Will revert if signature with given index doesn't exist.
+     * @param index     Signature index
+     * @return          Raw payload with signature
+     */
+    function getStoredSignature(uint256 index) external view returns (bytes memory);
 }

--- a/packages/contracts-core/contracts/interfaces/ISnapshotHub.sol
+++ b/packages/contracts-core/contracts/interfaces/ISnapshotHub.sol
@@ -15,10 +15,10 @@ interface ISnapshotHub {
     /**
      * @notice Returns saved attestation with the given nonce.
      * @dev Reverts if attestation with given nonce hasn't been created yet.
-     * @param nonce         Nonce for the attestation
+     * @param attNonce      Nonce for the attestation
      * @return attPayload   Raw payload with formatted Attestation data
      */
-    function getAttestation(uint32 nonce) external view returns (bytes memory attPayload);
+    function getAttestation(uint32 attNonce) external view returns (bytes memory attPayload);
 
     /**
      * @notice Returns the state with the highest known nonce submitted by a given Agent.
@@ -36,20 +36,28 @@ interface ISnapshotHub {
     function getLatestNotaryAttestation(address notary) external view returns (bytes memory attPayload);
 
     /**
-     * @notice Returns Guard snapshot for the list of all accepted Guard snapshots.
+     * @notice Returns Guard snapshot from the list of all accepted Guard snapshots.
      * @dev Reverts if snapshot with given index hasn't been accepted yet.
      * @param index             Snapshot index in the list of all Guard snapshots
-     * @return snapshotPayload  Raw payload with Guard snapshot
+     * @return snapPayload      Raw payload with Guard snapshot
+     * @return snapSignature    Raw payload with Guard signature for snapshot
      */
-    function getGuardSnapshot(uint256 index) external view returns (bytes memory snapshotPayload);
+    function getGuardSnapshot(uint256 index)
+        external
+        view
+        returns (bytes memory snapPayload, bytes memory snapSignature);
 
     /**
-     * @notice Returns Notary snapshot that was used for creating an attestation with a given nonce.
-     * @dev Reverts if attestation with given nonce hasn't been created yet.
-     * @param nonce             Nonce for the attestation
-     * @return snapshotPayload  Raw payload with Notary snapshot used for creating the attestation
+     * @notice Returns Notary snapshot from the list of all accepted Guard snapshots.
+     * @dev Reverts if snapshot with given index hasn't been accepted yet.
+     * @param index             Snapshot index in the list of all Notary snapshots
+     * @return snapPayload      Raw payload with Notary snapshot
+     * @return snapSignature    Raw payload with Notary signature for snapshot
      */
-    function getNotarySnapshot(uint256 nonce) external view returns (bytes memory snapshotPayload);
+    function getNotarySnapshot(uint256 index)
+        external
+        view
+        returns (bytes memory snapPayload, bytes memory snapSignature);
 
     /**
      * @notice Returns Notary snapshot that was used for creating a given attestation.
@@ -57,9 +65,13 @@ interface ISnapshotHub {
      *  - Attestation payload is not properly formatted.
      *  - Attestation is invalid (doesn't have a matching Notary snapshot).
      * @param attPayload        Raw payload with attestation data
-     * @return snapshotPayload  Raw payload with Notary snapshot used for creating the attestation
+     * @return snapPayload      Raw payload with Notary snapshot
+     * @return snapSignature    Raw payload with Notary signature for snapshot
      */
-    function getNotarySnapshot(bytes memory attPayload) external view returns (bytes memory snapshotPayload);
+    function getNotarySnapshot(bytes memory attPayload)
+        external
+        view
+        returns (bytes memory snapPayload, bytes memory snapSignature);
 
     /**
      * @notice Returns proof of inclusion of (root, origin) fields of a given snapshot's state
@@ -67,9 +79,9 @@ interface ISnapshotHub {
      * @dev Reverts if any of these is true:
      *  - Attestation with given nonce hasn't been created yet.
      *  - State index is out of range of snapshot list.
-     * @param nonce         Nonce for the attestation
+     * @param attNonce      Nonce for the attestation
      * @param stateIndex    Index of state in the attestation's snapshot
      * @return snapProof    The snapshot proof
      */
-    function getSnapshotProof(uint256 nonce, uint256 stateIndex) external view returns (bytes32[] memory snapProof);
+    function getSnapshotProof(uint32 attNonce, uint256 stateIndex) external view returns (bytes32[] memory snapProof);
 }

--- a/packages/contracts-core/contracts/interfaces/InterfaceDestination.sol
+++ b/packages/contracts-core/contracts/interfaces/InterfaceDestination.sol
@@ -25,18 +25,14 @@ interface InterfaceDestination {
      * > - Attestation payload is not properly formatted.
      * > - Attestation signer is in Dispute.
      * > - Attestation's snapshot root has been previously submitted.
-     * @param notary            Address of the Notary who signed the receipt
      * @param status            Structure specifying agent status: (flag, domain, index)
+     * @param sigIndex          Index of stored Notary signature
      * @param attPayload        Raw payload with Attestation data
-     * @param attSignature      Notary signature for the Attestation
      * @return wasAccepted      Whether the Attestation was accepted
      */
-    function acceptAttestation(
-        address notary,
-        AgentStatus memory status,
-        bytes memory attPayload,
-        bytes memory attSignature
-    ) external returns (bool wasAccepted);
+    function acceptAttestation(AgentStatus memory status, uint256 sigIndex, bytes memory attPayload)
+        external
+        returns (bool wasAccepted);
 
     // ═══════════════════════════════════════════════════ VIEWS ═══════════════════════════════════════════════════════
 
@@ -46,8 +42,8 @@ interface InterfaceDestination {
     function attestationsAmount() external view returns (uint256);
 
     /**
-     * @notice Returns a Notary-signed attestation with a given index. Index refers to the list of all attestations
-     * accepted by this contract.
+     * @notice Returns a Notary-signed attestation with a given index.
+     * > Index refers to the list of all attestations accepted by this contract.
      * @param index             Attestation index
      * @return attPayload       Raw payload with Attestation data
      * @return attSignature     Notary signature for the reported attestation

--- a/packages/contracts-core/contracts/interfaces/InterfaceSummit.sol
+++ b/packages/contracts-core/contracts/interfaces/InterfaceSummit.sol
@@ -15,18 +15,14 @@ interface InterfaceSummit {
      * > - Receipt payload is not properly formatted.
      * > - Receipt signer is in Dispute.
      * > - Receipt's snapshot root is unknown.
-     * @param notary            Address of the Notary who signed the receipt
      * @param status            Structure specifying agent status: (flag, domain, index)
+     * @param sigIndex          Index of stored Notary signature
      * @param rcptPayload       Raw payload with receipt data
-     * @param rcptSignature     Notary signature for the receipt
      * @return wasAccepted      Whether the receipt was accepted
      */
-    function acceptReceipt(
-        address notary,
-        AgentStatus memory status,
-        bytes memory rcptPayload,
-        bytes memory rcptSignature
-    ) external returns (bool wasAccepted);
+    function acceptReceipt(AgentStatus memory status, uint256 sigIndex, bytes memory rcptPayload)
+        external
+        returns (bool wasAccepted);
 
     /**
      * @notice Accepts a snapshot, which local `AgentManager` verified to have been signed by an active Agent.
@@ -40,20 +36,15 @@ interface InterfaceSummit {
      * > - Called by anyone other than local `AgentManager`.
      * > - Snapshot payload is not properly formatted.
      * > - Snapshot contains a state older then the Agent has previously submitted.
-     * > - Agent is a Notary, and they are in Dispute.
-     * @param agent             Address of the Agent who signed the snapshot
      * @param status            Structure specifying agent status: (flag, domain, index)
+     * @param sigIndex          Index of stored Agent signature
      * @param snapPayload       Raw payload with snapshot data
-     * @param snapSignature     Agent signature for the snapshot
      * @return attPayload       Raw payload with data for attestation derived from Notary snapshot.
      *                          Empty payload, if a Guard snapshot was submitted.
      */
-    function acceptSnapshot(
-        address agent,
-        AgentStatus memory status,
-        bytes memory snapPayload,
-        bytes memory snapSignature
-    ) external returns (bytes memory attPayload);
+    function acceptSnapshot(AgentStatus memory status, uint256 sigIndex, bytes memory snapPayload)
+        external
+        returns (bytes memory attPayload);
 
     // ════════════════════════════════════════════════ TIPS LOGIC ═════════════════════════════════════════════════════
 
@@ -103,16 +94,4 @@ interface InterfaceSummit {
      * @return statePayload Raw payload with latest active Guard state for origin
      */
     function getLatestState(uint32 origin) external view returns (bytes memory statePayload);
-
-    /**
-     * @notice Returns a Notary-signed snapshot with a given index.
-     * Index refers to the list of all Notary snapshots accepted by this contract.
-     * @param nonce             Attestation nonce created from Notary snapshot
-     * @return snapPayload      Raw payload with Attestation data
-     * @return snapSignature    Notary signature for the reported attestation
-     */
-    function getSignedSnapshot(uint256 nonce)
-        external
-        view
-        returns (bytes memory snapPayload, bytes memory snapSignature);
 }

--- a/packages/contracts-core/contracts/manager/AgentManager.sol
+++ b/packages/contracts-core/contracts/manager/AgentManager.sol
@@ -35,8 +35,11 @@ abstract contract AgentManager is MessagingBase, VerificationManager, AgentManag
     // (agent => their dispute status)
     mapping(address => Dispute) internal _disputes;
 
+    // TODO: optimize this
+    bytes[] internal _storedSignatures;
+
     /// @dev gap for upgrade safety
-    uint256[47] private __GAP; // solhint-disable-line var-name-mixedcase
+    uint256[46] private __GAP; // solhint-disable-line var-name-mixedcase
 
     // ════════════════════════════════════════════════ INITIALIZER ════════════════════════════════════════════════════
 
@@ -280,6 +283,11 @@ abstract contract AgentManager is MessagingBase, VerificationManager, AgentManag
         return _disputes[agent];
     }
 
+    /// @inheritdoc IAgentManager
+    function getStoredSignature(uint256 index) external view returns (bytes memory) {
+        return _storedSignatures[index];
+    }
+
     // ══════════════════════════════════════════════ INTERNAL LOGIC ═══════════════════════════════════════════════════
 
     /// @dev Hook that is called after agent was slashed in AgentManager and AgentSecured contracts were notified.
@@ -336,6 +344,12 @@ abstract contract AgentManager is MessagingBase, VerificationManager, AgentManag
     function _updateDispute(address agent, Dispute memory dispute) internal {
         _disputes[agent] = dispute;
         emit DisputeUpdated(agent, dispute);
+    }
+
+    /// @dev Saves the signature and returns its index.
+    function _saveSignature(bytes memory signature) internal returns (uint256 sigIndex) {
+        sigIndex = _storedSignatures.length;
+        _storedSignatures.push(signature);
     }
 
     // ══════════════════════════════════════════════ INTERNAL VIEWS ═══════════════════════════════════════════════════

--- a/packages/contracts-core/contracts/manager/BondingManager.sol
+++ b/packages/contracts-core/contracts/manager/BondingManager.sol
@@ -74,7 +74,10 @@ contract BondingManager is AgentManager, BondingManagerEvents, InterfaceBondingM
         if (status.domain != 0) {
             require(_disputes[agent].flag == DisputeFlag.None, "Notary is in dispute");
         }
-        return InterfaceSummit(destination).acceptSnapshot(agent, status, snapPayload, snapSignature);
+        // Store Agent signature for the Snapshot
+        uint256 sigIndex = _saveSignature(snapSignature);
+        attPayload = InterfaceSummit(destination).acceptSnapshot(status, sigIndex, snapPayload);
+        emit SnapshotAccepted(status.domain, agent, snapPayload, snapSignature);
     }
 
     /// @inheritdoc InterfaceBondingManager
@@ -87,7 +90,12 @@ contract BondingManager is AgentManager, BondingManagerEvents, InterfaceBondingM
         status.verifyActive();
         // Notary needs to be not in dispute
         require(_disputes[notary].flag == DisputeFlag.None, "Notary is in dispute");
-        return InterfaceSummit(destination).acceptReceipt(notary, status, rcptPayload, rcptSignature);
+        // Store Notary signature for the Snapshot
+        uint256 sigIndex = _saveSignature(rcptSignature);
+        wasAccepted = InterfaceSummit(destination).acceptReceipt(status, sigIndex, rcptPayload);
+        if (wasAccepted) {
+            emit ReceiptAccepted(status.domain, notary, rcptPayload, rcptSignature);
+        }
     }
 
     // ══════════════════════════════════════════ VERIFY AGENT STATEMENTS ══════════════════════════════════════════════

--- a/packages/contracts-core/contracts/manager/LightManager.sol
+++ b/packages/contracts-core/contracts/manager/LightManager.sol
@@ -59,7 +59,12 @@ contract LightManager is AgentManager, InterfaceLightManager {
         require(status.domain == localDomain, "Wrong Notary domain");
         // Notary needs to be not in dispute
         require(_disputes[notary].flag == DisputeFlag.None, "Notary is in dispute");
-        return InterfaceDestination(destination).acceptAttestation(notary, status, attPayload, attSignature);
+        // Store Notary signature for the attestation
+        uint256 sigIndex = _saveSignature(attSignature);
+        wasAccepted = InterfaceDestination(destination).acceptAttestation(status, sigIndex, attPayload);
+        if (wasAccepted) {
+            emit AttestationAccepted(status.domain, notary, attPayload, attSignature);
+        }
     }
 
     /// @inheritdoc InterfaceLightManager

--- a/packages/contracts-core/test/mocks/DestinationMock.t.sol
+++ b/packages/contracts-core/test/mocks/DestinationMock.t.sol
@@ -12,12 +12,10 @@ contract DestinationMock is ExecutionHubMock, AgentSecuredMock, InterfaceDestina
 
     function passAgentRoot() external returns (bool rootPassed, bool rootPending) {}
 
-    function acceptAttestation(
-        address notary,
-        AgentStatus memory status,
-        bytes memory attPayload,
-        bytes memory attSignature
-    ) external returns (bool wasAccepted) {}
+    function acceptAttestation(AgentStatus memory status, uint256 sigIndex, bytes memory attPayload)
+        external
+        returns (bool wasAccepted)
+    {}
 
     function attestationsAmount() external view returns (uint256) {}
 

--- a/packages/contracts-core/test/mocks/SummitMock.t.sol
+++ b/packages/contracts-core/test/mocks/SummitMock.t.sol
@@ -10,19 +10,15 @@ contract SummitMock is SnapshotHubMock, AgentSecuredMock, InterfaceSummit {
     /// @notice Prevents this contract from being included in the coverage report
     function testSummitMock() external {}
 
-    function acceptReceipt(
-        address notary,
-        AgentStatus memory status,
-        bytes memory rcptPayload,
-        bytes memory rcptSignature
-    ) external returns (bool wasAccepted) {}
+    function acceptReceipt(AgentStatus memory status, uint256 sigIndex, bytes memory rcptPayload)
+        external
+        returns (bool wasAccepted)
+    {}
 
-    function acceptSnapshot(
-        address agent,
-        AgentStatus memory status,
-        bytes memory snapPayload,
-        bytes memory snapSignature
-    ) external returns (bytes memory attPayload) {}
+    function acceptSnapshot(AgentStatus memory status, uint256 sigIndex, bytes memory snapPayload)
+        external
+        returns (bytes memory attPayload)
+    {}
 
     function distributeTips() external returns (bool queuePopped) {}
 
@@ -33,10 +29,4 @@ contract SummitMock is SnapshotHubMock, AgentSecuredMock, InterfaceSummit {
     function receiptQueueLength() external view returns (uint256) {}
 
     function getLatestState(uint32 origin) external view returns (bytes memory statePayload) {}
-
-    function getSignedSnapshot(uint256 nonce)
-        external
-        view
-        returns (bytes memory snapPayload, bytes memory snapSignature)
-    {}
 }

--- a/packages/contracts-core/test/mocks/hubs/SnapshotHubMock.t.sol
+++ b/packages/contracts-core/test/mocks/hubs/SnapshotHubMock.t.sol
@@ -10,17 +10,29 @@ contract SnapshotHubMock is ISnapshotHub {
 
     function isValidAttestation(bytes memory attPayload) external view returns (bool isValid) {}
 
-    function getAttestation(uint32 nonce) external view returns (bytes memory attPayload) {}
+    function getAttestation(uint32 attNonce) external view returns (bytes memory attPayload) {}
 
     function getLatestAgentState(uint32 origin, address agent) external view returns (bytes memory statePayload) {}
 
     function getLatestNotaryAttestation(address notary) external view returns (bytes memory attPayload) {}
 
-    function getGuardSnapshot(uint256 index) external view returns (bytes memory snapshotPayload) {}
+    function getGuardSnapshot(uint256 index)
+        external
+        view
+        returns (bytes memory snapPayload, bytes memory snapSignature)
+    {}
 
-    function getNotarySnapshot(uint256 nonce) external view returns (bytes memory snapshotPayload) {}
+    function getNotarySnapshot(uint256 index)
+        external
+        view
+        returns (bytes memory snapPayload, bytes memory snapSignature)
+    {}
 
-    function getNotarySnapshot(bytes memory attPayload) external view returns (bytes memory snapshotPayload) {}
+    function getNotarySnapshot(bytes memory attPayload)
+        external
+        view
+        returns (bytes memory snapPayload, bytes memory snapSignature)
+    {}
 
-    function getSnapshotProof(uint256 nonce, uint256 stateIndex) external view returns (bytes32[] memory snapProof) {}
+    function getSnapshotProof(uint32 attNonce, uint256 stateIndex) external view returns (bytes32[] memory snapProof) {}
 }

--- a/packages/contracts-core/test/suite/Destination.t.sol
+++ b/packages/contracts-core/test/suite/Destination.t.sol
@@ -118,7 +118,7 @@ contract DestinationTest is ExecutionHubTest {
         // Mock a call from lightManager, could as well use the empty values as they won't be checked for validity
         vm.prank(address(lightManager));
         AgentStatus memory status;
-        assertFalse(InterfaceDestination(destination).acceptAttestation(address(0), status, "", ""));
+        assertFalse(InterfaceDestination(destination).acceptAttestation(status, 0, ""));
         (uint40 snapRootTime, uint40 agentRootTime, uint32 index) = InterfaceDestination(destination).destStatus();
         assertEq(snapRootTime, firstRootSubmittedAt);
         assertEq(agentRootTime, firstRootSubmittedAt);

--- a/packages/contracts-core/test/suite/Summit.t.sol
+++ b/packages/contracts-core/test/suite/Summit.t.sol
@@ -158,6 +158,12 @@ contract SummitTest is AgentSecuredTest {
             }
         }
 
+        for (uint32 i = 0; i < DOMAIN_AGENTS; ++i) {
+            (bytes memory snapPayload, bytes memory snapSignature) = ISnapshotHub(summit).getGuardSnapshot(i);
+            assertEq(snapPayload, guardSnapshots[i].snapshot, "!snapshot");
+            assertEq(snapSignature, guardSnapshots[i].signature, "!signature");
+        }
+
         // Check global latest state
         checkLatestState();
     }
@@ -234,7 +240,7 @@ contract SummitTest is AgentSecuredTest {
         }
 
         for (uint32 i = 0; i < DOMAIN_AGENTS; ++i) {
-            (bytes memory snapPayload, bytes memory snapSignature) = InterfaceSummit(summit).getSignedSnapshot(i + 1);
+            (bytes memory snapPayload, bytes memory snapSignature) = ISnapshotHub(summit).getNotarySnapshot(i);
             assertEq(snapPayload, snapPayloads[i], "!payload");
             assertEq(snapSignature, snapSignatures[i], "!signature");
         }

--- a/packages/contracts-core/test/suite/manager/AgentManager.t.sol
+++ b/packages/contracts-core/test/suite/manager/AgentManager.t.sol
@@ -21,6 +21,7 @@ abstract contract AgentManagerTest is MessagingBaseTest {
     using Address for address;
 
     uint256 internal rootSubmittedAt;
+    uint256 private _signatureIndex;
 
     function test_setup() public virtual {
         assertEq(address(testedAM().destination()), localDestination());
@@ -235,6 +236,10 @@ abstract contract AgentManagerTest is MessagingBaseTest {
     }
 
     // ══════════════════════════════════════════════════ HELPERS ══════════════════════════════════════════════════════
+
+    function nextSignatureIndex() public returns (uint256 sigIndex) {
+        sigIndex = _signatureIndex++;
+    }
 
     function checkAgentStatus(address agent, AgentStatus memory status, AgentFlag flag) public virtual override {
         super.checkAgentStatus(agent, status, flag);

--- a/packages/contracts-core/test/suite/manager/BondingManager.t.sol
+++ b/packages/contracts-core/test/suite/manager/BondingManager.t.sol
@@ -234,7 +234,7 @@ contract BondingManagerTest is AgentManagerTest {
         vm.expectCall(
             summit,
             abi.encodeWithSelector(
-                InterfaceSummit.acceptSnapshot.selector, agent, getAgentStatus(agent), snapPayload, snapSig
+                InterfaceSummit.acceptSnapshot.selector, getAgentStatus(agent), nextSignatureIndex(), snapPayload
             )
         );
         bondingManager.submitSnapshot(snapPayload, snapSig);
@@ -250,7 +250,7 @@ contract BondingManagerTest is AgentManagerTest {
         vm.expectCall(
             summit,
             abi.encodeWithSelector(
-                InterfaceSummit.acceptSnapshot.selector, guard, getAgentStatus(guard), snapPayload, snapSig
+                InterfaceSummit.acceptSnapshot.selector, getAgentStatus(guard), nextSignatureIndex(), snapPayload
             )
         );
         bondingManager.submitSnapshot(snapPayload, snapSig);
@@ -273,7 +273,7 @@ contract BondingManagerTest is AgentManagerTest {
         vm.expectCall(
             summit,
             abi.encodeWithSelector(
-                InterfaceSummit.acceptReceipt.selector, notary, getAgentStatus(notary), receiptPayload, receiptSig
+                InterfaceSummit.acceptReceipt.selector, getAgentStatus(notary), nextSignatureIndex(), receiptPayload
             )
         );
         bondingManager.submitReceipt(receiptPayload, receiptSig);

--- a/packages/contracts-core/test/suite/manager/LightManager.t.sol
+++ b/packages/contracts-core/test/suite/manager/LightManager.t.sol
@@ -121,10 +121,9 @@ contract LightManagerTest is AgentManagerTest {
             destination,
             abi.encodeWithSelector(
                 InterfaceDestination.acceptAttestation.selector,
-                notary,
                 getAgentStatus(notary),
-                attPayload,
-                attSignature
+                nextSignatureIndex(),
+                attPayload
             )
         );
         lightManager.submitAttestation(attPayload, attSignature);


### PR DESCRIPTION
We had to disable a bunch of tests after generating the go stuff for messaging003. This PR re-enables many of those tests, especially the end-to-end tests and the executor tests and the encoder/decoder tests and the parity tests.