### PR TITLE
Add TokenAddr mapping to pool liq calculations

### DIFF
--- a/packages/sdk-router/src/sdk.test.ts
+++ b/packages/sdk-router/src/sdk.test.ts
@@ -230,10 +230,14 @@ describe('SynapseSDK', () => {
       const providers = [arbitrumProvider]
       const Synapse = new SynapseSDK(chainIds, providers)
       const tokenAmount = BigNumber.from('1000000')
+      const tokenAmount2 = BigNumber.from('2000000')
       const amount = await Synapse.calculateAddLiquidity(
         42161,
         '0xa067668661C84476aFcDc6fA5D758C4c01C34352',
-        [tokenAmount, tokenAmount]
+        {
+          '0x3ea9B0ab55F34Fb188824Ee288CeaEfC63cf908e': tokenAmount,
+          '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1': tokenAmount2,
+        }
       )
       console.log(amount?.toString())
       expect(amount?.toString()?.length).toBeGreaterThan(0)
@@ -250,7 +254,7 @@ describe('SynapseSDK', () => {
         '0xa067668661C84476aFcDc6fA5D758C4c01C34352',
         BigNumber.from('1000000')
       )
-      expect(amounts?.length).toBeGreaterThan(0)
+      expect(Object.keys(amounts)?.length).toBeGreaterThan(0)
     })
   })
 })

--- a/packages/sdk-router/src/sdk.ts
+++ b/packages/sdk-router/src/sdk.ts
@@ -3,7 +3,7 @@ import invariant from 'tiny-invariant'
 import { BigNumber } from '@ethersproject/bignumber'
 import { BytesLike } from '@ethersproject/bytes'
 import { PopulatedTransaction } from 'ethers'
-import { AddressZero } from '@ethersproject/constants'
+import { AddressZero, Zero } from '@ethersproject/constants'
 import { Interface } from '@ethersproject/abi'
 import { Contract } from '@ethersproject/contracts'
 
@@ -293,19 +293,33 @@ class SynapseSDK {
   public async calculateAddLiquidity(
     chainId: number,
     poolAddress: string,
-    amounts: BigNumber[]
+    amounts: Record<string, BigNumber>
   ): Promise<BigNumber> {
     const router: SynapseRouter = this.synapseRouters[chainId]
-    return router.routerContract.calculateAddLiquidity(poolAddress, amounts)
+    const poolTokens = await router.routerContract.poolTokens(poolAddress)
+    const amountArr: BigNumber[] = []
+    poolTokens.map((token) => {
+      amountArr.push(amounts[token.token] ?? Zero)
+    })
+    return router.routerContract.calculateAddLiquidity(poolAddress, amountArr)
   }
 
   public async calculateRemoveLiquidity(
     chainId: number,
     poolAddress: string,
     amount: BigNumber
-  ): Promise<BigNumber[]> {
+  ): Promise<Record<string, BigNumber>> {
     const router: SynapseRouter = this.synapseRouters[chainId]
-    return router.routerContract.calculateRemoveLiquidity(poolAddress, amount)
+    const amounts = await router.routerContract.calculateRemoveLiquidity(
+      poolAddress,
+      amount
+    )
+    const poolTokens = await router.routerContract.poolTokens(poolAddress)
+    const amountRecord: Record<string, BigNumber> = {}
+    poolTokens.map((token, index) => {
+      amountRecord[token.token] = amounts[index]
+    })
+    return amountRecord
   }
 }
 


### PR DESCRIPTION
**Description**
Changing the input type for `calculateAddLiquidity` and output type for `calculateRemoveLiquidity`.

`calculateAddLiquidity`
Instead of passing in an array of values, a obj with Record<PoolTokenAddr, BigNumber> will be required. The router function `poolTokens` will be used to generate an array of values of appropriate order and length.

`calculateRemoveLiquidity`
For the return, the same type as the input above - Record<PoolTokenAddr, BigNumber>  - will be used. This return will be populated in a similar manner using the router function `poolTokens`.