### PR TITLE
Refreshes balances when account changes

### DIFF
--- a/packages/synapse-interface/pages/bridge/index.tsx
+++ b/packages/synapse-interface/pages/bridge/index.tsx
@@ -104,7 +104,7 @@ const BridgePage = ({
     return () => {
       clearInterval(interval)
     }
-  }, [bridgeTxHash, fromChainId])
+  }, [bridgeTxHash, fromChainId, address])
 
   useEffect(() => {
     if (!router.isReady) {

--- a/packages/synapse-interface/pages/pool/PoolBody.tsx
+++ b/packages/synapse-interface/pages/pool/PoolBody.tsx
@@ -66,7 +66,7 @@ const PoolBody = ({
           console.log('Could not get pool data', err)
         })
     }
-  }, [connectedChainId, pool, poolChainId])
+  }, [connectedChainId, pool, poolChainId, address])
 
   return (
     <>

--- a/packages/synapse-interface/pages/swap/SwapCard.tsx
+++ b/packages/synapse-interface/pages/swap/SwapCard.tsx
@@ -175,7 +175,7 @@ const SwapCard = ({
       setFromTokens(tokens)
     })
     return
-  }, [connectedChainId, swapTxnHash])
+  }, [connectedChainId, swapTxnHash, address])
 
   /*
   useEffect Triggers: toToken, fromInput, toChainId, time


### PR DESCRIPTION
**Description**
- There are a number of `useEffect` hooks which call functions that update a user's balances across different pages. `account` needs to be added to dependency arrays so that those balances update when a user changes their account.