### PR TITLE
Fix README Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ## Contributing
 
 Read through [CONTRIBUTING.md](./CONTRIBUTING.md) for a general overview of our contribution process.
-Then check out our list of [good first issues](https://github.com/ethereum-optimism/optimism/contribute) to find something fun to work on!
+Then check out our list of [good first issues](https://github.com/synapsecns/sanguine/contribute) to find something fun to work on!
 
 ## Directory Structure
 


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**
The text links to ethereum-optimism repo's good first issue. Updated the README to point to this repo, but it seems like no 'good first issues' are configured.

**Additional context**
Should this just link to the issues page as the `/contribute` page on the repo has not been configured yet?
