### PR TITLE
speedup foundry snapshot a bit

### DIFF
--- a/.github/workflows/foundry-tests.yml
+++ b/.github/workflows/foundry-tests.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   coverage:
     name: Foundry Coverage
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
@@ -48,7 +48,7 @@ jobs:
           attempt_delay: 30000
 
   snapshot:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     name: Foundry Gas Snapshot
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/foundry-tests.yml
+++ b/.github/workflows/foundry-tests.yml
@@ -10,7 +10,7 @@ on:
       - '.github/workflows/foundry-tests.yml'
 
 jobs:
-  check:
+  coverage:
     name: Foundry Coverage
     runs-on: ubuntu-latest-16-cores
     steps:
@@ -47,6 +47,25 @@ jobs:
           attempt_limit: 5
           attempt_delay: 30000
 
+  snapshot:
+    runs-on: ubuntu-latest-16-cores
+    name: Foundry Gas Snapshot
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Setup Node JS
+        uses: ./.github/actions/setup-nodejs
+
+      - name: Installing dependencies
+        working-directory: ./packages/contracts-core
+        run: yarn install --immutable
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
       - name: Run snapshot
         working-directory: ./packages/contracts-core
         run: forge snapshot >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**

Since going open source, the ubuntu-latest-16cores has stopped working (See: #1028), while this requires some further investigation to see if we can fix, we can split up two particularly slow jobs in the mean time
