### PR TITLE
Removes 404ing portfolio link

### DIFF
--- a/packages/synapse-interface/components/layouts/LandingPageWrapper/index.tsx
+++ b/packages/synapse-interface/components/layouts/LandingPageWrapper/index.tsx
@@ -17,7 +17,6 @@ import {
   DOCS_URL,
   FORUM_URL,
   LANDING_PATH,
-  PORTFOLIO_PATH,
   TELEGRAM_URL,
   TWITTER_URL,
   getBuySynUrl,
@@ -247,11 +246,6 @@ function MoreInfoButtons() {
         to={NAVIGATION.Contracts.path}
         labelText={NAVIGATION.Contracts.text}
         description="View contract related information such as contract addresses"
-      />
-      <MoreInfoItem
-        to={NAVIGATION.Portfolio.path}
-        labelText={NAVIGATION.Portfolio.text}
-        description="View your portfolio of related assets on this chain"
       />
     </>
   )

--- a/packages/synapse-interface/constants/routes.ts
+++ b/packages/synapse-interface/constants/routes.ts
@@ -6,7 +6,6 @@ import {
   LANDING_PATH,
   BRIDGE_PATH,
   CONTRACTS_PATH,
-  PORTFOLIO_PATH,
 } from './urls'
 
 interface RouteObject {
@@ -52,10 +51,5 @@ export const NAVIGATION: RouteObject = {
     path: CONTRACTS_PATH,
     text: 'Contracts',
     match: '/contracts',
-  },
-  Portfolio: {
-    path: PORTFOLIO_PATH,
-    text: 'Portfolio',
-    match: '/portfolio',
   },
 }

--- a/packages/synapse-interface/constants/urls/index.tsx
+++ b/packages/synapse-interface/constants/urls/index.tsx
@@ -22,7 +22,6 @@ export const POOLS_PATH = '/pools'
 export const POOL_PATH = '/pool'
 export const BRIDGE_PATH = '/'
 export const CONTRACTS_PATH = '/contracts'
-export const PORTFOLIO_PATH = '/portfolio'
 export const STATISTICS_PATH = '/statistics'
 export const LANDING_PATH = '/landing'
 export const TERMS_OF_SERVICE_PATH =


### PR DESCRIPTION
Removes unsupported link:

<img width="343" alt="Screen Shot 2023-06-14 at 11 01 22 AM" src="https://github.com/synapsecns/sanguine/assets/104046418/aa6d95f1-7d37-40ba-9e20-4d13a3b8507e">

27488976f5624900ee3a61e2291210211e0cbc02: [synapse-interface preview link ](https://sanguine-synapse-interface-qz62ggm5s-synapsecns.vercel.app)