### PR TITLE
FE: Hotfix - Stake page balances

### DIFF
--- a/packages/synapse-interface/pages/stake/StakeCard.tsx
+++ b/packages/synapse-interface/pages/stake/StakeCard.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { useAccount, useNetwork } from 'wagmi'
 import { formatUnits } from '@ethersproject/units'
 import { Zero } from '@ethersproject/constants'
+import { Address } from '@wagmi/core'
 
 import { usePendingTxWrapper } from '@/utils/hooks/usePendingTxWrapper'
 import { getTokenAllowance } from '@/utils/actions/getTokenAllowance'
@@ -59,8 +60,8 @@ const StakeCard = ({ address, chainId, pool }: StakeCardProps) => {
   })
 
   useEffect(() => {
-    if (!address || !chainId || !stakingPoolId) return
-    getStakedBalance(`0x${address.slice(2)}`, chainId, stakingPoolId)
+    if (!address || !chainId || stakingPoolId == null) return
+    getStakedBalance(address as Address, chainId, stakingPoolId)
       .then((data) => {
         setUserStakeData(data)
       })

--- a/packages/synapse-interface/pages/stake/StakeCard.tsx
+++ b/packages/synapse-interface/pages/stake/StakeCard.tsx
@@ -60,7 +60,7 @@ const StakeCard = ({ address, chainId, pool }: StakeCardProps) => {
   })
 
   useEffect(() => {
-    if (!address || !chainId || stakingPoolId == null) return
+    if (!address || !chainId || stakingPoolId === null) return
     getStakedBalance(address as Address, chainId, stakingPoolId)
       .then((data) => {
         setUserStakeData(data)

--- a/packages/synapse-interface/utils/actions/getStakedBalance.ts
+++ b/packages/synapse-interface/utils/actions/getStakedBalance.ts
@@ -9,9 +9,7 @@ export const getStakedBalance = async (
   chainId: number,
   poolId: number
 ) => {
-  const miniChefContractAddress: `0x${string}` = `0x${MINICHEF_ADDRESSES[
-    chainId
-  ].slice(2)}`
+  const miniChefContractAddress: Address = MINICHEF_ADDRESSES[chainId]
   try {
     const data: ReadContractResult = await readContracts({
       contracts: [


### PR DESCRIPTION
Fixes stake page balances not displaying, due to a bug caused from poolId being 0 & `!stakingPoolId` returning true.  