### PR TITLE
disable confirm checks on scribe

### DIFF
--- a/services/scribe/node/scribe.go
+++ b/services/scribe/node/scribe.go
@@ -44,6 +44,10 @@ func NewScribe(eventDB db.EventDB, clients map[uint32][]backfill.ScribeBackend, 
 	}, nil
 }
 
+// checkFinality checks if the block is final on the chain.
+// and deletes irrelevant blocks.
+const checkFinality = false
+
 // Start starts the scribe. This works by starting a backfill and recording what the
 // current block, which it will backfill to. Then, each chain will listen for new block
 // heights and backfill to that height.
@@ -73,6 +77,9 @@ func (s Scribe) Start(ctx context.Context) error {
 
 		// Check confirmations
 		g.Go(func() error {
+			if !checkFinality {
+				return nil
+			}
 			b := &backoff.Backoff{
 				Factor: 2,
 				Jitter: true,


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**


These don't work and intermittently remove old logs. These should be removed until this is no longer the case.