### PR TITLE
Clears search when exiting slideOver

### DIFF
--- a/packages/synapse-interface/components/StateManagedBridge/ChainSlideOver.tsx
+++ b/packages/synapse-interface/components/StateManagedBridge/ChainSlideOver.tsx
@@ -66,6 +66,7 @@ export const ChainSlideOver = ({
 
   const onClose = useCallback(() => {
     setCurrentIdx(-1)
+    setSearchStr('')
     dispatch(setShowSlideOver(false))
   }, [setShowSlideOver])
 

--- a/packages/synapse-interface/components/StateManagedBridge/TokenSlideOver.tsx
+++ b/packages/synapse-interface/components/StateManagedBridge/TokenSlideOver.tsx
@@ -75,6 +75,7 @@ export const TokenSlideOver = ({
 
   function onClose() {
     setCurrentIdx(-1)
+    setSearchStr('')
     dispatch(setShowSlideOver(false))
   }
 

--- a/packages/synapse-interface/store/store.ts
+++ b/packages/synapse-interface/store/store.ts
@@ -1,4 +1,5 @@
 import { configureStore } from '@reduxjs/toolkit'
+
 import bridgeReducer, { tokenDecimalMiddleware } from '@/slices/bridgeSlice'
 import bridgeDisplayReducer from '@/slices/bridgeDisplaySlice'
 


### PR DESCRIPTION
null
6d1e0c598ca6f462c73bb0d8e5dcfc562f0d05e5: [synapse-interface preview link ](https://sanguine-synapse-interface-80gua7x3v-synapsecns.vercel.app)
766cebd253faeff208de9d34a9dc0c7da3db5220: [synapse-interface preview link ](https://sanguine-synapse-interface-h680r3f10-synapsecns.vercel.app)
754f9fc1fa48508600d5842782a96b781fd8b164: [synapse-interface preview link ](https://sanguine-synapse-interface-ci69m3lnl-synapsecns.vercel.app)