### PR TITLE
CCTP relayer backoff respects context

### DIFF
--- a/services/cctp-relayer/config/config.go
+++ b/services/cctp-relayer/config/config.go
@@ -3,10 +3,11 @@ package config
 import (
 	"context"
 	"fmt"
-	"github.com/ImVexed/fasturl"
-	submitterConfig "github.com/synapsecns/sanguine/ethergo/submitter/config"
 	"os"
 	"path/filepath"
+
+	"github.com/ImVexed/fasturl"
+	submitterConfig "github.com/synapsecns/sanguine/ethergo/submitter/config"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/jftuga/ellipsis"
@@ -27,8 +28,6 @@ type Config struct {
 	// Signer contains the unbonded signer config for agents
 	// (this is signer used to submit transactions)
 	Signer ethConfig.SignerConfig `yaml:"unbonded_signer"`
-	// HTTPBackoffInitialInterval is the initial interval for attestation request retries
-	HTTPBackoffInitialIntervalMs int `yaml:"http_backoff_initial_interval_ms"`
 	// RetryInterval is the interval for attestation request retries
 	RetryIntervalMS int `yaml:"retry_interval_ms"`
 	// HTTPBackoffMaxElapsedTime is the max elapsed time for attestation request retries

--- a/services/cctp-relayer/config/config_test.go
+++ b/services/cctp-relayer/config/config_test.go
@@ -31,8 +31,7 @@ func configFixture(c ConfigSuite) config.Config {
 			Type: ethConfig.FileType.String(),
 			File: filet.TmpFile(c.T(), "", testWallet.PrivateKeyHex()).Name(),
 		},
-		HTTPBackoffInitialIntervalMs: int(gofakeit.Int64()),
-		HTTPBackoffMaxElapsedTimeMs:  int(gofakeit.Int64()),
+		HTTPBackoffMaxElapsedTimeMs: int(gofakeit.Int64()),
 	}
 }
 


### PR DESCRIPTION
**Description**
Use the core backoff library instead of external `backoff` so that the retry can be cancelled when the context is cancelled.
