### PR TITLE
Fix Tx Confirmation Bug

### DIFF
--- a/ethergo/submitter/README.md
+++ b/ethergo/submitter/README.md
@@ -1,0 +1,7 @@
+# Submitter
+
+Submitter is a module that submits transactions to an evm based-blockchain and bumps them/checks for completion until they are done. It is designed to abstract away gas bumping, confirmation checking, etc from the caller.
+
+
+<!-- TODO: mermade diagram of confirmation queue and process queue -->
+<!-- aditionally, should describe cases in which submit transaction will return an error-->

--- a/ethergo/submitter/queue.go
+++ b/ethergo/submitter/queue.go
@@ -147,6 +147,15 @@ func (t *txSubmitterImpl) checkAndSetConfirmation(ctx context.Context, chainClie
 		return nil
 	}
 
+	// we're going to take every tx for this nonce and get a receipt for it
+	// because there can only be one transaction per nonce, as soon as we know which one has a receipt, we can assume all the
+	// others are replaced.
+	//
+	// There are a few constraints on the logic below as it's currently implemented. Namely that the number of txes
+	// can't be bigger than batch size.
+	//
+	// the other constraint is we treat all errors as "tx not found" errors. This is fine because we only store txes in cases
+	//
 	calls := make([]w3types.Caller, len(txes))
 	receipts := make([]types.Receipt, len(txes))
 	for i := range calls {
@@ -155,7 +164,6 @@ func (t *txSubmitterImpl) checkAndSetConfirmation(ctx context.Context, chainClie
 
 	err := chainClient.BatchWithContext(ctx, calls...)
 	foundSuccessfulTX := false
-
 	if err != nil {
 		// there's no way around this type inference
 		//nolint: errorlint
@@ -173,7 +181,7 @@ func (t *txSubmitterImpl) checkAndSetConfirmation(ctx context.Context, chainClie
 				txes[i].Status = db.Confirmed
 			}
 		}
-	} else if receipts[0].TxHash != txes[0].Hash() {
+	} else if receipts[0].TxHash == txes[0].Hash() {
 		// there must be only one tx, so we can just check the first one
 		// TODO: handle the case where there is more than one
 		txes[0].Status = db.Confirmed

--- a/ethergo/submitter/submitter.go
+++ b/ethergo/submitter/submitter.go
@@ -38,7 +38,11 @@ type TransactionSubmitter interface {
 	// SubmitTransaction submits a transaction to the chain.
 	// the transaction is not guaranteed to be executed immediately, only at some point in the future.
 	// the nonce is returned, and can be used to track the status of the transaction.
-	SubmitTransaction(parentCtx context.Context, chainID *big.Int, call ContractCallType) (nonce uint64, err error)
+	SubmitTransaction(ctx context.Context, chainID *big.Int, call ContractCallType) (nonce uint64, err error)
+	// GetNonceStatus gets the status of a nonce on a given chain
+	// GetNonceStatus(ctx context.Context, chainID *big.Int, nonce uint64) (status core.NonceStatus, err error)
+	// GetTXHash gets the tx hash for a given chain and nonce.
+	//GetTXHash(ctx context.Context, chainID *big.Int, nonce uint64) (txHash common.Hash, err error)
 }
 
 // txSubmitterImpl is the implementation of the transaction submitter.

--- a/ethergo/submitter/submitter.go
+++ b/ethergo/submitter/submitter.go
@@ -39,10 +39,6 @@ type TransactionSubmitter interface {
 	// the transaction is not guaranteed to be executed immediately, only at some point in the future.
 	// the nonce is returned, and can be used to track the status of the transaction.
 	SubmitTransaction(ctx context.Context, chainID *big.Int, call ContractCallType) (nonce uint64, err error)
-	// GetNonceStatus gets the status of a nonce on a given chain
-	// GetNonceStatus(ctx context.Context, chainID *big.Int, nonce uint64) (status core.NonceStatus, err error)
-	// GetTXHash gets the tx hash for a given chain and nonce.
-	//GetTXHash(ctx context.Context, chainID *big.Int, nonce uint64) (txHash common.Hash, err error)
 }
 
 // txSubmitterImpl is the implementation of the transaction submitter.

--- a/ethergo/submitter/submitter_test.go
+++ b/ethergo/submitter/submitter_test.go
@@ -207,3 +207,34 @@ func (s *SubmitterSuite) TestCheckAndSetConfirmation() {
 
 	s.Require().Equal(duplicateCount, replacedCount)
 }
+
+func (s *SubmitterSuite) TestCheckAndSetConfirmationSingleTx() {
+	cfg := &config.Config{}
+	ts := submitter.NewTestTransactionSubmitter(s.metrics, s.signer, s, s.store, cfg)
+
+	tb := s.testBackends[0]
+	confirmedTx := ethMocks.MockTx(s.GetTestContext(), s.T(), tb, s.localAccount, types.LegacyTxType)
+	allTxes := []db.TX{{
+		Transaction: confirmedTx,
+		Status:      db.Pending,
+	}}
+
+	chainClient, err := s.GetClient(s.GetTestContext(), tb.GetBigChainID())
+	s.Require().NoError(err)
+
+	err = ts.CheckAndSetConfirmation(s.GetTestContext(), chainClient, allTxes)
+	s.Require().NoError(err)
+
+	txs, err := s.store.GetAllTXAttemptByStatus(s.GetTestContext(), s.signer.Address(), tb.GetBigChainID(), db.ReplacedOrConfirmed, db.Confirmed, db.Replaced)
+	s.Require().NoError(err)
+
+	for _, tx := range txs {
+		//nolint: exhaustive
+		switch tx.Status {
+		case db.Confirmed:
+			s.Require().Equal(tx.Hash(), confirmedTx.Hash())
+		default:
+			s.Failf("unexpected status: %s", tx.Status.String())
+		}
+	}
+}

--- a/services/cctp-relayer/go.mod
+++ b/services/cctp-relayer/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/Flaque/filet v0.0.0-20201012163910-45f684403088
 	github.com/ImVexed/fasturl v0.0.0-20200730185836-b0c0fbead04e
 	github.com/brianvoe/gofakeit/v6 v6.20.1
-	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/davecgh/go-spew v1.1.1
 	github.com/ethereum/go-ethereum v1.10.26
 	github.com/ipfs/go-log v1.0.5

--- a/services/cctp-relayer/go.sum
+++ b/services/cctp-relayer/go.sum
@@ -251,8 +251,6 @@ github.com/c-bata/go-prompt v0.2.6 h1:POP+nrHE+DfLYx370bedwNhsqmpCUynWPxuHi0C5vZ
 github.com/c-bata/go-prompt v0.2.6/go.mod h1:/LMAke8wD2FsNu9EXNdHxNLbd9MedkPnCdfpU9wwHfY=
 github.com/celo-org/celo-blockchain v0.0.0-20210222234634-f8c8f6744526/go.mod h1:4tbv23s4i0AU7+KN5UP2RaB5c9OMXedtx9F7wJ+s0Jo=
 github.com/celo-org/celo-bls-go v0.2.4/go.mod h1:eXUCLXu5F1yfd3M+3VaUk5ZUXaA0sLK2rWdLC1Cfaqo=
-github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
-github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.1.3 h1:cFAlzYUlVYDysBEH2T5hyJZMh3+5+WCBvSnK6Q8UtC4=
 github.com/cenkalti/backoff/v4 v4.1.3/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=


### PR DESCRIPTION
**Description**

As part of #1091, we need to build a better interface for getting the status of transactions for callers to get tx completion data. This will involve the introduction of several new methods to the `TransactionSubmitter` service in future prs.

```go
	// GetNonceStatus gets the status of a nonce on a given chain
	 GetNonceStatus(ctx context.Context, chainID *big.Int, nonce uint64) (status core.NonceStatus, err error)
	// GetTXHash gets the tx hash for a given chain and nonce.
	GetTXHash(ctx context.Context, chainID *big.Int, nonce uint64) (txHash common.Hash, err error)
```

This should solve the current confirmation queue issue.