### PR TITLE
allow every chain to show volume even if 0 upon scrolling through graph

### DIFF
--- a/packages/explorer-ui/components/misc/ToolTip.tsx
+++ b/packages/explorer-ui/components/misc/ToolTip.tsx
@@ -84,7 +84,7 @@ export const CurrencyTooltip = ({
           {names.map((u, index) => {
             const name = names[index]
             const value = values[index]
-            if (value === 0 || name === 'total') {
+            if (name === 'total') {
               return null
             }
             return (


### PR DESCRIPTION
Description
This small edit makes it such that every chain show up upon hovering over the graphs.

![Screenshot 2023-07-06 at 12 25 52 AM](https://github.com/synapsecns/sanguine/assets/103143573/0f0a6287-5117-476f-997e-7a1812536df6)

4bc3f5c53918f3e3de8cbc2451facf0ae2a6b034: [explorer-ui preview link ](https://sanguine-d05xyvxux-synapsecns.vercel.app)