### PR TITLE
Fixes total locked display

### DIFF
--- a/packages/synapse-interface/pages/pool/PoolInfoSection/index.tsx
+++ b/packages/synapse-interface/pages/pool/PoolInfoSection/index.tsx
@@ -60,9 +60,9 @@ const PoolInfoSection = ({
         <InfoListItem
           labelText="Total Liquidity"
           content={
-            poolData?.totalLockedUSDStr ? (
+            poolData?.totalLockedStr ? (
               <AugmentWithUnits
-                content={poolData.totalLockedUSDStr}
+                content={poolData.totalLockedStr}
                 label={pool.priceUnits}
               />
             ) : (


### PR DESCRIPTION
- Was displaying USD vs. Native Currency total
4d2f388bcbfe44720ad92c7f5e11fcee37f720c2: [synapse-interface preview link ](https://sanguine-synapse-interface-bhai41f09-synapsecns.vercel.app)