### PR TITLE
Update timeout limit on omnirpc

### DIFF
--- a/services/omnirpc/chainmanager/manager.go
+++ b/services/omnirpc/chainmanager/manager.go
@@ -2,15 +2,16 @@ package chainmanager
 
 import (
 	"context"
-	"github.com/synapsecns/sanguine/services/omnirpc/config"
-	"github.com/synapsecns/sanguine/services/omnirpc/rpcinfo"
 	"sort"
 	"sync"
 	"time"
+
+	"github.com/synapsecns/sanguine/services/omnirpc/config"
+	"github.com/synapsecns/sanguine/services/omnirpc/rpcinfo"
 )
 
 // rpcTimeout is how long to wait for a response.
-const rpcTimeout = time.Second * 5
+const rpcTimeout = time.Second * 30
 
 // ChainManager manages chain context.
 type ChainManager interface {


### PR DESCRIPTION
**Description**
Some responses, such as requests with lots of data in them (sybil on polygon) result in longer rpc responses. Updating the rpc timout var to match the fasthttp client config of having a max of 30s for timeout.
