### PR TITLE
Fix: allow API to return results with decimals

### DIFF
--- a/packages/rest-api/app.ts
+++ b/packages/rest-api/app.ts
@@ -123,9 +123,9 @@ app.get('/swap', async (req, res) => {
 
       // Add response field with adjusted maxAmountOutStr (to account for decimals)
       const payload: any = resp
-      payload.maxAmountOutStr = parseInt(
-        formatBNToString(resp.maxAmountOut, toTokenDecimals),
-        10
+      payload.maxAmountOutStr = formatBNToString(
+        resp.maxAmountOut,
+        toTokenDecimals
       )
       res.json(payload)
     })
@@ -200,9 +200,9 @@ app.get('/bridge', async (req, res) => {
 
       // Add response field with adjusted maxAmountOutStr (to account for decimals)
       const payload: any = resp
-      payload.maxAmountOutStr = parseInt(
-        formatBNToString(resp.maxAmountOut, toTokenDecimals),
-        10
+      payload.maxAmountOutStr = formatBNToString(
+        resp.maxAmountOut,
+        toTokenDecimals
       )
       res.json(payload)
     })
@@ -239,9 +239,8 @@ const formatBNToString = (
 
     if (rawNumber === 0) {
       return rawNumber.toFixed(1)
-    } else {
-      return rawNumber.toFixed(decimalPlaces)
     }
+    return rawNumber.toString()
   }
 }
 

--- a/packages/rest-api/package.json
+++ b/packages/rest-api/package.json
@@ -19,7 +19,7 @@
     "@ethersproject/bignumber": "^5.7.0",
     "@ethersproject/providers": "^5.7.2",
     "@ethersproject/units": "5.7.0",
-    "@synapsecns/sdk-router": "^0.1.27",
+    "@synapsecns/sdk-router": "0.2.4",
     "bignumber": "^1.1.0",
     "ethers": "5.7.2",
     "express": "^4.18.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6173,27 +6173,6 @@
     ts-jest "^29.0.5"
     yargs "^17.6.2"
 
-"@synapsecns/sdk-router@^0.1.27":
-  version "0.1.27"
-  resolved "https://registry.yarnpkg.com/@synapsecns/sdk-router/-/sdk-router-0.1.27.tgz#3f346e0dcc838ea3600527e2f6a939f66825459a"
-  integrity sha512-yvpBPt+++Xbsx7xz4vGJh4SU0CW8FNUviGMFJnJi2okS12shNDXxUeqyo4wuD92bet21ozy0JWGzeFg2KfNtXw==
-  dependencies:
-    "@babel/core" "^7.20.12"
-    "@ethersproject/abi" "^5.7.0"
-    "@ethersproject/abstract-provider" "^5.7.0"
-    "@ethersproject/address" "^5.7.0"
-    "@ethersproject/bignumber" "^5.7.0"
-    "@ethersproject/bytes" "^5.7.0"
-    "@ethersproject/constants" "^5.7.0"
-    "@ethersproject/contracts" "^5.7.0"
-    babel-jest "^29.4.1"
-    big.js "^5.2.2"
-    decimal.js-light "^2.5.1"
-    ethers "^5.7.2"
-    jsbi "^4.3.0"
-    tiny-invariant "^1.2.0"
-    toformat "^2.0.0"
-
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
   resolved "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz"


### PR DESCRIPTION
**Description**
Allows the API to return results that have decimal values.

**Additional context**
For example, a query to `/bridge?fromChain=1&toChain=42161&fromToken=gOHM&toToken=gOHM&amount=10` would result with `maxAmountOutStr` of 9, when the underlying human-readable value is actually 9.995. After applying this fix we get the expected result of 9.995.
