### PR TITLE
Fraudulent guard detection

### DIFF
--- a/agents/agents/agentsintegration/agentsintegration_test.go
+++ b/agents/agents/agentsintegration/agentsintegration_test.go
@@ -206,7 +206,7 @@ func (u *AgentsIntegrationSuite) TestAgentsE2E() {
 
 	Equal(u.T(), encodedNotaryTestConfig, decodedAgentConfigBackToEncodedBytes)
 
-	guard, err := guard.NewGuard(u.GetTestContext(), guardTestConfig, omniRPCClient, u.GuardTestDB, u.GuardMetrics)
+	guard, err := guard.NewGuard(u.GetTestContext(), guardTestConfig, omniRPCClient, scribeClient.ScribeClient, u.GuardTestDB, u.GuardMetrics)
 	Nil(u.T(), err)
 
 	tips := types.NewTips(big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0))

--- a/agents/agents/executor/executor.go
+++ b/agents/agents/executor/executor.go
@@ -69,8 +69,6 @@ type Executor struct {
 	config executor.Config
 	// executorDB is the executor agent database.
 	executorDB db.ExecutorDB
-	// scribeClient is the client to the Scribe gRPC server.
-	scribeClient client.ScribeClient
 	// grpcClient is the gRPC client.
 	grpcClient pbscribe.ScribeServiceClient
 	// grpcConn is the gRPC connection.
@@ -213,7 +211,6 @@ func NewExecutor(ctx context.Context, config executor.Config, executorDB db.Exec
 	return &Executor{
 		config:         config,
 		executorDB:     executorDB,
-		scribeClient:   scribeClient,
 		grpcConn:       conn,
 		grpcClient:     grpcClient,
 		signer:         executorSigner,

--- a/agents/agents/executor/executor_utils.go
+++ b/agents/agents/executor/executor_utils.go
@@ -45,7 +45,7 @@ func (e Executor) logToAttestation(log ethTypes.Log, chainID uint32) (types.Atte
 
 // logToSnapshot converts the log to a snapshot.
 func (e Executor) logToSnapshot(log ethTypes.Log, chainID uint32) (types.Snapshot, error) {
-	snapshot, domain, ok := e.chainExecutors[chainID].inboxParser.ParseSnapshotAccepted(log)
+	snapshot, domain, _, ok := e.chainExecutors[chainID].inboxParser.ParseSnapshotAccepted(log)
 	if !ok {
 		return nil, fmt.Errorf("could not parse snapshot")
 	}

--- a/agents/agents/guard/fraud_test.go
+++ b/agents/agents/guard/fraud_test.go
@@ -1,0 +1,272 @@
+package guard_test
+
+import (
+	"crypto/rand"
+	"fmt"
+	"github.com/Flaque/filet"
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	. "github.com/stretchr/testify/assert"
+	"github.com/synapsecns/sanguine/agents/agents/guard"
+	"github.com/synapsecns/sanguine/agents/agents/notary"
+	"github.com/synapsecns/sanguine/agents/config"
+	"github.com/synapsecns/sanguine/agents/types"
+	signerConfig "github.com/synapsecns/sanguine/ethergo/signer/config"
+	omniClient "github.com/synapsecns/sanguine/services/omnirpc/client"
+	"github.com/synapsecns/sanguine/services/scribe/backfill"
+	"github.com/synapsecns/sanguine/services/scribe/client"
+	scribeConfig "github.com/synapsecns/sanguine/services/scribe/config"
+	"github.com/synapsecns/sanguine/services/scribe/node"
+	"math/big"
+	"time"
+)
+
+func (g GuardSuite) TestReportFraudulentStateInSnapshot() {
+	testConfig := config.AgentConfig{
+		Domains: map[string]config.DomainConfig{
+			"origin_client":      g.OriginDomainClient.Config(),
+			"destination_client": g.DestinationDomainClient.Config(),
+			"summit_client":      g.SummitDomainClient.Config(),
+		},
+		DomainID:       uint32(0),
+		SummitDomainID: g.SummitDomainClient.Config().DomainID,
+		BondedSigner: signerConfig.SignerConfig{
+			Type: signerConfig.FileType.String(),
+			File: filet.TmpFile(g.T(), "", g.GuardBondedWallet.PrivateKeyHex()).Name(),
+		},
+		UnbondedSigner: signerConfig.SignerConfig{
+			Type: signerConfig.FileType.String(),
+			File: filet.TmpFile(g.T(), "", g.GuardUnbondedWallet.PrivateKeyHex()).Name(),
+		},
+		RefreshIntervalSeconds: 5,
+	}
+
+	omniRPCClient := omniClient.NewOmnirpcClient(g.TestOmniRPC, g.GuardMetrics, omniClient.WithCaptureReqRes())
+
+	omniiiii := omniRPCClient.GetEndpoint(int(g.SummitDomainClient.Config().DomainID), 1)
+	fmt.Println("OMNIIIIIIII", omniiiii)
+
+	// Scribe setup.
+	originClient, err := backfill.DialBackend(g.GetTestContext(), g.TestBackendOrigin.RPCAddress(), g.ScribeMetrics)
+	Nil(g.T(), err)
+	destinationClient, err := backfill.DialBackend(g.GetTestContext(), g.TestBackendDestination.RPCAddress(), g.ScribeMetrics)
+	Nil(g.T(), err)
+	summitClient, err := backfill.DialBackend(g.GetTestContext(), g.TestBackendSummit.RPCAddress(), g.ScribeMetrics)
+	Nil(g.T(), err)
+
+	clients := map[uint32][]backfill.ScribeBackend{
+		uint32(g.TestBackendOrigin.GetChainID()):      {originClient, originClient},
+		uint32(g.TestBackendDestination.GetChainID()): {destinationClient, destinationClient},
+		uint32(g.TestBackendSummit.GetChainID()):      {summitClient, summitClient},
+	}
+	originConfig := scribeConfig.ContractConfig{
+		Address:    g.OriginContract.Address().String(),
+		StartBlock: 0,
+	}
+	originChainConfig := scribeConfig.ChainConfig{
+		ChainID:               uint32(g.TestBackendOrigin.GetChainID()),
+		BlockTimeChunkSize:    1,
+		ContractSubChunkSize:  1,
+		RequiredConfirmations: 0,
+		Contracts:             []scribeConfig.ContractConfig{originConfig},
+	}
+	destinationConfig := scribeConfig.ContractConfig{
+		Address:    g.LightInboxOnDestination.Address().String(),
+		StartBlock: 0,
+	}
+	destinationChainConfig := scribeConfig.ChainConfig{
+		ChainID:               uint32(g.TestBackendDestination.GetChainID()),
+		BlockTimeChunkSize:    1,
+		ContractSubChunkSize:  1,
+		RequiredConfirmations: 0,
+		Contracts:             []scribeConfig.ContractConfig{destinationConfig},
+	}
+	summitConfig := scribeConfig.ContractConfig{
+		Address:    g.InboxOnSummit.Address().String(),
+		StartBlock: 0,
+	}
+	summitChainConfig := scribeConfig.ChainConfig{
+		ChainID:               uint32(g.TestBackendSummit.GetChainID()),
+		BlockTimeChunkSize:    1,
+		ContractSubChunkSize:  1,
+		RequiredConfirmations: 0,
+		Contracts:             []scribeConfig.ContractConfig{summitConfig},
+	}
+	scribeConfig := scribeConfig.Config{
+		Chains: []scribeConfig.ChainConfig{originChainConfig, destinationChainConfig, summitChainConfig},
+	}
+
+	scribe, err := node.NewScribe(g.ScribeTestDB, clients, scribeConfig, g.ScribeMetrics)
+	Nil(g.T(), err)
+	scribeClient := client.NewEmbeddedScribe("sqlite", g.DBPath, g.ScribeMetrics)
+
+	go func() {
+		scribeErr := scribeClient.Start(g.GetTestContext())
+		Nil(g.T(), scribeErr)
+	}()
+	go func() {
+		scribeError := scribe.Start(g.GetTestContext())
+		Nil(g.T(), scribeError)
+	}()
+
+	guard, err := guard.NewGuard(g.GetTestContext(), testConfig, omniRPCClient, scribeClient.ScribeClient, g.GuardTestDB, g.GuardMetrics)
+	Nil(g.T(), err)
+
+	go func() {
+		guardErr := guard.Start(g.GetTestContext())
+		Nil(g.T(), guardErr)
+	}()
+
+	notaryTestConfig := config.AgentConfig{
+		Domains: map[string]config.DomainConfig{
+			"origin_client":      g.OriginDomainClient.Config(),
+			"destination_client": g.DestinationDomainClient.Config(),
+			"summit_client":      g.SummitDomainClient.Config(),
+		},
+		DomainID:       g.DestinationDomainClient.Config().DomainID,
+		SummitDomainID: g.SummitDomainClient.Config().DomainID,
+		BondedSigner: signerConfig.SignerConfig{
+			Type: signerConfig.FileType.String(),
+			File: filet.TmpFile(g.T(), "", g.NotaryBondedWallet.PrivateKeyHex()).Name(),
+		},
+		UnbondedSigner: signerConfig.SignerConfig{
+			Type: signerConfig.FileType.String(),
+			File: filet.TmpFile(g.T(), "", g.NotaryUnbondedWallet.PrivateKeyHex()).Name(),
+		},
+		RefreshIntervalSeconds: 5,
+	}
+
+	notary, err := notary.NewNotary(g.GetTestContext(), notaryTestConfig, omniRPCClient, g.NotaryTestDB, g.NotaryMetrics)
+	Nil(g.T(), err)
+
+	_ = notary
+
+	//var badStateRoot [32]byte
+	//for i := 0; i < 32; i++ {
+	//	badStateRoot[i] = byte(i)
+	//}
+	//badGasData := types.NewGasData(uint16(7), uint16(7), uint16(7), uint16(7), uint16(7), uint16(7))
+	//badBlockNumberBigInt := new(big.Int).SetUint64(10)
+	//badTimeStampBigInt := new(big.Int).SetUint64(10)
+	//originID := g.OriginDomainClient.Config().DomainID
+	//badStateNonce := uint32(100)
+	//
+	//badState := types.NewState(badStateRoot, originID, badStateNonce, badBlockNumberBigInt, badTimeStampBigInt, badGasData)
+	//
+	//badSnapshotStates := make([]types.State, 0, 1)
+	//badSnapshotStates = append(badSnapshotStates, badState)
+	//
+	//badSnapshot := types.NewSnapshot(badSnapshotStates)
+	//
+	//badSnapshotSignature, badEncodedSnapshot, _, err := badSnapshot.SignSnapshot(g.GetTestContext(), g.NotaryBondedSigner)
+	//Nil(g.T(), err)
+	//
+	//badSnapshotRawSig, err := types.EncodeSignature(badSnapshotSignature)
+	//Nil(g.T(), err)
+	//
+	//txContextSummit := g.TestBackendSummit.GetTxContext(g.GetTestContext(), g.SummitMetadata.OwnerPtr())
+	//badSummitTx, err := g.InboxOnSummit.SubmitSnapshot(
+	//	txContextSummit.TransactOpts,
+	//	badEncodedSnapshot,
+	//	badSnapshotRawSig,
+	//)
+	//
+	//Nil(g.T(), err)
+	//_ = badSummitTx
+
+	gasData := types.NewGasData(gofakeit.Uint16(), gofakeit.Uint16(), gofakeit.Uint16(), gofakeit.Uint16(), gofakeit.Uint16(), gofakeit.Uint16())
+
+	gasDataEncoded, err := types.EncodeGasData(gasData)
+	Nil(g.T(), err)
+
+	fmt.Println("GAS DATA LENGTH: ", len(gasDataEncoded))
+
+	fraudulentState := types.NewState(
+		common.BigToHash(big.NewInt(gofakeit.Int64())),
+		g.OriginDomainClient.Config().DomainID,
+		1,
+		big.NewInt(int64(gofakeit.Int32())),
+		big.NewInt(int64(gofakeit.Int32())),
+		gasData,
+	)
+
+	encodedState, err := types.EncodeState(fraudulentState)
+	Nil(g.T(), err)
+
+	decodeState, err := types.DecodeState(encodedState)
+	Nil(g.T(), err)
+
+	Equal(g.T(), decodeState, fraudulentState)
+
+	fmt.Println("STATE LENGTH: ", len(encodedState))
+
+	fraudulentSnapshot := types.NewSnapshot([]types.State{fraudulentState})
+	encodedFraudulentSnapshot, err := types.EncodeSnapshot(fraudulentSnapshot)
+	Nil(g.T(), err)
+
+	fmt.Println("SNAPSHOT LENGTH FROM ENCODE: ", len(encodedFraudulentSnapshot))
+
+	snapshotSignature, encodedSnapshot, _, err := fraudulentSnapshot.SignSnapshot(g.GetTestContext(), g.NotaryBondedSigner)
+	Nil(g.T(), err)
+
+	fmt.Println("SNAPSHOT LENGTH: ", len(encodedSnapshot))
+
+	// Checking if stateAmount (1) * state length (62) == snapshot.length
+	// Also checks if stateAmount != 0 && <= 32
+
+	//opts, err := g.NotaryUnbondedSigner.GetTransactor(g.GetTestContext(), g.TestBackendSummit.GetBigChainID())
+	//Nil(g.T(), err)
+
+	txContextSummit := g.TestBackendSummit.GetTxContext(g.GetTestContext(), g.SummitMetadata.OwnerPtr())
+
+	transactOpts := bind.NewKeyedTransactor(g.NotaryUnbondedWallet.PrivateKey())
+
+	tx, err := g.SummitDomainClient.Inbox().SubmitSnapshot(transactOpts, g.NotaryUnbondedSigner, encodedSnapshot, snapshotSignature)
+	fmt.Printf("TXXXXXXXx: %v\n", tx)
+
+	Nil(g.T(), err)
+	NotNil(g.T(), tx)
+
+	g.TestBackendSummit.WaitForConfirmation(g.GetTestContext(), tx)
+
+	txReceipt, err := g.TestBackendSummit.TransactionReceipt(g.GetTestContext(), tx.Hash())
+	Nil(g.T(), err)
+
+	fmt.Println("TXRECEIPTTTT", txReceipt.Status)
+
+	fmt.Println("TXHASHHHHHHH", tx.Hash().String())
+
+	fmt.Println("STOP")
+
+	g.Eventually(func() bool {
+		time.Sleep(5 * time.Second)
+		// Maybe bonded address. tbd
+		status, err := g.SummitDomainClient.BondingManager().DisputeStatus(g.GetTestContext(), g.NotaryBondedSigner.Address())
+		Nil(g.T(), err)
+
+		if status.DisputeFlag == uint8(1) {
+			return true
+		} else {
+			bumpTx, err := g.TestContractOnSummit.EmitAgentsEventA(transactOpts, big.NewInt(gofakeit.Int64()), big.NewInt(gofakeit.Int64()), big.NewInt(gofakeit.Int64()))
+			Nil(g.T(), err)
+			g.TestBackendSummit.WaitForConfirmation(g.GetTestContext(), bumpTx)
+			fmt.Println("FALSE")
+			return false
+		}
+	})
+}
+
+func getNewUint40() *big.Int {
+	// Max random value, a 130-bits integer, i.e 2^96 - 1
+	max := new(big.Int)
+	max.Exp(big.NewInt(2), big.NewInt(40), nil).Sub(max, big.NewInt(1))
+
+	// Generate cryptographically strong pseudo-random between 0 - max
+	n, err := rand.Int(rand.Reader, max)
+	if err != nil {
+		panic(err)
+	}
+
+	return n
+}

--- a/agents/agents/guard/guard_test.go
+++ b/agents/agents/guard/guard_test.go
@@ -3,6 +3,7 @@ package guard_test
 import (
 	signerConfig "github.com/synapsecns/sanguine/ethergo/signer/config"
 	omniClient "github.com/synapsecns/sanguine/services/omnirpc/client"
+	"github.com/synapsecns/sanguine/services/scribe/client"
 	"math/big"
 	"os"
 	"testing"
@@ -24,47 +25,54 @@ func RemoveGuardTempFile(t *testing.T, fileName string) {
 	Nil(t, err)
 }
 
-func (u GuardSuite) TestGuardE2E() {
+func (g GuardSuite) TestGuardE2E() {
+	g.T().Skip()
 	testConfig := config.AgentConfig{
 		Domains: map[string]config.DomainConfig{
-			"origin_client":      u.OriginDomainClient.Config(),
-			"destination_client": u.DestinationDomainClient.Config(),
-			"summit_client":      u.SummitDomainClient.Config(),
+			"origin_client":      g.OriginDomainClient.Config(),
+			"destination_client": g.DestinationDomainClient.Config(),
+			"summit_client":      g.SummitDomainClient.Config(),
 		},
 		DomainID:       uint32(0),
-		SummitDomainID: u.SummitDomainClient.Config().DomainID,
+		SummitDomainID: g.SummitDomainClient.Config().DomainID,
 		BondedSigner: signerConfig.SignerConfig{
 			Type: signerConfig.FileType.String(),
-			File: filet.TmpFile(u.T(), "", u.GuardBondedWallet.PrivateKeyHex()).Name(),
+			File: filet.TmpFile(g.T(), "", g.GuardBondedWallet.PrivateKeyHex()).Name(),
 		},
 		UnbondedSigner: signerConfig.SignerConfig{
 			Type: signerConfig.FileType.String(),
-			File: filet.TmpFile(u.T(), "", u.GuardUnbondedWallet.PrivateKeyHex()).Name(),
+			File: filet.TmpFile(g.T(), "", g.GuardUnbondedWallet.PrivateKeyHex()).Name(),
 		},
 		RefreshIntervalSeconds: 5,
 	}
 	encodedTestConfig, err := testConfig.Encode()
-	Nil(u.T(), err)
+	Nil(g.T(), err)
 
 	tempConfigFile, err := os.CreateTemp("", "guard_temp_config.yaml")
-	Nil(u.T(), err)
-	defer RemoveGuardTempFile(u.T(), tempConfigFile.Name())
+	Nil(g.T(), err)
+	defer RemoveGuardTempFile(g.T(), tempConfigFile.Name())
 
 	numBytesWritten, err := tempConfigFile.Write(encodedTestConfig)
-	Nil(u.T(), err)
-	Positive(u.T(), numBytesWritten)
+	Nil(g.T(), err)
+	Positive(g.T(), numBytesWritten)
 
 	decodedAgentConfig, err := config.DecodeAgentConfig(tempConfigFile.Name())
-	Nil(u.T(), err)
+	Nil(g.T(), err)
 
 	decodedAgentConfigBackToEncodedBytes, err := decodedAgentConfig.Encode()
-	Nil(u.T(), err)
+	Nil(g.T(), err)
 
-	Equal(u.T(), encodedTestConfig, decodedAgentConfigBackToEncodedBytes)
+	Equal(g.T(), encodedTestConfig, decodedAgentConfigBackToEncodedBytes)
 
-	omniRPCClient := omniClient.NewOmnirpcClient(u.TestOmniRPC, u.GuardMetrics, omniClient.WithCaptureReqRes())
-	guard, err := guard.NewGuard(u.GetTestContext(), testConfig, omniRPCClient, u.GuardTestDB, u.GuardMetrics)
-	Nil(u.T(), err)
+	omniRPCClient := omniClient.NewOmnirpcClient(g.TestOmniRPC, g.GuardMetrics, omniClient.WithCaptureReqRes())
+	scribeClient := client.NewEmbeddedScribe("sqlite", g.DBPath, g.ScribeMetrics)
+	go func() {
+		scribeErr := scribeClient.Start(g.GetTestContext())
+		Nil(g.T(), scribeErr)
+	}()
+
+	guard, err := guard.NewGuard(g.GetTestContext(), testConfig, omniRPCClient, scribeClient.ScribeClient, g.GuardTestDB, g.GuardMetrics)
+	Nil(g.T(), err)
 
 	tips := types.NewTips(big.NewInt(int64(0)), big.NewInt(int64(0)), big.NewInt(int64(0)), big.NewInt(int64(0)))
 
@@ -72,64 +80,64 @@ func (u GuardSuite) TestGuardE2E() {
 
 	body := []byte{byte(gofakeit.Uint32())}
 
-	txContextOrigin := u.TestBackendOrigin.GetTxContext(u.GetTestContext(), u.OriginContractMetadata.OwnerPtr())
+	txContextOrigin := g.TestBackendOrigin.GetTxContext(g.GetTestContext(), g.OriginContractMetadata.OwnerPtr())
 	txContextOrigin.Value = types.TotalTips(tips)
 
-	txContextTestClientOrigin := u.TestBackendOrigin.GetTxContext(u.GetTestContext(), u.TestClientMetadataOnOrigin.OwnerPtr())
+	txContextTestClientOrigin := g.TestBackendOrigin.GetTxContext(g.GetTestContext(), g.TestClientMetadataOnOrigin.OwnerPtr())
 
 	gasLimit := uint64(10000000)
 	version := uint32(1)
-	testClientOnOriginTx, err := u.TestClientOnOrigin.SendMessage(
+	testClientOnOriginTx, err := g.TestClientOnOrigin.SendMessage(
 		txContextTestClientOrigin.TransactOpts,
-		uint32(u.TestBackendDestination.GetChainID()),
-		u.TestClientMetadataOnDestination.Address(),
+		uint32(g.TestBackendDestination.GetChainID()),
+		g.TestClientMetadataOnDestination.Address(),
 		optimisticSeconds,
 		gasLimit,
 		version,
 		body)
 
-	u.Nil(err)
-	u.TestBackendOrigin.WaitForConfirmation(u.GetTestContext(), testClientOnOriginTx)
+	g.Nil(err)
+	g.TestBackendOrigin.WaitForConfirmation(g.GetTestContext(), testClientOnOriginTx)
 
 	go func() {
 		// we don't check errors here since this will error on cancellation at the end of the test
-		_ = guard.Start(u.GetTestContext())
+		_ = guard.Start(g.GetTestContext())
 	}()
 
-	u.Eventually(func() bool {
-		_ = awsTime.SleepWithContext(u.GetTestContext(), time.Second*5)
+	g.Eventually(func() bool {
+		_ = awsTime.SleepWithContext(g.GetTestContext(), time.Second*5)
 
-		rawState, err := u.SummitContract.GetLatestAgentState(
-			&bind.CallOpts{Context: u.GetTestContext()},
-			u.OriginDomainClient.Config().DomainID,
-			u.GuardBondedSigner.Address())
+		rawState, err := g.SummitContract.GetLatestAgentState(
+			&bind.CallOpts{Context: g.GetTestContext()},
+			g.OriginDomainClient.Config().DomainID,
+			g.GuardBondedSigner.Address())
 
-		Nil(u.T(), err)
+		Nil(g.T(), err)
 
 		if len(rawState) == 0 {
 			return false
 		}
 
 		state, err := types.DecodeState(rawState)
-		Nil(u.T(), err)
+		Nil(g.T(), err)
 		return state.Nonce() >= uint32(1)
 	})
 
 	// Now make sure GetLatestState works as well
-	u.Eventually(func() bool {
-		_ = awsTime.SleepWithContext(u.GetTestContext(), time.Second*5)
+	g.Eventually(func() bool {
+		_ = awsTime.SleepWithContext(g.GetTestContext(), time.Second*5)
 
-		rawState, err := u.SummitContract.GetLatestState(
-			&bind.CallOpts{Context: u.GetTestContext()},
-			u.OriginDomainClient.Config().DomainID)
-		Nil(u.T(), err)
+		rawState, err := g.SummitContract.GetLatestState(
+			&bind.CallOpts{Context: g.GetTestContext()},
+			g.OriginDomainClient.Config().DomainID)
+		Nil(g.T(), err)
 
 		if len(rawState) == 0 {
 			return false
 		}
 
 		state, err := types.DecodeState(rawState)
-		Nil(u.T(), err)
+		Nil(g.T(), err)
 		return state.Nonce() >= uint32(1)
 	})
 }

--- a/agents/agents/guard/guard_test.go
+++ b/agents/agents/guard/guard_test.go
@@ -1,13 +1,14 @@
 package guard_test
 
 import (
-	signerConfig "github.com/synapsecns/sanguine/ethergo/signer/config"
-	omniClient "github.com/synapsecns/sanguine/services/omnirpc/client"
-	"github.com/synapsecns/sanguine/services/scribe/client"
 	"math/big"
 	"os"
 	"testing"
 	"time"
+
+	signerConfig "github.com/synapsecns/sanguine/ethergo/signer/config"
+	omniClient "github.com/synapsecns/sanguine/services/omnirpc/client"
+	"github.com/synapsecns/sanguine/services/scribe/client"
 
 	"github.com/Flaque/filet"
 	awsTime "github.com/aws/smithy-go/time"
@@ -26,7 +27,6 @@ func RemoveGuardTempFile(t *testing.T, fileName string) {
 }
 
 func (g GuardSuite) TestGuardE2E() {
-	g.T().Skip()
 	testConfig := config.AgentConfig{
 		Domains: map[string]config.DomainConfig{
 			"origin_client":      g.OriginDomainClient.Config(),

--- a/agents/agents/guard/suite_test.go
+++ b/agents/agents/guard/suite_test.go
@@ -23,10 +23,10 @@ func NewGuardSuite(tb testing.TB) *GuardSuite {
 	}
 }
 
-func (u *GuardSuite) SetupTest() {
+func (g *GuardSuite) SetupTest() {
 	chainwatcher.PollInterval = time.Second
 
-	u.SimulatedBackendsTestSuite.SetupTest()
+	g.SimulatedBackendsTestSuite.SetupTest()
 }
 
 func TestGuardSuite(t *testing.T) {

--- a/agents/config/agent_config.go
+++ b/agents/config/agent_config.go
@@ -17,6 +17,8 @@ import (
 type AgentConfig struct {
 	// DBConfig is the database configuration.
 	DBConfig DBConfig `yaml:"db_config"`
+	// ScribeConfig is the scribe configuration.
+	ScribeConfig ScribeConfig `yaml:"scribe_config"`
 	// Domains stores all the domains
 	Domains DomainConfigs `yaml:"domains"`
 	// DomainID is the domain of the chain that this agent is assigned to.

--- a/agents/config/domain.go
+++ b/agents/config/domain.go
@@ -9,7 +9,7 @@ import (
 )
 
 // DomainConfigs contains a map of name->domain config.
-type DomainConfigs map[uint32]DomainConfig
+type DomainConfigs map[string]DomainConfig
 
 // IsValid validates the domain configs by asserting no two domains appear twice
 // it also calls IsValid on each individual DomainConfig.

--- a/agents/config/domain.go
+++ b/agents/config/domain.go
@@ -9,7 +9,7 @@ import (
 )
 
 // DomainConfigs contains a map of name->domain config.
-type DomainConfigs map[string]DomainConfig
+type DomainConfigs map[uint32]DomainConfig
 
 // IsValid validates the domain configs by asserting no two domains appear twice
 // it also calls IsValid on each individual DomainConfig.

--- a/agents/config/executor/config.go
+++ b/agents/config/executor/config.go
@@ -18,7 +18,7 @@ type Config struct {
 	// DBConfig is the database configuration.
 	DBConfig config.DBConfig `yaml:"db_config"`
 	// ScribeConfig is the scribe configuration.
-	ScribeConfig ScribeConfig `yaml:"scribe_config"`
+	ScribeConfig config.ScribeConfig `yaml:"scribe_config"`
 	// Chains stores all chain information
 	Chains ChainConfigs `yaml:"chains"`
 	// SummitChainID is the chain ID of the chain that the summit contract is deployed on.

--- a/agents/config/executor/config_test.go
+++ b/agents/config/executor/config_test.go
@@ -21,7 +21,7 @@ func configFixture(c ConfigSuite) executor.Config {
 			Type:   "sqlite",
 			Source: gofakeit.Word(),
 		},
-		ScribeConfig: executor.ScribeConfig{
+		ScribeConfig: config.ScribeConfig{
 			Type: "embedded",
 			EmbeddedDBConfig: config.DBConfig{
 				Type:   "mysql",

--- a/agents/config/scribe.go
+++ b/agents/config/scribe.go
@@ -1,9 +1,8 @@
-package executor
+package config
 
 import (
 	"context"
 	"fmt"
-	"github.com/synapsecns/sanguine/agents/config"
 	scribeConfig "github.com/synapsecns/sanguine/services/scribe/config"
 )
 
@@ -13,7 +12,7 @@ type ScribeConfig struct {
 	Type string `yaml:"type"`
 
 	// EmbeddedDBConfig is the database configuration for an embedded scribe.
-	EmbeddedDBConfig config.DBConfig `yaml:"embedded_db_config,omitempty"`
+	EmbeddedDBConfig DBConfig `yaml:"embedded_db_config,omitempty"`
 	// EmbeddedScribeConfig is the config for the embedded scribe.
 	EmbeddedScribeConfig scribeConfig.Config `yaml:"embedded_scribe_config,omitempty"`
 

--- a/agents/contracts/inbox/parser.go
+++ b/agents/contracts/inbox/parser.go
@@ -46,6 +46,7 @@ func (p parserImpl) EventType(log ethTypes.Log) (_ EventType, ok bool) {
 
 // ParseSnapshotAccepted parses a SnapshotAccepted event.
 func (p parserImpl) ParseSnapshotAccepted(log ethTypes.Log) (_ types.Snapshot, domain uint32, agentSig []byte, ok bool) {
+	fmt.Printf("ParseSnapshotAccepted: %v\n", log)
 	inboxSnapshot, err := p.filterer.ParseSnapshotAccepted(log)
 	if err != nil {
 		return nil, 0, nil, false
@@ -55,6 +56,8 @@ func (p parserImpl) ParseSnapshotAccepted(log ethTypes.Log) (_ types.Snapshot, d
 	if err != nil {
 		return nil, 0, nil, false
 	}
+	fmt.Printf("inboxSnapshot: %v\n", inboxSnapshot)
+	fmt.Printf("inboxSnapshot.Signature: %v\n", inboxSnapshot.SnapSignature)
 
 	return snapshot, inboxSnapshot.Domain, inboxSnapshot.SnapSignature, true
 }

--- a/agents/contracts/inbox/parser.go
+++ b/agents/contracts/inbox/parser.go
@@ -46,7 +46,6 @@ func (p parserImpl) EventType(log ethTypes.Log) (_ EventType, ok bool) {
 
 // ParseSnapshotAccepted parses a SnapshotAccepted event.
 func (p parserImpl) ParseSnapshotAccepted(log ethTypes.Log) (_ types.Snapshot, domain uint32, agentSig []byte, ok bool) {
-	fmt.Printf("ParseSnapshotAccepted: %v\n", log)
 	inboxSnapshot, err := p.filterer.ParseSnapshotAccepted(log)
 	if err != nil {
 		return nil, 0, nil, false
@@ -56,8 +55,6 @@ func (p parserImpl) ParseSnapshotAccepted(log ethTypes.Log) (_ types.Snapshot, d
 	if err != nil {
 		return nil, 0, nil, false
 	}
-	fmt.Printf("inboxSnapshot: %v\n", inboxSnapshot)
-	fmt.Printf("inboxSnapshot.Signature: %v\n", inboxSnapshot.SnapSignature)
 
 	return snapshot, inboxSnapshot.Domain, inboxSnapshot.SnapSignature, true
 }

--- a/agents/contracts/inbox/parser.go
+++ b/agents/contracts/inbox/parser.go
@@ -13,7 +13,7 @@ type Parser interface {
 	// EventType is the event type.
 	EventType(log ethTypes.Log) (_ EventType, ok bool)
 	// ParseSnapshotAccepted parses a SnapshotAccepted event.
-	ParseSnapshotAccepted(log ethTypes.Log) (_ types.Snapshot, domain uint32, ok bool)
+	ParseSnapshotAccepted(log ethTypes.Log) (_ types.Snapshot, domain uint32, agentSig []byte, ok bool)
 }
 
 type parserImpl struct {
@@ -45,18 +45,18 @@ func (p parserImpl) EventType(log ethTypes.Log) (_ EventType, ok bool) {
 }
 
 // ParseSnapshotAccepted parses a SnapshotAccepted event.
-func (p parserImpl) ParseSnapshotAccepted(log ethTypes.Log) (_ types.Snapshot, domain uint32, ok bool) {
+func (p parserImpl) ParseSnapshotAccepted(log ethTypes.Log) (_ types.Snapshot, domain uint32, agentSig []byte, ok bool) {
 	inboxSnapshot, err := p.filterer.ParseSnapshotAccepted(log)
 	if err != nil {
-		return nil, 0, false
+		return nil, 0, nil, false
 	}
 
 	snapshot, err := types.DecodeSnapshot(inboxSnapshot.SnapPayload)
 	if err != nil {
-		return nil, 0, false
+		return nil, 0, nil, false
 	}
 
-	return snapshot, inboxSnapshot.Domain, true
+	return snapshot, inboxSnapshot.Domain, inboxSnapshot.SnapSignature, true
 }
 
 // EventType is the type of the summit events

--- a/agents/domains/domain.go
+++ b/agents/domains/domain.go
@@ -3,9 +3,11 @@ package domains
 import (
 	"context"
 	"errors"
+	ethTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/synapsecns/sanguine/agents/contracts/destination"
 	"github.com/synapsecns/sanguine/agents/contracts/inbox"
 	"github.com/synapsecns/sanguine/agents/contracts/lightinbox"
+	"github.com/synapsecns/sanguine/agents/contracts/origin"
 	"github.com/synapsecns/sanguine/ethergo/signer/nonce"
 	"math/big"
 
@@ -47,6 +49,10 @@ type DomainClient interface {
 
 // OriginContract represents the origin contract on a particular chain.
 type OriginContract interface {
+	// GetContractRef gets the origin contract ref.
+	GetContractRef() *origin.OriginRef
+	// IsValidState checks if the given state is valid on its origin.
+	IsValidState(ctx context.Context, statePayload []byte) (isValid bool, err error)
 	// FetchSortedMessages fetches all messages in order form lowest->highest in a given block range
 	FetchSortedMessages(ctx context.Context, from uint32, to uint32) (messages []types.Message, err error)
 	// SuggestLatestState gets the latest state on the origin
@@ -73,6 +79,8 @@ type InboxContract interface {
 	GetContractRef() *inbox.InboxRef
 	// GetNonceManager gets the nonce manager for the inbox.
 	GetNonceManager() nonce.Manager
+	// SubmitStateReportWithSnapshot reports to the inbox that a state within a snapshot is invalid.
+	SubmitStateReportWithSnapshot(ctx context.Context, signer signer.Signer, stateIndex int64, signature signer.Signature, snapPayload []byte, snapSignature []byte) (tx *ethTypes.Transaction, err error)
 	// SubmitSnapshot submits a snapshot to the inbox (via the Inbox).
 	SubmitSnapshot(ctx context.Context, signer signer.Signer, encodedSnapshot []byte, signature signer.Signature) error
 }

--- a/agents/domains/domain.go
+++ b/agents/domains/domain.go
@@ -83,6 +83,8 @@ type BondingManagerContract interface {
 	GetAgentRoot(ctx context.Context) ([32]byte, error)
 	// GetProof gets the proof that the agent is in the Agent Merkle Tree
 	GetProof(ctx context.Context, bondedAgentSigner signer.Signer) ([][32]byte, error)
+	// DisputeStatus gets the dispute status for the given agent.
+	DisputeStatus(ctx context.Context, address common.Address) (disputeStatus DisputeStatus, err error)
 }
 
 // DestinationContract contains the interface for the destination.

--- a/agents/domains/domain.go
+++ b/agents/domains/domain.go
@@ -3,9 +3,10 @@ package domains
 import (
 	"context"
 	"errors"
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
-	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/event"
@@ -69,6 +70,7 @@ type SummitContract interface {
 
 // InboxContract contains the interface for the inbox.
 type InboxContract interface {
+	LightInboxContract
 	// SubmitStateReportWithSnapshot reports to the inbox that a state within a snapshot is invalid.
 	SubmitStateReportWithSnapshot(ctx context.Context, signer signer.Signer, stateIndex int64, signature signer.Signature, snapPayload []byte, snapSignature []byte) (tx *ethTypes.Transaction, err error)
 	// SubmitSnapshot submits a snapshot to the inbox (via the Inbox).
@@ -109,6 +111,8 @@ type LightInboxContract interface {
 		agentRoot [32]byte,
 		snapGas []*big.Int,
 	) (tx *ethTypes.Transaction, err error)
+	// VerifyStateWithSnapshot verifies a state within a snapshot.
+	VerifyStateWithSnapshot(ctx context.Context, signer signer.Signer, stateIndex int64, signature signer.Signature, snapPayload []byte, snapSignature []byte) (tx *ethTypes.Transaction, err error)
 }
 
 // LightManagerContract contains the interface for the light manager.

--- a/agents/domains/evm/bondingmanager.go
+++ b/agents/domains/evm/bondingmanager.go
@@ -74,3 +74,17 @@ func (a bondingManagerContract) GetProof(ctx context.Context, bondedAgentSigner 
 
 	return proof, nil
 }
+
+func (a bondingManagerContract) DisputeStatus(ctx context.Context, address common.Address) (disputeStatus domains.DisputeStatus, err error) {
+	rawDispute, err := a.contract.DisputeStatus(&bind.CallOpts{Context: ctx}, address)
+	if err != nil {
+		return domains.DisputeStatus{}, fmt.Errorf("could not retrieve dispute status: %w", err)
+	}
+
+	return domains.DisputeStatus{
+		DisputeFlag: rawDispute.Flag,
+		Rival:       rawDispute.Rival,
+		FraudProver: rawDispute.FraudProver,
+		DisputePtr:  rawDispute.DisputePtr,
+	}, nil
+}

--- a/agents/domains/evm/inbox.go
+++ b/agents/domains/evm/inbox.go
@@ -3,6 +3,9 @@ package evm
 import (
 	"context"
 	"fmt"
+	"math/big"
+	"strings"
+
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
@@ -12,8 +15,6 @@ import (
 	"github.com/synapsecns/sanguine/ethergo/chain"
 	"github.com/synapsecns/sanguine/ethergo/signer/nonce"
 	"github.com/synapsecns/sanguine/ethergo/signer/signer"
-	"math/big"
-	"strings"
 )
 
 // NewInboxContract returns a bound inbox contract.
@@ -34,6 +35,7 @@ func NewInboxContract(ctx context.Context, client chain.Chain, inboxAddress comm
 }
 
 type inboxContract struct {
+	lightInboxContract
 	// contract contains the conract handle
 	contract *inbox.InboxRef
 	// client contains the evm client
@@ -63,6 +65,10 @@ func (a inboxContract) SubmitStateReportWithSnapshot(ctx context.Context, signer
 
 	// TODO: Is there a way to get a return value from a contractTransactor call?
 	tx, err = a.contract.SubmitStateReportWithSnapshot(transactOpts, big.NewInt(stateIndex), rawSig, snapPayload, snapSignature)
+	fmt.Printf("TX: %v\n", tx)
+	if tx != nil {
+		fmt.Printf("state report hash: %v\n", tx.Hash())
+	}
 	if err != nil {
 		// TODO: Why is this done? And if it is necessary, we should functionalize it.
 		if strings.Contains(err.Error(), "nonce too low") {

--- a/agents/domains/evm/inbox.go
+++ b/agents/domains/evm/inbox.go
@@ -65,10 +65,6 @@ func (a inboxContract) SubmitStateReportWithSnapshot(ctx context.Context, signer
 
 	// TODO: Is there a way to get a return value from a contractTransactor call?
 	tx, err = a.contract.SubmitStateReportWithSnapshot(transactOpts, big.NewInt(stateIndex), rawSig, snapPayload, snapSignature)
-	fmt.Printf("TX: %v\n", tx)
-	if tx != nil {
-		fmt.Printf("state report hash: %v\n", tx.Hash())
-	}
 	if err != nil {
 		// TODO: Why is this done? And if it is necessary, we should functionalize it.
 		if strings.Contains(err.Error(), "nonce too low") {

--- a/agents/domains/evm/inbox.go
+++ b/agents/domains/evm/inbox.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"fmt"
 	"github.com/ethereum/go-ethereum/common"
+	ethTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/synapsecns/sanguine/agents/contracts/inbox"
 	"github.com/synapsecns/sanguine/agents/domains"
 	"github.com/synapsecns/sanguine/agents/types"
 	"github.com/synapsecns/sanguine/ethergo/chain"
 	"github.com/synapsecns/sanguine/ethergo/signer/nonce"
 	"github.com/synapsecns/sanguine/ethergo/signer/signer"
+	"math/big"
 	"strings"
 )
 
@@ -46,6 +48,37 @@ func (a inboxContract) GetContractRef() *inbox.InboxRef {
 
 func (a inboxContract) GetNonceManager() nonce.Manager {
 	return a.nonceManager
+}
+
+func (a inboxContract) SubmitStateReportWithSnapshot(ctx context.Context, signer signer.Signer, stateIndex int64, signature signer.Signature, snapPayload []byte, snapSignature []byte) (tx *ethTypes.Transaction, err error) {
+	transactor, err := signer.GetTransactor(ctx, a.client.GetBigChainID())
+	if err != nil {
+		return nil, fmt.Errorf("could not sign tx: %w", err)
+	}
+
+	transactOpts, err := a.nonceManager.NewKeyedTransactor(transactor)
+	if err != nil {
+		return nil, fmt.Errorf("could not create tx: %w", err)
+	}
+
+	transactOpts.Context = ctx
+
+	rawSig, err := types.EncodeSignature(signature)
+	if err != nil {
+		return nil, fmt.Errorf("could not encode signature: %w", err)
+	}
+
+	// TODO: Is there a way to get a return value from a contractTransactor call?
+	tx, err = a.contract.SubmitStateReportWithSnapshot(transactOpts, big.NewInt(stateIndex), rawSig, snapPayload, snapSignature)
+	if err != nil {
+		// TODO: Why is this done? And if it is necessary, we should functionalize it.
+		if strings.Contains(err.Error(), "nonce too low") {
+			a.nonceManager.ClearNonce(signer.Address())
+		}
+		return nil, fmt.Errorf("could not submit state report: %w", err)
+	}
+
+	return tx, nil
 }
 
 func (a inboxContract) SubmitSnapshot(ctx context.Context, signer signer.Signer, encodedSnapshot []byte, signature signer.Signature) error {

--- a/agents/domains/evm/lightinbox.go
+++ b/agents/domains/evm/lightinbox.go
@@ -79,10 +79,6 @@ func (a lightInboxContract) VerifyStateWithSnapshot(ctx context.Context, signer 
 
 	// TODO: Is there a way to get a return value from a contractTransactor call?
 	tx, err = a.contract.VerifyStateWithSnapshot(transactOpts, big.NewInt(stateIndex), snapPayload, snapSignature)
-	fmt.Printf("TX: %v\n", tx)
-	if tx != nil {
-		fmt.Printf("state report hash: %v\n", tx.Hash())
-	}
 	if err != nil {
 		// TODO: Why is this done? And if it is necessary, we should functionalize it.
 		if strings.Contains(err.Error(), "nonce too low") {

--- a/agents/domains/evm/origin.go
+++ b/agents/domains/evm/origin.go
@@ -36,12 +36,25 @@ func NewOriginContract(ctx context.Context, client chain.Chain, originAddress co
 // domains.OriginContract.
 type originContract struct {
 	// contract contains the contract handle
-	contract origin.IOrigin
+	contract *origin.OriginRef
 	// client is the client
 	//nolint: staticcheck
 	client chain.Chain
 	// nonceManager is the nonce manager used for transacting
 	nonceManager nonce.Manager
+}
+
+func (o originContract) GetContractRef() *origin.OriginRef {
+	return o.contract
+}
+
+func (o originContract) IsValidState(ctx context.Context, statePayload []byte) (isValid bool, err error) {
+	isValid, err = o.contract.IsValidState(&bind.CallOpts{Context: ctx}, statePayload)
+	if err != nil {
+		return false, fmt.Errorf("could not check if state is valid: %w", err)
+	}
+
+	return isValid, nil
 }
 
 func (o originContract) FetchSortedMessages(ctx context.Context, from uint32, to uint32) (messages []types.Message, err error) {

--- a/agents/domains/types.go
+++ b/agents/domains/types.go
@@ -1,0 +1,18 @@
+package domains
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"math/big"
+)
+
+// DisputeStatus is the return type from DisputeStatus.
+type DisputeStatus struct {
+	// DisputeFlag is the 0: None; 1: Pending; 2: Slashed.
+	DisputeFlag uint8
+	// Rival is the address of the rival.
+	Rival common.Address
+	// FraudProver is the address of the fraud prover.
+	FraudProver common.Address
+	// DisputePtr is the value of the dispute pointer.
+	DisputePtr *big.Int
+}

--- a/agents/testutil/simulated_backends_suite.go
+++ b/agents/testutil/simulated_backends_suite.go
@@ -1,6 +1,10 @@
 package testutil
 
 import (
+	"math/big"
+	"sync"
+	"testing"
+
 	"github.com/Flaque/filet"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params"
@@ -41,9 +45,6 @@ import (
 	scribedb "github.com/synapsecns/sanguine/services/scribe/db"
 	scribesqlite "github.com/synapsecns/sanguine/services/scribe/db/datastore/sql/sqlite"
 	scribeMetadata "github.com/synapsecns/sanguine/services/scribe/metadata"
-	"math/big"
-	"sync"
-	"testing"
 )
 
 // SimulatedBackendsTestSuite can be used as the base for any test needing simulated backends
@@ -345,21 +346,6 @@ func (a *SimulatedBackendsTestSuite) SetupTest() {
 		a.TestBackendDestination,
 		a.TestBackendSummit,
 	}
-
-	/*
-		a.TestDeployManager.BulkDeploy(a.GetTestContext(), testBackends,
-			InboxType,
-			BondingManagerHarnessType,
-			SummitHarnessType,
-			AgentsTestContractType,
-			DestinationHarnessType,
-			OriginHarnessType,
-			TestClientType,
-			PingPongClientType,
-			LightInboxType,
-			LightManagerHarnessType,
-		)
-	*/
 
 	wg.Add(3)
 	go func() {

--- a/agents/types/encoder.go
+++ b/agents/types/encoder.go
@@ -111,14 +111,21 @@ func EncodeState(state State) ([]byte, error) {
 	b := make([]byte, 0)
 	originBytes := make([]byte, uint32Len)
 	nonceBytes := make([]byte, uint32Len)
+	//blockNumberBytes := make([]byte, uint40Len)
+	//timestampBytes := make([]byte, uint40Len)
 
 	binary.BigEndian.PutUint32(originBytes, state.Origin())
 	binary.BigEndian.PutUint32(nonceBytes, state.Nonce())
 	root := state.Root()
 
+	//PutUint40(blockNumberBytes, state.BlockNumber().Uint64())
+	//PutUint40(timestampBytes, state.Timestamp().Uint64())
+
 	b = append(b, root[:]...)
 	b = append(b, originBytes...)
 	b = append(b, nonceBytes...)
+	//b = append(b, blockNumberBytes...)
+	//b = append(b, timestampBytes...)
 	b = append(b, math.PaddedBigBytes(state.BlockNumber(), uint40Len)...)
 	b = append(b, math.PaddedBigBytes(state.Timestamp(), uint40Len)...)
 
@@ -130,6 +137,15 @@ func EncodeState(state State) ([]byte, error) {
 
 	return b, nil
 }
+
+//func PutUint40(b []byte, v uint64) {
+//	_ = b[4] // early bounds check to guarantee safety of writes below
+//	b[0] = byte(v >> 32)
+//	b[1] = byte(v >> 24)
+//	b[2] = byte(v >> 16)
+//	b[3] = byte(v >> 8)
+//	b[4] = byte(v)
+//}
 
 // DecodeState decodes a state.
 func DecodeState(toDecode []byte) (State, error) {


### PR DESCRIPTION
**Description**
Addresses the `Fraudulent Snapshot by a Guard/Notary` section in #1118.


**Additional context**
Note that here the `Guard` only slashes the accused agent by calling `verifyStateWithSnapshot()` but does not yet submit a state report on chains other than origin.

- Adds `TestReportFraudulentStateInSnapshot` which verifies that the `AgentStatues` is marked as `Fraudulent` after the slashing
- `InboxContract` now has embedded `LightInboxContract` to mirror the inheritance relationship in solidity and reduce duplication

**Metadata**
- Fixes #1118
