### PR TITLE
Fix/synapse UI usdc

### DIFF
--- a/packages/synapse-interface/constants/tokens/master.tsx
+++ b/packages/synapse-interface/constants/tokens/master.tsx
@@ -431,7 +431,7 @@ export const USDC = new Token({
     [CHAINS.DOGE.id]: [CHAINS.ETH.id, CHAINS.DOGE.id],
   },
   symbol: 'USDC',
-  name: 'USD Circle',
+  name: 'USDC',
   logo: usdcLogo,
   description: `
     USD Coin (known by its ticker USDC) is a stablecoin that is pegged to the

--- a/packages/synapse-interface/constants/tokens/master.tsx
+++ b/packages/synapse-interface/constants/tokens/master.tsx
@@ -431,7 +431,7 @@ export const USDC = new Token({
     [CHAINS.DOGE.id]: [CHAINS.ETH.id, CHAINS.DOGE.id],
   },
   symbol: 'USDC',
-  name: 'USDC',
+  name: 'USD Coin',
   logo: usdcLogo,
   description: `
     USD Coin (known by its ticker USDC) is a stablecoin that is pegged to the


### PR DESCRIPTION
Update USDC name to USD Coin
10a395302a1600bf5c4d3f13bbed1cd899add8d4: [synapse-interface preview link ](https://sanguine-synapse-interface-7e3c94ydv-synapsecns.vercel.app)