### PR TITLE
Add scroll after network changes during approval flow

### DIFF
--- a/packages/synapse-interface/components/Portfolio/SingleNetworkPortfolio.tsx
+++ b/packages/synapse-interface/components/Portfolio/SingleNetworkPortfolio.tsx
@@ -203,6 +203,7 @@ const PortfolioTokenAsset = ({
     } else {
       try {
         await switchNetwork({ chainId: portfolioChainId })
+        await scrollToTop()
         await approveToken(ROUTER_ADDRESS, portfolioChainId, tokenAddress).then(
           (success) => {
             success && fetchPortfolioBalancesCallback()

--- a/packages/synapse-interface/components/layouts/LandingPageWrapper/TopBarNavLink.tsx
+++ b/packages/synapse-interface/components/layouts/LandingPageWrapper/TopBarNavLink.tsx
@@ -1,6 +1,5 @@
-import Link from 'next/link'
 import { useRouter } from 'next/router'
-import { BASE_PATH } from '@/constants/urls'
+import Link from 'next/link'
 
 export function TopBarNavLink({
   labelText,
@@ -11,7 +10,7 @@ export function TopBarNavLink({
   labelText: string
   to: string
   className?: string
-  match?: string
+  match?: string | RegExp | { startsWith: string; endsWith: string }
 }) {
   const router = useRouter()
 
@@ -28,7 +27,13 @@ export function TopBarNavLink({
     group items-center px-2 my-2 font-normal tracking-wide
     transform-gpu transition-all duration-75
     text-white ${
-      match && router.asPath.includes(match)
+      match &&
+      (typeof match === 'string'
+        ? router.asPath.includes(match)
+        : match instanceof RegExp
+        ? match.test(router.asPath)
+        : router.asPath.startsWith(match.startsWith) &&
+          router.asPath.endsWith(match.endsWith))
         ? 'text-opacity-100'
         : 'text-opacity-30'
     }

--- a/packages/synapse-interface/components/layouts/LandingPageWrapper/index.tsx
+++ b/packages/synapse-interface/components/layouts/LandingPageWrapper/index.tsx
@@ -196,41 +196,17 @@ function PopoverPanelContainer({
 }
 
 function TopBarButtons() {
-  return (
-    <>
-      <TopBarNavLink
-        to={NAVIGATION.About.path}
-        labelText={NAVIGATION.About.text}
-        match={NAVIGATION.About.match}
-      />
-      <TopBarNavLink
-        to={NAVIGATION.Bridge.path}
-        labelText={NAVIGATION.Bridge.text}
-        match={NAVIGATION.Bridge.match}
-      />
-      <TopBarNavLink
-        to={NAVIGATION.Swap.path}
-        labelText={NAVIGATION.Swap.text}
-        match={NAVIGATION.Swap.match}
-      />
-      <TopBarNavLink
-        to={NAVIGATION.Pools.path}
-        labelText={NAVIGATION.Pools.text}
-        match={NAVIGATION.Pools.match}
-      />
-      <TopBarNavLink
-        to={NAVIGATION.Stake.path}
-        labelText={NAVIGATION.Stake.text}
-        match={NAVIGATION.Stake.match}
-      />
-      <TopBarNavLink
-        className="hidden mdl:block"
-        to={NAVIGATION.Analytics.path}
-        labelText={NAVIGATION.Analytics.text}
-        match={NAVIGATION.Analytics.match}
-      />
-    </>
-  )
+  const topBarNavLinks = Object.entries(NAVIGATION).map(([key, value]) => (
+    <TopBarNavLink
+      key={key}
+      to={value.path}
+      labelText={value.text}
+      match={value.match}
+      className={key === 'Analytics' ? 'hidden mdl:block' : ''}
+    />
+  ))
+
+  return <>{topBarNavLinks}</>
 }
 
 function MoreInfoButtons() {
@@ -284,34 +260,11 @@ function SocialButtons() {
 }
 
 function MobileBarButtons() {
-  return (
-    <>
-      <MobileBarItem
-        to={NAVIGATION.About.path}
-        labelText={NAVIGATION.About.text}
-      />
-      <MobileBarItem
-        to={NAVIGATION.Bridge.path}
-        labelText={NAVIGATION.Bridge.text}
-      />
-      <MobileBarItem
-        to={NAVIGATION.Swap.path}
-        labelText={NAVIGATION.Swap.text}
-      />
-      <MobileBarItem
-        to={NAVIGATION.Pools.path}
-        labelText={NAVIGATION.Pools.text}
-      />
-      <MobileBarItem
-        to={NAVIGATION.Stake.path}
-        labelText={NAVIGATION.Stake.text}
-      />
-      <MobileBarItem
-        to={NAVIGATION.Analytics.path}
-        labelText={NAVIGATION.Analytics.text}
-      />
-    </>
-  )
+  const mobileBarItems = Object.entries(NAVIGATION).map(([key, value]) => (
+    <MobileBarItem key={key} to={value.path} labelText={value.text} />
+  ))
+
+  return <>{mobileBarItems}</>
 }
 
 function MobileBarItem({ to, labelText }: { to: string; labelText: string }) {

--- a/packages/synapse-interface/constants/routes.ts
+++ b/packages/synapse-interface/constants/routes.ts
@@ -5,7 +5,6 @@ import {
   POOLS_PATH,
   LANDING_PATH,
   BRIDGE_PATH,
-  CONTRACTS_PATH,
 } from './urls'
 
 export interface RouteObject {
@@ -50,9 +49,4 @@ export const NAVIGATION: RouteObject = {
     text: 'Explorer',
     match: null,
   },
-  // Contracts: {
-  //   path: CONTRACTS_PATH,
-  //   text: 'Contracts',
-  //   match: '/contracts',
-  // },
 }

--- a/packages/synapse-interface/constants/routes.ts
+++ b/packages/synapse-interface/constants/routes.ts
@@ -50,9 +50,9 @@ export const NAVIGATION: RouteObject = {
     text: 'Explorer',
     match: null,
   },
-  Contracts: {
-    path: CONTRACTS_PATH,
-    text: 'Contracts',
-    match: '/contracts',
-  },
+  // Contracts: {
+  //   path: CONTRACTS_PATH,
+  //   text: 'Contracts',
+  //   match: '/contracts',
+  // },
 }

--- a/packages/synapse-interface/constants/routes.ts
+++ b/packages/synapse-interface/constants/routes.ts
@@ -8,11 +8,11 @@ import {
   CONTRACTS_PATH,
 } from './urls'
 
-interface RouteObject {
-  [name: string]: {
+export interface RouteObject {
+  [key: string]: {
     path: string
     text: string
-    match: string | null
+    match: string | RegExp | { startsWith: string; endsWith: string }
   }
 }
 
@@ -25,7 +25,10 @@ export const NAVIGATION: RouteObject = {
   Bridge: {
     path: BRIDGE_PATH,
     text: 'Bridge',
-    match: '/?outputChain',
+    match: {
+      startsWith: '/',
+      endsWith: '/',
+    },
   },
   Swap: {
     path: SWAP_PATH,


### PR DESCRIPTION
- Reset Portfolio viewport during Approval flow after users switch network
- Bridge to be highlighted when on Bridge experience in Navbar

789fac488e1f5385af8212d11f58cba9ee70187d: [synapse-interface preview link ](https://sanguine-synapse-interface-8nvtbwwct-synapsecns.vercel.app)
4de0680379580bf5f2fb8f30b42b79021959f69b: [synapse-interface preview link ](https://sanguine-synapse-interface-o35q1s3iq-synapsecns.vercel.app)
6071f36f043b16772d649fc00b152bb4054f24dc: [synapse-interface preview link ](https://sanguine-synapse-interface-kaikb3fus-synapsecns.vercel.app)