### PR TITLE
Contract path links out directly to contracts in docs

### DIFF
--- a/packages/synapse-interface/constants/routes.ts
+++ b/packages/synapse-interface/constants/routes.ts
@@ -5,6 +5,7 @@ import {
   POOLS_PATH,
   LANDING_PATH,
   BRIDGE_PATH,
+  CONTRACTS_PATH,
 } from './urls'
 
 export interface RouteObject {
@@ -47,6 +48,11 @@ export const NAVIGATION: RouteObject = {
   Analytics: {
     path: ANALYTICS_PATH,
     text: 'Explorer',
+    match: null,
+  },
+  Contracts: {
+    path: CONTRACTS_PATH,
+    text: 'Contracts',
     match: null,
   },
 }

--- a/packages/synapse-interface/constants/urls/index.tsx
+++ b/packages/synapse-interface/constants/urls/index.tsx
@@ -21,7 +21,8 @@ export const STAKE_PATH = '/stake'
 export const POOLS_PATH = '/pools'
 export const POOL_PATH = '/pool'
 export const BRIDGE_PATH = '/'
-export const CONTRACTS_PATH = '/contracts'
+export const CONTRACTS_PATH =
+  'https://docs.synapseprotocol.com/reference/contract-addresses'
 export const STATISTICS_PATH = '/statistics'
 export const LANDING_PATH = '/landing'
 export const TERMS_OF_SERVICE_PATH =

--- a/packages/synapse-interface/cypress/e2e/navigation.cy.ts
+++ b/packages/synapse-interface/cypress/e2e/navigation.cy.ts
@@ -42,7 +42,7 @@ describe('Navbar', () => {
       const routes = fixture.routes
       cy.get('nav[data-test-id="desktop-nav"]')
         .children('a')
-        .should('have.length', 6)
+        .should('have.length', routes.length)
         .each(($a, index) => {
           expect($a.text()).to.equal(routes[index])
         })
@@ -89,7 +89,7 @@ describe('Navbar', () => {
       const routes = fixture.routes
       cy.get('div[data-test-id="mobile-nav"]')
         .children('a')
-        .should('have.length', 6)
+        .should('have.length', routes.length)
         .each(($a, index) => {
           expect($a.text()).to.equal(routes[index])
         })

--- a/packages/synapse-interface/cypress/fixtures/navigation.json
+++ b/packages/synapse-interface/cypress/fixtures/navigation.json
@@ -1,3 +1,11 @@
 {
-  "routes": ["About", "Bridge", "Swap", "Pools", "Stake", "Explorer"]
+  "routes": [
+    "About",
+    "Bridge",
+    "Swap",
+    "Pools",
+    "Stake",
+    "Explorer",
+    "Contracts"
+  ]
 }


### PR DESCRIPTION
Adds back contracts path and links to contracts in docs directly

<img width="363" alt="Screen Shot 2023-07-14 at 8 53 21 AM" src="https://github.com/synapsecns/sanguine/assets/104046418/f1457c2f-789f-4a7c-8f08-9d978be7df0c">

e3a4d11fdd80182fb0a240f3f6ad7c18ea63761a: [synapse-interface preview link ](https://sanguine-synapse-interface-ep9uy1odj-synapsecns.vercel.app)
ff233686703ba7c971ee08f914cbf078a725e010: [synapse-interface preview link ](https://sanguine-synapse-interface-2iyh3qrbx-synapsecns.vercel.app)
9d1846ad42b1c59342de43edcffbe20daa2e2212: [synapse-interface preview link ](https://sanguine-synapse-interface-n7nzyvdcm-synapsecns.vercel.app)