### PR TITLE
Hotfix/synapse bigint state

### DIFF
--- a/packages/synapse-interface/components/StateManagedBridge/BridgeTransactionButton.tsx
+++ b/packages/synapse-interface/components/StateManagedBridge/BridgeTransactionButton.tsx
@@ -1,4 +1,5 @@
 import { useSelector } from 'react-redux'
+import { useMemo } from 'react'
 import { TransactionButton } from '@/components/buttons/TransactionButton'
 import { EMPTY_BRIDGE_QUOTE, EMPTY_BRIDGE_QUOTE_ZERO } from '@/constants/bridge'
 import { RootState } from '@/store/store'
@@ -59,10 +60,16 @@ export const BridgeTransactionButton = ({
 
   let buttonProperties
 
-  const fromValueBigInt = stringToBigInt(
-    fromValue,
-    fromToken.decimals[fromChainId]
-  )
+  // const fromValueBigInt = stringToBigInt(
+  //   fromValue,
+  //   fromToken.decimals[fromChainId]
+  // )
+
+  const fromTokenDecimals: number | undefined = fromToken.decimals[fromChainId]
+
+  const fromValueBigInt = useMemo(() => {
+    return fromTokenDecimals ? stringToBigInt(fromValue, fromTokenDecimals) : 0
+  }, [fromValue, fromTokenDecimals])
 
   if (!isLoading && bridgeQuote?.feeAmount === 0n && fromValueBigInt > 0) {
     buttonProperties = {

--- a/packages/synapse-interface/components/StateManagedBridge/BridgeTransactionButton.tsx
+++ b/packages/synapse-interface/components/StateManagedBridge/BridgeTransactionButton.tsx
@@ -60,11 +60,6 @@ export const BridgeTransactionButton = ({
 
   let buttonProperties
 
-  // const fromValueBigInt = stringToBigInt(
-  //   fromValue,
-  //   fromToken.decimals[fromChainId]
-  // )
-
   const fromTokenDecimals: number | undefined = fromToken.decimals[fromChainId]
 
   const fromValueBigInt = useMemo(() => {

--- a/packages/synapse-interface/components/StateManagedBridge/InputContainer.tsx
+++ b/packages/synapse-interface/components/StateManagedBridge/InputContainer.tsx
@@ -59,6 +59,7 @@ export const InputContainer = () => {
 
   useEffect(() => {
     if (
+      fromToken.decimals[fromChainId] &&
       stringToBigInt(fromValue, fromToken.decimals[fromChainId]) !== 0n &&
       stringToBigInt(fromValue, fromToken.decimals[fromChainId]) ===
         fromTokenBalance

--- a/packages/synapse-interface/pages/state-managed-bridge/index.tsx
+++ b/packages/synapse-interface/pages/state-managed-bridge/index.tsx
@@ -210,7 +210,10 @@ const StateManagedBridge = () => {
     console.log(`[useEffect] fromToken`, fromToken.symbol)
     console.log(`[useEffect] toToken`, toToken.symbol)
     // TODO: Double serialization happening somewhere??
-    if (stringToBigInt(fromValue, fromToken.decimals[fromChainId]) > 0n) {
+    if (
+      fromToken.decimals[fromChainId] &&
+      stringToBigInt(fromValue, fromToken.decimals[fromChainId]) > 0n
+    ) {
       console.log('trying to set bridge quote')
       getAndSetBridgeQuote()
     } else {


### PR DESCRIPTION
Fix for fromTokenDecimals error thrown from being `undefined` as a result of token not existing on switched `fromChain`
