### PR TITLE
fix/next-title

### DIFF
--- a/packages/synapse-interface/pages/_app.tsx
+++ b/packages/synapse-interface/pages/_app.tsx
@@ -1,6 +1,7 @@
 import '@styles/global.css'
 import '@rainbow-me/rainbowkit/styles.css'
 import type { AppProps } from 'next/app'
+import Head from 'next/head'
 import '@/patch'
 
 import {
@@ -30,7 +31,7 @@ import {
   RainbowKitProvider,
   darkTheme,
   getDefaultWallets,
-  connectorsForWallets
+  connectorsForWallets,
 } from '@rainbow-me/rainbowkit'
 import { JsonRpcProvider } from '@ethersproject/providers'
 import { jsonRpcProvider } from 'wagmi/providers/jsonRpc'
@@ -76,13 +77,16 @@ for (const chain of rawChains) {
   })
 }
 
-const { chains, publicClient, webSocketPublicClient } = configureChains(chainsMatured, [
-  jsonRpcProvider({
-    rpc: (chain) => ({
-      http: chain['configRpc'],
+const { chains, publicClient, webSocketPublicClient } = configureChains(
+  chainsMatured,
+  [
+    jsonRpcProvider({
+      rpc: (chain) => ({
+        http: chain['configRpc'],
+      }),
     }),
-  }),
-])
+  ]
+)
 
 const projectId = 'ab0a846bc693996606734d788cb6561d'
 
@@ -92,29 +96,32 @@ const { wallets } = getDefaultWallets({
   chains,
 })
 
-const connectors = connectorsForWallets([
-  ...wallets,
-]);
+const connectors = connectorsForWallets([...wallets])
 
 export const wagmiConfig = createConfig({
   autoConnect: true,
   connectors,
   publicClient,
-  webSocketPublicClient
+  webSocketPublicClient,
 })
 
 const App = ({ Component, pageProps }: AppProps) => {
   return (
-    <WagmiConfig config={wagmiConfig}>
-      <RainbowKitProvider chains={chains} theme={darkTheme()}>
-        <SynapseProvider chains={chains}>
-          <Provider store={store}>
-            <Component {...pageProps} />
-            <CustomToaster />
-          </Provider>
-        </SynapseProvider>
-      </RainbowKitProvider>
-    </WagmiConfig>
+    <>
+      <Head>
+        <title>Synapse Protocol</title>
+      </Head>
+      <WagmiConfig config={wagmiConfig}>
+        <RainbowKitProvider chains={chains} theme={darkTheme()}>
+          <SynapseProvider chains={chains}>
+            <Provider store={store}>
+              <Component {...pageProps} />
+              <CustomToaster />
+            </Provider>
+          </SynapseProvider>
+        </RainbowKitProvider>
+      </WagmiConfig>
+    </>
   )
 }
 

--- a/packages/synapse-interface/pages/_document.tsx
+++ b/packages/synapse-interface/pages/_document.tsx
@@ -3,9 +3,7 @@ import { Head, Html, Main, NextScript } from 'next/document'
 const Document = () => {
   return (
     <Html lang="en">
-      <Head>
-        <title>Synapse Protocol</title>
-      </Head>
+      <Head />
       <body>
         <Main />
         <NextScript />


### PR DESCRIPTION
Fix for following error: 

Warning: <title> should not be used in _document.js's <Head>. https://nextjs.org/docs/messages/no-document-title

Moving <title> in `_app.tsx` to follow next rules
5490c0beca0967a041f3bdf678a69319ae80a6df: [synapse-interface preview link ](https://sanguine-synapse-interface-86gycnxk7-synapsecns.vercel.app)