### PR TITLE
use resty by default

### DIFF
--- a/services/omnirpc/http/client.go
+++ b/services/omnirpc/http/client.go
@@ -68,7 +68,7 @@ func NewClient(clientType ClientType) Client {
 	case Resty:
 		return NewRestyClient()
 	default:
-		return NewFastHTTPClient()
+		return NewRestyClient()
 	}
 }
 


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**

FastHTTP was causing issues with multiple providers that had tepid support for multiplexing. This changes resty to be the default option