### PR TITLE
Feat/rest api upgrade

### DIFF
--- a/packages/rest-api/README.md
+++ b/packages/rest-api/README.md
@@ -1,3 +1,81 @@
 # Swap/Bridge REST API Quoter
 
-run with `npx tsx app.ts`
+To run locally:
+\`npm start\`
+
+To make requests, use https://synapse-rest-api-v2.herokuapp.com/
+
+The Synapse Rest API supports four main functions
+
+## /swap
+
+which returns the following
+
+- \`routerAddress\` (string) - The address of the router contract
+- \`maxAmountOut\` (object) - The maximum amount of tokens that can be swapped out. Contains:
+  - \`type\` (string) - The data type
+  - \`hex\` (string) - The amount encoded in hexidecimal
+- \`query\` (object) - Parameters for the swap query:
+  - \`0\` (string) - Router contract address
+  - \`1\` (string) - Address of tokenIn
+  - \`2\` (object) - Amount of tokenIn to swap (same structure as maxAmountOut)
+  - \`3\` (object) - Minimum amount of tokenOut requested (same structure as maxAmountOut)
+  - \`4\` (string) - Encoded params for swap routing
+  - \`swapAdapter\` (string) - Address of the swap adapter contract
+  - \`tokenOut\` (string) - Address of tokenOut
+  - \`minAmountOut\` (object) - Minimum amount of tokenOut required (same structure as maxAmountOut)
+  - \`deadline\` (object) - Deadline parameter for the swap (same structure as maxAmountOut)
+  - \`rawParams\` (string) - Encoded hex string containing swap parameters
+- \`maxAmountOutStr\` (string) - The maxAmountOut value formatted as a decimal string
+
+All \`/swap\` requests should be formatted like such:
+
+\`/swap?chain=1&fromToken=USDC&toToken=DAI&amount=100\`
+
+## /bridge
+
+which returns all transaction information
+
+- \`feeAmount\` (object) - The fee amount for the swap. Contains:
+  - \`type\` (string) - Data type
+  - \`hex\` (string) - Fee amount encoded in hex
+- \`feeConfig\` (array) - Fee configuration parameters, contains:
+  - \`0\` (number) - Gas price
+  - \`1\` (object) - Fee percentage denominator (hex encoded BigNumber)
+  - \`2\` (object) - Protocol fee percentage numerator (hex encoded BigNumber)
+- \`routerAddress\` (string) - Address of the router contract
+- \`maxAmountOut\` (object) - Maximum amount receivable from swap, structure same as above
+- \`originQuery\` (object) - Original swap query parameters, contains:
+  - \`swapAdapter\` (string) - Swap adapter address
+  - \`tokenOut\` (string) - Address of output token
+  - \`minAmountOut\` (object) - Minimum output token amount
+  - \`deadline\` (object) - Expiry time
+  - \`rawParams\` (string) - Encoded hex params
+- \`destQuery\` (object) - Destination swap query parameters, structure similar to originQuery above.
+- \`maxAmountOutStr\` (string) - maxAmountOut as a decimal string.
+
+All \`/bridge\` requests should be formatted like such:
+
+\`/bridge?fromChain=1&toChain=42161&fromToken=USDC&toToken=USDC&amount=1000000\`
+
+## /swapTxInfo
+
+which returns the following
+
+- \`'data'\`: The binary data that forms the input to the transaction.
+- \`'to'\`: The address of the Synapse Router (the synapse bridge contract)
+
+All \`/swapTxInfo\` requests should be formatted like such:
+
+\`/swap?chain=1&fromToken=USDC&toToken=DAI&amount=100\`
+
+## /bridgeTxInfo
+
+which returns the following
+
+- \`'data'\`: The binary data that forms the input to the transaction.
+- \`'to'\`: The address of the Synapse Router (the synapse bridge contract)
+
+All \`/bridgeTxInfo\` requests should be formatted like such:
+
+\`/bridgeTxInfo?fromChain=1&toChain=42161&fromToken=USDC&toToken=USDC&amount=1000000&destAddress=0xcc78d2f004c9de9694ff6a9bbdee4793d30f3842\`

--- a/packages/rest-api/app.ts
+++ b/packages/rest-api/app.ts
@@ -2,12 +2,37 @@ import { JsonRpcProvider } from '@ethersproject/providers'
 import { SynapseSDK } from '@synapsecns/sdk-router'
 import { BigNumber } from '@ethersproject/bignumber'
 import { formatUnits } from '@ethersproject/units'
-import express from 'express'
+import * as express from 'express'
+// import express from 'express'
 
-import chains from './config/chains.json'
-import tokens from './config/tokens.json'
+import * as chainsData from './config/chains.json'
+import * as tokensData from './config/tokens.json'
+
+// import chains from './config/chains.json'
+// import tokens from './config/tokens.json'
 // To run locally you may need to add the "node --experimental-json-modules app.js" flag for the following jsons to be read
 
+interface Tokens {
+  [key: string]: {
+    addresses: {
+      [key: string]: string
+    }
+    decimals: {
+      [key: string]: number
+    }
+    description: string
+  }
+}
+
+const tokens: Tokens = tokensData as any
+
+interface Chains {
+  id: number
+  name: string
+  rpc: string
+}
+
+const chains: Chains[] = chainsData as any
 // Constants
 const TEN = BigNumber.from(10)
 const tokenHtml = Object.keys(tokens)
@@ -80,12 +105,14 @@ app.get('/swap', async (req, res) => {
   const toTokenSymbol = String(query.toToken)
 
   // Get Token Addresses
-  const fromTokenAddress = tokens[fromTokenSymbol]?.addresses?.[chainId]
-  const toTokenAddress = tokens[toTokenSymbol]?.addresses?.[chainId]
+  const fromTokenAddress =
+    tokens[fromTokenSymbol]?.addresses?.[chainId as string]
+  const toTokenAddress = tokens[toTokenSymbol]?.addresses?.[chainId as string]
 
   // Get Token Decimals
-  const fromTokenDecimals = tokens[fromTokenSymbol]?.decimals?.[chainId]
-  const toTokenDecimals = tokens[toTokenSymbol]?.decimals?.[chainId]
+  const fromTokenDecimals =
+    tokens[fromTokenSymbol]?.decimals?.[chainId as string]
+  const toTokenDecimals = tokens[toTokenSymbol]?.decimals?.[chainId as string]
 
   // Handle invalid params (either token symbols or chainIDs)
   // TODO: add error handling for missing params
@@ -157,12 +184,14 @@ app.get('/bridge', async (req, res) => {
   const toTokenSymbol = String(query.toToken)
 
   // Get Token Addresses
-  const fromTokenAddress = tokens[fromTokenSymbol]?.addresses?.[fromChain]
-  const toTokenAddress = tokens[toTokenSymbol]?.addresses?.[toChain]
+  const fromTokenAddress =
+    tokens[fromTokenSymbol]?.addresses?.[fromChain as string]
+  const toTokenAddress = tokens[toTokenSymbol]?.addresses?.[toChain as string]
 
   // Get Token Decimals
-  const fromTokenDecimals = tokens[fromTokenSymbol]?.decimals?.[fromChain]
-  const toTokenDecimals = tokens[toTokenSymbol]?.decimals?.[toChain]
+  const fromTokenDecimals =
+    tokens[fromTokenSymbol]?.decimals?.[fromChain as string]
+  const toTokenDecimals = tokens[toTokenSymbol]?.decimals?.[toChain as string]
 
   // Handle invalid params (either token symbols or chainIDs)
   // TODO: add error handling for missing params

--- a/packages/rest-api/app.ts
+++ b/packages/rest-api/app.ts
@@ -163,7 +163,7 @@ app.get('/swap', async (req, res) => {
       <h1>Invalid Request</h1>
       <code>${err}</code>
       <hr/>
-      <b>Ensure that your request matches the following format: /swap?chain=1&fromToken=UƒSDC&toToken=DAI&amount=100</b>
+      <b>Ensure that your request matches the following format: /swap?chain=1&fromToken=USDC&toToken=DAI&amount=100</b>
       <h2>Available Tokens (symbols to use)</h2>
       ${tokenHtml}`
       )
@@ -249,6 +249,169 @@ app.get('/bridge', async (req, res) => {
     })
 })
 
+// Beginning of txInfo functions --> These return the txInfo to actually bridge
+app.get('/swapTxInfo', async (req, res) => {
+  // Access query params
+  const query = req.query
+
+  // Chain
+  const chainId = query.chain
+
+  // Symbols
+  const fromTokenSymbol = String(query.fromToken)
+  const toTokenSymbol = String(query.toToken)
+
+  // Get Token Addresses
+  const fromTokenAddress =
+    tokens[fromTokenSymbol]?.addresses?.[chainId as string]
+  const toTokenAddress = tokens[toTokenSymbol]?.addresses?.[chainId as string]
+
+  // Get Token Decimals
+  const fromTokenDecimals =
+    tokens[fromTokenSymbol]?.decimals?.[chainId as string]
+  const toTokenDecimals = tokens[toTokenSymbol]?.decimals?.[chainId as string]
+
+  // Handle invalid params (either token symbols or chainIDs)
+  // TODO: add error handling for missing params
+  if (
+    !fromTokenAddress ||
+    !toTokenAddress ||
+    !fromTokenDecimals ||
+    !toTokenDecimals
+  ) {
+    res.send(
+      `
+      <h1>Invalid Params</h1>
+      <hr/>
+      <b>Ensure that your request matches the following format: /swap?chain=1&fromToken=USDC&toToken=DAI&amount=100</b>
+      <h2>Available Tokens (symbols to use)</h2>
+      ${tokenHtml}`
+    )
+    return
+  }
+
+  // Handle amount
+  const amount = BigNumber.from(query.amount).mul(TEN.pow(fromTokenDecimals))
+
+  // Send request w/Synapse SDK
+  Synapse.swapQuote(
+    Number(chainId),
+    fromTokenAddress,
+    toTokenAddress,
+    BigNumber.from(amount)
+  )
+    .then((resp) => {
+      Synapse.swap(
+        Number(chainId),
+        fromTokenAddress,
+        toTokenAddress,
+        BigNumber.from(amount),
+        resp.query
+      ).then((txInfo) => {
+        res.json(txInfo)
+      })
+    })
+    .catch((err) => {
+      // TODO: do a better return here
+      res.send(
+        `
+      <h1>Invalid Request</h1>
+      <code>${err}</code>
+      <hr/>
+      <b>Ensure that your request matches the following format: /swapTxInfo?chain=1&fromToken=USDC&toToken=DAI&amount=100</b>
+      <h2>Available Tokens (symbols to use)</h2>
+      ${tokenHtml}`
+      )
+    })
+})
+
+//BridgeTxInfo
+app.get('/bridgeTxInfo', async (req, res) => {
+  // Access query params
+  const query = req.query
+
+  // Chains
+  const fromChain = query.fromChain
+  const toChain = query.toChain
+
+  // Symbols
+  const fromTokenSymbol = String(query.fromToken)
+  const toTokenSymbol = String(query.toToken)
+
+  // Get Token Addresses
+  const fromTokenAddress =
+    tokens[fromTokenSymbol]?.addresses?.[fromChain as string]
+  const toTokenAddress = tokens[toTokenSymbol]?.addresses?.[toChain as string]
+
+  // Get Token Decimals
+  const fromTokenDecimals =
+    tokens[fromTokenSymbol]?.decimals?.[fromChain as string]
+  const toTokenDecimals = tokens[toTokenSymbol]?.decimals?.[toChain as string]
+
+  //Get to Address on destination chain
+  const destAddress = String(query.destAddress)
+
+  //Router Address:
+  const routerAddress = '0x7e7a0e201fd38d3adaa9523da6c109a07118c96a'
+
+  // Handle invalid params (either token symbols or chainIDs)
+  // TODO: add error handling for missing params
+  if (
+    !fromTokenAddress ||
+    !toTokenAddress ||
+    !fromTokenDecimals ||
+    !toTokenDecimals
+  ) {
+    res.send(
+      `
+        <h1>Invalid Request</h1>
+        <hr/>
+        <b>Ensure that your request matches the following format: /bridgeTxInfo?fromChain=1&toChain=42161&fromToken=USDC&toToken=USDC&amount=1000000&destAddress=0xcc78d2f004c9de9694ff6a9bbdee4793d30f3842</b>
+        <h2>Available Tokens (symbols to use)</h2>
+        ${tokenHtml}`
+    )
+    return
+  }
+
+  // Handle amount
+  const amount = BigNumber.from(query.amount).mul(TEN.pow(fromTokenDecimals))
+
+  // Send request w/Synapse SDK
+  Synapse.bridgeQuote(
+    Number(fromChain),
+    Number(toChain),
+    fromTokenAddress,
+    toTokenAddress,
+    BigNumber.from(amount)
+  )
+    .then((resp) => {
+      Synapse.bridge(
+        destAddress,
+        routerAddress,
+        Number(fromChain),
+        Number(toChain),
+        fromTokenAddress,
+        BigNumber.from(amount),
+        resp.originQuery,
+        resp.destQuery
+      ).then((txInfo) => {
+        res.json(txInfo)
+      })
+    })
+    .catch((err) => {
+      // TODO: do a better return here
+      res.send(
+        `
+        <h1>Invalid Request</h1>
+        <code>${err}</code>
+        <hr/>
+        <b>Ensure that your request matches the following format: /bridgeTxInfo?fromChain=1&toChain=42161&fromToken=USDC&toToken=USDC&amount=1000000&destAddress=0xcc78d2f004c9de9694ff6a9bbdee4793d30f3842</b>
+        <h2>Available Tokens (symbols to use)</h2>
+        ${tokenHtml}`
+      )
+    })
+})
+
 export const server = app.listen(port, () => {
   console.log(`Server listening at ${port}`)
 })
@@ -272,144 +435,3 @@ const formatBNToString = (
     return rawNumber.toString()
   }
 }
-
-// TODO @Defi-Moses, need to add these endpoints
-
-// //Swap Transaction Get
-// app.get('/swap', async (req, res) => {
-//   // Access query params
-//   const query = req.query
-
-//   // Chain
-//   const chainId = query.chain
-
-//   // Symbols
-//   const fromTokenSymbol = String(query.fromToken)
-//   const toTokenSymbol = String(query.toToken)
-
-//   // Get Token Addresses
-//   const fromTokenAddress = tokens[fromTokenSymbol]?.addresses?.[chainId]
-//   const toTokenAddress = tokens[toTokenSymbol]?.addresses?.[chainId]
-
-//   // Get Token Decimals
-//   const fromTokenDecimals = tokens[fromTokenSymbol]?.decimals?.[chainId]
-//   const toTokenDecimals = tokens[toTokenSymbol]?.decimals?.[chainId]
-
-//   // Handle invalid params (either token symbols or chainIDs)
-//   // TODO: add error handling for missing params
-//   if (!fromTokenAddress || !toTokenAddress || !fromTokenDecimals || !toTokenDecimals) {
-//     res.send(
-//       `
-//       <h1>Invalid Params</h1>
-//       <hr/>
-//       <b>Ensure that your request matches the following format: /swap?chain=1&fromToken=USDC&toToken=DAI&amount=100</b>
-//       <h2>Available Tokens (symbols to use)</h2>
-//       ${tokenHtml}`)
-//     return
-//   }
-
-//   // Handle amount
-//   const amount = BigNumber.from(query.amount).mul(TEN.pow(fromTokenDecimals))
-
-//   // Send request w/Synapse SDK
-//   Synapse.swap(
-//     Number(chainId),
-//     fromTokenAddress,
-//     toTokenAddress,
-//     BigNumber.from(amount)
-//   ).then((resp) => {
-//     Synapse.swap(
-//       Number(chainId),
-//       fromTokenAddress, //these are wrong
-//       toTokenAddress, // also wrong
-//       BigNumber.from(amount),
-//       resp.query
-//     ).then((txInfo) => {
-//       res.json(txInfo)
-//     })
-//   }).catch((err) => {
-//     // TODO: do a better return here
-//     res.send(
-//       `
-//       <h1>Invalid Request</h1>
-//       <code>${err}</code>
-//       <hr/>
-//       <b>Ensure that your request matches the following format: /swap?chain=1&fromToken=UƒSDC&toToken=DAI&amount=100</b>
-//       <h2>Available Tokens (symbols to use)</h2>
-//       ${tokenHtml}`)
-//   })
-// })
-
-// //Bridge Transaction Get
-// app.get(
-//   '/bridgeQuote',
-//   async (req, res) => {
-//     // Access query params
-//     const query = req.query
-
-//     // Chains
-//     const fromChain = query.fromChain
-//     const toChain = query.toChain
-
-//     // Symbols
-//     const fromTokenSymbol = String(query.fromToken)
-//     const toTokenSymbol = String(query.toToken)
-
-//     // Get Token Addresses
-//     const fromTokenAddress = tokens[fromTokenSymbol]?.addresses?.[fromChain]
-//     const toTokenAddress = tokens[toTokenSymbol]?.addresses?.[toChain]
-
-//     // Get Token Decimals
-//     const fromTokenDecimals = tokens[fromTokenSymbol]?.decimals?.[fromChain]
-//     const toTokenDecimals = tokens[toTokenSymbol]?.decimals?.[toChain]
-
-//     const destAddress = query.destAddress
-
-//     // Handle invalid params (either token symbols or chainIDs)
-//     // TODO: add error handling for missing params
-//     if (!fromTokenAddress || !toTokenAddress || !fromTokenDecimals || !toTokenDecimals) {
-//       res.send(
-//         `
-//         <h1>Invalid Request</h1>
-//         <hr/>
-//         <b>Ensure that your request matches the following format: /bridge?fromChain=1&toChain=42161&fromToken=USDC&toToken=USDC&amount=1000000&destAddress=0x0AF91FA049A7e1894F480bFE5bBa20142C6c29a9</b>
-//         <h2>Available Tokens (symbols to use)</h2>
-//         ${tokenHtml}`)
-//       return
-//     }
-
-//     // Handle amount
-//     const amount = BigNumber.from(query.amount).mul(TEN.pow(fromTokenDecimals))
-
-//     // Send request w/Synapse SDK
-//     Synapse.bridge(
-//       Number(fromChain),
-//       Number(toChain),
-//       fromTokenAddress,
-//       toTokenAddress,
-//       BigNumber.from(amount)
-//     ).then((resp) => {
-//       Synapse.bridgeQuote(
-//         destAddress, // Need to edit
-//         Number(fromChain),
-//         Number(toChain),
-//         toTokenAddress,
-//         BigNumber.from(amount),
-//         resp.originQuery,
-//         resp.destQuery
-//       ).then((txInfo) => {
-//         res.json(txInfo)
-//       })
-//     }).catch((err) => {
-//       // TODO: do a better return here
-//       res.send(
-//         `
-//         <h1>Invalid Request</h1>
-//         <code>${err}</code>
-//         <hr/>
-//         <b>Ensure that your request matches the following format: /bridge?fromChain=1&toChain=42161&fromToken=USDC&toToken=USDC&amount=1000000</b>
-//         <h2>Available Tokens (symbols to use)</h2>
-//         ${tokenHtml}`)
-//     })
-//   }
-// )

--- a/packages/rest-api/package.json
+++ b/packages/rest-api/package.json
@@ -14,7 +14,7 @@
     "ci:lint": "npm run lint:check",
     "build:go": " ",
     "build:slither": " ",
-    "build": "tsc app.ts",
+    "build": "tsc app.ts --resolveJsonModule --skipLibCheck",
     "postinstall": "npm run build"
   },
   "dependencies": {

--- a/packages/rest-api/package.json
+++ b/packages/rest-api/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "test": "tsdx test",
-    "start": " node app.js",
+    "start": "npx tsx app.ts",
     "test:coverage": "echo 'No tests defined.'",
     "lint:fix": "npm run lint -- --fix",
     "lint:check": "eslint . --max-warnings=0",

--- a/packages/rest-api/package.json
+++ b/packages/rest-api/package.json
@@ -13,7 +13,9 @@
     "lint:check": "eslint . --max-warnings=0",
     "ci:lint": "npm run lint:check",
     "build:go": " ",
-    "build:slither": " "
+    "build:slither": " ",
+    "build": "tsc",
+    "postinstall": "npm run build"
   },
   "dependencies": {
     "@ethersproject/bignumber": "^5.7.0",

--- a/packages/rest-api/package.json
+++ b/packages/rest-api/package.json
@@ -7,14 +7,14 @@
   },
   "scripts": {
     "test": "tsdx test",
-    "start": "npx tsx app.ts",
+    "start": "node app.js",
     "test:coverage": "echo 'No tests defined.'",
     "lint:fix": "npm run lint -- --fix",
     "lint:check": "eslint . --max-warnings=0",
     "ci:lint": "npm run lint:check",
     "build:go": " ",
     "build:slither": " ",
-    "build": "tsc",
+    "build": "tsc app.ts",
     "postinstall": "npm run build"
   },
   "dependencies": {
@@ -27,5 +27,8 @@
     "express": "^4.18.2",
     "supertest": "^6.3.3"
   },
-  "description": "A node.js project exposing a rest api for synapse sdk quotes"
+  "description": "A node.js project exposing a rest api for synapse sdk quotes",
+  "devDependencies": {
+    "typescript": "^5.1.6"
+  }
 }

--- a/packages/rest-api/tsconfig.json
+++ b/packages/rest-api/tsconfig.json
@@ -1,20 +1,32 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
     "forceConsistentCasingInFileNames": true,
-    "noEmit": true,
+    "noEmit": false,
     "esModuleInterop": true,
-    "module": "esnext",
+    "allowSyntheticDefaultImports": true,
+    "module": "CommonJS",
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "incremental": true,
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "rootDir": ""
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/packages/rest-api/tsconfig.json
+++ b/packages/rest-api/tsconfig.json
@@ -25,6 +25,7 @@
     "next-env.d.ts",
     "**/*.ts",
     "**/*.tsx",
+    "../app.ts",
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**
This upgrade reconfigures dependencies so that it is compatible with heroku deployment, adds two new functions that allow users to generate the raw transaction data in python (so they can acutually bridge once connected to Web3), and updates the ReadMe. 

**Additional context**
Ideally @nautsimon @dwasse can review the two new functions (very slight changes) to confirm that the output transaction data is correct. This also probably needs more robust testing
**Metadata**
- Fixes #[Link to Issue]
