### PR TITLE
Fix/synapse UI mobile quotes

### DIFF
--- a/packages/synapse-interface/components/StateManagedBridge/InputContainer.tsx
+++ b/packages/synapse-interface/components/StateManagedBridge/InputContainer.tsx
@@ -1,15 +1,16 @@
 import React, { useEffect, useState, useRef } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useAccount } from 'wagmi'
-import { RootState } from '@/store/store'
 
-import { updateFromValue } from '@/slices/bridgeSlice'
-import { setShowFromTokenSlideOver } from '@/slices/bridgeDisplaySlice'
-import SelectTokenDropdown from '@/components/input/TokenAmountInput/SelectTokenDropdown'
-import MiniMaxButton from '../buttons/MiniMaxButton'
 import { formatBigIntToString, stringToBigInt } from '@/utils/bigint/format'
-import { OriginChainLabel } from './OriginChainLabel'
+import SelectTokenDropdown from '@/components/input/TokenAmountInput/SelectTokenDropdown'
+import { OriginChainLabel } from '@/components/StateManagedBridge/OriginChainLabel'
+import MiniMaxButton from '@/components/buttons/MiniMaxButton'
+import { RootState } from '@/store/store'
+import { setShowFromTokenSlideOver } from '@/slices/bridgeDisplaySlice'
+import { updateFromValue } from '@/slices/bridgeSlice'
 import { cleanNumberInput } from '@/utils/cleanNumberInput'
+import { CHAINS_BY_ID } from '@/constants/chains'
 
 export const inputRef = React.createRef<HTMLInputElement>()
 
@@ -23,9 +24,9 @@ export const InputContainer = () => {
     bridgeTxHashes,
   } = useSelector((state: RootState) => state.bridge)
   const [showValue, setShowValue] = useState('')
-
   const [hasMounted, setHasMounted] = useState(false)
   const previousBridgeTxHashesRef = useRef<string[]>([])
+  // const currentChainName = CHAINS_BY_ID[fromChainId]?.name
 
   useEffect(() => {
     setHasMounted(true)
@@ -116,7 +117,10 @@ export const InputContainer = () => {
           />
         </div>
       </div>
-      <div data-test-id="origin-input" className="flex h-16 mb-4 space-x-2">
+      <div className="flex pb-1 ml-3 text-xs text-white md:hidden">
+        Origin: {CHAINS_BY_ID[fromChainId]?.name}
+      </div>
+      <div data-test-id="origin-input" className="flex mb-4 space-x-2">
         <div
           className={`
             flex flex-grow items-center

--- a/packages/synapse-interface/components/StateManagedBridge/InputContainer.tsx
+++ b/packages/synapse-interface/components/StateManagedBridge/InputContainer.tsx
@@ -116,7 +116,7 @@ export const InputContainer = () => {
           />
         </div>
       </div>
-      <div className="flex h-16 mb-4 space-x-2">
+      <div data-test-id="origin-input" className="flex h-16 mb-4 space-x-2">
         <div
           className={`
             flex flex-grow items-center

--- a/packages/synapse-interface/components/StateManagedBridge/OutputContainer.tsx
+++ b/packages/synapse-interface/components/StateManagedBridge/OutputContainer.tsx
@@ -49,7 +49,7 @@ export const OutputContainer = ({}) => {
         </div>
       </div>
       <div className="flex pb-1 ml-3 text-xs text-white md:hidden">
-        Destination: {CHAINS_BY_ID[fromChainId]?.name}
+        Destination: {CHAINS_BY_ID[toChainId]?.name}
       </div>
       <div
         data-test-id="destination-output"

--- a/packages/synapse-interface/components/StateManagedBridge/OutputContainer.tsx
+++ b/packages/synapse-interface/components/StateManagedBridge/OutputContainer.tsx
@@ -8,6 +8,7 @@ import LoadingSpinner from '../ui/tailwind/LoadingSpinner'
 import { DestinationChainLabel } from './DestinationChainLabel'
 import SwitchButton from '../buttons/SwitchButton'
 import { setFromChainId, setToChainId } from '@/slices/bridgeSlice'
+import { CHAINS_BY_ID } from '@/constants/chains'
 
 export const OutputContainer = ({}) => {
   const dispatch = useDispatch()
@@ -47,7 +48,13 @@ export const OutputContainer = ({}) => {
           />
         </div>
       </div>
-      <div className="flex h-16 mb-4 space-x-2">
+      <div className="flex pb-1 ml-3 text-xs text-white md:hidden">
+        Destination: {CHAINS_BY_ID[fromChainId]?.name}
+      </div>
+      <div
+        data-test-id="destination-output"
+        className="flex h-16 mb-4 space-x-2"
+      >
         <div
           className={`
             flex flex-grow items-center

--- a/packages/synapse-interface/pages/state-managed-bridge/index.tsx
+++ b/packages/synapse-interface/pages/state-managed-bridge/index.tsx
@@ -540,7 +540,7 @@ const StateManagedBridge = () => {
                 bg-bgBase
               `}
         >
-          <div ref={bridgeDisplayRef}>
+          <div data-test-id="bridge-display" ref={bridgeDisplayRef}>
             <Transition show={showFromTokenSlideOver} {...TRANSITION_PROPS}>
               <animated.div className={springClass}>
                 <TokenSlideOver


### PR DESCRIPTION
Addressing issue where Users are seeing differing quotes between Desktop / Mobile. 

Looked into the issue and reached the following conclusions:
- Bridge quotes will be the same on Mobile or Desktop, if Origin/Destination chain + token are the same (code confirms this)
- Users are likely to be confused by what the current origin/destination chain is on mobile devices (we are hiding the selected chain names on mobile devices) 

To solve for this, PR adds small text above Origin Input / Destination Output for what the Origin network / Destination network currently is
84e6465248bffc5d4b90a5d80fcd6c67fd3c504c: [synapse-interface preview link ](https://sanguine-synapse-interface-gpptsg8fe-synapsecns.vercel.app)