### PR TITLE
Explorer Bridgewatcher

### DIFF
--- a/services/explorer/graphql/client/queries/queries.graphql
+++ b/services/explorer/graphql/client/queries/queries.graphql
@@ -261,3 +261,56 @@ query GetLeaderboard($duration: Duration, $chainID: Int, $useMv: Boolean, $page:
     avgVolumeUSD
   }
 }
+
+
+query GetOriginBridgeTx($chainID: Int, $txnHash: String) {
+  response: getOriginBridgeTx(
+    chainID: $chainID
+    txnHash: $txnHash
+  ) {
+    bridgeTx {
+      chainID
+      destinationChainID
+      address
+      txnHash
+      value
+      formattedValue
+      USDValue
+      tokenAddress
+      tokenSymbol
+      blockNumber
+      time
+      formattedTime
+    }
+    pending
+    type
+    kappa
+  }
+}
+query GetDestinationBridgeTx($chainID: Int, $kappa: String, $address: String, $timestamp: Int) {
+  response: getDestinationBridgeTx(
+    chainID: $chainID
+    address: $address
+    kappa: $kappa
+    timestamp: $timestamp
+
+  ) {
+    bridgeTx {
+      chainID
+      destinationChainID
+      address
+      txnHash
+      value
+      formattedValue
+      USDValue
+      tokenAddress
+      tokenSymbol
+      blockNumber
+      time
+      formattedTime
+    }
+    pending
+    type
+    kappa
+  }
+}

--- a/services/explorer/graphql/server/graph/model/models_gen.go
+++ b/services/explorer/graphql/server/graph/model/models_gen.go
@@ -53,6 +53,14 @@ type BridgeTransaction struct {
 	SwapSuccess *bool        `json:"swapSuccess"`
 }
 
+// BridgeWatcherTx represents a single sided bridge transaction specifically for the bridge watcher.
+type BridgeWatcherTx struct {
+	BridgeTx *PartialInfo  `json:"bridgeTx"`
+	Pending  *bool         `json:"pending"`
+	Type     *BridgeTxType `json:"type"`
+	Kappa    *string       `json:"kappa"`
+}
+
 // DateResult is a given statistic for a given date.
 type DateResult struct {
 	Date  *string  `json:"date"`
@@ -186,6 +194,47 @@ type ValueResult struct {
 type VolumeByChainID struct {
 	ChainID *int     `json:"chainID"`
 	Total   *float64 `json:"total"`
+}
+
+type BridgeTxType string
+
+const (
+	BridgeTxTypeOrigin      BridgeTxType = "ORIGIN"
+	BridgeTxTypeDestination BridgeTxType = "DESTINATION"
+)
+
+var AllBridgeTxType = []BridgeTxType{
+	BridgeTxTypeOrigin,
+	BridgeTxTypeDestination,
+}
+
+func (e BridgeTxType) IsValid() bool {
+	switch e {
+	case BridgeTxTypeOrigin, BridgeTxTypeDestination:
+		return true
+	}
+	return false
+}
+
+func (e BridgeTxType) String() string {
+	return string(e)
+}
+
+func (e *BridgeTxType) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = BridgeTxType(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid BridgeTxType", str)
+	}
+	return nil
+}
+
+func (e BridgeTxType) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 type DailyStatisticType string

--- a/services/explorer/graphql/server/graph/queries.resolvers.go
+++ b/services/explorer/graphql/server/graph/queries.resolvers.go
@@ -395,6 +395,30 @@ func (r *queryResolver) Leaderboard(ctx context.Context, duration *model.Duratio
 	return leaderboardRes, nil
 }
 
+// GetOriginBridgeTx is the resolver for the getOriginBridgeTx field.
+func (r *queryResolver) GetOriginBridgeTx(ctx context.Context, chainID *int, txnHash *string) (*model.BridgeWatcherTx, error) {
+	if chainID == nil || txnHash == nil {
+		return nil, fmt.Errorf("chainID and txnHash must be provided")
+	}
+	results, err := r.GetOriginBridgeTxBW(ctx, *chainID, *txnHash)
+	if err != nil {
+		return nil, fmt.Errorf("could not get message bus transactions %w", err)
+	}
+	return results, nil
+}
+
+// GetDestinationBridgeTx is the resolver for the getDestinationBridgeTx field.
+func (r *queryResolver) GetDestinationBridgeTx(ctx context.Context, chainID *int, address *string, kappa *string, timestamp *int) (*model.BridgeWatcherTx, error) {
+	if chainID == nil || address == nil || kappa == nil || timestamp == nil {
+		return nil, fmt.Errorf("chainID, txnHash, kappa, and timestamp must be provided")
+	}
+	results, err := r.GetDestinationBridgeTxBW(ctx, *chainID, *address, *kappa, *timestamp)
+	if err != nil {
+		return nil, fmt.Errorf("could not get message bus transactions %w", err)
+	}
+	return results, nil
+}
+
 // Query returns resolvers.QueryResolver implementation.
 func (r *Resolver) Query() resolvers.QueryResolver { return &queryResolver{r} }
 

--- a/services/explorer/graphql/server/graph/schema/queries.graphql
+++ b/services/explorer/graphql/server/graph/schema/queries.graphql
@@ -120,6 +120,26 @@ Ranked chainIDs by volume
     page:           Int = 1
   ): [Leaderboard]
 
+
+  """
+  GetOriginBridgeTx is the bridge watcher endpoint for getting an origin bridge tx (BETA).
+  """
+  getOriginBridgeTx(
+    chainID:      Int
+    txnHash:       String
+  ): BridgeWatcherTx
+
+
+  """
+  GetDestinationBridgeTx is the bridge watcher endpoint for getting an destination bridge tx (BETA).
+  """
+  getDestinationBridgeTx(
+    chainID:      Int
+    address:     String
+    kappa:      String
+    timestamp:   Int
+  ): BridgeWatcherTx
+
 }
 
 

--- a/services/explorer/graphql/server/graph/schema/types.graphql
+++ b/services/explorer/graphql/server/graph/schema/types.graphql
@@ -27,6 +27,20 @@ type PartialInfo {
   time:           Int
   formattedTime: String
 }
+
+enum BridgeTxType {
+  ORIGIN
+  DESTINATION
+}
+"""
+BridgeWatcherTx represents a single sided bridge transaction specifically for the bridge watcher.
+"""
+type BridgeWatcherTx {
+  bridgeTx: PartialInfo
+  pending:      Boolean
+  type:  BridgeTxType
+  kappa:        String
+}
 """
 DateResult is a given statistic for a given date.
 """


### PR DESCRIPTION
**Description**
Adding new endpoints to explorer for retrieving origin and destination txs for bridgewatcher to
- reduce rpc load on the fe
- provide more reliability
- build off existing services stack
