### PR TITLE
log txsubmitter exit

### DIFF
--- a/ethergo/submitter/submitter.go
+++ b/ethergo/submitter/submitter.go
@@ -106,6 +106,7 @@ func (t *txSubmitterImpl) Start(ctx context.Context) error {
 			logger.Warn(err)
 		}
 		if shouldExit {
+			logger.Warn("exiting transaction submitter")
 			return nil
 		}
 	}


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**

emit a log when the txsubmitter routine exits
