### PR TITLE
Fix: sdk deadlines

### DIFF
--- a/packages/sdk-router/src/sdk.ts
+++ b/packages/sdk-router/src/sdk.ts
@@ -20,9 +20,8 @@ import {
   SynapseCCTPRouterQuery,
   SynapseRouterQuery,
 } from './utils/types'
+import {TEN_MINUTES, ONE_WEEK, calculateDeadline} from './utils/deadlines'
 import { SynapseCCTPRouter } from './SynapseCCTPRouter'
-const ONE_WEEK_DEADLINE = BigNumber.from(Math.floor(Date.now() / 1000) + 604800) // one week in the future
-const TEN_MIN_DEADLINE = BigNumber.from(Math.floor(Date.now() / 1000) + 600) // ten minutes in the future
 
 type SynapseRouters = {
   [key: number]: SynapseRouter
@@ -311,7 +310,7 @@ class SynapseSDK {
     } else {
       formattedOriginQuery = { ...(originQuery as SynapseRouterQuery) }
     }
-    formattedOriginQuery.deadline = deadline ?? TEN_MIN_DEADLINE
+    formattedOriginQuery.deadline = deadline ?? calculateDeadline(TEN_MINUTES)
 
     let isSwap = false
     if ((destQuery as SynapseCCTPRouterQuery).routerAdapter) {
@@ -320,7 +319,7 @@ class SynapseSDK {
     } else {
       formattedDestQuery = { ...(destQuery as SynapseRouterQuery) }
     }
-    formattedDestQuery.deadline = ONE_WEEK_DEADLINE
+    formattedDestQuery.deadline = calculateDeadline(ONE_WEEK)
 
     let feeAmount!: BigNumber
     let feeConfig!: FeeConfig
@@ -670,7 +669,7 @@ class SynapseSDK {
     }
 
     const query = { ...(rawQuery as SynapseRouterQuery) }
-    query.deadline = deadline ?? TEN_MIN_DEADLINE
+    query.deadline = deadline ?? calculateDeadline(TEN_MINUTES)
     const maxAmountOut = query.minAmountOut
 
     return {

--- a/packages/sdk-router/src/sdk.ts
+++ b/packages/sdk-router/src/sdk.ts
@@ -20,7 +20,7 @@ import {
   SynapseCCTPRouterQuery,
   SynapseRouterQuery,
 } from './utils/types'
-import {TEN_MINUTES, ONE_WEEK, calculateDeadline} from './utils/deadlines'
+import { TEN_MINUTES, ONE_WEEK, calculateDeadline } from './utils/deadlines'
 import { SynapseCCTPRouter } from './SynapseCCTPRouter'
 
 type SynapseRouters = {

--- a/packages/sdk-router/src/utils/deadlines.ts
+++ b/packages/sdk-router/src/utils/deadlines.ts
@@ -1,0 +1,9 @@
+import { BigNumber } from '@ethersproject/bignumber'
+
+// Default periods for deadlines on origin and destination chains respectively, in seconds
+export const TEN_MINUTES = 10 * 60
+export const ONE_WEEK = 7 * 24 * 60 * 60
+
+export const calculateDeadline = (seconds: number) => {
+  return BigNumber.from(Math.floor(Date.now() / 1000) + seconds)
+}


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**
- Fixed issue with static deadlines produced by the SDK.
- Updated SynapseRouter address on Base to match the default `0x7E7..96a` address