### PR TITLE
De-duplicate agent signing logic

### DIFF
--- a/agents/agents/guard/fraud.go
+++ b/agents/agents/guard/fraud.go
@@ -87,7 +87,7 @@ func (g Guard) shouldSubmitStateReport(ctx context.Context, snapshot *types.Frau
 // isStateSlashable checks if a state is slashable, i.e. if the state is valid on the
 // Origin, and if the agent is in a slashable status.
 func (g Guard) isStateSlashable(ctx context.Context, state types.State, agent common.Address) (bool, error) {
-	statePayload, err := types.EncodeState(state)
+	statePayload, err := state.Encode()
 	if err != nil {
 		return false, fmt.Errorf("could not encode state: %w", err)
 	}
@@ -142,7 +142,7 @@ func (g Guard) handleValidAttestation(ctx context.Context, fraudAttestation *typ
 
 	// Verify each state in the snapshot.
 	for stateIndex, state := range snapshot.States() {
-		snapPayload, err := types.EncodeSnapshot(snapshot)
+		snapPayload, err := snapshot.Encode()
 		if err != nil {
 			return fmt.Errorf("could not encode snapshot: %w", err)
 		}

--- a/agents/types/attestation.go
+++ b/agents/types/attestation.go
@@ -74,15 +74,14 @@ func (a attestation) Timestamp() *big.Int {
 	return a.timestamp
 }
 
-//nolint:dupl
 func (a attestation) SignAttestation(ctx context.Context, signer signer.Signer, valid bool) (signer.Signature, []byte, common.Hash, error) {
-	var attestationSalt []byte
+	var attestationSalt string
 	if valid {
-		attestationSalt = []byte("ATTESTATION_VALID_SALT")
+		attestationSalt = AttestationValidSalt
 	} else {
-		attestationSalt = []byte("ATTESTATION_INVALID_SALT")
+		attestationSalt = AttestationInvalidSalt
 	}
-	return SignEncoder(ctx, signer, a, attestationSalt)
+	return signEncoder(ctx, signer, a, attestationSalt)
 }
 
 // GetAttestationDataHash generates the data hash from the agent root and SnapGasHash.

--- a/agents/types/receipt.go
+++ b/agents/types/receipt.go
@@ -99,13 +99,12 @@ func (r receipt) FinalExecutor() common.Address {
 	return r.finalExecutor
 }
 
-//nolint:dupl
 func (r receipt) SignReceipt(ctx context.Context, signer signer.Signer, valid bool) (signer.Signature, []byte, common.Hash, error) {
-	var receiptSalt []byte
+	var receiptSalt string
 	if valid {
-		receiptSalt = []byte("RECEIPT_VALID_SALT")
+		receiptSalt = ReceiptValidSalt
 	} else {
-		receiptSalt = []byte("RECEIPT_INVALID_SALT")
+		receiptSalt = ReceiptInvalidSalt
 	}
-	return SignEncoder(ctx, signer, r, receiptSalt)
+	return signEncoder(ctx, signer, r, receiptSalt)
 }

--- a/agents/types/receipt.go
+++ b/agents/types/receipt.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/synapsecns/sanguine/ethergo/signer/signer"
@@ -22,6 +21,7 @@ const (
 
 // Receipt is the receipt interface.
 type Receipt interface {
+	Encoder
 	// Origin is the origin of the receipt.
 	Origin() uint32
 	// Destination is the destination of the receipt.
@@ -101,22 +101,11 @@ func (r receipt) FinalExecutor() common.Address {
 
 //nolint:dupl
 func (r receipt) SignReceipt(ctx context.Context, signer signer.Signer, valid bool) (signer.Signature, []byte, common.Hash, error) {
-	encodedReceipt, err := EncodeReceipt(r)
-	if err != nil {
-		return nil, nil, common.Hash{}, fmt.Errorf("could not encode receipt: %w", err)
-	}
-
 	var receiptSalt []byte
 	if valid {
 		receiptSalt = []byte("RECEIPT_VALID_SALT")
 	} else {
 		receiptSalt = []byte("RECEIPT_INVALID_SALT")
 	}
-
-	signature, hashedReceipt, err := sign(ctx, signer, encodedReceipt, receiptSalt)
-	if err != nil {
-		return nil, nil, common.Hash{}, fmt.Errorf("could not sign receipt: %w", err)
-	}
-
-	return signature, encodedReceipt, hashedReceipt, nil
+	return SignEncoder(ctx, signer, r, receiptSalt)
 }

--- a/agents/types/salt.go
+++ b/agents/types/salt.go
@@ -1,0 +1,21 @@
+package types
+
+// Note: these salt values are taken from contracts/libs/Constants.sol.
+
+// AttestationValidSalt is the salt for ATTESTATION_VALID_SALT.
+const AttestationValidSalt = "ATTESTATION_VALID_SALT"
+
+// AttestationInvalidSalt is the salt for ATTESTATION_INVALID_SALT.
+const AttestationInvalidSalt = "ATTESTATION_INVALID_SALT"
+
+// ReceiptValidSalt is the salt for RECEIPT_VALID_SALT.
+const ReceiptValidSalt = "RECEIPT_VALID_SALT"
+
+// ReceiptInvalidSalt is the salt for RECEIPT_INVALID_SALT.
+const ReceiptInvalidSalt = "RECEIPT_INVALID_SALT"
+
+// SnapshotValidSalt is the salt for SNAPSHOT_VALID_SALT.
+const SnapshotValidSalt = "SNAPSHOT_VALID_SALT"
+
+// StateInvalidSalt is the salt for STATE_INVALID_SALT.
+const StateInvalidSalt = "STATE_INVALID_SALT"

--- a/agents/types/snapshot.go
+++ b/agents/types/snapshot.go
@@ -74,9 +74,8 @@ func (s snapshot) TreeHeight() uint32 {
 	return uint32(math.Log2(float64(len(s.states) * 2)))
 }
 
-//nolint:dupl
 func (s snapshot) SignSnapshot(ctx context.Context, signer signer.Signer) (signer.Signature, []byte, common.Hash, error) {
-	return SignEncoder(ctx, signer, s, []byte("SNAPSHOT_VALID_SALT"))
+	return signEncoder(ctx, signer, s, SnapshotValidSalt)
 }
 
 var _ Snapshot = &snapshot{}

--- a/agents/types/snapshot.go
+++ b/agents/types/snapshot.go
@@ -12,6 +12,7 @@ import (
 
 // Snapshot is the snapshot interface.
 type Snapshot interface {
+	Encoder
 	// States are the states of the snapshot.
 	States() []State
 
@@ -75,17 +76,7 @@ func (s snapshot) TreeHeight() uint32 {
 
 //nolint:dupl
 func (s snapshot) SignSnapshot(ctx context.Context, signer signer.Signer) (signer.Signature, []byte, common.Hash, error) {
-	encodedSnapshot, err := EncodeSnapshot(s)
-	if err != nil {
-		return nil, nil, common.Hash{}, fmt.Errorf("could not encode snapshot: %w", err)
-	}
-
-	signature, hashedSnapshot, err := sign(ctx, signer, encodedSnapshot, []byte("SNAPSHOT_VALID_SALT"))
-	if err != nil {
-		return nil, nil, common.Hash{}, fmt.Errorf("could not sign snapshot: %w", err)
-	}
-
-	return signature, encodedSnapshot, hashedSnapshot, nil
+	return SignEncoder(ctx, signer, s, []byte("SNAPSHOT_VALID_SALT"))
 }
 
 var _ Snapshot = &snapshot{}

--- a/agents/types/snapshot.go
+++ b/agents/types/snapshot.go
@@ -5,10 +5,7 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/ethereum/go-ethereum/crypto"
-
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/synapsecns/sanguine/core"
 	"github.com/synapsecns/sanguine/core/merkle"
 	"github.com/synapsecns/sanguine/ethergo/signer/signer"
 )
@@ -83,20 +80,11 @@ func (s snapshot) SignSnapshot(ctx context.Context, signer signer.Signer) (signe
 		return nil, nil, common.Hash{}, fmt.Errorf("could not encode snapshot: %w", err)
 	}
 
-	snapshotSalt := crypto.Keccak256Hash([]byte("SNAPSHOT_VALID_SALT"))
-
-	hashedEncodedSnapshot := crypto.Keccak256Hash(encodedSnapshot).Bytes()
-	toSign := append(snapshotSalt.Bytes(), hashedEncodedSnapshot...)
-
-	hashedSnapshot, err := HashRawBytes(toSign)
-	if err != nil {
-		return nil, nil, common.Hash{}, fmt.Errorf("could not hash snapshot: %w", err)
-	}
-
-	signature, err := signer.SignMessage(ctx, core.BytesToSlice(hashedSnapshot), false)
+	signature, hashedSnapshot, err := sign(ctx, signer, encodedSnapshot, []byte("SNAPSHOT_VALID_SALT"))
 	if err != nil {
 		return nil, nil, common.Hash{}, fmt.Errorf("could not sign snapshot: %w", err)
 	}
+
 	return signature, encodedSnapshot, hashedSnapshot, nil
 }
 

--- a/agents/types/state.go
+++ b/agents/types/state.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/synapsecns/sanguine/core"
 	"github.com/synapsecns/sanguine/ethergo/signer/signer"
 )
 
@@ -118,19 +117,9 @@ func (s state) SignState(ctx context.Context, signer signer.Signer) (signer.Sign
 		return nil, nil, common.Hash{}, fmt.Errorf("failed to encode state: %w", err)
 	}
 
-	stateSalt := crypto.Keccak256Hash([]byte("STATE_INVALID_SALT"))
-
-	hashedEncodedState := crypto.Keccak256Hash(encodedState).Bytes()
-	toSign := append(stateSalt.Bytes(), hashedEncodedState...)
-
-	hashedState, err := HashRawBytes(toSign)
+	signature, hashedState, err := sign(ctx, signer, encodedState, []byte("STATE_INVALID_SALT"))
 	if err != nil {
-		return nil, nil, common.Hash{}, fmt.Errorf("failed to hash state: %w", err)
-	}
-
-	signature, err := signer.SignMessage(ctx, core.BytesToSlice(hashedState), false)
-	if err != nil {
-		return nil, nil, common.Hash{}, fmt.Errorf("failed to sign state: %w", err)
+		return nil, nil, common.Hash{}, fmt.Errorf("could not sign state: %w", err)
 	}
 
 	return signature, encodedState, hashedState, nil

--- a/agents/types/state.go
+++ b/agents/types/state.go
@@ -110,9 +110,8 @@ func (s state) SubLeaves() (leftLeaf, rightLeaf [32]byte, err error) {
 	return
 }
 
-//nolint:dupl
 func (s state) SignState(ctx context.Context, signer signer.Signer) (signer.Signature, []byte, common.Hash, error) {
-	return SignEncoder(ctx, signer, s, []byte("STATE_INVALID_SALT"))
+	return signEncoder(ctx, signer, s, StateInvalidSalt)
 }
 
 var _ State = state{}

--- a/agents/types/utils.go
+++ b/agents/types/utils.go
@@ -10,19 +10,26 @@ import (
 	"github.com/synapsecns/sanguine/ethergo/signer/signer"
 )
 
+// SignEncoder encodes a type, and signs it with the given salt.
+func SignEncoder(ctx context.Context, signer signer.Signer, encoder Encoder, salt []byte) (signer.Signature, []byte, common.Hash, error) {
+	// Encode the given type.
+	encoded, err := encoder.Encode()
+	if err != nil {
+		return nil, nil, common.Hash{}, fmt.Errorf("could not encode receipt: %w", err)
+	}
 
-func sign(ctx context.Context, signer signer.Signer, encoded, salt []byte) (signer.Signature, common.Hash, error) {
-	hashedEncodedReceipt := crypto.Keccak256Hash(encoded).Bytes()
-	toSign := append(crypto.Keccak256Hash(salt).Bytes(), hashedEncodedReceipt...)
-
+	// Hash the encoded type, and concatenate with hashed salt.
+	hashedEncoded := crypto.Keccak256Hash(encoded).Bytes()
+	toSign := append(crypto.Keccak256Hash(salt).Bytes(), hashedEncoded...)
 	hashedDigest, err := HashRawBytes(toSign)
 	if err != nil {
-		return nil, common.Hash{}, fmt.Errorf("could not hash receipt: %w", err)
+		return nil, nil, common.Hash{}, fmt.Errorf("could not hash receipt: %w", err)
 	}
 
+	// Sign the message.
 	signature, err := signer.SignMessage(ctx, core.BytesToSlice(hashedDigest), false)
 	if err != nil {
-		return nil, common.Hash{}, fmt.Errorf("could not sign: %w", err)
+		return nil, nil, common.Hash{}, fmt.Errorf("could not sign: %w", err)
 	}
-	return signature, hashedDigest, nil
+	return signature, encoded, hashedDigest, nil
 }

--- a/agents/types/utils.go
+++ b/agents/types/utils.go
@@ -11,7 +11,7 @@ import (
 )
 
 // SignEncoder encodes a type, and signs it with the given salt.
-func SignEncoder(ctx context.Context, signer signer.Signer, encoder Encoder, salt []byte) (signer.Signature, []byte, common.Hash, error) {
+func signEncoder(ctx context.Context, signer signer.Signer, encoder Encoder, salt string) (signer.Signature, []byte, common.Hash, error) {
 	// Encode the given type.
 	encoded, err := encoder.Encode()
 	if err != nil {
@@ -20,7 +20,7 @@ func SignEncoder(ctx context.Context, signer signer.Signer, encoder Encoder, sal
 
 	// Hash the encoded type, and concatenate with hashed salt.
 	hashedEncoded := crypto.Keccak256Hash(encoded).Bytes()
-	toSign := append(crypto.Keccak256Hash(salt).Bytes(), hashedEncoded...)
+	toSign := append(crypto.Keccak256Hash([]byte(salt)).Bytes(), hashedEncoded...)
 	hashedDigest, err := HashRawBytes(toSign)
 	if err != nil {
 		return nil, nil, common.Hash{}, fmt.Errorf("could not hash receipt: %w", err)

--- a/agents/types/utils.go
+++ b/agents/types/utils.go
@@ -1,0 +1,28 @@
+package types
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/synapsecns/sanguine/core"
+	"github.com/synapsecns/sanguine/ethergo/signer/signer"
+)
+
+
+func sign(ctx context.Context, signer signer.Signer, encoded, salt []byte) (signer.Signature, common.Hash, error) {
+	hashedEncodedReceipt := crypto.Keccak256Hash(encoded).Bytes()
+	toSign := append(crypto.Keccak256Hash(salt).Bytes(), hashedEncodedReceipt...)
+
+	hashedDigest, err := HashRawBytes(toSign)
+	if err != nil {
+		return nil, common.Hash{}, fmt.Errorf("could not hash receipt: %w", err)
+	}
+
+	signature, err := signer.SignMessage(ctx, core.BytesToSlice(hashedDigest), false)
+	if err != nil {
+		return nil, common.Hash{}, fmt.Errorf("could not sign: %w", err)
+	}
+	return signature, hashedDigest, nil
+}


### PR DESCRIPTION
Adds `Encoder` interface to allow for de-duplication of agent type signing logic.
