### PR TITLE
update foundry tag

### DIFF
--- a/ethergo/backends/anvil/anvil.go
+++ b/ethergo/backends/anvil/anvil.go
@@ -76,10 +76,8 @@ func NewAnvilBackend(ctx context.Context, t *testing.T, args *OptionBuilder) *Ba
 
 	runOptions := &dockertest.RunOptions{
 		Repository: "ghcr.io/foundry-rs/foundry",
-		// Note: https://github.com/foundry-rs/foundry/commit/6e041f9751efa6b75420689b862df05b0934022b introduces a breaking change with regards to
-		// eth_BsendTransaction. The commit changes the way tx fields are detected. This will be fixed (on the anvil or ethergo sides) in a future version.
-		Tag: "nightly-7398b65e831f2339d1d0a0bb05ade799e4f9d01e",
-		Cmd: []string{strings.Join(append([]string{"anvil"}, commandArgs...), " ")},
+		Tag:        "latest",
+		Cmd:        []string{strings.Join(append([]string{"anvil"}, commandArgs...), " ")},
 		Labels: map[string]string{
 			"test-id": uuid.New().String(),
 		},

--- a/ethergo/backends/anvil/anvil.go
+++ b/ethergo/backends/anvil/anvil.go
@@ -345,6 +345,7 @@ func (f *Backend) ImpersonateAccount(ctx context.Context, address common.Address
 		NoSend:   true,
 	})
 
+	// TODO: test both legacy and dynamic tx types
 	err = anvilClient.SendUnsignedTransaction(ctx, address, tx)
 	assert.Nilf(f.T(), err, "could not send unsigned transaction for chain %d: %v from %s", f.GetChainID(), err, address.String())
 

--- a/ethergo/backends/anvil/client.go
+++ b/ethergo/backends/anvil/client.go
@@ -198,8 +198,8 @@ func (c *Client) EnableTraces(ctx context.Context) error {
 	return c.callAnvilContext(ctx, nil, "enableTraces")
 }
 
-// anvilTransaction represents a transaction that will serialize to the correct JSON.
-type anvilTransaction struct {
+// anvilTransactionLegacy represents a transaction that will serialize to the correct JSON.
+type anvilTransactionLegacy struct {
 	From            string `json:"from"`
 	To              string `json:"to"`
 	GasPrice        string `json:"gasPrice"`
@@ -210,19 +210,48 @@ type anvilTransaction struct {
 	TransactionType string `json:"type"`
 }
 
+// anvilTransactionDynamic represents a transaction that will serialize to the correct JSON.
+type anvilTransactionDynamic struct {
+	From                 string `json:"from"`
+	To                   string `json:"to"`
+	MaxFeePerGas         string `json:"maxFeePerGas"`
+	MaxPriorityFeePerGas string `json:"maxPriorityFeePerGas"`
+	Gas                  string `json:"gas"`
+	Value                string `json:"value,omitempty"`
+	Data                 string `json:"data"`
+	Nonce                string `json:"nonce"`
+	TransactionType      string `json:"type"`
+}
+
 // SendUnsignedTransaction sends a transaction to the anvil node.
 // It is the responsibility of the caller to call impersonateAccount and revertImpersonatedAccount.
 func (c *Client) SendUnsignedTransaction(ctx context.Context, from common.Address, tx *types.Transaction) error {
-	anTx := anvilTransaction{
-		From:            from.Hex(),
-		To:              tx.To().Hex(),
-		GasPrice:        bigIntToString(tx.GasPrice().Int64()),
-		Gas:             bigIntToString(int64(tx.Gas())),
-		Data:            hex.EncodeToString(tx.Data()),
-		Nonce:           bigIntToString(int64(tx.Nonce())),
-		Value:           fmt.Sprintf("%x", tx.Value()),
-		TransactionType: bigIntToString(int64(tx.Type())),
+	var anTx interface{}
+	if tx.Type() == types.LegacyTxType {
+		anTx = anvilTransactionLegacy{
+			From:            from.Hex(),
+			To:              tx.To().Hex(),
+			GasPrice:        bigIntToString(tx.GasPrice().Int64()),
+			Gas:             bigIntToString(int64(tx.Gas())),
+			Data:            hex.EncodeToString(tx.Data()),
+			Nonce:           bigIntToString(int64(tx.Nonce())),
+			Value:           fmt.Sprintf("%x", tx.Value()),
+			TransactionType: bigIntToString(int64(tx.Type())),
+		}
+	} else {
+		anTx = anvilTransactionDynamic{
+			From:                 from.Hex(),
+			To:                   tx.To().Hex(),
+			MaxFeePerGas:         bigIntToString(tx.GasPrice().Int64()),
+			MaxPriorityFeePerGas: bigIntToString(tx.GasPrice().Int64()),
+			Gas:                  bigIntToString(int64(tx.Gas())),
+			Data:                 hex.EncodeToString(tx.Data()),
+			Nonce:                bigIntToString(int64(tx.Nonce())),
+			Value:                fmt.Sprintf("%x", tx.Value()),
+			TransactionType:      bigIntToString(int64(tx.Type())),
+		}
 	}
+
 	// nolint: wrapcheck
 	return c.CallContext(ctx, nil, "eth_sendTransaction", anTx)
 }


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**

Fixes foundry tag, if this works thanks to https://github.com/foundry-rs/foundry/pull/5414 should pave the path for a built in explorer for foundry backends

I managed to fix this before opening up an issue on foundry, but here's my draft below if useful:

> Since [6e041f9751efa6b75420689b862df05b0934022b](https://github.com/foundry-rs/foundry/commit/6e041f9751efa6b75420689b862df05b0934022b) I've noticed what I think is a regression (and is definitely a behavior change in anvil) with regards to handling of account impersonation and unsigned transaction handling. At commit [7398b65e831f2339d1d0a0bb05ade799e4f9d01e](https://github.com/foundry-rs/foundry/commit/7398b65e831f2339d1d0a0bb05ade799e4f9d01e) (the previous commit, the following sequence was possible:
> 
> <img width="294" alt="image" src="https://github.com/foundry-rs/foundry/assets/83933037/acb0249a-a265-4909-85e0-a96ec32f2aa0">
> 
> You can test this yourself by running the account impersonation test [here](https://github.com/synapsecns/sanguine/blob/master/ethergo/backends/anvil/anvil_test.go#L48-L65). This will [run against](https://github.com/synapsecns/sanguine/blob/master/ethergo/backends/anvil/anvil.go#L81C9-L81C57) `nightly-7398b65e831f2339d1d0a0bb05ade799e4f9d01e` and work fine.
> 
> At the very next commit (up to latest/nightly tags) this same sequence will not work. You can try this out here: https://github.com/synapsecns/sanguine/pull/1265 or by adjusting the tag yourself. The following error is returned:
> 
> <img width="470" alt="image" src="https://github.com/foundry-rs/foundry/assets/83933037/5a264aed-bbb3-49bb-8295-bb60bdbe70ab">
> 
> What I'm not sure about is if this is a regression is implicit or if the previous behavior was incorrect and my code just worked with it. I can see foundry-rs/foundry/pull/4663 does enforce the checking of type.
> 
> Is the intended behavior that both maxFeePerGas and maxPriorityFeePerGas must be set if type 2 is used?

The answer was yes.