### PR TITLE
fix omnirpc port default behavior

### DIFF
--- a/services/omnirpc/cmd/flags.go
+++ b/services/omnirpc/cmd/flags.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"github.com/phayes/freeport"
 	"github.com/urfave/cli/v2"
 	"os"
 	"path/filepath"
@@ -16,8 +15,6 @@ var chainIDFlag = &cli.IntFlag{
 var portFlag = &cli.IntFlag{
 	Name:  "port",
 	Usage: "port to run the omniproxy on",
-	// default to an open port
-	Value: freeport.GetPort(),
 }
 
 // set the default dir to the users home path/omnirpc.yaml.


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**

Fixes omnirpc bug where `port` set in the config is ignored. This bug was present because the default value for the command line is always set:

![image](https://github.com/synapsecns/sanguine/assets/83933037/834366a8-167e-4e56-a23f-cd92476f75e5)


and since the command line is prioritized over the config file:

<img width="573" alt="image" src="https://github.com/synapsecns/sanguine/assets/83933037/312dee3c-e773-40c6-891f-3516b54018f3">

config file is always ignored!