### PR TITLE
Fix: enable swaps from native ETH in FE

### DIFF
--- a/packages/synapse-interface/constants/tokens/master.tsx
+++ b/packages/synapse-interface/constants/tokens/master.tsx
@@ -1001,7 +1001,12 @@ export const ETH = new Token({
   color: 'sky',
   visibilityRank: 101,
   priorityRank: 2,
-  swapableOn: [CHAINS.BASE.id],
+  swapableOn: [
+    CHAINS.ARBITRUM.id,
+    CHAINS.BASE.id,
+    CHAINS.BOBA.id,
+    CHAINS.OPTIMISM.id,
+  ],
 })
 
 export const MOVR = new Token({

--- a/packages/synapse-interface/constants/tokens/swapMaster.ts
+++ b/packages/synapse-interface/constants/tokens/swapMaster.ts
@@ -20,7 +20,7 @@ export const WETH = new Token({
   logo: wethLogo,
   description: 'ERC-20 Wrapped form of ETH',
   swapableType: 'ETH',
-  swapableOn: [CHAINS.ARBITRUM.id, CHAINS.BOBA.id, CHAINS.OPTIMISM.id],
+  // swapableOn: [CHAINS.ARBITRUM.id, CHAINS.BOBA.id, CHAINS.OPTIMISM.id],
   color: 'sky',
   priorityRank: 3,
 })


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**
- Adds `ETH` to Swap Page on Arbitrum, Boba and Optimism.
- Removes `WETH` from Swap Page on Arbitrum, Boba and Optimism.
6509407a0d3c4b03c18c6f561dd4067cc83d07e0: [synapse-interface preview link ](https://sanguine-synapse-interface-7t5z18luo-synapsecns.vercel.app)