### PR TITLE
Sufficient balance useMemo to update when chain/token updates

### DIFF
--- a/packages/synapse-interface/components/StateManagedBridge/BridgeTransactionButton.tsx
+++ b/packages/synapse-interface/components/StateManagedBridge/BridgeTransactionButton.tsx
@@ -65,7 +65,7 @@ export const BridgeTransactionButton = ({
       stringToBigInt(fromValue, fromToken?.decimals[fromChainId]) <=
       balanceForToken
     )
-  }, [balanceForToken, fromValue])
+  }, [balanceForToken, fromValue, fromChainId, toChainId, toToken])
 
   const isButtonDisabled =
     isLoading ||


### PR DESCRIPTION
Update Bridge Transaction button state when bridge inputs (chain / token) is updated by user
1ddf77871aa8cce397eea9218966215306f917bc: [synapse-interface preview link ](https://sanguine-synapse-interface-ja7rlkthy-synapsecns.vercel.app)