### PR TITLE
Fix: SDK failing test

### DIFF
--- a/packages/sdk-router/src/sdk.test.ts
+++ b/packages/sdk-router/src/sdk.test.ts
@@ -317,7 +317,7 @@ describe('SynapseSDK', () => {
 
       const { data, to } = await Synapse.bridge(
         '0x0AF91FA049A7e1894F480bFE5bBa20142C6c29a9',
-        '0x7e7a0e201fd38d3adaa9523da6c109a07118c96a',
+        routerAddress!,
         42161,
         10,
         '0x7F5c764cBc14f9669B88837ca1490cCa17c31607',


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**
One of the tests assumed that `SynapseRouter` will be used for Arbitrum -> Optimism transfer, but now SynapseCCTPRouter provides a better quote.

**Additional context**
- Error popped up in #1328 
