### PR TITLE
fix wrong domain in deploy script

### DIFF
--- a/packages/contracts-core/script/DeployMessaging003Base.s.sol
+++ b/packages/contracts-core/script/DeployMessaging003Base.s.sol
@@ -151,7 +151,7 @@ abstract contract DeployMessaging003BaseScript is DeployerUtils {
         require(agentManager != address(0), "Agent Manager not set");
         require(statementInbox != address(0), "Statement Inbox not set");
         require(agentManager.code.length > 0, "Agent Manager not deployed");
-        constructorArgs = abi.encode(localDomain, agentManager, statementInbox);
+        constructorArgs = abi.encode(synapseDomain, agentManager, statementInbox);
         deployment = factoryDeploy(DESTINATION, type(Destination).creationCode, constructorArgs);
     }
 

--- a/packages/contracts-core/script/DeployMessaging003LightChain.s.sol
+++ b/packages/contracts-core/script/DeployMessaging003LightChain.s.sol
@@ -41,7 +41,7 @@ contract DeployMessaging003LightChainScript is DeployMessaging003BaseScript {
     /// @dev Deploys Inbox or LightInbox
     /// Note: requires AgentManager, Origin and Destination addresses to be set
     function _deployStatementInbox() internal override returns (address deployment, bytes memory constructorArgs) {
-        // new LightInbox(domain)
+        // new LightInbox(synapseDomain)
         constructorArgs = abi.encode(synapseDomain);
         deployment = factoryDeploy(statementInboxName(), type(LightInbox).creationCode, constructorArgs);
         require(agentManager != address(0), "Agent Manager not set");

--- a/packages/contracts-core/script/DeployMessaging003LightChain.s.sol
+++ b/packages/contracts-core/script/DeployMessaging003LightChain.s.sol
@@ -21,7 +21,7 @@ contract DeployMessaging003LightChainScript is DeployMessaging003BaseScript {
     /// Note: requires Origin, Destination and StatementInbox addresses to be set
     function _deployAgentManager() internal override returns (address deployment, bytes memory constructorArgs) {
         // new LightManager(domain)
-        constructorArgs = abi.encode(localDomain);
+        constructorArgs = abi.encode(synapseDomain);
         deployment = factoryDeploy(agentManagerName(), type(LightManager).creationCode, constructorArgs);
         require(origin != address(0), "Origin not set");
         require(destination != address(0), "Destination not set");

--- a/packages/contracts-core/script/DeployMessaging003SynChain.s.sol
+++ b/packages/contracts-core/script/DeployMessaging003SynChain.s.sol
@@ -48,7 +48,7 @@ contract DeployMessaging003SynChainScript is DeployMessaging003BaseScript {
     /// Note: requires AgentManager, Origin, Destination and Summit addresses to be set
     function _deployStatementInbox() internal override returns (address deployment, bytes memory constructorArgs) {
         // new Inbox(domain)
-        constructorArgs = abi.encode(localDomain);
+        constructorArgs = abi.encode(synapseDomain);
         deployment = factoryDeploy(statementInboxName(), type(Inbox).creationCode, constructorArgs);
         require(agentManager != address(0), "Agent Manager not set");
         require(origin != address(0), "Origin not set");

--- a/packages/contracts-core/script/DeployMessaging003SynChain.s.sol
+++ b/packages/contracts-core/script/DeployMessaging003SynChain.s.sol
@@ -21,7 +21,7 @@ contract DeployMessaging003SynChainScript is DeployMessaging003BaseScript {
     /// Note: requires Origin, Destination, StatementInbox and Summit addresses to be set
     function _deployAgentManager() internal override returns (address deployment, bytes memory constructorArgs) {
         // new BondingManager(domain)
-        constructorArgs = abi.encode(localDomain);
+        constructorArgs = abi.encode(synapseDomain);
         deployment = factoryDeploy(agentManagerName(), type(BondingManager).creationCode, constructorArgs);
         require(origin != address(0), "Origin not set");
         require(destination != address(0), "Destination not set");


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**

Uncovered while working on #1274, I appear to have broken this in #1308. The agent manager constructor was still passed the local domain instead of the synapse domain
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

---
- Refactor: Updated the domain variable name from `localDomain` to `synapseDomain` across multiple scripts in the `contracts-core` package. This change ensures consistency and clarity in the codebase.
- Bug Fix: Corrected the constructor arguments for deploying various contracts such as `LightManager`, `LightInbox`, `BondingManager`, and `Inbox`. The updated domain address (`synapseDomain`) is now correctly passed during these deployments, ensuring proper contract initialization.
---
<!-- end of auto-generated comment: release notes by coderabbit.ai -->