### PR TITLE
remove unused scribe config params

### DIFF
--- a/services/scribe/config/config.go
+++ b/services/scribe/config/config.go
@@ -14,12 +14,8 @@ import (
 type Config struct {
 	// Chains stores all chain information
 	Chains ChainConfigs `yaml:"chains"`
-	// RefreshRate is the rate at which the scribe will refresh the last block height in seconds.
-	RefreshRate uint `yaml:"refresh_rate"`
 	// RPCURL is the url of the omnirpc.
 	RPCURL string `yaml:"rpc_url"`
-	// ConfirmationRefreshRate is the rate at which the scribe will refresh the last confirmed block height in seconds.
-	ConfirmationRefreshRate int64 `yaml:"confirmation_refresh_rate"`
 }
 
 // IsValid makes sure the config is valid. This is done by calling IsValid() on each

--- a/services/scribe/config/config_test.go
+++ b/services/scribe/config/config_test.go
@@ -36,8 +36,7 @@ func (c ConfigSuite) TestConfigEncodeDecode() {
 				},
 			},
 		},
-		RefreshRate: uint(gofakeit.Uint8()),
-		RPCURL:      gofakeit.URL(),
+		RPCURL: gofakeit.URL(),
 	}
 
 	encodedConfig, err := testConfig.Encode()

--- a/services/scribe/service/scribe_test.go
+++ b/services/scribe/service/scribe_test.go
@@ -186,7 +186,6 @@ func (s *ScribeSuite) TestLivefillParity() {
 		maticID: "https://api.polygonscan.com/api",
 	}
 	scribeConfig := config.Config{
-		RefreshRate: 1,
 		Chains: []config.ChainConfig{
 			{
 				ChainID:              ethID,


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**

Remove two global scribe params that appear to be unused found when working on #1381 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

---
- Refactor: Removed `RefreshRate` and `ConfirmationRefreshRate` fields from the `Config` struct in `services/scribe/config/config.go`. This change simplifies the configuration by eliminating unused refresh rates for updating block heights.
- Test: Updated tests in `services/scribe/config/config_test.go` and `services/scribe/service/scribe_test.go` to reflect the removal of the `RefreshRate` field. These changes ensure that our tests remain accurate and reliable after the refactor.
---
<!-- end of auto-generated comment: release notes by coderabbit.ai -->