### PR TITLE
add messaging deploy block

### DIFF
--- a/packages/contracts-core/contracts/base/MessagingBase.sol
+++ b/packages/contracts-core/contracts/base/MessagingBase.sol
@@ -20,6 +20,8 @@ abstract contract MessagingBase is MultiCallable, Versioned, OwnableUpgradeable 
     uint32 public immutable localDomain;
     // @notice Domain of the Synapse chain, set once upon contract creation
     uint32 public immutable synapseDomain;
+    // @notice deploy block of the contract
+    uint32 public immutable deployBlock;
 
     // ══════════════════════════════════════════════════ STORAGE ══════════════════════════════════════════════════════
 
@@ -30,6 +32,11 @@ abstract contract MessagingBase is MultiCallable, Versioned, OwnableUpgradeable 
         // TODO: do we want to/need to check for overflow?
         localDomain = uint32(block.chainid);
         synapseDomain = synapseDomain_;
+        deployBlock = block.number;
+    }
+
+    function deployBlock() external returns (uint32) {
+        return deployBlock;
     }
 
     // TODO: Implement pausing


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**

Since the plan is to deploy #1381 before we resolve this:

> In scribe configs, start_block should be the deploy block of the contract. This is especially important for executors since they need to rebuild the entire merkle tree from logs on each chain. In the past I've built a [generate](https://github.com/synapsecns/sanguine/blob/master/services/scribe/cmd/commands.go#L173) command that generates a scribe config based on a hardhat deploy folder using [this parser](https://pkg.go.dev/github.com/synapsecns/sanguine/ethergo/parser/hardhat). However this is not available for foundry. Do we know why this is/is there a way to fix this?

Wanted to create a new issue w/ a potential solution. This isn't my favorite approach, but I'd like to at least have a separate place to discuss this vs a deployer utils approach so this doesn't get lost pre-deploy. As such this'll be a draft
