### PR TITLE
Adds balance chain tokens for chain dropdown

### DIFF
--- a/packages/synapse-interface/components/StateManagedBridge/components/SelectSpecificNetworkButton.tsx
+++ b/packages/synapse-interface/components/StateManagedBridge/components/SelectSpecificNetworkButton.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { CHAINS_BY_ID } from '@constants/chains'
 import Image from 'next/image'
 import {
@@ -10,6 +10,11 @@ import {
   getNetworkButtonBorderActive,
   getMenuItemStyleForChain,
 } from '@/styles/chains'
+import { usePortfolioState } from '@/slices/portfolio/hooks'
+import {
+  TokenWithBalanceAndAllowances,
+  sortTokensByBalanceDescending,
+} from '@/utils/actions/fetchPortfolioBalances'
 
 export const SelectSpecificNetworkButton = ({
   itemChainId,
@@ -50,7 +55,7 @@ export const SelectSpecificNetworkButton = ({
       ref={ref}
       tabIndex={active ? 1 : 0}
       className={`
-        flex items-center
+        flex items-center justify-between
         transition-all duration-75
         w-full 
         px-2 py-4
@@ -74,17 +79,105 @@ export const SelectSpecificNetworkButton = ({
 
 function ButtonContent({ chainId }: { chainId: number }) {
   const chain = CHAINS_BY_ID[chainId]
+  const { balancesAndAllowances } = usePortfolioState()
+
+  const balanceTokens =
+    balancesAndAllowances &&
+    balancesAndAllowances[chainId] &&
+    sortTokensByBalanceDescending(
+      balancesAndAllowances[chainId].filter((bt) => bt.balance > 0n)
+    )
 
   return chain ? (
     <>
-      <Image
-        src={chain.chainImg}
-        alt="Switch Network"
-        className="ml-2 mr-4 rounded-full w-7 h-7"
-      />
-      <div className="flex-col text-left">
-        <div className="text-lg font-normal text-white">{chain.name}</div>
+      <div className="flex items-center space-x-2">
+        <Image
+          src={chain.chainImg}
+          alt="Switch Network"
+          className="ml-2 rounded-full w-7 h-7"
+        />
+        <div className="flex-col text-left">
+          <div className="text-lg font-normal text-white">{chain.name}</div>
+        </div>
       </div>
+      {balanceTokens && balanceTokens.length > 0 ? (
+        <ChainTokens balanceTokens={balanceTokens} />
+      ) : null}
     </>
   ) : null
+}
+
+const ChainTokens = ({
+  balanceTokens = [],
+}: {
+  balanceTokens: TokenWithBalanceAndAllowances[]
+}) => {
+  const [isHovered, setIsHovered] = useState(false)
+  const hasOneToken = useMemo(
+    () => balanceTokens && balanceTokens.length > 0,
+    [balanceTokens]
+  )
+  const hasTwoTokens = useMemo(
+    () => balanceTokens && balanceTokens.length > 1,
+    [balanceTokens]
+  )
+  const numOverTwoTokens = useMemo(
+    () =>
+      balanceTokens && balanceTokens.length - 2 > 0
+        ? balanceTokens.length - 2
+        : 0,
+    [balanceTokens]
+  )
+
+  return (
+    <div
+      data-test-id="chain-tokens"
+      className="flex flex-row items-center cursor-pointer hover-trigger"
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      {hasOneToken && (
+        <Image
+          loading="lazy"
+          className="w-5 h-5 rounded-md"
+          alt={`${balanceTokens[0].token.symbol} img`}
+          src={balanceTokens[0].token.icon}
+        />
+      )}
+      {hasTwoTokens && (
+        <Image
+          loading="lazy"
+          className="w-5 h-5 ml-1.5 rounded-md"
+          alt={`${balanceTokens[1].token.symbol} img`}
+          src={balanceTokens[1].token.icon}
+        />
+      )}
+      {numOverTwoTokens > 0 && (
+        <div className="ml-1.5 text-white">+ {numOverTwoTokens}</div>
+      )}
+      <div className="relative inline-block">
+        {isHovered && (
+          <div
+            className={`
+              absolute -ml-28 z-50 hover-content p-2 text-white
+              border border-solid border-[#252537]
+              bg-[#101018] rounded-md
+            `}
+          >
+            {balanceTokens.map(
+              (token: TokenWithBalanceAndAllowances, key: number) => {
+                const tokenSymbol = token.token.symbol
+                const balance = token.parsedBalance
+                return (
+                  <div className="whitespace-nowrap" key={key}>
+                    {balance} {tokenSymbol}
+                  </div>
+                )
+              }
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
 }

--- a/packages/synapse-interface/constants/chains/master.tsx
+++ b/packages/synapse-interface/constants/chains/master.tsx
@@ -406,7 +406,7 @@ export const DOGE: Chain = {
 }
 
 export const BASE: Chain = {
-  priorityRank: 1,
+  priorityRank: 90,
   id: 8453,
   chainSymbol: 'ETH',
   name: 'Base',


### PR DESCRIPTION


896f9c6e29e7dffc3162d9f5a8ab3b26dd748773: [synapse-interface preview link ](https://sanguine-synapse-interface-flttau5cz-synapsecns.vercel.app)
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Enhanced the `SelectSpecificNetworkButton` component to display token balances for each network, improving visibility and user experience.
- Update: Adjusted the priority rank of the `BASE` chain from 1 to 90 in the `master.tsx` file. This change may affect the order of chains displayed in the interface.
- New Component: Introduced a new `ChainTokens` component that renders token balances and provides additional information on hover.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
c99cfc740f1c886d9152901b0dcfca052d571f07: [synapse-interface preview link ](https://sanguine-synapse-interface-15l102z6h-synapsecns.vercel.app)
9813a52df87af7a59ce65dd5b422e886c486273a: [synapse-interface preview link ](https://sanguine-synapse-interface-heyjl6evw-synapsecns.vercel.app)