### PR TITLE
Fix git-changes-action when module was unchanged

### DIFF
--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -2,12 +2,16 @@ name: 'Close stale issues and PRs'
 on:
   schedule:
     - cron: '30 1 * * *'
+  workflow_dispatch:
+  push:
+    paths:
+      - '.github/workflows/close-stale.yml'
 
 jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v4
+      - uses: actions/stale@v8
         with:
           stale-pr-message: 'This PR is stale because it has been open 14 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
           exempt-pr-labels: exempt-stale

--- a/.github/workflows/fail-on-needs-generate.yaml
+++ b/.github/workflows/fail-on-needs-generate.yaml
@@ -10,7 +10,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
       - name: Fail on needs-go-generate
         run: echo Failed, needs go generate. && exit 1
   check-generate-yarn:
@@ -18,6 +17,5 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
       - name: Fail on needs-go-yarn
         run: echo Failed, needs yarn install. && exit 1

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,7 +28,7 @@ jobs:
       package_count_deps: ${{ steps.length.outputs.FILTER_LENGTH_DEPS }}
 
       unchanged_deps: ${{ steps.filter_go.outputs.unchanged_modules_deps }}
-      unchanged_package_count_deps: ${{ steps.length.outputs.FILTERED_PATHS_NODEPS }}
+      unchanged_package_count_deps: ${{ steps.length.outputs.FILTER_LENGTH_UNCHANGED_DEPS }}
 
       # These have no dependencies included in the change outputs
       packages_nodeps: ${{ steps.filter_go_nodeps.outputs.changed_modules }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,7 +37,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          # TODO: this can be shorter, maybe 500-1,000? This may be slower (see: https://github.com/CocoaPods/CocoaPods/issues/4989#issuecomment-193772935)
           fetch-depth: 0
+          # TODO: is this neccesary?
           submodules: 'recursive'
 
       # note: after this action is pushed, whatever this ends up being should go back to latest.

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -484,7 +484,7 @@ jobs:
     name: Remove Generate Label From Unused Jobs
     runs-on: ubuntu-latest
     needs: [changes, pr_metadata]
-    if: ${{ github.event_name != 'pull_request' && needs.changes.outputs.unchanged_package_count_deps > 0 && contains(needs.pr_metadata.outputs.labels), 'needs-go-generate') }}
+    if: ${{ github.event_name != 'pull_request' && needs.changes.outputs.unchanged_package_count_deps > 0 && contains(needs.pr_metadata.outputs.labels, 'needs-go-generate') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -357,7 +357,7 @@ jobs:
         id: find_pr
       # TODO: https://stackoverflow.com/a/75429845 consider splitting w/ gql to reduce limit hit
       - run: |
-          labels="$(gh api repos/$OWNER/$REPO_NAME/pulls/$PULL_REQUEST_NUMBER --jq '.labels.[].name')"
+          labels="$(gh api repos/$OWNER/$REPO_NAME/pulls/$PULL_REQUEST_NUMBER)"
           echo "$labels"
         shell: bash
         env:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -491,9 +491,7 @@ jobs:
           remove-labels: 'needs-go-generate-${{matrix.package}}'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ needs.pr_metadata.outputs.issue_number }}
-      - run: |
-          x=${{ toJson(needs.pr_metadata.outputs.pr-labels) }}
-          echo $x
+
 
 
   check-generation:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -503,6 +503,8 @@ jobs:
           remove-labels: 'needs-go-generate-${{matrix.package}}'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ needs.pr_metadata.outputs.issue_number }}
+      - run: |
+          echo "No changes to ${{needs.pr_metadata.outputs.labels}}. Skipping."
 
 
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -496,6 +496,13 @@ jobs:
           remove-labels: 'needs-go-generate-${{matrix.package}}'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ needs.pr_metadata.outputs.issue_number }}
+      - name: Remove Label
+        if: contains(needs.pr_metadata.outputs.labels, 'needs-go-generate-${{matrix.package}}')
+        uses: andymckay/labeler@3a4296e9dcdf9576b0456050db78cfd34853f260
+        with:
+          remove-labels: 'needs-go-generate-${{matrix.package}}'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ needs.pr_metadata.outputs.issue_number }}
 
 
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -110,7 +110,7 @@ jobs:
           submodules: 'recursive'
 
       - name: Cache Docker images.
-        uses: ScribeMD/docker-cache@0.2.6
+        uses: ScribeMD/docker-cache@0.3.6
         with:
           key: docker-test-${{ runner.os }}-${{ matrix.package }}
 
@@ -397,7 +397,7 @@ jobs:
           submodules: 'recursive'
 
       - name: Cache Docker images.
-        uses: ScribeMD/docker-cache@0.2.6
+        uses: ScribeMD/docker-cache@0.3.6
         with:
           key: docker-generate-${{ runner.os }}-${{ matrix.package }}
 
@@ -518,7 +518,7 @@ jobs:
           submodules: 'recursive'
 
       - name: Cache Docker images.
-        uses: ScribeMD/docker-cache@0.2.6
+        uses: ScribeMD/docker-cache@0.3.6
         with:
           key: docker-generate-${{ runner.os }}-${{ matrix.package }}
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -346,6 +346,8 @@ jobs:
     # this is needed to prevent us from hitting the github api rate limit
     name: Get PR Metadata
     runs-on: ubuntu-latest
+    # not stricly true, but this job is fast enough to not block and we want to prioritize canceling outdated because downstream jobs can use many workers
+    needs: cancel-outdated
     # currently, this matches the logic in the go generate check. If we ever add more checks that run on all packages, we should
     # change this to run on those pushes
     if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -355,7 +355,7 @@ jobs:
     steps:
       - uses: jwalton/gh-find-current-pr@v1
         id: find_pr
-      - uses: LucasRoesler/get-repo-owner-actions@v1.0
+      - uses: LucasRoesler/get-repo-owner-action@v1.0
         id: get_owner
       - name: Get PR labels
         id: pr-labels

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -484,10 +484,6 @@ jobs:
     name: Remove Generate Label From Unused Jobs
     runs-on: ubuntu-latest
     needs: [changes, pr_metadata]
-    # prevent this from hogging more than one machine, should take no more than 3 seconds * number of packages (currently 15)
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-label-generation
-      cancel-in-progress: false
     if: ${{ github.event_name != 'pull_request' && needs.changes.outputs.unchanged_package_count_deps > 0 }}
     strategy:
       fail-fast: false

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -482,6 +482,9 @@ jobs:
     name: Remove Generate Label From Unused Jobs
     runs-on: ubuntu-latest
     needs: [changes, pr_metadata]
+    # prevent this from hogging more than one machine, should take no more than 3 seconds * number of packages (currently 15)
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-label-generation
     if: ${{ github.event_name != 'pull_request' && needs.changes.outputs.unchanged_package_count_deps > 0 }}
     strategy:
       fail-fast: false

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -496,15 +496,6 @@ jobs:
           remove-labels: 'needs-go-generate-${{matrix.package}}'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ needs.pr_metadata.outputs.issue_number }}
-      - name: Remove Label
-        if: contains(needs.pr_metadata.outputs.labels, "needs-go-generate-${{matrix.package}}")
-        uses: andymckay/labeler@3a4296e9dcdf9576b0456050db78cfd34853f260
-        with:
-          remove-labels: 'needs-go-generate-${{matrix.package}}'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ needs.pr_metadata.outputs.issue_number }}
-      - run: |
-          echo "No changes to ${{needs.pr_metadata.outputs.labels}}. Skipping."
 
 
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -118,6 +118,7 @@ jobs:
         uses: actions/cache@v3
         with:
           # see https://github.com/mvdan/github-actions-golang
+          # also: https://glebbahmutov.com/blog/do-not-let-npm-cache-snowball/ w/ go build (workaround now is having a cache that just gets expired at night)
           path: |
             ~/go/pkg/mod
             ~/.cache/go-build
@@ -284,6 +285,7 @@ jobs:
         uses: actions/cache@v3
         with:
           # see https://github.com/mvdan/github-actions-golang
+          # also: https://glebbahmutov.com/blog/do-not-let-npm-cache-snowball/ w/ go build (workaround now is having a cache that just gets expired at night)
           path: |
             ~/go/pkg/mod
             ~/.cache/go-build
@@ -423,6 +425,7 @@ jobs:
         uses: actions/cache@v3
         with:
           # see https://github.com/mvdan/github-actions-golang
+          # also: https://glebbahmutov.com/blog/do-not-let-npm-cache-snowball/ w/ go build (workaround now is having a cache that just gets expired at night)
           path: |
             ~/go/pkg/mod
             ~/.cache/go-build
@@ -551,6 +554,7 @@ jobs:
         if: ${{ !contains(matrix.package, 'services/cctp-relayer') }}
         with:
           # see https://github.com/mvdan/github-actions-golang
+          # also: https://glebbahmutov.com/blog/do-not-let-npm-cache-snowball/ w/ go build (workaround now is having a cache that just gets expired at night)
           path: |
             ~/go/pkg/mod
             ~/.cache/go-build

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -364,7 +364,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
-          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+          PULL_REQUEST_NUMBER: ${{ steps.find_pr.outputs.pr }}
 
   # check if we need to rerun go generate as a result of solidity changes. Note, this will only run on solidity changes.
   # TODO: consolidate w/ go change check. This will run twice on agents

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -362,7 +362,7 @@ jobs:
           metadata="$(gh api repos/$OWNER/$REPO_NAME/pulls/$PULL_REQUEST_NUMBER)"
 
           # Extract the labels in JSON format from the metadata
-          labels_json="$(echo "$metadata" | jq -r '[.labels[].name]')"
+          labels_json="$(echo "$metadata" | jq -r -c '[.labels[].name]')"
 
           # Set the full metadata including the labels as the GitHub Actions step output
           echo "::set-output name=METADATA::$metadata"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -476,7 +476,7 @@ jobs:
           issue-number: ${{ needs.pr_metadata.outputs.issue_number }}
 
       - name: Remove Label
-        if: steps.verify-changed-files.outputs.files_changed != 'true'
+        if: ${{ contains(fromJson(needs.pr_metadata.outputs.labels), format('needs-go-generate-{0}', matrix.package)) && steps.verify-changed-files.outputs.files_changed != 'true' }}
         uses: andymckay/labeler@3a4296e9dcdf9576b0456050db78cfd34853f260
         with:
           remove-labels: 'needs-go-generate-${{matrix.package}}'
@@ -494,8 +494,14 @@ jobs:
         # only do on agents for now. Anything that relies on solidity in a package should do this
         package: ${{ fromJSON(needs.changes.outputs.unchanged_deps) }}
     steps:
+      - name: Turnstyle
+        # no need for this if we're not goint to remove anyway
+        if: ${{ contains(fromJson(needs.pr_metadata.outputs.labels), format('needs-go-generate-{0}', matrix.package)) }}
+        uses: softprops/turnstyle@v1
+
       - name: Remove Label
         if: ${{ contains(fromJson(needs.pr_metadata.outputs.labels), format('needs-go-generate-{0}', matrix.package)) }}
+        # labels can't be removed in parallel
         uses: andymckay/labeler@3a4296e9dcdf9576b0456050db78cfd34853f260
         with:
           remove-labels: 'needs-go-generate-${{matrix.package}}'
@@ -636,7 +642,7 @@ jobs:
           issue-number: ${{ needs.pr_metadata.outputs.issue_number }}
 
       - name: Remove Label
-        if: steps.verify-changed-files.outputs.files_changed != 'true'
+        if: ${{ contains(fromJson(needs.pr_metadata.outputs.labels), format('needs-go-generate-{0}', matrix.package)) && steps.verify-changed-files.outputs.files_changed != 'true' }}
         uses: andymckay/labeler@3a4296e9dcdf9576b0456050db78cfd34853f260
         with:
           remove-labels: 'needs-go-generate-${{matrix.package}}'

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,9 +24,11 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       # Expose matched filters as job 'packages' output variable
-      packages_deps: ${{ steps.filter_go_deps.outputs.changed_modules }}
+      packages_deps: ${{ steps.filter_go.outputs.changed_modules_deps }}
+      unchanged_deps: ${{ steps.filter_go.outputs.changed_modules_deps }}
       packages_nodeps: ${{ steps.filter_go_nodeps.outputs.changed_modules }}
       package_count_deps: ${{ steps.length.outputs.FILTER_LENGTH_DEPS }}
+      unchanged_package_count_deps: ${{ steps.length.outputs.FILTERED_PATHS_NODEPS }}
       package_count_nodeps: ${{ steps.length.outputs.FILTER_LENGTH_NODEPS }}
       solidity_changes: ${{ steps.filter_solidity.outputs.any_changed }}
     steps:
@@ -35,17 +37,10 @@ jobs:
           fetch-depth: 0
           submodules: 'recursive'
 
-      - uses: docker://ghcr.io/synapsecns/sanguine/git-changes-action:latest
-        id: filter_go_deps
+      # note: after this action is pushed, whatever this ends up being should go back to latest.
+      - uses: docker://ghcr.io/synapsecns/sanguine/git-changes-action:e4c85e74bf0592c0efa71476c3246675ec77fc28
+        id: filter_go
         with:
-          include_deps: true
-          github_token: ${{ secrets.WORKFLOW_PAT }}
-          timeout: '10m'
-
-      - uses: docker://ghcr.io/synapsecns/sanguine/git-changes-action:latest
-        id: filter_go_nodeps
-        with:
-          include_deps: false
           github_token: ${{ secrets.WORKFLOW_PAT }}
           timeout: '10m'
 
@@ -65,11 +60,15 @@ jobs:
           export FILTER_LENGTH_DEPS=$(echo $FILTERED_PATHS_DEPS | jq '. | length')
           echo "##[set-output name=FILTER_LENGTH_DEPS;]$(echo $FILTER_LENGTH_DEPS)"
 
+          export FILTER_LENGTH_UNCHANGED_DEPS=$(echo $UNCHANGED_DEPS | jq '. | length')
+          echo "##[set-output name=FILTER_LENGTH_UNCHANGED_DEPS;]$(echo $FILTER_LENGTH_UNCHANGED_DEPS)"
+
           export FILTER_LENGTH_NODEPS=$(echo $FILTERED_PATHS_NODEPS | jq '. | length')
           echo "##[set-output name=FILTER_LENGTH_NODEPS;]$(echo $FILTER_LENGTH_NODEPS)"
         env:
-          FILTERED_PATHS_DEPS: ${{ steps.filter_go_deps.outputs.changed_modules }}
-          FILTERED_PATHS_NODEPS: ${{ steps.filter_go_nodeps.outputs.changed_modules }}
+          FILTERED_PATHS_DEPS: ${{ steps.filter_go.outputs.changed_modules_deps }}
+          UNCHANGED_DEPS: ${{ steps.filter_go.outputs.unchanged_modules_deps }}
+          FILTERED_PATHS_NODEPS: ${{ steps.filter_go.outputs.changed_modules }}
 
   test:
     name: Go Coverage
@@ -453,6 +452,26 @@ jobs:
           remove-labels: 'needs-go-generate-${{matrix.package}}'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ needs.issue_number.outputs.issue_number }}
+
+  remove-label-generation:
+    name: Remove Generate Label
+    runs-on: ubuntu-latest
+    needs: [changes, issue_number]
+    if: ${{ github.event_name != 'pull_request' && needs.changes.outputs.unchanged_package_count_deps > 0 }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # only do on agents for now. Anything that relies on solidity in a package should do this
+        package: ${{ fromJSON(needs.changes.outputs.unchanged_deps) }}
+    steps:
+      - name: Remove Label
+        if: contains( github.event.pull_request.labels.*.name, 'needs-go-generate-${{matrix.package}}')
+        uses: andymckay/labeler@3a4296e9dcdf9576b0456050db78cfd34853f260
+        with:
+          remove-labels: 'needs-go-generate-${{matrix.package}}'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ needs.issue_number.outputs.issue_number }}
+
 
   check-generation:
     name: Go Generate (Module Changes)

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -311,6 +311,7 @@ jobs:
     if: ${{ needs.changes.outputs.package_count_nodeps > 0 }}
     strategy:
       fail-fast: false
+      max-parallel: 8
       matrix:
         # Parse JSON array containing names of all filters matching any of changed files
         # e.g. ['package1', 'package2'] if both package folders contains changes
@@ -490,17 +491,11 @@ jobs:
     if: ${{ github.event_name != 'pull_request' && needs.changes.outputs.unchanged_package_count_deps > 0 && contains(needs.pr_metadata.outputs.labels, 'needs-go-generate') }}
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         # only do on agents for now. Anything that relies on solidity in a package should do this
         package: ${{ fromJSON(needs.changes.outputs.unchanged_deps) }}
     steps:
-      - name: Turnstyle
-        # no need for this if we're not goint to remove anyway
-        if: ${{ contains(fromJson(needs.pr_metadata.outputs.labels), format('needs-go-generate-{0}', matrix.package)) }}
-        uses: softprops/turnstyle@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Remove Label
         if: ${{ contains(fromJson(needs.pr_metadata.outputs.labels), format('needs-go-generate-{0}', matrix.package)) }}
         # labels can't be removed in parallel

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -342,26 +342,29 @@ jobs:
           GOMEMLIMIT: 6GiB
           GOGC: -1
 
-  issue_number:
+  pr_metadata:
     # this is needed to prevent us from hitting the github api rate limit
     name: Get The Issue Number
-    needs: changes
     runs-on: ubuntu-latest
     # currently, this matches the logic in the go generate check. If we ever add more checks that run on all packages, we should
     # change this to run on those pushes
-    if: ${{ github.event_name != 'pull_request' && (needs.changes.outputs.solidity_changes == 'true' || needs.changes.outputs.package_count_deps > 0 ) }}
+    if: ${{ github.event_name != 'pull_request' }}
     outputs:
       issue_number: ${{ steps.find_pr.outputs.pr }}
+      labels: ${{ steps.pr-labels.outputs.labels }}
     steps:
       - uses: jwalton/gh-find-current-pr@v1
         id: find_pr
+      - name: Get PR labels
+        id: pr-labels
+        uses: joerick/pr-labels-action@v1.0.8
 
   # check if we need to rerun go generate as a result of solidity changes. Note, this will only run on solidity changes.
   # TODO: consolidate w/ go change check. This will run twice on agents
   check-generation-solidity:
     name: Go Generate (Solidity Only)
     runs-on: ubuntu-latest
-    needs: [changes, issue_number]
+    needs: [changes, pr_metadata]
     if: ${{ github.event_name != 'pull_request' && needs.changes.outputs.solidity_changes == 'true' }}
     strategy:
       fail-fast: false
@@ -448,7 +451,7 @@ jobs:
         with:
           add-labels: 'needs-go-generate-${{matrix.package}}'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ needs.issue_number.outputs.issue_number }}
+          issue-number: ${{ needs.pr_metadata.outputs.issue_number }}
 
       - name: Remove Label
         if: steps.verify-changed-files.outputs.files_changed != 'true'
@@ -456,12 +459,12 @@ jobs:
         with:
           remove-labels: 'needs-go-generate-${{matrix.package}}'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ needs.issue_number.outputs.issue_number }}
+          issue-number: ${{ needs.pr_metadata.outputs.issue_number }}
 
   remove-label-generation:
-    name: Remove Generate Label
+    name: Remove Generate Label From Unused Jobs
     runs-on: ubuntu-latest
-    needs: [changes, issue_number]
+    needs: [changes, pr_metadata]
     if: ${{ github.event_name != 'pull_request' && needs.changes.outputs.unchanged_package_count_deps > 0 }}
     strategy:
       fail-fast: false
@@ -470,13 +473,13 @@ jobs:
         package: ${{ fromJSON(needs.changes.outputs.unchanged_deps) }}
     steps:
       - name: Remove Label
-#        if: contains( github.event.pull_request.labels.*.name, 'needs-go-generate-${{matrix.package}}')
-        if: contains(github.event.pull_request.labels.*.name, 'needs-go-generate-core')
+        # see: https://github.com/joerick/pr-labels-action#how-do-i-use-this for explanation of spaces
+        if: contains(needs.pr_metadata.outputs.pr-labels, ' needs-go-generate-${{matrix.package}} ')
         uses: andymckay/labeler@3a4296e9dcdf9576b0456050db78cfd34853f260
         with:
           remove-labels: 'needs-go-generate-${{matrix.package}}'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ needs.issue_number.outputs.issue_number }}
+          issue-number: ${{ needs.pr_metadata.outputs.issue_number }}
       - run: |
           x=${{ toJson(github.event.pull_request.labels.*.name) }}
           echo $x
@@ -485,7 +488,7 @@ jobs:
   check-generation:
     name: Go Generate (Module Changes)
     runs-on: ubuntu-latest
-    needs: [changes, issue_number]
+    needs: [changes, pr_metadata]
     if: ${{ github.event_name != 'pull_request' && needs.changes.outputs.package_count_deps > 0 }}
     strategy:
       fail-fast: false
@@ -610,7 +613,7 @@ jobs:
         with:
           add-labels: 'needs-go-generate-${{matrix.package}}'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ needs.issue_number.outputs.issue_number }}
+          issue-number: ${{ needs.pr_metadata.outputs.issue_number }}
 
       - name: Remove Label
         if: steps.verify-changed-files.outputs.files_changed != 'true'
@@ -618,4 +621,4 @@ jobs:
         with:
           remove-labels: 'needs-go-generate-${{matrix.package}}'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ needs.issue_number.outputs.issue_number }}
+          issue-number: ${{ needs.pr_metadata.outputs.issue_number }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -355,13 +355,16 @@ jobs:
     steps:
       - uses: jwalton/gh-find-current-pr@v1
         id: find_pr
-      - uses: LucasRoesler/get-repo-owner-action@v1.0
-        id: get_owner
-      - name: Get PR labels
-        id: pr-labels
-        run: |
-          gh api -H "Accept: application/vnd.github+json" /repos/${{ steps.get_owner.outputs.owner }}/${{ github.event.repository.name }}/issues/${{ steps.find_pr.outputs.pr }}/labels | jq '[.[].name]' > /tmp/label_list
-          cat /tmp/label_list
+      # TODO: https://stackoverflow.com/a/75429845 consider splitting w/ gql to reduce limit hit
+      - run: |
+          labels="$(gh api repos/$OWNER/$REPO_NAME/pulls/$PULL_REQUEST_NUMBER --jq '.labels.[].name')"
+          echo "$labels"
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
 
   # check if we need to rerun go generate as a result of solidity changes. Note, this will only run on solidity changes.
   # TODO: consolidate w/ go change check. This will run twice on agents

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,12 +23,15 @@ jobs:
     name: Change Detection
     runs-on: ubuntu-latest
     outputs:
-      # Expose matched filters as job 'packages' output variable
+      # Expose matched filters as job 'packages' output variable with a trailing _deps for dependencies
       packages_deps: ${{ steps.filter_go.outputs.changed_modules_deps }}
-      unchanged_deps: ${{ steps.filter_go.outputs.changed_modules_deps }}
-      packages_nodeps: ${{ steps.filter_go_nodeps.outputs.changed_modules }}
       package_count_deps: ${{ steps.length.outputs.FILTER_LENGTH_DEPS }}
+
+      unchanged_deps: ${{ steps.filter_go.outputs.unchanged_modules_deps }}
       unchanged_package_count_deps: ${{ steps.length.outputs.FILTERED_PATHS_NODEPS }}
+
+      # These have no dependencies included in the change outputs
+      packages_nodeps: ${{ steps.filter_go_nodeps.outputs.changed_modules }}
       package_count_nodeps: ${{ steps.length.outputs.FILTER_LENGTH_NODEPS }}
       solidity_changes: ${{ steps.filter_solidity.outputs.any_changed }}
     steps:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -462,7 +462,7 @@ jobs:
     name: Remove Generate Label
     runs-on: ubuntu-latest
     needs: [changes, issue_number]
-#    if: ${{ github.event_name != 'pull_request' && needs.changes.outputs.unchanged_package_count_deps > 0 }}
+    if: ${{ github.event_name != 'pull_request' && needs.changes.outputs.unchanged_package_count_deps > 0 }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -498,6 +498,8 @@ jobs:
         # no need for this if we're not goint to remove anyway
         if: ${{ contains(fromJson(needs.pr_metadata.outputs.labels), format('needs-go-generate-{0}', matrix.package)) }}
         uses: softprops/turnstyle@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Remove Label
         if: ${{ contains(fromJson(needs.pr_metadata.outputs.labels), format('needs-go-generate-{0}', matrix.package)) }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -359,9 +359,12 @@ jobs:
       # TODO: https://stackoverflow.com/a/75429845 consider splitting w/ gql to reduce limit hit
       - run: |
           metadata="$(gh api repos/$OWNER/$REPO_NAME/pulls/$PULL_REQUEST_NUMBER)"
-          echo "##[set-output name=METADATA;]$(echo METADATA)"
 
+          # Extract the labels in JSON format from the metadata
           labels_json="$(echo "$metadata" | jq '.labels.[].name' | jq -s .)"
+
+          # Set the full metadata including the labels as the GitHub Actions step output
+          echo "::set-output name=METADATA::$metadata"
           echo "::set-output name=LABELS::$labels_json"
         id: metadata
         shell: bash

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -490,7 +490,7 @@ jobs:
         package: ${{ fromJSON(needs.changes.outputs.unchanged_deps) }}
     steps:
       - name: Remove Label
-        if: contains(fromJson(needs.pr_metadata.outputs.labels), 'needs-go-generate-${{matrix.package}}')
+        if: ${{ contains(fromJson(needs.pr_metadata.outputs.labels), 'needs-go-generate-${{matrix.package}}') }}
         uses: andymckay/labeler@3a4296e9dcdf9576b0456050db78cfd34853f260
         with:
           remove-labels: 'needs-go-generate-${{matrix.package}}'

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -358,14 +358,16 @@ jobs:
         id: find_pr
       # TODO: https://stackoverflow.com/a/75429845 consider splitting w/ gql to reduce limit hit
       - run: |
+          # Fetch the metadata
           metadata="$(gh api repos/$OWNER/$REPO_NAME/pulls/$PULL_REQUEST_NUMBER)"
 
           # Extract the labels in JSON format from the metadata
-          labels_json="$(echo "$metadata" | jq '.labels.[].name' | jq -s .)"
+          labels_json="$(echo "$metadata" | jq '[.labels[].name]')"
 
           # Set the full metadata including the labels as the GitHub Actions step output
           echo "::set-output name=METADATA::$metadata"
           echo "::set-output name=LABELS::$labels_json"
+
         id: metadata
         shell: bash
         env:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -468,7 +468,7 @@ jobs:
         package: ${{ fromJSON(needs.changes.outputs.unchanged_deps) }}
     steps:
       - name: Remove Label
-#        if: contains( github.event.pull_request.labels.*.name, 'needs-go-generate-${{matrix.package}}')
+        if: contains( github.event.pull_request.labels.*.name, 'needs-go-generate-${{matrix.package}}')
         uses: andymckay/labeler@3a4296e9dcdf9576b0456050db78cfd34853f260
         with:
           remove-labels: 'needs-go-generate-${{matrix.package}}'

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -490,7 +490,7 @@ jobs:
         package: ${{ fromJSON(needs.changes.outputs.unchanged_deps) }}
     steps:
       - name: Remove Label
-        if: ${{ contains(fromJson(needs.pr_metadata.outputs.labels), 'needs-go-generate-${{matrix.package}}') }}
+        if: ${{ contains(fromJson(needs.pr_metadata.outputs.labels), format('needs-go-generate-{0}', matrix.package)) }}
         uses: andymckay/labeler@3a4296e9dcdf9576b0456050db78cfd34853f260
         with:
           remove-labels: 'needs-go-generate-${{matrix.package}}'

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -261,7 +261,7 @@ jobs:
     name: Build
     needs: changes
     runs-on: ${{ matrix.platform }}
-    if: ${{ needs.changes.outputs.package_count_deps > 0 }}
+    if: ${{ needs.changes.outputs.package_count_deps > 0 && github.event_name != 'pull_request' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -484,7 +484,7 @@ jobs:
     name: Remove Generate Label From Unused Jobs
     runs-on: ubuntu-latest
     needs: [changes, pr_metadata]
-    if: ${{ github.event_name != 'pull_request' && needs.changes.outputs.unchanged_package_count_deps > 0 }}
+    if: ${{ github.event_name != 'pull_request' && needs.changes.outputs.unchanged_package_count_deps > 0 && contains(needs.pr_metadata.outputs.labels), 'needs-go-generate') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -126,7 +126,7 @@ jobs:
             ${{ runner.os }}-test-${{matrix.package}}
 
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
 
@@ -274,7 +274,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
 
@@ -312,7 +312,7 @@ jobs:
         # e.g. ['package1', 'package2'] if both package folders contains changes
         package: ${{ fromJSON(needs.changes.outputs.packages_nodeps) }}
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           # see: https://github.com/golangci/golangci-lint/issues/3420, moving to go 1.20 requires a new golangci-lint version
           # TODO: with this being 3 behind this should be done sooner rather than later.
@@ -391,7 +391,7 @@ jobs:
         run: npx lerna exec npm run build:go --parallel
 
       # Setup Go
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.21.x
 
@@ -517,7 +517,7 @@ jobs:
         if: ${{ contains(matrix.package, 'agents') }}
 
       # Setup Go
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.21.x
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -487,6 +487,7 @@ jobs:
     # prevent this from hogging more than one machine, should take no more than 3 seconds * number of packages (currently 15)
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-label-generation
+      cancel-in-progress: false
     if: ${{ github.event_name != 'pull_request' && needs.changes.outputs.unchanged_package_count_deps > 0 }}
     strategy:
       fail-fast: false

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -468,7 +468,7 @@ jobs:
         package: ${{ fromJSON(needs.changes.outputs.unchanged_deps) }}
     steps:
       - name: Remove Label
-        if: contains( github.event.pull_request.labels.*.name, 'needs-go-generate-${{matrix.package}}')
+#        if: contains( github.event.pull_request.labels.*.name, 'needs-go-generate-${{matrix.package}}')
         uses: andymckay/labeler@3a4296e9dcdf9576b0456050db78cfd34853f260
         with:
           remove-labels: 'needs-go-generate-${{matrix.package}}'

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -357,8 +357,8 @@ jobs:
         id: find_pr
       # TODO: https://stackoverflow.com/a/75429845 consider splitting w/ gql to reduce limit hit
       - run: |
-          labels="$(gh api repos/$OWNER/$REPO_NAME/pulls/$PULL_REQUEST_NUMBER)"
-          echo "$labels"
+          metadata="$(gh api repos/$OWNER/$REPO_NAME/pulls/$PULL_REQUEST_NUMBER)"
+          echo "metadata"
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -460,7 +460,7 @@ jobs:
     name: Remove Generate Label
     runs-on: ubuntu-latest
     needs: [changes, issue_number]
-    if: ${{ github.event_name != 'pull_request' && needs.changes.outputs.unchanged_package_count_deps > 0 }}
+#    if: ${{ github.event_name != 'pull_request' && needs.changes.outputs.unchanged_package_count_deps > 0 }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -470,7 +470,8 @@ jobs:
         package: ${{ fromJSON(needs.changes.outputs.unchanged_deps) }}
     steps:
       - name: Remove Label
-        if: contains( github.event.pull_request.labels.*.name, 'needs-go-generate-${{matrix.package}}')
+#        if: contains( github.event.pull_request.labels.*.name, 'needs-go-generate-${{matrix.package}}')
+        if: contains(github.event.pull_request.labels.*.name, 'needs-go-generate-core')
         uses: andymckay/labeler@3a4296e9dcdf9576b0456050db78cfd34853f260
         with:
           remove-labels: 'needs-go-generate-${{matrix.package}}'

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -351,14 +351,19 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
     outputs:
       issue_number: ${{ steps.find_pr.outputs.pr }}
-      labels: ${{ steps.pr-labels.outputs.labels }}
+      metadata: ${{ steps.metadata.outputs.METADATA }}
+      labels: ${{ steps.metadata.outputs.LABELS }}
     steps:
       - uses: jwalton/gh-find-current-pr@v1
         id: find_pr
       # TODO: https://stackoverflow.com/a/75429845 consider splitting w/ gql to reduce limit hit
       - run: |
           metadata="$(gh api repos/$OWNER/$REPO_NAME/pulls/$PULL_REQUEST_NUMBER)"
-          echo "metadata"
+          echo "##[set-output name=METADATA;]$(echo METADATA)"
+
+          labels_json="$(echo "$metadata" | jq '.labels.[].name' | jq -s .)"
+          echo "::set-output name=LABELS::$labels_json"
+        id: metadata
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -480,8 +485,7 @@ jobs:
         package: ${{ fromJSON(needs.changes.outputs.unchanged_deps) }}
     steps:
       - name: Remove Label
-        # see: https://github.com/joerick/pr-labels-action#how-do-i-use-this for explanation of spaces
-        if: contains(needs.pr_metadata.outputs.pr-labels, ' needs-go-generate-${{matrix.package}} ')
+        if: contains(fromJson(needs.pr_metadata.outputs.labels), 'needs-go-generate-${{matrix.package}}')
         uses: andymckay/labeler@3a4296e9dcdf9576b0456050db78cfd34853f260
         with:
           remove-labels: 'needs-go-generate-${{matrix.package}}'

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -344,7 +344,7 @@ jobs:
 
   pr_metadata:
     # this is needed to prevent us from hitting the github api rate limit
-    name: Get The Issue Number
+    name: Get PR Metadata
     runs-on: ubuntu-latest
     # currently, this matches the logic in the go generate check. If we ever add more checks that run on all packages, we should
     # change this to run on those pushes
@@ -481,7 +481,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ needs.pr_metadata.outputs.issue_number }}
       - run: |
-          x=${{ toJson(github.event.pull_request.labels.*.name) }}
+          x=${{ toJson(needs.pr_metadata.outputs.pr-labels) }}
           echo $x
 
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -468,8 +468,9 @@ jobs:
           echo "Changed files: ${{ steps.verify-changed-files.outputs.changed_files }}"
 
         # Fail if files need regeneration
+        # TODO: this can run into a bit of a race condition if any other label is removed/added while this is run, look into fixing this by dispatching another workflow
       - name: Add Label
-        if: steps.verify-changed-files.outputs.files_changed == 'true'
+        if: ${{ !contains(fromJson(needs.pr_metadata.outputs.labels), format('needs-go-generate-{0}', matrix.package)) && steps.verify-changed-files.outputs.files_changed == 'true' }}
         uses: andymckay/labeler@3a4296e9dcdf9576b0456050db78cfd34853f260
         with:
           add-labels: 'needs-go-generate-${{matrix.package}}'
@@ -630,8 +631,9 @@ jobs:
           echo "Changed files: ${{ steps.verify-changed-files.outputs.changed_files }}"
 
         # Fail if files need regeneration
+        # TODO: this can run into a bit of a race condition if any other label is removed/added while this is run, look into fixing this by dispatching another workflow
       - name: Add Label
-        if: steps.verify-changed-files.outputs.files_changed == 'true'
+        if: ${{ !contains(fromJson(needs.pr_metadata.outputs.labels), format('needs-go-generate-{0}', matrix.package)) && steps.verify-changed-files.outputs.files_changed == 'true' }}
         uses: andymckay/labeler@3a4296e9dcdf9576b0456050db78cfd34853f260
         with:
           add-labels: 'needs-go-generate-${{matrix.package}}'

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -362,7 +362,7 @@ jobs:
           metadata="$(gh api repos/$OWNER/$REPO_NAME/pulls/$PULL_REQUEST_NUMBER)"
 
           # Extract the labels in JSON format from the metadata
-          labels_json="$(echo "$metadata" | jq '[.labels[].name]')"
+          labels_json="$(echo "$metadata" | jq -r '[.labels[].name]')"
 
           # Set the full metadata including the labels as the GitHub Actions step output
           echo "::set-output name=METADATA::$metadata"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -355,9 +355,13 @@ jobs:
     steps:
       - uses: jwalton/gh-find-current-pr@v1
         id: find_pr
+      - uses: LucasRoesler/get-repo-owner-actions@v1.0
+        id: get_owner
       - name: Get PR labels
         id: pr-labels
-        uses: joerick/pr-labels-action@v1.0.8
+        run: |
+          gh api -H "Accept: application/vnd.github+json" /repos/${{ steps.get_owner.outputs.owner }}/${{ github.event.repository.name }}/issues/${{ steps.find_pr.outputs.pr }}/labels | jq '[.[].name]' > /tmp/label_list
+          cat /tmp/label_list
 
   # check if we need to rerun go generate as a result of solidity changes. Note, this will only run on solidity changes.
   # TODO: consolidate w/ go change check. This will run twice on agents

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -497,7 +497,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ needs.pr_metadata.outputs.issue_number }}
       - name: Remove Label
-        if: contains(needs.pr_metadata.outputs.labels, 'needs-go-generate-${{matrix.package}}')
+        if: contains(needs.pr_metadata.outputs.labels, "needs-go-generate-${{matrix.package}}")
         uses: andymckay/labeler@3a4296e9dcdf9576b0456050db78cfd34853f260
         with:
           remove-labels: 'needs-go-generate-${{matrix.package}}'

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -477,6 +477,9 @@ jobs:
           remove-labels: 'needs-go-generate-${{matrix.package}}'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ needs.issue_number.outputs.issue_number }}
+      - run: |
+          x=${{ toJson(github.event.pull_request.labels.*.name) }}
+          echo $x
 
 
   check-generation:

--- a/.github/workflows/goreleaser-actions.yml
+++ b/.github/workflows/goreleaser-actions.yml
@@ -24,7 +24,7 @@ jobs:
 
 
       - name: Cache Docker images.
-        uses: ScribeMD/docker-cache@0.2.6
+        uses: ScribeMD/docker-cache@0.3.6
         with:
           key: docker-release-${{ runner.os }}-${{ matrix.package }}
 

--- a/.github/workflows/goreleaser-actions.yml
+++ b/.github/workflows/goreleaser-actions.yml
@@ -168,7 +168,7 @@ jobs:
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: 1.20.x
 

--- a/.github/workflows/goreleaser-actions.yml
+++ b/.github/workflows/goreleaser-actions.yml
@@ -87,7 +87,7 @@ jobs:
     if: ${{ format('refs/heads/{0}', github.event.repository.default_branch) == github.ref || contains(github.event.head_commit.message, '[goreleaser]') }}
     outputs:
       # Expose matched filters as job 'packages' output variable
-      packages: ${{ steps.filter_go.outputs.changed_modules }}
+      packages: ${{ steps.filter_go.outputs.changed_modules_deps }}
       package_count: ${{ steps.length.outputs.FILTER_LENGTH }}
     steps:
       - uses: actions/checkout@v4
@@ -95,10 +95,9 @@ jobs:
           fetch-depth: 0
           submodules: 'recursive'
 
-      - uses: docker://ghcr.io/synapsecns/sanguine/git-changes-action:latest
+      - uses: docker://ghcr.io/synapsecns/sanguine/git-changes-action:e4c85e74bf0592c0efa71476c3246675ec77fc28
         id: filter_go
         with:
-          include_deps: true
           github_token: ${{ secrets.WORKFLOW_PAT }}
 
       - id: length
@@ -106,7 +105,7 @@ jobs:
           export FILTER_LENGTH=$(echo $FILTERED_PATHS | jq '. | length')
           echo "##[set-output name=FILTER_LENGTH;]$(echo $FILTER_LENGTH)"
         env:
-          FILTERED_PATHS: ${{ steps.filter_go.outputs.changed_modules }}
+          FILTERED_PATHS: ${{ steps.filter_go.outputs.changed_modules_deps }}
 
   # TODO: we may want to dry run this on prs
   run-goreleaser:

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -7,6 +7,7 @@ on:
   push:
     paths:
       - 'charts/**'
+      - '.github/workflows/helm-test.yml'
 
 # TODO: it'd be nice to eventually work this into release process on new images
 # definitely not a right now thing
@@ -38,7 +39,7 @@ jobs:
         with:
           version: v3.9.2
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.7
 

--- a/.github/workflows/jaeger-ui.yml
+++ b/.github/workflows/jaeger-ui.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Cache Docker images.
-        uses: ScribeMD/docker-cache@0.2.6
+        uses: ScribeMD/docker-cache@0.3.6
         with:
           key: docker-release-jaeger
 

--- a/contrib/git-changes-action/README.md
+++ b/contrib/git-changes-action/README.md
@@ -14,7 +14,7 @@ This GitHub Action exports a variable that contains the list of Go modules chang
 
 ```yaml
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: 'recursive'
@@ -26,14 +26,12 @@ This GitHub Action exports a variable that contains the list of Go modules chang
       - uses: docker://ghcr.io/synapsecns/sanguine/git-changes-action:latest
         id: filter_go
         with:
-          include_deps: true
           github_token: ${{ secrets.github_token }}
           timeout: "1m" # optional, defaults to 1m
 ```
 
 You can customize the behavior of the git-changes script by using the following inputs:
 
- - `include_deps`: A boolean that controls whether dependent modules are included in the list of changed modules. Set to true by default.
  - `github_token`: The token to use for authentication with the GitHub API. This is required to fetch information about the current pull request.
  - `timeout`: The maximum time to wait for the GitHub API to respond. Defaults to 1 minute.
 
@@ -41,6 +39,9 @@ The output of the git-changes script is a comma-separated list of Go module path
 
 ```yaml
       - run: echo "Changed modules: ${{ steps.filter_go.outputs.changed_modules }}"
+      - run: echo "Unchanged modules: ${{ steps.filter_go.outputs.unchanged_modules }}"
+      - run: echo "Changed modules (including dependencies): ${{ steps.filter_go.outputs.changed_modules_deps }}"
+      - run: echo "Unchanged modules (including dependencies): ${{ steps.filter_go.outputs.unchanged_modules_deps }}"
 ```
 
 ## Example
@@ -67,7 +68,6 @@ jobs:
       - uses: docker://ghcr.io/synapsecns/sanguine/git-changes-action:latest
         id: filter_go
         with:
-          include_deps: true
           github_token: ${{ secrets.github_token }}
           timeout: "1m"
 

--- a/contrib/git-changes-action/README.md
+++ b/contrib/git-changes-action/README.md
@@ -97,30 +97,31 @@ Each module in the `go.work` is visited. If any changes were detected by the pre
 
 ```mermaid
 sequenceDiagram
-    participant GW as go.work
-    participant M as Module
-    participant CML as Changed_Module_List
-    participant ID as include_dependencies
-    participant D as Dependency
+  participant GW as go.work
+  participant M as Module
+  participant CML as Changed_Module_List
+  participant UML as Unchanged_Module_List
+  participant D as Dependency
 
-    GW->>M: Visit Module
-    Note over M: Check for changes
-    M-->>GW: Changes Detected?
-    alt Changes Detected
-        GW->>CML: Add Module to Changed_Module_List
-    else No Changes Detected
-        GW-->>M: Skip Module
+  GW->>M: Visit Module
+  Note over M: Check for changes
+  M-->>GW: Changes Detected?
+  alt Changes Detected
+    GW->>CML: Add Module to Changed_Module_List
+    M->>D: Has Dependency in go.work?
+    alt Has Dependency
+      GW->>CML: Add Dependency to Changed_Module_List
+    else No Dependency
+      M-->>GW: No Dependency to Add
     end
-    GW->>ID: include_dependencies On?
-    alt include_dependencies On
-        M->>D: Has Dependency in go.work?
-        alt Has Dependency
-            GW->>CML: Add Dependency to Changed_Module_List
-        else No Dependency
-            M-->>GW: No Dependency to Add
-        end
-    else include_dependencies Off
-        GW-->>M: Skip Dependency Check
+  else No Changes Detected
+    GW->>UML: Add Module to Unchanged_Module_List
+    M->>D: Has Dependency in go.work?
+    alt Has Dependency
+      GW->>UML: Add Dependency to Unchanged_Module_List
+    else No Dependency
+      M-->>GW: No Dependency to Add
     end
-    GW->>GW: Continue Until All Modules Visited
+  end
+  GW->>GW: Continue Until All Modules Visited
 ```

--- a/contrib/git-changes-action/main.go
+++ b/contrib/git-changes-action/main.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/synapsecns/sanguine/contrib/git-changes-action/detector/tree"
 	"os"
 	"sort"
 	"strings"
@@ -32,8 +33,6 @@ func main() {
 		panic(fmt.Errorf("failed to parse timeout: %w", err))
 	}
 
-	includeDeps := getIncludeDeps()
-
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
@@ -42,44 +41,57 @@ func main() {
 		panic(err)
 	}
 
-	modules, err := detector.DetectChangedModules(workingDirectory, ct, includeDeps)
+	noDepChanged, noDepUnchanged, err := outputModuleChanges(workingDirectory, ct, false)
 	if err != nil {
 		panic(err)
 	}
 
-	var changedModules []string
-	for module, changed := range modules {
-		if !changed {
-			continue
-		}
+	depChanged, depUnchanged, err := outputModuleChanges(workingDirectory, ct, true)
+	if err != nil {
+		panic(err)
+	}
 
-		changedModules = append(changedModules, strings.TrimPrefix(module, "./"))
+	githubactions.SetOutput("changed_modules", noDepChanged)
+	githubactions.SetOutput("unchanged_modules", noDepUnchanged)
+
+	githubactions.SetOutput("changed_modules_deps", depChanged)
+	githubactions.SetOutput("unchanged_modules_deps", depUnchanged)
+}
+
+// outputModuleChanges outputs the changed modules.
+// this wraps detector.DetectChangedModules and handles the output formatting to be parsable by github actions.
+// the final output is a json array of strings.
+func outputModuleChanges(workingDirectory string, ct tree.Tree, includeDeps bool) (changedJson string, unchangedJson string, err error) {
+	modules, err := detector.DetectChangedModules(workingDirectory, ct, includeDeps)
+	if err != nil {
+		return changedJson, unchangedJson, fmt.Errorf("failed to detect changed modules w/ include deps set to %v: %w", includeDeps, err)
+	}
+
+	var changedModules, unchangedModules []string
+	for module, changed := range modules {
+		modName := strings.TrimPrefix(module, "./")
+
+		if changed {
+			changedModules = append(changedModules, modName)
+		} else {
+			unchangedModules = append(unchangedModules, modName)
+		}
 	}
 
 	sort.Strings(changedModules)
-	marshalledJSON, err := json.Marshal(changedModules)
+	sort.Strings(unchangedModules)
+
+	marshalledChanged, err := json.Marshal(changedModules)
 	if err != nil {
-		panic(err)
+		return changedJson, unchangedJson, fmt.Errorf("failed to marshall changed module json w/ include deps set to %v: %w", includeDeps, err)
 	}
 
-	if len(changedModules) == 0 {
-		fmt.Println("no modules changed")
-	} else {
-		fmt.Printf("setting output to %s\n", marshalledJSON)
+	marshalledUnchanged, err := json.Marshal(unchangedModules)
+	if err != nil {
+		return changedJson, unchangedJson, fmt.Errorf("failed to marshall unchanged module json w/ include deps set to %v: %w", includeDeps, err)
 	}
-	githubactions.SetOutput("changed_modules", string(marshalledJSON))
-}
 
-// getIncludeDeps gets the include deps setting.
-// If it is not set, it defaults to false.
-func getIncludeDeps() (includeDeps bool) {
-	rawIncludeDeps := githubactions.GetInput("include_deps")
-
-	includeDeps = false
-	if rawIncludeDeps == "true" {
-		includeDeps = true
-	}
-	return
+	return string(marshalledChanged), string(marshalledUnchanged), nil
 }
 
 // getTimeout gets the timeout setting. If it is not set, it defaults to 1 minute.

--- a/contrib/git-changes-action/main.go
+++ b/contrib/git-changes-action/main.go
@@ -61,10 +61,10 @@ func main() {
 // outputModuleChanges outputs the changed modules.
 // this wraps detector.DetectChangedModules and handles the output formatting to be parsable by github actions.
 // the final output is a json array of strings.
-func outputModuleChanges(workingDirectory string, ct tree.Tree, includeDeps bool) (changedJson string, unchangedJson string, err error) {
+func outputModuleChanges(workingDirectory string, ct tree.Tree, includeDeps bool) (changedJSON string, unchangedJson string, err error) {
 	modules, err := detector.DetectChangedModules(workingDirectory, ct, includeDeps)
 	if err != nil {
-		return changedJson, unchangedJson, fmt.Errorf("failed to detect changed modules w/ include deps set to %v: %w", includeDeps, err)
+		return changedJSON, unchangedJson, fmt.Errorf("failed to detect changed modules w/ include deps set to %v: %w", includeDeps, err)
 	}
 
 	var changedModules, unchangedModules []string
@@ -83,12 +83,12 @@ func outputModuleChanges(workingDirectory string, ct tree.Tree, includeDeps bool
 
 	marshalledChanged, err := json.Marshal(changedModules)
 	if err != nil {
-		return changedJson, unchangedJson, fmt.Errorf("failed to marshall changed module json w/ include deps set to %v: %w", includeDeps, err)
+		return changedJSON, unchangedJson, fmt.Errorf("failed to marshall changed module json w/ include deps set to %v: %w", includeDeps, err)
 	}
 
 	marshalledUnchanged, err := json.Marshal(unchangedModules)
 	if err != nil {
-		return changedJson, unchangedJson, fmt.Errorf("failed to marshall unchanged module json w/ include deps set to %v: %w", includeDeps, err)
+		return changedJSON, unchangedJson, fmt.Errorf("failed to marshall unchanged module json w/ include deps set to %v: %w", includeDeps, err)
 	}
 
 	return string(marshalledChanged), string(marshalledUnchanged), nil


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**

As #1397 & #579 pointed out if a module is changed and then unchanged, the needs-go-generate action is not removed (this is blocking #1382 rn). For this reason, this pr:

- consolidates actions for `include_deps`=true and `include_deps`=false. This will also help with #1390 by halving api requests by git-changes-action. Further work could be done here by consolidating goreleaser into `go.yml` the future 
- Remove unchanged module labels. This is honestly kind of a pain and could lead to api rate limiting issues. The way we're going to deal with this is by starting an action for each label, but only running it if the event is a pull request and [this condition](https://stackoverflow.com/a/59588725) is met. Once this is done we can also add this to the needs-go-generate check to reduce the number of api calls to remove a lebl further helping w/ #1390 

Lesson from #1400: paralell removal is not possible


## Future Work

 -  This will still break is a module is deleted entirely and the `needs-go-generate-x...` label is on a pr , but I believe this is an acceptable edge case. If we want we can rule this out by adding the number of unchanged modules to changed modules and dividing by total and removing excess, but this seems gratuitous at present

 - One other thing I figured out is that for some reason these generation actions are ran on a `push` rather than a `pull_request` level creating the need for two additional api requests. We should figure out if there was a reason for this and fix it if not
 - This spins up *a lot* of jobs, but their total duration is on average ~3 seconds, and they usually don't do anything.
 - Run in a single job rather than one per unchanged. This is mostly aesthetic at this time since these hardly have any overhead. see #1400 for why this is neccesary, removing labels in paralell doesn't work)
 - Labels can't be removed in paralell rn, so the other jobs are broken
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Chore: Updated various GitHub Actions workflows, improving their efficiency and maintainability. This includes version updates for actions such as `actions/stale`, `actions/checkout`, `actions/setup-go`, and `actions/setup-python`.
- Refactor: Enhanced the `git-changes-action` by introducing a new function `outputModuleChanges` to improve modularity and output structure for GitHub Actions.
- Bug Fix: Removed unused steps in the `fail-on-needs-generate.yaml` workflow, enhancing its performance.
- New Feature: Added a job to remove the "needs-go-generate" label from unused jobs in the `go.yml` workflow.
- Documentation: Updated the README for `git-changes-action` to reflect recent changes and improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->