### PR TITLE
Fix white screen error

### DIFF
--- a/packages/synapse-interface/components/StateManagedBridge/BridgeTransactionButton.tsx
+++ b/packages/synapse-interface/components/StateManagedBridge/BridgeTransactionButton.tsx
@@ -128,7 +128,7 @@ export const BridgeTransactionButton = ({
     }
   } else if (chain?.id != fromChainId && fromValueBigInt > 0) {
     buttonProperties = {
-      label: `Switch to ${chains.find((c) => c.id === fromChainId).name}`,
+      label: `Switch to ${chains.find((c) => c.id === fromChainId)?.name}`,
       onClick: () => switchNetwork(fromChainId),
       pendingLabel: 'Switching chains',
     }


### PR DESCRIPTION
Fix for white screen when disconnecting wallet when pending transaction action in metamask wallet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Updated the label of the `BridgeTransactionButton` component in the Synapse Interface package. The button now dynamically displays the name of the current chain based on the `fromChainId`. This change enhances user experience by providing clearer information when switching networks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
706c2cd4365a9f9300b66762522e55a5a9bb25fc: [synapse-interface preview link ](https://sanguine-synapse-interface-axpzduoej-synapsecns.vercel.app)