### PR TITLE
Removes deprecated warning message

### DIFF
--- a/packages/synapse-interface/components/Warning.tsx
+++ b/packages/synapse-interface/components/Warning.tsx
@@ -1,53 +1,14 @@
-import { useMemo } from 'react'
-
-import { DISCORD_URL, TWITTER_URL } from '@/constants/urls'
-import { AVALANCHE, DOGE, FANTOM, HARMONY } from '@/constants/chains/master'
+import { DOGE, FANTOM, HARMONY } from '@/constants/chains/master'
 import { useBridgeState } from '@/slices/bridge/hooks'
-import { CCTP_ROUTER_ADDRESS } from '@/utils/actions/fetchPortfolioBalances'
 
 export const Warning = () => {
-  const { fromChainId, toChainId, fromToken, bridgeQuote } = useBridgeState()
-
-  const isCCTP = useMemo(() => {
-    return (
-      fromChainId &&
-      fromToken &&
-      fromChainId !== AVALANCHE.id &&
-      fromToken?.swapableType === 'USD' &&
-      bridgeQuote.routerAddress.toLowerCase() ===
-        CCTP_ROUTER_ADDRESS.toLowerCase()
-    )
-  }, [bridgeQuote, fromToken])
+  const { fromChainId, toChainId } = useBridgeState()
 
   const isChainHarmony = [fromChainId, toChainId].includes(HARMONY.id)
   const isChainFantom = [fromChainId, toChainId].includes(FANTOM.id)
   const isChainDoge = [fromChainId, toChainId].includes(DOGE.id)
 
-  if (isCCTP) {
-    return (
-      <WarningMessage
-        header="This route uses the Circle cross-chain transfer protocol."
-        message={
-          <>
-            <p className="mb-2">
-              CCTP transfers may take up to 20 minutes to complete.
-            </p>
-            <p>
-              Follow{' '}
-              <a target="_blank" className="underline" href={TWITTER_URL}>
-                Twitter
-              </a>{' '}
-              or{' '}
-              <a target="_blank" className="underline" href={DISCORD_URL}>
-                Discord
-              </a>{' '}
-              for updates as more CCTP routes become available.
-            </p>
-          </>
-        }
-      />
-    )
-  } else if (isChainHarmony) {
+  if (isChainHarmony) {
     return (
       <WarningMessage
         header="Warning! The Harmony bridge has been exploited."


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Removed unused imports and variables in `Warning.tsx` for cleaner code.
- Change: The `Warning` component no longer displays a warning message for CCTP transfers, focusing on Harmony bridge exploit warnings. This change enhances the user experience by providing more relevant alerts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
4f7a22024876fed3a4cf40149a70085fd13d8ece: [synapse-interface preview link ](https://sanguine-synapse-interface-qt8iljcy4-synapsecns.vercel.app)