### PR TITLE
Fix explorer fe destination contract link

### DIFF
--- a/packages/explorer-ui/pages/tx/[kappa].tsx
+++ b/packages/explorer-ui/pages/tx/[kappa].tsx
@@ -43,7 +43,7 @@ export default function BridgeTransaction({ queryResult }) {
     if (eventType == 10 || eventType == 11) {
       return CHAIN_EXPLORER_URLS[chainID] + '/address/' + CCTP_CONTRACTS[chainID]
     }
-    return CHAIN_EXPLORER_URLS[chainId] + '/address/' + BRIDGE_CONTRACTS[fromInfo.chainID]
+    return CHAIN_EXPLORER_URLS[chainId] + '/address/' + BRIDGE_CONTRACTS[chainID]
   }
   const transaction = queryResult.bridgeTransactions[0]
   const { pending, fromInfo, toInfo } = transaction

--- a/packages/explorer-ui/pages/tx/[kappa].tsx
+++ b/packages/explorer-ui/pages/tx/[kappa].tsx
@@ -43,7 +43,7 @@ export default function BridgeTransaction({ queryResult }) {
     if (eventType == 10 || eventType == 11) {
       return CHAIN_EXPLORER_URLS[chainID] + '/address/' + CCTP_CONTRACTS[chainID]
     }
-    return CHAIN_EXPLORER_URLS[chainId] + '/address/' + BRIDGE_CONTRACTS[chainID]
+    return CHAIN_EXPLORER_URLS[chainID] + '/address/' + BRIDGE_CONTRACTS[chainID]
   }
   const transaction = queryResult.bridgeTransactions[0]
   const { pending, fromInfo, toInfo } = transaction


### PR DESCRIPTION
**Description**
Ensure that the destination contract link goes to the correct block explorer link.


d4724d2cbf28b5eb1fc4b4eadf69a7bb934499c7: [explorer-ui preview link ](https://sanguine-5otpvsoxz-synapsecns.vercel.app)
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Bug Fix:**

- Fixed an issue in the `BridgeTransaction` function where the incorrect bridge contract address was being used. The system now correctly uses the bridge contract address based on the `chainID` value, ensuring accurate and consistent data across different event types. This change enhances the reliability of transaction processing and improves user experience by providing accurate information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
54f5b4def5da63ecc4c86c968ee62f1eb53cd6af: [explorer-ui preview link ](https://sanguine-r9b6v2icw-synapsecns.vercel.app)