### PR TITLE
Fix/activity pending

### DIFF
--- a/packages/synapse-interface/components/Portfolio/Transaction/PendingTransaction.tsx
+++ b/packages/synapse-interface/components/Portfolio/Transaction/PendingTransaction.tsx
@@ -197,6 +197,7 @@ const TransactionStatusDetails = ({
     'flex bg-tint border-t border-surface text-sm items-center'
 
   if (transactionStatus === TransactionStatus.PENDING_WALLET_ACTION) {
+    console.log('1')
     return (
       <div
         data-test-id="pending-wallet-action-status"
@@ -209,6 +210,7 @@ const TransactionStatusDetails = ({
   }
 
   if (transactionStatus === TransactionStatus.INITIALIZING) {
+    console.log('2')
     return (
       <div
         data-test-id="initializing-status"
@@ -229,6 +231,7 @@ const TransactionStatusDetails = ({
   }
 
   if (transactionStatus === TransactionStatus.PENDING) {
+    console.log('3')
     const handleOriginExplorerClick = () => {
       const explorerLink: string = getExplorerTxUrl({
         chainId: originChain.id,

--- a/packages/synapse-interface/components/Portfolio/Transaction/PendingTransaction.tsx
+++ b/packages/synapse-interface/components/Portfolio/Transaction/PendingTransaction.tsx
@@ -252,7 +252,7 @@ const TransactionStatusDetails = ({
       >
         {isDelayed ? (
           <>
-            <div className="flex items-center p-1 ml-1 rounded-sm cursor-pointer">
+            <div className="flex items-center p-1 ml-1 rounded-sm cursor-default">
               <div className="text-[#FFDD33]">Taking longer than expected.</div>
             </div>
             <TransactionOptions

--- a/packages/synapse-interface/components/Portfolio/Transaction/PendingTransaction.tsx
+++ b/packages/synapse-interface/components/Portfolio/Transaction/PendingTransaction.tsx
@@ -197,7 +197,6 @@ const TransactionStatusDetails = ({
     'flex bg-tint border-t border-surface text-sm items-center'
 
   if (transactionStatus === TransactionStatus.PENDING_WALLET_ACTION) {
-    console.log('1')
     return (
       <div
         data-test-id="pending-wallet-action-status"
@@ -210,7 +209,6 @@ const TransactionStatusDetails = ({
   }
 
   if (transactionStatus === TransactionStatus.INITIALIZING) {
-    console.log('2')
     return (
       <div
         data-test-id="initializing-status"
@@ -231,7 +229,6 @@ const TransactionStatusDetails = ({
   }
 
   if (transactionStatus === TransactionStatus.PENDING) {
-    console.log('3')
     const handleOriginExplorerClick = () => {
       const explorerLink: string = getExplorerTxUrl({
         chainId: originChain.id,
@@ -248,14 +245,6 @@ const TransactionStatusDetails = ({
       window.open(explorerLink, '_blank', 'noopener,noreferrer')
     }
 
-    const handleSynapseExplorerTxClick = () => {
-      const explorerLink: string = getTransactionExplorerLink({
-        kappa,
-        fromChainId: originChain.id,
-      })
-      window.open(explorerLink, '_blank', 'noopener,noreferrer')
-    }
-
     return (
       <div
         data-test-id="pending-status"
@@ -263,15 +252,7 @@ const TransactionStatusDetails = ({
       >
         {isDelayed ? (
           <>
-            <div
-              className="flex cursor-pointer hover:bg-[#101018] rounded-sm hover:text-[#FFDD33] hover:underline p-1 ml-1 items-center"
-              onClick={handleSynapseExplorerTxClick}
-            >
-              {/* <Image
-                className="w-4 h-4 ml-1 mr-1.5 my-auto rounded-full"
-                src={destinationChain.explorerImg}
-                alt={`${destinationChain.explorerName} logo`}
-              /> */}
+            <div className="flex items-center p-1 ml-1 rounded-sm cursor-pointer">
               <div className="text-[#FFDD33]">Taking longer than expected.</div>
             </div>
             <TransactionOptions

--- a/packages/synapse-interface/components/Portfolio/Transaction/TransactionOptions.tsx
+++ b/packages/synapse-interface/components/Portfolio/Transaction/TransactionOptions.tsx
@@ -35,7 +35,6 @@ export const TransactionOptions = ({
       originChain &&
       transactionStatus === TransactionStatus.COMPLETED
     ) {
-      console.log('a')
       const explorerLink: string = getTransactionExplorerLink({
         kappa,
         fromChainId: originChain.id,
@@ -43,21 +42,18 @@ export const TransactionOptions = ({
       })
       window.open(explorerLink, '_blank', 'noopener,noreferrer')
     } else if (isDelayed) {
-      console.log('b')
       const explorerLink: string = getTransactionExplorerLink({
         kappa,
         fromChainId: originChain.id,
       })
       window.open(explorerLink, '_blank', 'noopener,noreferrer')
     } else if (transactionHash) {
-      console.log('c')
       const explorerLink: string = getExplorerAddressUrl({
         chainId: destinationChain.id,
         address: connectedAddress,
       })
       window.open(explorerLink, '_blank', 'noopener,noreferrer')
     } else {
-      console.log('d')
       const explorerLink: string = getExplorerAddressUrl({
         chainId: originChain.id,
         address: connectedAddress,

--- a/packages/synapse-interface/components/Portfolio/Transaction/TransactionOptions.tsx
+++ b/packages/synapse-interface/components/Portfolio/Transaction/TransactionOptions.tsx
@@ -35,6 +35,7 @@ export const TransactionOptions = ({
       originChain &&
       transactionStatus === TransactionStatus.COMPLETED
     ) {
+      console.log('a')
       const explorerLink: string = getTransactionExplorerLink({
         kappa,
         fromChainId: originChain.id,
@@ -42,18 +43,21 @@ export const TransactionOptions = ({
       })
       window.open(explorerLink, '_blank', 'noopener,noreferrer')
     } else if (isDelayed) {
+      console.log('b')
       const explorerLink: string = getTransactionExplorerLink({
         kappa,
         fromChainId: originChain.id,
       })
       window.open(explorerLink, '_blank', 'noopener,noreferrer')
     } else if (transactionHash) {
-      const explorerLink: string = getExplorerTxUrl({
-        chainId: originChain.id,
-        hash: transactionHash,
+      console.log('c')
+      const explorerLink: string = getExplorerAddressUrl({
+        chainId: destinationChain.id,
+        address: connectedAddress,
       })
       window.open(explorerLink, '_blank', 'noopener,noreferrer')
     } else {
+      console.log('d')
       const explorerLink: string = getExplorerAddressUrl({
         chainId: originChain.id,
         address: connectedAddress,

--- a/packages/synapse-interface/slices/transactions/updater.tsx
+++ b/packages/synapse-interface/slices/transactions/updater.tsx
@@ -82,6 +82,7 @@ export default function Updater(): null {
   // Start fetch when connected address exists
   useEffect(() => {
     if (address && isWindowFocused && !masqueradeActive) {
+      console.log('got hit')
       fetchUserHistoricalActivity({
         address: address,
         startTime: queryHistoricalTime,
@@ -107,7 +108,12 @@ export default function Updater(): null {
         startTime: queryPendingTime,
       })
     }
-  }, [address, masqueradeActive, searchedBalancesAndAllowances])
+  }, [
+    address,
+    masqueradeActive,
+    searchedBalancesAndAllowances,
+    isWindowFocused,
+  ])
 
   // Unsubscribe when address is unconnected/disconnected
   useEffect(() => {

--- a/packages/synapse-interface/slices/transactions/updater.tsx
+++ b/packages/synapse-interface/slices/transactions/updater.tsx
@@ -82,7 +82,6 @@ export default function Updater(): null {
   // Start fetch when connected address exists
   useEffect(() => {
     if (address && isWindowFocused && !masqueradeActive) {
-      console.log('got hit')
       fetchUserHistoricalActivity({
         address: address,
         startTime: queryHistoricalTime,


### PR DESCRIPTION
Add fix for following: 
- Recent Transactions updating after user refocuses / start re-polling
- Fix broken links / misdirected link based on Pending Transaction state
- Remove onClick callback + hover on Delayed Pending Transaction

5b3a0c6fb59b7cf7f2885637178c1a5a5dc1f1bc: [synapse-interface preview link ](https://sanguine-synapse-interface-gezjratuj-synapsecns.vercel.app)

7181e880d595759777e177c955e67a37e2f6200b: [synapse-interface preview link ](https://sanguine-synapse-interface-ile8sy1qg-synapsecns.vercel.app)
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Release Notes for the Pull Request:**

- Refactor: Simplified the transaction handling in `PendingTransaction.tsx` by removing unnecessary functionality and streamlining the code.
- Bug Fix: Updated the logic for generating explorer links in `TransactionOptions.tsx` to use the destination chain and connected address, ensuring accurate link generation.
- Chore: Added console log statement in `updater.tsx` for improved debugging.
- Refactor: Modified the dependencies of the `useEffect` hook in `updater.tsx` to include `isWindowFocused`, enhancing responsiveness to window focus changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
93df711b77408c39ea7154aa89be03f778b9830d: [synapse-interface preview link ](https://sanguine-synapse-interface-i673pws4b-synapsecns.vercel.app)