### PR TITLE
Update multicall fetch to handle error

### DIFF
--- a/packages/synapse-interface/components/Portfolio/Portfolio.tsx
+++ b/packages/synapse-interface/components/Portfolio/Portfolio.tsx
@@ -218,10 +218,10 @@ export function filterPortfolioBalancesWithBalances(
       filteredBalances: NetworkTokenBalancesAndAllowances,
       [key, tokenWithBalances]
     ) => {
-      const filtered = tokenWithBalances.filter(
+      const filtered = tokenWithBalances?.filter(
         (token: TokenWithBalanceAndAllowance) => token.balance > 0n
       )
-      if (filtered.length > 0) {
+      if (filtered?.length > 0) {
         filteredBalances[key] = filtered
       }
       return filteredBalances

--- a/packages/synapse-interface/utils/actions/fetchPortfolioBalances.tsx
+++ b/packages/synapse-interface/utils/actions/fetchPortfolioBalances.tsx
@@ -111,59 +111,13 @@ const getTokensAllowances = async (
 }
 
 /**
+ * Fetch Balances and Allowances per Supported Chain
  * @param address: wallet address to fetch balance of
  * @param chainId?: specific network to fetch balances from
  * @returns addresses' token balances and allowances
  * If specifying chainId parameter, function will only fetch from single network
  * If chainId is undefined, function will fetch from all supported networks
  */
-// export const fetchPortfolioBalances = async (
-//   address: string,
-//   chainId?: number | undefined | null
-// ): Promise<{
-//   balancesAndAllowances: NetworkTokenBalancesAndAllowances
-//   status: FetchState
-//   error?: any | undefined
-// }> => {
-//   const balanceRecord = {}
-//   const availableChains: string[] = Object.keys(BRIDGABLE_TOKENS)
-//   const isSingleNetworkCall: boolean = typeof chainId === 'number'
-
-//   const filteredChains: string[] = availableChains.filter((chain: string) => {
-//     return isSingleNetworkCall ? Number(chain) === chainId : chain !== '2000' // need to figure out whats wrong with Dogechain
-//   })
-
-//   try {
-//     const balancePromises = filteredChains.map(async (chainId) => {
-//       const currentChainId = Number(chainId)
-//       const currentChainTokens = BRIDGABLE_TOKENS[chainId]
-//       const [tokenBalances, tokenAllowances] = await Promise.all([
-//         getTokenBalances(address, currentChainTokens, currentChainId),
-//         getTokensAllowances(
-//           address,
-//           ROUTER_ADDRESS,
-//           currentChainTokens,
-//           currentChainId
-//         ),
-//       ])
-//       const mergedBalancesAndAllowances = mergeBalancesAndAllowances(
-//         tokenBalances,
-//         tokenAllowances
-//       )
-//       return { currentChainId, mergedBalancesAndAllowances }
-//     })
-//     const balances = await Promise.all(balancePromises)
-//     balances.forEach(({ currentChainId, mergedBalancesAndAllowances }) => {
-//       balanceRecord[currentChainId] = mergedBalancesAndAllowances
-//     })
-
-//     return { balancesAndAllowances: balanceRecord, status: FetchState.VALID }
-//   } catch (error) {
-//     console.error('error from fetch:', error)
-//     return { balancesAndAllowances: {}, status: FetchState.INVALID, error }
-//   }
-// }
-
 export const fetchPortfolioBalances = async (
   address: string,
   chainId?: number | undefined | null


### PR DESCRIPTION
fix multicall aggregate3 call error / potential rpc rate limiting / rpc error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Bug Fix: Enhanced the `filterPortfolioBalancesWithBalances` function in Portfolio.tsx to prevent errors when `tokenWithBalances` is null or undefined. This ensures a smoother user experience when filtering portfolio balances.
- Refactor: Improved error handling in the `fetchPortfolioBalances` function within fetchPortfolioBalances.tsx. The function now uses `Promise.allSettled` for better management of both successful and failed promises, providing more robust data fetching for portfolio balances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
577d413f2b575c21640cddaa12d73562f2c10092: [synapse-interface preview link ](https://sanguine-synapse-interface-c1vhwt4zp-synapsecns.vercel.app)
c259d616f4b6353507e88d9f9c21729e93046b32: [synapse-interface preview link ](https://sanguine-synapse-interface-2892j4mos-synapsecns.vercel.app)