### PR TITLE
cleanup stale

### DIFF
--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -25,4 +25,5 @@ jobs:
     steps:
       - uses: fpicalausa/remove-stale-branches@v1
         with:
+          operations-per-run: 50
           stale-branch-message: "@{author} Your branch [{branchName}]({branchUrl}) hasn't been updated in the last 60 days and is marked as stale. It will be removed in a week. If a pull request is open on this branch, you can ignore this message, you can always restore your branch on the pull request link. \r\nIf you want to keep this branch around, delete this comment or add new commits to this branch.	"

--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -26,4 +26,5 @@ jobs:
       - uses: fpicalausa/remove-stale-branches@v1
         with:
           operations-per-run: 50
+          days-before-branch-delete: 3
           stale-branch-message: "@{author} Your branch [{branchName}]({branchUrl}) hasn't been updated in the last 60 days and is marked as stale. It will be removed in a week. If a pull request is open on this branch, you can ignore this message, you can always restore your branch on the pull request link. \r\nIf you want to keep this branch around, delete this comment or add new commits to this branch.	"

--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -27,4 +27,5 @@ jobs:
         with:
           operations-per-run: 50
           days-before-branch-delete: 3
+          # yamllint disable-line
           stale-branch-message: "@{author} Your branch [{branchName}]({branchUrl}) hasn't been updated in the last 60 days and is marked as stale. It will be removed in a week. If a pull request is open on this branch, you can ignore this message, you can always restore your branch on the pull request link. \r\nIf you want to keep this branch around, delete this comment or add new commits to this branch.	"

--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -23,7 +23,4 @@ jobs:
     name: Remove Stale Branches
     runs-on: ubuntu-latest
     steps:
-      # TODO: enable
       - uses: fpicalausa/remove-stale-branches@v1
-        with:
-          dry-run: true # Check out the console output before setting this to false

--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -1,4 +1,4 @@
-name: 'Close stale issues and PRs'
+name: 'Close stale issues, branches and PRs'
 on:
   schedule:
     - cron: '30 1 * * *'
@@ -8,7 +8,7 @@ on:
       - '.github/workflows/close-stale.yml'
 
 jobs:
-  stale:
+  stale-prs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v8
@@ -19,3 +19,11 @@ jobs:
           days-before-pr-stale: 14
           days-before-close: 5
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+  stale-branches:
+    name: Remove Stale Branches
+    runs-on: ubuntu-latest
+    steps:
+      # TODO: enable
+      - uses: fpicalausa/remove-stale-branches@v1
+        with:
+          dry-run: true # Check out the console output before setting this to false

--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -24,3 +24,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: fpicalausa/remove-stale-branches@v1
+        with:
+          stale-branch-message: "@{author} Your branch [{branchName}]({branchUrl}) hasn't been updated in the last 60 days and is marked as stale. It will be removed in a week. If a pull request is open on this branch, you can ignore this message, you can always restore your branch on the pull request link. \r\nIf you want to keep this branch around, delete this comment or add new commits to this branch.	"


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**

Dry run [here](https://github.com/synapsecns/sanguine/actions/runs/6418093691)
Real run [here](https://github.com/synapsecns/sanguine/actions/runs/6418103894)
Warning example [here](https://github.com/synapsecns/sanguine/commit/a758eb568449f03ab37d025457c606dc52419034#commitcomment-129218316)
Action docs here [https://github.com/marketplace/actions/remove-stale-branches#%EF%B8%8F-caution](https://github.com/marketplace/actions/remove-stale-branches#%EF%B8%8F-caution)

Going to wait for noise complains on real run before merging


- [x] One suggestion: mention if this is a closed pr that branch can always be restored in `stale-branch-message`




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added a new job "stale-branches" to the GitHub Actions workflow. This job will identify and remove stale branches in the repository, improving codebase cleanliness and management.
- Refactor: Renamed the existing job from "stale" to "stale-prs" for better clarity. This job continues to close stale issues and pull requests.
- Chore: Updated the message for removing stale branches, enhancing communication clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->