### PR TITLE
Fix: ToB-01 (attestation nonce overflow)

### DIFF
--- a/packages/contracts-core/contracts/hubs/SnapshotHub.sol
+++ b/packages/contracts-core/contracts/hubs/SnapshotHub.sol
@@ -15,12 +15,15 @@ import {AgentSecured} from "../base/AgentSecured.sol";
 import {SnapshotHubEvents} from "../events/SnapshotHubEvents.sol";
 import {ISnapshotHub} from "../interfaces/ISnapshotHub.sol";
 import {IStatementInbox} from "../interfaces/IStatementInbox.sol";
+// ═════════════════════════════ EXTERNAL IMPORTS ══════════════════════════════
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
 /// @notice `SnapshotHub` is a parent contract for `Summit`. It is responsible for the following:
 /// - Accepting and storing Guard and Notary snapshots to keep track of all the remote `Origin` states.
 /// - Generating and storing Attestations derived from Notary snapshots, as well as verifying their validity.
 abstract contract SnapshotHub is AgentSecured, SnapshotHubEvents, ISnapshotHub {
     using AttestationLib for bytes;
+    using SafeCast for uint256;
     using StateLib for bytes;
 
     /// @notice Struct that represents stored State of Origin contract
@@ -258,7 +261,7 @@ abstract contract SnapshotHub is AgentSecured, SnapshotHubEvents, ISnapshotHub {
         uint256 sigIndex
     ) internal returns (bytes memory attPayload) {
         // Attestation nonce is its index in `_attestations` array
-        uint32 attNonce = uint32(_attestations.length);
+        uint32 attNonce = _attestations.length.toUint32();
         bytes32 snapGasHash = GasDataLib.snapGasHash(snapshot.snapGas());
         SummitAttestation memory summitAtt = _toSummitAttestation(snapshot.calculateRoot(), agentRoot, snapGasHash);
         attPayload = _formatSummitAttestation(summitAtt, attNonce);

--- a/packages/contracts-core/contracts/hubs/SnapshotHub.sol
+++ b/packages/contracts-core/contracts/hubs/SnapshotHub.sol
@@ -261,6 +261,7 @@ abstract contract SnapshotHub is AgentSecured, SnapshotHubEvents, ISnapshotHub {
         uint256 sigIndex
     ) internal returns (bytes memory attPayload) {
         // Attestation nonce is its index in `_attestations` array
+        // TODO: consider using more than 32 bits for attestation nonces
         uint32 attNonce = _attestations.length.toUint32();
         bytes32 snapGasHash = GasDataLib.snapGasHash(snapshot.snapGas());
         SummitAttestation memory summitAtt = _toSummitAttestation(snapshot.calculateRoot(), agentRoot, snapGasHash);


### PR DESCRIPTION
**Description**
- Fixes ToB-01 issue by adding a safe cast when deriving the attestation nonce.
- Issue for usage of 32 bits for the attestation nonces: #1429 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Refactor:**
- Updated the `SnapshotHub.sol` contract to use OpenZeppelin's `SafeCast` library for safe type conversion. This change enhances the security of the contract by preventing potential overflow errors when casting `uint256` values to `uint32`. The `attNonce` variable now uses the `toUint32()` function from `SafeCast` for this purpose.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->