### PR TITLE
Fix: ToB-14 (tips with eoa recipient)

### DIFF
--- a/packages/contracts-core/contracts/hubs/ExecutionHub.sol
+++ b/packages/contracts-core/contracts/hubs/ExecutionHub.sol
@@ -18,6 +18,7 @@ import {
     MessageOptimisticPeriod,
     NotaryInDispute
 } from "../libs/Errors.sol";
+import {SafeCall} from "../libs/SafeCall.sol";
 import {MerkleMath} from "../libs/merkle/MerkleMath.sol";
 import {Header, Message, MessageFlag, MessageLib} from "../libs/memory/Message.sol";
 import {Receipt, ReceiptLib} from "../libs/memory/Receipt.sol";
@@ -49,6 +50,7 @@ abstract contract ExecutionHub is AgentSecured, ReentrancyGuardUpgradeable, Exec
     using ByteString for MemView;
     using MessageLib for bytes;
     using ReceiptLib for bytes;
+    using SafeCall for address;
     using TypeCasts for bytes32;
 
     /// @notice Struct representing stored data for the snapshot root
@@ -218,18 +220,20 @@ abstract contract ExecutionHub is AgentSecured, ReentrancyGuardUpgradeable, Exec
         address recipient = baseMessage.recipient().bytes32ToAddress();
         // Forward message content to the recipient, and limit the amount of forwarded gas
         if (gasleft() <= gasLimit) revert GasSuppliedTooLow();
-        try IMessageRecipient(recipient).receiveBaseMessage{gas: gasLimit}({
-            origin: header.origin(),
-            nonce: header.nonce(),
-            sender: baseMessage.sender(),
-            proofMaturity: proofMaturity,
-            version: request.version(),
-            content: baseMessage.content().clone()
-        }) {
-            return true;
-        } catch {
-            return false;
-        }
+        // receiveBaseMessage(origin, nonce, sender, proofMaturity, version, content)
+        bytes memory payload = abi.encodeCall(
+            IMessageRecipient.receiveBaseMessage,
+            (
+                header.origin(),
+                header.nonce(),
+                baseMessage.sender(),
+                proofMaturity,
+                request.version(),
+                baseMessage.content().clone()
+            )
+        );
+        // Pass the base message to the recipient, return the success status of the call
+        return recipient.safeCall({gasLimit: gasLimit, msgValue: 0, payload: payload});
     }
 
     /// @dev Uses message body for a call to AgentManager, and checks the returned magic value to ensure that

--- a/packages/contracts-core/contracts/libs/SafeCall.sol
+++ b/packages/contracts-core/contracts/libs/SafeCall.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+/// @notice Library for performing safe calls to the recipients.
+/// Inspired by https://github.com/nomad-xyz/ExcessivelySafeCall
+library SafeCall {
+    /// @notice Performs a call to the recipient using the provided gas limit, msg.value and payload
+    /// in a safe way:
+    /// - If the recipient is not a contract, false is returned instead of reverting.
+    /// - If the recipient call reverts for any reason, false is returned instead of reverting.
+    /// - If the recipient call succeeds, true is returned, and any returned data is ignored.
+    /// @param recipient        The recipient of the call
+    /// @param gasLimit         The gas limit to use for the call
+    /// @param msgValue         The msg.value to use for the call
+    /// @param payload          The payload to use for the call
+    /// @return success         True if the call succeeded, false otherwise
+    function safeCall(address recipient, uint256 gasLimit, uint256 msgValue, bytes memory payload)
+        internal
+        returns (bool success)
+    {
+        // Exit early if the recipient is not a contract
+        if (recipient.code.length == 0) return false;
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            // Perform the call to the recipient, while ignoring any returned data
+            // call(g, a, v, in, insize, out, outsize) => returns 0 on error, 1 on success
+            success := call(gasLimit, recipient, msgValue, add(payload, 0x20), mload(payload), 0, 0)
+        }
+    }
+}

--- a/packages/contracts-core/test/harnesses/libs/SafeCallHarness.t.sol
+++ b/packages/contracts-core/test/harnesses/libs/SafeCallHarness.t.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {SafeCall} from "../../../contracts/libs/SafeCall.sol";
+
+contract SafeCallHarness {
+    function safeCall(address recipient, uint256 gasLimit, uint256 msgValue, bytes memory payload)
+        external
+        returns (bool)
+    {
+        bool success = SafeCall.safeCall(recipient, gasLimit, msgValue, payload);
+        return success;
+    }
+}

--- a/packages/contracts-core/test/mocks/CalleeMocks.t.sol
+++ b/packages/contracts-core/test/mocks/CalleeMocks.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+contract CalleeMock {
+    uint256 public secret;
+
+    /// @notice Prevents this contract from being included in the coverage report
+    function testCalleeMock() external {}
+
+    function setSecret(uint256 _secret) external payable {
+        secret = _secret;
+    }
+}
+
+contract CalleeReturnDataMock {
+    uint256 public secret;
+
+    /// @notice Prevents this contract from being included in the coverage report
+    function testCalleeReturnDataMock() external {}
+
+    function setSecret(uint256 _secret) external payable returns (bool) {
+        secret = _secret;
+        return true;
+    }
+}

--- a/packages/contracts-core/test/suite/hubs/ExecutionHub.t.sol
+++ b/packages/contracts-core/test/suite/hubs/ExecutionHub.t.sol
@@ -106,6 +106,31 @@ abstract contract ExecutionHubTest is AgentSecuredTest {
         verify_receipt_valid(rcptPayload);
     }
 
+    function test_execute_base_recipientEOA(Random memory random) public {
+        recipient = random.nextAddress();
+        // Create some simple data
+        (RawBaseMessage memory rbm, RawHeader memory rh, SnapshotMock memory sm) = createDataRevertTest(random);
+        // Create messages and get origin proof
+        RawMessage memory rm = createBaseMessages(rbm, rh, localDomain());
+        msgPayload = rm.formatMessage();
+        msgLeaf = rm.castToMessage().leaf();
+        bytes32[] memory originProof = getLatestProof(rh.nonce - 1);
+        // Create snapshot proof
+        adjustSnapshot(sm);
+        (bytes32 snapRoot, bytes32[] memory snapProof) = prepareExecution(sm);
+        // Make sure that optimistic period is over
+        uint32 timePassed = random.nextUint32();
+        timePassed = uint32(bound(timePassed, rh.optimisticPeriod, rh.optimisticPeriod + 1 days));
+        skip(timePassed);
+        vm.expectEmit();
+        emit Executed(rh.origin, msgLeaf, false);
+        vm.prank(executor);
+        testedEH().execute(msgPayload, originProof, snapProof, sm.rsi.stateIndex, rbm.request.gasLimit);
+        bytes memory rcptPayloadFirst =
+            verify_messageStatus(msgLeaf, snapRoot, sm.rsi.stateIndex, MessageStatus.Failed, executor, address(0));
+        verify_receipt_valid(rcptPayloadFirst);
+    }
+
     function test_execute_base_recipientReverted_thenSuccess(Random memory random) public {
         recipient = address(new RevertingApp());
         // Create some simple data

--- a/packages/contracts-core/test/suite/libs/SafeCall.t.sol
+++ b/packages/contracts-core/test/suite/libs/SafeCall.t.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {SynapseLibraryTest} from "../../utils/SynapseLibraryTest.t.sol";
+
+import {CalleeMock, CalleeReturnDataMock} from "../../mocks/CalleeMocks.t.sol";
+import {SafeCallHarness} from "../../harnesses/libs/SafeCallHarness.t.sol";
+
+// solhint-disable func-name-mixedcase
+contract SafeCallTest is SynapseLibraryTest {
+    SafeCallHarness internal libHarness;
+
+    CalleeMock internal callee;
+    CalleeReturnDataMock internal calleeReturnData;
+    address internal eoa;
+
+    function setUp() public {
+        libHarness = new SafeCallHarness();
+        callee = new CalleeMock();
+        calleeReturnData = new CalleeReturnDataMock();
+        eoa = makeAddr("EOA");
+        vm.label(address(callee), "callee");
+        vm.label(address(calleeReturnData), "calleeReturnData");
+    }
+
+    function test_safeCall_callsRecipient() public {
+        bytes memory payload = abi.encodeCall(CalleeMock.setSecret, (42));
+        // 100k gas should be enough for a simple call
+        assertTrue(libHarness.safeCall(address(callee), 100_000, 0, payload));
+        assertEq(callee.secret(), 42);
+    }
+
+    function test_safeCall_callsRecipient_withReturnData() public {
+        bytes memory payload = abi.encodeCall(CalleeReturnDataMock.setSecret, (42));
+        // 100k gas should be enough for a simple call
+        assertTrue(libHarness.safeCall(address(calleeReturnData), 100_000, 0, payload));
+        assertEq(calleeReturnData.secret(), 42);
+    }
+
+    function test_safeCall_forwardsMsgValue() public {
+        uint256 msgValue = 1337;
+        deal(address(libHarness), msgValue);
+        bytes memory payload = abi.encodeCall(CalleeMock.setSecret, (42));
+        // 100k gas should be enough for a simple call
+        assertTrue(libHarness.safeCall(address(callee), 100_000, msgValue, payload));
+        assertEq(address(callee).balance, msgValue);
+    }
+
+    function test_safeCall_forwardsMsgValue_withReturnData() public {
+        uint256 msgValue = 1337;
+        deal(address(libHarness), msgValue);
+        bytes memory payload = abi.encodeCall(CalleeReturnDataMock.setSecret, (42));
+        // 100k gas should be enough for a simple call
+        assertTrue(libHarness.safeCall(address(calleeReturnData), 100_000, msgValue, payload));
+        assertEq(address(calleeReturnData).balance, msgValue);
+    }
+
+    function test_safeCall_setsGasLimit() public {
+        bytes memory payload = abi.encodeCall(CalleeMock.setSecret, (42));
+        // 10k gas should not be enough for a storage write
+        assertFalse(libHarness.safeCall(address(callee), 10_000, 0, payload));
+    }
+
+    function test_safeCall_returnsFalse_onRevert() public {
+        bytes memory payload = abi.encodeCall(CalleeMock.setSecret, (42));
+        // Force the call to revert
+        vm.mockCallRevert(address(callee), payload, "GM");
+        assertFalse(libHarness.safeCall(address(callee), 100_000, 0, payload));
+    }
+
+    function test_safeCall_returnsFalse_recipientEOA() public {
+        bytes memory payload = abi.encodeCall(CalleeMock.setSecret, (42));
+        assertFalse(libHarness.safeCall(eoa, 100_000, 0, payload));
+    }
+}

--- a/packages/contracts-core/test/suite/libs/SafeCall.t.sol
+++ b/packages/contracts-core/test/suite/libs/SafeCall.t.sol
@@ -26,14 +26,16 @@ contract SafeCallTest is SynapseLibraryTest {
     function test_safeCall_callsRecipient() public {
         bytes memory payload = abi.encodeCall(CalleeMock.setSecret, (42));
         // 100k gas should be enough for a simple call
-        assertTrue(libHarness.safeCall(address(callee), 100_000, 0, payload));
+        bool success = libHarness.safeCall(address(callee), 100_000, 0, payload);
+        assertTrue(success);
         assertEq(callee.secret(), 42);
     }
 
     function test_safeCall_callsRecipient_withReturnData() public {
         bytes memory payload = abi.encodeCall(CalleeReturnDataMock.setSecret, (42));
         // 100k gas should be enough for a simple call
-        assertTrue(libHarness.safeCall(address(calleeReturnData), 100_000, 0, payload));
+        bool success = libHarness.safeCall(address(calleeReturnData), 100_000, 0, payload);
+        assertTrue(success);
         assertEq(calleeReturnData.secret(), 42);
     }
 
@@ -42,7 +44,8 @@ contract SafeCallTest is SynapseLibraryTest {
         deal(address(libHarness), msgValue);
         bytes memory payload = abi.encodeCall(CalleeMock.setSecret, (42));
         // 100k gas should be enough for a simple call
-        assertTrue(libHarness.safeCall(address(callee), 100_000, msgValue, payload));
+        bool success = libHarness.safeCall(address(callee), 100_000, msgValue, payload);
+        assertTrue(success);
         assertEq(address(callee).balance, msgValue);
     }
 
@@ -51,25 +54,29 @@ contract SafeCallTest is SynapseLibraryTest {
         deal(address(libHarness), msgValue);
         bytes memory payload = abi.encodeCall(CalleeReturnDataMock.setSecret, (42));
         // 100k gas should be enough for a simple call
-        assertTrue(libHarness.safeCall(address(calleeReturnData), 100_000, msgValue, payload));
+        bool success = libHarness.safeCall(address(calleeReturnData), 100_000, msgValue, payload);
+        assertTrue(success);
         assertEq(address(calleeReturnData).balance, msgValue);
     }
 
     function test_safeCall_setsGasLimit() public {
         bytes memory payload = abi.encodeCall(CalleeMock.setSecret, (42));
         // 10k gas should not be enough for a storage write
-        assertFalse(libHarness.safeCall(address(callee), 10_000, 0, payload));
+        bool success = libHarness.safeCall(address(callee), 10_000, 0, payload);
+        assertFalse(success);
     }
 
     function test_safeCall_returnsFalse_onRevert() public {
         bytes memory payload = abi.encodeCall(CalleeMock.setSecret, (42));
         // Force the call to revert
         vm.mockCallRevert(address(callee), payload, "GM");
-        assertFalse(libHarness.safeCall(address(callee), 100_000, 0, payload));
+        bool success = libHarness.safeCall(address(callee), 100_000, 0, payload);
+        assertFalse(success);
     }
 
     function test_safeCall_returnsFalse_recipientEOA() public {
         bytes memory payload = abi.encodeCall(CalleeMock.setSecret, (42));
-        assertFalse(libHarness.safeCall(eoa, 100_000, 0, payload));
+        bool success = libHarness.safeCall(eoa, 100_000, 0, payload);
+        assertFalse(success);
     }
 }


### PR DESCRIPTION
**Description**
- Fixed ToB-14 issue by ensuring that `executeBaseMessage` doesn't revert if the recipient is EOA.
- This is achieved by using a new library for performing such "safe calls" instead of `try/catch` block that ends up in revert, if the target contract doesn't contain any code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Introduced `SafeCall` library in `contracts-core` package to safely perform calls to recipient contracts, improving the robustness of contract interactions.
- Test: Added comprehensive test coverage for the `SafeCall` library in `SafeCallTest`, ensuring its correct functionality across various scenarios including out-of-gas and revert situations.
- Test: Enhanced `ExecutionHubTest` with a new function `test_execute_base_recipientEOA` to validate execution of base messages with externally owned account recipients.
- Chore: Created mock contracts `CalleeMock` and `CalleeReturnDataMock` for testing purposes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->