### PR TITLE
Fix/reset output

### DIFF
--- a/packages/synapse-interface/slices/bridge/reducer.ts
+++ b/packages/synapse-interface/slices/bridge/reducer.ts
@@ -456,6 +456,9 @@ export const bridgeSlice = createSlice({
     setBridgeQuote: (state, action: PayloadAction<BridgeQuote>) => {
       state.bridgeQuote = action.payload
     },
+    resetBridgeQuote: (state) => {
+      state.bridgeQuote = initialState.bridgeQuote
+    },
     updateFromValue: (state, action: PayloadAction<string>) => {
       state.fromValue = action.payload
     },
@@ -563,6 +566,7 @@ export const bridgeSlice = createSlice({
 
 export const {
   setBridgeQuote,
+  resetBridgeQuote,
   setFromChainId,
   setToChainId,
   setFromToken,

--- a/packages/synapse-interface/slices/bridge/updater.tsx
+++ b/packages/synapse-interface/slices/bridge/updater.tsx
@@ -10,6 +10,7 @@ import {
   updateDebouncedFromValue,
   updateDebouncedToTokensFromValue,
 } from './actions'
+import { resetBridgeQuote } from './reducer'
 import { Token } from '@/utils/types'
 import { stringToBigInt } from '@/utils/bigint/format'
 import { useSynapseContext } from '@/utils/providers/SynapseProvider'
@@ -25,6 +26,7 @@ export default function Updater(): null {
     toToken,
     toTokens,
     fromValue,
+    bridgeQuote,
     debouncedFromValue,
     debouncedToTokensFromValue,
   }: BridgeState = useBridgeState()
@@ -105,6 +107,13 @@ export default function Updater(): null {
       dispatch(resetFetchedBridgeQuotes())
     }
   }, [debouncedToTokensFromValue, toTokens])
+
+  // Clear bridge quote if input is empty
+  useEffect(() => {
+    if (debouncedFromValue === initialState.debouncedFromValue) {
+      dispatch(resetBridgeQuote())
+    }
+  }, [debouncedFromValue, bridgeQuote])
 
   return null
 }


### PR DESCRIPTION
In the scenario that the user clears the Bridge Input amount around when bridge quotes are returned, this will fix any glitch where the output amount shows a bridge quote for a prior Input amount.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added a `resetBridgeQuote` action to the `bridgeSlice` reducer. This action allows the `bridgeQuote` state to be reset to its initial value, improving the user experience by ensuring that outdated or incorrect data is not displayed.
- Refactor: Updated the `bridge` updater to import and use the `resetBridgeQuote` function. This change enhances the application's responsiveness by clearing the bridge quote when the input is empty, preventing confusion or errors caused by stale data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
a6cf17e670fc3032deae9c3b5f8656a8f3a96f1c: [synapse-interface preview link ](https://sanguine-synapse-interface-k82za1o8d-synapsecns.vercel.app)