### PR TITLE
Fix: ToB-08 (indefinite stuck disputes)

### DIFF
--- a/packages/contracts-core/contracts/Destination.sol
+++ b/packages/contracts-core/contracts/Destination.sol
@@ -52,6 +52,9 @@ contract Destination is ExecutionHub, DestinationEvents, InterfaceDestination {
     /// @inheritdoc InterfaceDestination
     DestinationStatus public destStatus;
 
+    /// @inheritdoc InterfaceDestination
+    mapping(uint32 => uint32) public lastAttestationNonce;
+
     /// @dev Stored lookup data for all accepted Notary Attestations
     StoredAttData[] internal _storedAttestations;
 
@@ -98,6 +101,7 @@ contract Destination is ExecutionHub, DestinationEvents, InterfaceDestination {
         if (rootPassed) return false;
         // This will revert if payload is not an attestation
         Attestation att = attPayload.castToAttestation();
+        lastAttestationNonce[notaryIndex] = att.nonce();
         // This will revert if snapshot root has been previously submitted
         _saveAttestation(att, notaryIndex, sigIndex);
         _storedAttestations.push(StoredAttData({agentRoot: agentRoot, dataHash: att.dataHash()}));

--- a/packages/contracts-core/contracts/interfaces/InterfaceDestination.sol
+++ b/packages/contracts-core/contracts/interfaces/InterfaceDestination.sol
@@ -81,4 +81,10 @@ interface InterfaceDestination {
      * Returns Agent Merkle Root to be passed to LightManager once its optimistic period is over.
      */
     function nextAgentRoot() external view returns (bytes32);
+
+    /**
+     * @notice Returns the nonce of the last attestation submitted by a Notary with a given agent index.
+     * @dev Will return zero if the Notary hasn't submitted any attestations yet.
+     */
+    function lastAttestationNonce(uint32 notaryIndex) external view returns (uint32);
 }

--- a/packages/contracts-core/test/mocks/DestinationMock.t.sol
+++ b/packages/contracts-core/test/mocks/DestinationMock.t.sol
@@ -29,4 +29,6 @@ contract DestinationMock is ExecutionHubMock, AgentSecuredMock, InterfaceDestina
     function destStatus() external view returns (uint40 snapRootTime, uint40 agentRootTime, uint32 notaryIndex) {}
 
     function nextAgentRoot() external view returns (bytes32) {}
+
+    function lastAttestationNonce(uint32 notaryIndex) external view returns (uint32) {}
 }

--- a/packages/contracts-core/test/suite/Destination.t.sol
+++ b/packages/contracts-core/test/suite/Destination.t.sol
@@ -91,6 +91,7 @@ contract DestinationTest is ExecutionHubTest {
     }
 
     function test_submitAttestation(RawAttestation memory ra, uint32 rootSubmittedAt) public {
+        vm.assume(ra.nonce != 0);
         RawSnapshot memory rs = Random(ra.snapRoot).nextSnapshot();
         ra._snapGasHash = rs.snapGasHash();
         ra.setDataHash();
@@ -107,6 +108,7 @@ contract DestinationTest is ExecutionHubTest {
     }
 
     function test_submitAttestation_updatesAgentRoot(RawAttestation memory ra, uint32 rootSubmittedAt) public {
+        vm.assume(ra.nonce != 0);
         RawSnapshot memory rs = Random(ra.snapRoot).nextSnapshot();
         ra._snapGasHash = rs.snapGasHash();
         ra.setDataHash();
@@ -132,6 +134,7 @@ contract DestinationTest is ExecutionHubTest {
         uint32 firstRootSubmittedAt,
         uint32 timePassed
     ) public {
+        vm.assume(firstRA.nonce != 0 && secondRA.nonce != 0);
         bytes32 agentRootLM = lightManager.agentRoot();
         vm.assume(firstRA._agentRoot != agentRootLM);
         vm.assume(firstRA.snapRoot != secondRA.snapRoot);

--- a/packages/contracts-core/test/suite/Destination.t.sol
+++ b/packages/contracts-core/test/suite/Destination.t.sol
@@ -221,6 +221,34 @@ contract DestinationTest is ExecutionHubTest {
         assertEq(lightManager.agentRoot(), firstRA._agentRoot);
     }
 
+    function test_acceptAttestation_success_diffNotary_lowerNonce() public {
+        Random memory random = Random("salt");
+        RawAttestation memory firstRA = random.nextAttestation({nonce: 2});
+        test_submitAttestation({ra: firstRA, rootSubmittedAt: 1000});
+        skip(100);
+        RawSnapshot memory rawSnap = random.nextSnapshot();
+        uint256[] memory snapGas = rawSnap.snapGas();
+        RawAttestation memory secondRA = random.nextAttestation({rawSnap: rawSnap, nonce: 1});
+        address notary = domains[DOMAIN_LOCAL].agents[1];
+        (bytes memory attPayload, bytes memory attSig) = signAttestation(notary, secondRA);
+        bool success = lightInbox.submitAttestation(attPayload, attSig, secondRA._agentRoot, snapGas);
+        assertTrue(success);
+    }
+
+    function test_acceptAttestation_success_diffNotary_diffAtt_sameNonce() public {
+        Random memory random = Random("salt");
+        RawAttestation memory firstRA = random.nextAttestation({nonce: 2});
+        test_submitAttestation({ra: firstRA, rootSubmittedAt: 1000});
+        skip(100);
+        RawSnapshot memory rawSnap = random.nextSnapshot();
+        uint256[] memory snapGas = rawSnap.snapGas();
+        RawAttestation memory secondRA = random.nextAttestation({rawSnap: rawSnap, nonce: 2});
+        address notary = domains[DOMAIN_LOCAL].agents[1];
+        (bytes memory attPayload, bytes memory attSig) = signAttestation(notary, secondRA);
+        bool success = lightInbox.submitAttestation(attPayload, attSig, secondRA._agentRoot, snapGas);
+        assertTrue(success);
+    }
+
     function test_passAgentRoot_optimisticPeriodNotOver(
         RawAttestation memory ra,
         uint32 rootSubmittedAt,

--- a/packages/contracts-core/test/suite/Destination.t.sol
+++ b/packages/contracts-core/test/suite/Destination.t.sol
@@ -103,6 +103,7 @@ contract DestinationTest is ExecutionHubTest {
         lightInbox.submitAttestation(attPayload, attSig, ra._agentRoot, snapGas);
         (uint48 snapRootTime,,) = InterfaceDestination(localDestination()).destStatus();
         assertEq(snapRootTime, rootSubmittedAt);
+        assertEq(InterfaceDestination(localDestination()).lastAttestationNonce(agentIndex[notary]), ra.nonce);
     }
 
     function test_submitAttestation_updatesAgentRoot(RawAttestation memory ra, uint32 rootSubmittedAt) public {


### PR DESCRIPTION
**Description**
- Fixed ToB-08 by forcing the every Notary to submit the attestations in the ascending nonce order. This means that they are forced to submit a fresher attestation each time, which will contain the fresher agent root, inevitably resulting in the dispute resolution.
- The order enforcing is implemented on the individual level rather than overall in order to prevent malicious Notaries from submitting attestation with nonce that doesn't exist and effectively disabling other Notaries. Also prevents DoS attack by frontrunning attestation submission with useless attestation (having a single chain state for instance) having a higher nonce.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**New Feature:**
- Added nonce tracking for attestations in `Destination.sol`. This feature ensures that each attestation has a unique nonce, preventing replay attacks and ensuring the integrity of the attestation process.

**Test:**
- Added multiple test cases in `Destination.t.sol` to verify the correct handling of attestation nonces. These tests cover scenarios such as lower nonce, same nonce, and different notary with lower or same nonce.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->