### PR TITLE
Fix: ToB-16 (update gas data)

### DIFF
--- a/packages/contracts-core/contracts/Origin.sol
+++ b/packages/contracts-core/contracts/Origin.sol
@@ -132,6 +132,11 @@ contract Origin is StateHub, OriginEvents, InterfaceOrigin {
         _insertAndSave(messageHash);
         // Emit event with message information
         emit Sent(messageHash, messageNonce, destination, msgPayload);
+        // Update the gas oracle data. We do this after the provided tips are checked so that
+        // the provided message is sent in the event that the gas oracle data is updated to a higher value.
+        InterfaceGasOracle(gasOracle).updateGasData(destination);
+        // TODO: consider doing this before the message is sent, while adjusting GasOracle.getMinimumTips() to
+        // use the pending gas oracle data.
     }
 
     /// @dev Returns the minimum tips for sending a message to the given destination with the given request and content.

--- a/packages/contracts-core/test/suite/Origin.t.sol
+++ b/packages/contracts-core/test/suite/Origin.t.sol
@@ -173,6 +173,7 @@ contract OriginTest is AgentSecuredTest {
             emit StateSaved(state);
             vm.expectEmit();
             emit Sent(leafs[i], i + 1, DOMAIN_REMOTE, messages[i]);
+            vm.expectCall(gasOracle, abi.encodeCall(InterfaceGasOracle.updateGasData, (DOMAIN_REMOTE)));
             vm.prank(sender);
             (uint32 messageNonce, bytes32 messageHash) = InterfaceOrigin(origin).sendBaseMessage(
                 DOMAIN_REMOTE, addressToBytes32(recipient), period, encodedRequest, content


### PR DESCRIPTION
**Description**
- Fixes ToB-16 by explicitly calling `updateGasData(destination)` after the message to destination chain is sent. This will lead to `GasData` values (extracted from Notary attestations) to be propagated to `GasOracle` without adding any incentives for doing so. The only scenario where this doesn't happen is when no messages to given destination chain are sent, in which case the `GasOracle` data is irrelevant anyway.