### PR TITLE
Fix/masquerade checksum

### DIFF
--- a/packages/synapse-interface/components/Portfolio/SearchBar.tsx
+++ b/packages/synapse-interface/components/Portfolio/SearchBar.tsx
@@ -68,25 +68,25 @@ export const SearchBar = () => {
     return isTransactionHash(searchInput)
   }, [searchInput])
 
-  const checkSearchInputIsAddress: Address | null = useMemo(() => {
+  const checksumValidAddress: Address | null = useMemo(() => {
     return getValidAddress(searchInput)
   }, [searchInput])
 
   useEffect(() => {
     const masqueradeActive: boolean =
       Object.keys(searchedBalancesAndAllowances).length > 0
-    if (checkSearchInputIsAddress && !masqueradeActive) {
+    if (checksumValidAddress && !masqueradeActive) {
       dispatch(
         fetchAndStoreSearchInputPortfolioBalances(
-          checkSearchInputIsAddress as Address
+          checksumValidAddress as Address
         )
       )
     }
 
-    if (masqueradeActive && checkSearchInputIsAddress) {
+    if (masqueradeActive && checksumValidAddress) {
       clearSearchInput()
     }
-  }, [checkSearchInputIsAddress, searchedBalancesAndAllowances])
+  }, [checksumValidAddress, searchedBalancesAndAllowances])
 
   useEffect(() => {
     if (searchInputIsTransactionHash) {

--- a/packages/synapse-interface/components/Portfolio/SearchBar.tsx
+++ b/packages/synapse-interface/components/Portfolio/SearchBar.tsx
@@ -13,7 +13,7 @@ import {
   initialState as portfolioInitialState,
   PortfolioState,
 } from '@/slices/portfolio/reducer'
-import { isValidAddress } from '@/utils/isValidAddress'
+import { isValidAddress, getValidAddress } from '@/utils/isValidAddress'
 import { shortenAddress } from '@/utils/shortenAddress'
 import { isTransactionHash } from '@/utils/validators'
 import { getTransactionHashExplorerLink } from './Transaction/components/TransactionExplorerLink'
@@ -72,19 +72,27 @@ export const SearchBar = () => {
     return isTransactionHash(searchInput)
   }, [searchInput])
 
+  const checkSearchInputIsAddress: Address | null = useMemo(() => {
+    return getValidAddress(searchInput)
+  }, [searchInput])
+
+  console.log('checkSearchInputIsAddress:', checkSearchInputIsAddress)
+
   useEffect(() => {
     const masqueradeActive: boolean =
       Object.keys(searchedBalancesAndAllowances).length > 0
-    if (searchInputIsAddress && !masqueradeActive) {
+    if (checkSearchInputIsAddress && !masqueradeActive) {
       dispatch(
-        fetchAndStoreSearchInputPortfolioBalances(searchInput as Address)
+        fetchAndStoreSearchInputPortfolioBalances(
+          checkSearchInputIsAddress as Address
+        )
       )
     }
 
-    if (masqueradeActive && searchInputIsAddress) {
+    if (masqueradeActive && checkSearchInputIsAddress) {
       clearSearchInput()
     }
-  }, [searchInputIsAddress, searchedBalancesAndAllowances])
+  }, [checkSearchInputIsAddress, searchedBalancesAndAllowances])
 
   useEffect(() => {
     if (searchInputIsTransactionHash) {

--- a/packages/synapse-interface/components/Portfolio/SearchBar.tsx
+++ b/packages/synapse-interface/components/Portfolio/SearchBar.tsx
@@ -64,10 +64,6 @@ export const SearchBar = () => {
     }
   }, [activeTab])
 
-  const searchInputIsAddress: boolean = useMemo(() => {
-    return isValidAddress(searchInput)
-  }, [searchInput])
-
   const searchInputIsTransactionHash: boolean = useMemo(() => {
     return isTransactionHash(searchInput)
   }, [searchInput])
@@ -75,8 +71,6 @@ export const SearchBar = () => {
   const checkSearchInputIsAddress: Address | null = useMemo(() => {
     return getValidAddress(searchInput)
   }, [searchInput])
-
-  console.log('checkSearchInputIsAddress:', checkSearchInputIsAddress)
 
   useEffect(() => {
     const masqueradeActive: boolean =

--- a/packages/synapse-interface/slices/transactions/updater.tsx
+++ b/packages/synapse-interface/slices/transactions/updater.tsx
@@ -39,7 +39,7 @@ import {
   addPendingAwaitingCompletionTransaction,
   removePendingAwaitingCompletionTransaction,
 } from './actions'
-import { isValidAddress } from '@/utils/isValidAddress'
+import { isValidAddress, getValidAddress } from '@/utils/isValidAddress'
 import { checkTransactionsExist } from '@/components/Portfolio/Activity'
 
 const queryHistoricalTime: number = getTimeMinutesBeforeNow(oneMonthInMinutes)
@@ -99,11 +99,11 @@ export default function Updater(): null {
         searchedBalancesAndAllowances
       )[0] as Address
       fetchUserHistoricalActivity({
-        address: queriedAddress,
+        address: getValidAddress(queriedAddress),
         startTime: queryHistoricalTime,
       })
       fetchUserPendingActivity({
-        address: queriedAddress,
+        address: getValidAddress(queriedAddress),
         startTime: queryPendingTime,
       })
     }

--- a/packages/synapse-interface/slices/transactions/updater.tsx
+++ b/packages/synapse-interface/slices/transactions/updater.tsx
@@ -39,8 +39,7 @@ import {
   addPendingAwaitingCompletionTransaction,
   removePendingAwaitingCompletionTransaction,
 } from './actions'
-import { isValidAddress, getValidAddress } from '@/utils/isValidAddress'
-import { checkTransactionsExist } from '@/components/Portfolio/Activity'
+import { getValidAddress } from '@/utils/isValidAddress'
 
 const queryHistoricalTime: number = getTimeMinutesBeforeNow(oneMonthInMinutes)
 const queryPendingTime: number = getTimeMinutesBeforeNow(oneDayInMinutes)

--- a/packages/synapse-interface/utils/isValidAddress.tsx
+++ b/packages/synapse-interface/utils/isValidAddress.tsx
@@ -1,20 +1,22 @@
-import { getAddress } from '@ethersproject/address'
-import { getAddress as getAddressViem, Address } from 'viem'
+import { getAddress, Address, InvalidAddressError } from 'viem'
 
 export const isValidAddress = (address: string): boolean => {
   try {
     const validatedAddress: string = getAddress(address)
     return true
-  } catch (e: any) {
+  } catch (e: InvalidAddressError | any) {
+    console.error('isValidAddress error: ', e)
     return false
   }
 }
 
-export const getValidAddress = (address: string): Address | any => {
+export const getValidAddress = (
+  address: string
+): Address | InvalidAddressError => {
   try {
-    const validatedAddress: Address = getAddressViem(address)
+    const validatedAddress: Address = getAddress(address)
     return validatedAddress
-  } catch (e: any) {
+  } catch (e: InvalidAddressError | any) {
     console.error('getValidAddress error: ', e)
     return null
   }

--- a/packages/synapse-interface/utils/isValidAddress.tsx
+++ b/packages/synapse-interface/utils/isValidAddress.tsx
@@ -1,4 +1,5 @@
 import { getAddress } from '@ethersproject/address'
+import { getAddress as getAddressViem, Address } from 'viem'
 
 export const isValidAddress = (address: string): boolean => {
   try {
@@ -6,5 +7,15 @@ export const isValidAddress = (address: string): boolean => {
     return true
   } catch (e: any) {
     return false
+  }
+}
+
+export const getValidAddress = (address: string): Address | any => {
+  try {
+    const validatedAddress: Address = getAddressViem(address)
+    return validatedAddress
+  } catch (e: any) {
+    console.error('getValidAddress error: ', e)
+    return null
   }
 }

--- a/packages/synapse-interface/utils/isValidAddress.tsx
+++ b/packages/synapse-interface/utils/isValidAddress.tsx
@@ -10,9 +10,7 @@ export const isValidAddress = (address: string): boolean => {
   }
 }
 
-export const getValidAddress = (
-  address: string
-): Address | InvalidAddressError => {
+export const getValidAddress = (address: string): Address | any => {
   try {
     const validatedAddress: Address = getAddress(address)
     return validatedAddress


### PR DESCRIPTION
Pairing with @abtestingalpha to create fix for double checking queryable address is checksum'd prior to querying when in Masquerade Mode.


090131e56c58d4c5d6ca1caf15524e8fc5f45856: [synapse-interface preview link ](https://sanguine-synapse-interface-5sm89kxw3-synapsecns.vercel.app)
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Improved the address validation process in the search bar and transaction history. The system now uses a more robust method to validate and process addresses, enhancing the reliability of search results and transaction history retrieval.
- New Feature: The search bar now accepts and processes checksummed addresses, providing more accurate portfolio balance information and transaction history for users.
- Usability: The update ensures that only valid addresses are used when fetching user portfolio balances and transaction history, reducing potential errors and improving the overall user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
eb5b76602bbb85561de83722483acd26883f3325: [synapse-interface preview link ](https://sanguine-synapse-interface-ms4fyzlpm-synapsecns.vercel.app)