### PR TITLE
Fix: Zellic-3.3 (safety checks missing)

### DIFF
--- a/packages/contracts-core/contracts/Origin.sol
+++ b/packages/contracts-core/contracts/Origin.sol
@@ -4,7 +4,12 @@ pragma solidity 0.8.17;
 // ══════════════════════════════ LIBRARY IMPORTS ══════════════════════════════
 import {BaseMessageLib} from "./libs/memory/BaseMessage.sol";
 import {MAX_CONTENT_BYTES} from "./libs/Constants.sol";
-import {ContentLengthTooBig, EthTransferFailed, InsufficientEthBalance} from "./libs/Errors.sol";
+import {
+    ContentLengthTooBig,
+    EthTransferFailed,
+    IncorrectDestinationDomain,
+    InsufficientEthBalance
+} from "./libs/Errors.sol";
 import {GasData, GasDataLib} from "./libs/stack/GasData.sol";
 import {MemView, MemViewLib} from "./libs/memory/MemView.sol";
 import {Header, MessageLib, MessageFlag} from "./libs/memory/Message.sol";
@@ -35,6 +40,11 @@ contract Origin is StateHub, OriginEvents, InterfaceOrigin {
 
     address public immutable gasOracle;
 
+    modifier onlyRemoteDestination(uint32 destination) {
+        if (destination == localDomain) revert IncorrectDestinationDomain();
+        _;
+    }
+
     // ═════════════════════════════════════════ CONSTRUCTOR & INITIALIZER ═════════════════════════════════════════════
 
     // solhint-disable-next-line no-empty-blocks
@@ -63,7 +73,7 @@ contract Origin is StateHub, OriginEvents, InterfaceOrigin {
         uint32 optimisticPeriod,
         uint256 paddedRequest,
         bytes memory content
-    ) external payable returns (uint32 messageNonce, bytes32 messageHash) {
+    ) external payable onlyRemoteDestination(destination) returns (uint32 messageNonce, bytes32 messageHash) {
         // Check that content is not too large
         if (content.length > MAX_CONTENT_BYTES) revert ContentLengthTooBig();
         // This will revert if msg.value is lower than value of minimum tips
@@ -85,6 +95,7 @@ contract Origin is StateHub, OriginEvents, InterfaceOrigin {
     function sendManagerMessage(uint32 destination, uint32 optimisticPeriod, bytes memory payload)
         external
         onlyAgentManager
+        onlyRemoteDestination(destination)
         returns (uint32 messageNonce, bytes32 messageHash)
     {
         // AgentManager (checked via modifier) is responsible for constructing the calldata payload correctly.

--- a/packages/contracts-core/contracts/hubs/ExecutionHub.sol
+++ b/packages/contracts-core/contracts/hubs/ExecutionHub.sol
@@ -12,6 +12,7 @@ import {
     DuplicatedSnapshotRoot,
     IncorrectDestinationDomain,
     IncorrectMagicValue,
+    IncorrectOriginDomain,
     IncorrectSnapshotRoot,
     GasLimitTooLow,
     GasSuppliedTooLow,
@@ -121,6 +122,8 @@ abstract contract ExecutionHub is AgentSecured, ReentrancyGuardUpgradeable, Exec
         bytes32 msgLeaf = message.leaf();
         // Ensure message was meant for this domain
         if (header.destination() != localDomain) revert IncorrectDestinationDomain();
+        // Ensure message was not sent from this domain
+        if (header.origin() == localDomain) revert IncorrectOriginDomain();
         // Check that message has not been executed before
         ReceiptData memory rcptData = _receiptData[msgLeaf];
         if (rcptData.executor != address(0)) revert AlreadyExecuted();

--- a/packages/contracts-core/contracts/interfaces/IExecutionHub.sol
+++ b/packages/contracts-core/contracts/interfaces/IExecutionHub.sol
@@ -9,6 +9,8 @@ interface IExecutionHub {
      * previously submitted to this contract in a form of a signed Attestation.
      * Proven message is immediately executed by passing its contents to the specified recipient.
      * @dev Will revert if any of these is true:
+     *  - Message is not meant to be executed on this chain
+     *  - Message was sent from this chain
      *  - Message payload is not properly formatted.
      *  - Snapshot root (reconstructed from message hash and proofs) is unknown
      *  - Snapshot root is known, but was submitted by an inactive Notary

--- a/packages/contracts-core/contracts/interfaces/InterfaceBondingManager.sol
+++ b/packages/contracts-core/contracts/interfaces/InterfaceBondingManager.sol
@@ -59,6 +59,7 @@ interface InterfaceBondingManager {
      * for the OLD agent status.
      * Note: as an extra security check this function returns its own selector, so that
      * Destination could verify that a "remote" function was called when executing a manager message.
+     * Will revert if `msgOrigin` is equal to contract's local domain.
      * @param domain        Domain where the slashed agent was active
      * @param agent         Address of the slashed Agent
      * @param prover        Address that initially provided fraud proof to remote AgentManager

--- a/packages/contracts-core/contracts/interfaces/InterfaceOrigin.sol
+++ b/packages/contracts-core/contracts/interfaces/InterfaceOrigin.sol
@@ -7,6 +7,10 @@ interface InterfaceOrigin {
     /**
      * @notice Send a message to the recipient located on destination domain.
      * @dev Recipient has to conform to IMessageRecipient interface, otherwise message won't be delivered.
+     * Will revert if any of these is true:
+     * - `destination` is equal to contract's local domain
+     * - `content` length is greater than `MAX_CONTENT_BYTES`
+     * - `msg.value` is lower than value of minimum tips for the given message
      * @param destination           Domain of destination chain
      * @param recipient             Address of recipient on destination chain as bytes32
      * @param optimisticPeriod      Optimistic period for message execution on destination chain
@@ -29,6 +33,7 @@ interface InterfaceOrigin {
      * Note: (msgOrigin, proofMaturity) security args will be added to payload on the destination chain
      * so that the AgentManager could verify where the Manager Message came from and how mature is the proof.
      * Note: function is not payable, as no tips are required for sending a manager message.
+     * Will revert if `destination` is equal to contract's local domain.
      * @param destination           Domain of destination chain
      * @param optimisticPeriod      Optimistic period for message execution on destination chain
      * @param payload               Payload for calling AgentManager on destination chain (with extra security args)

--- a/packages/contracts-core/contracts/manager/BondingManager.sol
+++ b/packages/contracts-core/contracts/manager/BondingManager.sol
@@ -8,6 +8,7 @@ import {
     CallerNotDestination,
     CallerNotSummit,
     IncorrectAgentDomain,
+    IncorrectOriginDomain,
     IndexOutOfRange,
     MerkleTreeFull,
     MustBeSynapseDomain,
@@ -171,8 +172,9 @@ contract BondingManager is AgentManager, InterfaceBondingManager {
         // Check that merkle proof is mature enough
         // TODO: separate constant for slashing optimistic period
         if (proofMaturity < BONDING_OPTIMISTIC_PERIOD) revert SlashAgentOptimisticPeriod();
-        // TODO: do we need to save this?
-        msgOrigin;
+        // TODO: do we need to save domain where the agent was slashed?
+        // Message needs to be sent from the remote chain
+        if (msgOrigin == localDomain) revert IncorrectOriginDomain();
         // Slash agent and notify local AgentSecured contracts
         _slashAgent(domain, agent, prover);
         // Magic value to return is selector of the called function

--- a/packages/contracts-core/test/suite/Origin.t.sol
+++ b/packages/contracts-core/test/suite/Origin.t.sol
@@ -4,7 +4,12 @@ pragma solidity 0.8.17;
 import {IAgentSecured} from "../../contracts/interfaces/IAgentSecured.sol";
 import {InterfaceGasOracle} from "../../contracts/interfaces/InterfaceGasOracle.sol";
 import {IStateHub} from "../../contracts/interfaces/IStateHub.sol";
-import {EthTransferFailed, InsufficientEthBalance, TipsValueTooLow} from "../../contracts/libs/Errors.sol";
+import {
+    EthTransferFailed,
+    IncorrectDestinationDomain,
+    InsufficientEthBalance,
+    TipsValueTooLow
+} from "../../contracts/libs/Errors.sol";
 import {SNAPSHOT_MAX_STATES} from "../../contracts/libs/Constants.sol";
 import {TipsLib} from "../../contracts/libs/stack/Tips.sol";
 
@@ -96,6 +101,20 @@ contract OriginTest is AgentSecuredTest {
         InterfaceOrigin(origin).sendBaseMessage{value: msgValue}(
             DOMAIN_REMOTE, addressToBytes32(recipient), period, request.encodeRequest(), "test content"
         );
+    }
+
+    function test_sendBaseMessage_revert_sameDestination() public {
+        vm.expectRevert(IncorrectDestinationDomain.selector);
+        vm.prank(sender);
+        InterfaceOrigin(origin).sendBaseMessage(
+            localDomain(), addressToBytes32(recipient), period, request.encodeRequest(), "test content"
+        );
+    }
+
+    function test_sendManagementMessage_revert_sameDestination() public {
+        vm.expectRevert(IncorrectDestinationDomain.selector);
+        vm.prank(localAgentManager());
+        InterfaceOrigin(origin).sendManagerMessage(localDomain(), period, "test payload");
     }
 
     function test_getMinimumTipsValue(

--- a/packages/contracts-core/test/suite/hubs/ExecutionHub.t.sol
+++ b/packages/contracts-core/test/suite/hubs/ExecutionHub.t.sol
@@ -7,6 +7,7 @@ import {
     GasLimitTooLow,
     GasSuppliedTooLow,
     IncorrectDestinationDomain,
+    IncorrectOriginDomain,
     IncorrectMagicValue,
     IncorrectSnapshotRoot,
     MessageOptimisticPeriod,
@@ -324,6 +325,21 @@ abstract contract ExecutionHubTest is AgentSecuredTest {
         vm.prank(executor);
         testedEH().execute(msgPayload, originProof, snapProof, sm.rsi.stateIndex, rbm.request.gasLimit);
         verify_messageStatusNone(msgLeaf);
+    }
+
+    function test_execute_base_revert_originSameDomain() public {
+        RawBaseMessage memory rbm;
+        rbm.sender = rbm.recipient = addressToBytes32(recipient);
+        RawMessage memory rm;
+        rm.header.flag = uint8(MessageFlag.Base);
+        rm.header.origin = localDomain();
+        rm.header.destination = localDomain();
+        rm.header.nonce = 1;
+        rm.header.optimisticPeriod = 1 seconds;
+        rm.body = rbm.formatBaseMessage();
+        msgPayload = rm.formatMessage();
+        vm.expectRevert(IncorrectOriginDomain.selector);
+        testedEH().execute(msgPayload, new bytes32[](0), new bytes32[](0), 0, 0);
     }
 
     function test_execute_base_revert_reentrancy(Random memory random) public {

--- a/packages/contracts-core/test/suite/manager/BondingManager.t.sol
+++ b/packages/contracts-core/test/suite/manager/BondingManager.t.sol
@@ -9,6 +9,7 @@ import {
     AgentNotUnstaking,
     CallerNotSummit,
     MustBeSynapseDomain,
+    IncorrectOriginDomain,
     SlashAgentOptimisticPeriod,
     SynapseDomainForbidden
 } from "../../../contracts/libs/Errors.sol";
@@ -245,6 +246,14 @@ contract BondingManagerTest is AgentManagerTest {
         skip(proofMaturity);
         bytes memory msgPayload = managerMsgPayload(DOMAIN_REMOTE, remoteSlashAgentCalldata(0, address(0), address(0)));
         vm.expectRevert(SlashAgentOptimisticPeriod.selector);
+        managerMsgPrank(msgPayload);
+    }
+
+    function test_remoteSlashAgent_revert_sameOriginDomain() public {
+        uint32 proofMaturity = BONDING_OPTIMISTIC_PERIOD;
+        skip(proofMaturity);
+        bytes memory msgPayload = managerMsgPayload(DOMAIN_SYNAPSE, remoteSlashAgentCalldata(0, address(0), address(0)));
+        vm.expectRevert(IncorrectOriginDomain.selector);
         managerMsgPrank(msgPayload);
     }
 


### PR DESCRIPTION
**Description**
- Fixed Zellic 3.3 by adding the origin domain check in `BondingManager.remoteSlashAgent()` and `Destination.execute()`
- Also added a check to ensure message for the local domain could not be sent using `Origin`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

- New Feature: Introduced safeguards to prevent messages from being sent or executed within the same domain, enhancing the security and reliability of the system.
- Test: Added comprehensive tests to ensure the correct functioning of these new features and to prevent messages from being sent or executed within the same domain.
- Documentation: Updated function documentation to reflect new conditions under which functions will revert, improving clarity for developers interacting with the system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->