### PR TITLE
Fix: tips scaling in `Summit`

### DIFF
--- a/packages/contracts-core/contracts/events/SummitEvents.sol
+++ b/packages/contracts-core/contracts/events/SummitEvents.sol
@@ -7,7 +7,7 @@ abstract contract SummitEvents {
      * @notice Emitted when a tip is awarded to the actor, whether they are bonded or unbonded actor.
      * @param actor     Actor address
      * @param origin    Domain where tips were originally paid
-     * @param tip       Tip value, scaled down by TIPS_MULTIPLIER
+     * @param tip       Tip value, denominated in domain's wei
      */
     event TipAwarded(address actor, uint32 origin, uint256 tip);
 }


### PR DESCRIPTION

**Description**
Fixes a bug where `Summit` was storing actor tip values scaled down by `2**32` (as they appear in the message payload). As a result, the actors (bonded agents and unbonded executors) were previously gaining a tiny fraction of the message tips.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

- New Feature: Introduced a new system to track and manage tips earned by actors in the Summit contract. This feature enhances the transparency and accuracy of tip distribution.
- Documentation: Updated the description of the `TipAwarded` event in the `SummitEvents` contract to reflect the new tip calculation method.
- Test: Enhanced the `SummitTipsTest` contract with a new function to simulate the awarding of tips and improved existing functions for better accuracy in testing the earned tips of an actor.

These changes aim to improve the overall user experience by providing a more precise and transparent system for managing and tracking tips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->