### PR TITLE
Fix: incorrect fuzz tests

### DIFF
--- a/packages/contracts-core/test/suite/Summit.t.sol
+++ b/packages/contracts-core/test/suite/Summit.t.sol
@@ -88,7 +88,7 @@ contract SummitTest is AgentSecuredTest {
     }
 
     function test_acceptGuardSnapshot_revert_notInbox(address caller) public {
-        vm.assume(caller != localAgentManager());
+        vm.assume(caller != localInbox());
         vm.expectRevert(CallerNotInbox.selector);
         vm.prank(caller);
         InterfaceSummit(summit).acceptGuardSnapshot(0, 0, "");

--- a/packages/contracts-core/test/suite/client/BaseClient.t.sol
+++ b/packages/contracts-core/test/suite/client/BaseClient.t.sol
@@ -186,6 +186,22 @@ contract BaseClientTest is SynapseTest {
         client.receiveBaseMessage(rh.origin, rh.nonce, sender, secondsPassed, 0, "");
     }
 
+    function test_receiveBaseMessage_revert_optimisticPeriodMinus1Second() public {
+        uint32 timePassed = client.optimisticPeriod() - 1;
+        bytes32 sender = client.trustedSender(DOMAIN_REMOTE);
+        skip(timePassed);
+        vm.expectRevert(BaseClientOptimisticPeriod.selector);
+        vm.prank(destination);
+        client.receiveBaseMessage({
+            origin_: DOMAIN_REMOTE,
+            nonce: 1,
+            sender: sender,
+            proofMaturity: timePassed,
+            version: 0,
+            content: ""
+        });
+    }
+
     function test_receiveBaseMessage_revert_zeroProofMaturity(RawHeader memory rh, uint256 rootSubmittedAt) public {
         vm.assume(rh.origin != 0 && rh.origin != DOMAIN_LOCAL && rh.nonce != 0);
         uint32 optimisticPeriod = 0;

--- a/packages/contracts-core/test/suite/hubs/ExecutionHub.t.sol
+++ b/packages/contracts-core/test/suite/hubs/ExecutionHub.t.sol
@@ -257,6 +257,27 @@ abstract contract ExecutionHubTest is AgentSecuredTest {
         verify_messageStatusNone(msgLeaf);
     }
 
+    function test_execute_base_revert_optimisticPeriodMinus1Second() public {
+        Random memory random = Random("random salt");
+        // Create some simple data
+        (RawBaseMessage memory rbm, RawHeader memory rh, SnapshotMock memory sm) = createDataRevertTest(random);
+        // Create messages and get origin proof
+        RawMessage memory rm = createBaseMessages(rbm, rh, localDomain());
+        msgPayload = rm.formatMessage();
+        msgLeaf = rm.castToMessage().leaf();
+        vm.assume(rh.optimisticPeriod != 0);
+        bytes32[] memory originProof = getLatestProof(rh.nonce - 1);
+        // Create snapshot proof
+        adjustSnapshot(sm);
+        (, bytes32[] memory snapProof) = prepareExecution(sm);
+        // Make sure that optimistic period is NOT over
+        uint32 timePassed = rh.optimisticPeriod - 1;
+        skip(timePassed);
+        vm.expectRevert(MessageOptimisticPeriod.selector);
+        vm.prank(executor);
+        testedEH().execute(msgPayload, originProof, snapProof, sm.rsi.stateIndex, rbm.request.gasLimit);
+    }
+
     function test_execute_base_revert_gasLimitTooLow(Random memory random) public {
         // Create some simple data
         (RawBaseMessage memory rbm, RawHeader memory rh, SnapshotMock memory sm) = createDataRevertTest(random);

--- a/packages/contracts-core/test/suite/manager/BondingManager.t.sol
+++ b/packages/contracts-core/test/suite/manager/BondingManager.t.sol
@@ -248,6 +248,10 @@ contract BondingManagerTest is AgentManagerTest {
         managerMsgPrank(msgPayload);
     }
 
+    function test_remoteSlashAgent_revert_optimisticPeriodMinus1Second() public {
+        test_remoteSlashAgent_revert_optimisticPeriodNotOver(BONDING_OPTIMISTIC_PERIOD - 1);
+    }
+
     function test_completeSlashing_active(uint256 domainId, uint256 agentId, address slasher) public {
         (uint32 domain, address agent) = getAgent(domainId, agentId);
         // Initiate slashing

--- a/packages/contracts-core/test/suite/manager/BondingManager.t.sol
+++ b/packages/contracts-core/test/suite/manager/BondingManager.t.sol
@@ -242,7 +242,7 @@ contract BondingManagerTest is AgentManagerTest {
 
     function test_remoteSlashAgent_revert_optimisticPeriodNotOver(uint32 proofMaturity) public {
         proofMaturity = proofMaturity % BONDING_OPTIMISTIC_PERIOD;
-        skip(proofMaturity);
+        skipPeriod(proofMaturity);
         bytes memory msgPayload = managerMsgPayload(DOMAIN_REMOTE, remoteSlashAgentCalldata(0, address(0), address(0)));
         vm.expectRevert(SlashAgentOptimisticPeriod.selector);
         managerMsgPrank(msgPayload);

--- a/packages/contracts-core/test/suite/manager/LightManager.t.sol
+++ b/packages/contracts-core/test/suite/manager/LightManager.t.sol
@@ -166,6 +166,10 @@ contract LightManagerTest is AgentManagerTest {
         managerMsgPrank(msgPayload);
     }
 
+    function test_remoteWithdrawTips_revert_optimisticPeriodMinus1Second() public {
+        test_remoteWithdrawTips_revert_optimisticPeriodNotOver(BONDING_OPTIMISTIC_PERIOD - 1);
+    }
+
     // ══════════════════════════════════════════════════ HELPERS ══════════════════════════════════════════════════════
 
     /// @notice Returns local domain for the tested contract

--- a/packages/contracts-core/test/suite/manager/LightManager.t.sol
+++ b/packages/contracts-core/test/suite/manager/LightManager.t.sol
@@ -160,7 +160,7 @@ contract LightManagerTest is AgentManagerTest {
 
     function test_remoteWithdrawTips_revert_optimisticPeriodNotOver(uint32 proofMaturity) public {
         proofMaturity = proofMaturity % BONDING_OPTIMISTIC_PERIOD;
-        skip(proofMaturity);
+        skipPeriod(proofMaturity);
         bytes memory msgPayload = managerMsgPayload(DOMAIN_SYNAPSE, remoteWithdrawTipsCalldata(address(0), 0));
         vm.expectRevert(WithdrawTipsOptimisticPeriod.selector);
         managerMsgPrank(msgPayload);


### PR DESCRIPTION

**Description**
Fixes the fuzz tests which were implemented wrong and led to flakes like that:

https://github.com/synapsecns/sanguine/actions/runs/6589443478/attempts/1#summary-17903936450
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

- Test: Added new test scenarios across multiple modules to ensure system stability when the optimistic period is set to one second less than the bonding optimistic period.
- Refactor: Updated the logic in the `SummitTest` contract to enhance system security by checking if the caller is not the local inbox.
- Test: Introduced additional test cases in the `BaseClient`, `ExecutionHub`, `BondingManager`, and `LightManager` modules to validate the system's response to specific edge cases.
  
These changes aim to improve the robustness of the system by ensuring it handles edge cases correctly, enhancing overall system reliability and security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->