### PR TITLE
Soft fail in cases where label is not present

### DIFF
--- a/.github/actions/remove-label/action.yml
+++ b/.github/actions/remove-label/action.yml
@@ -1,5 +1,5 @@
 name: Remove Label
-description: Remove\ a label to the issue or pull request
+description: Remove a label to the issue or pull request
 inputs:
   issue_number:
     description: 'The issue number to associate with. Defaults to the current issue or pull request number used to trigger the action.'

--- a/.github/actions/remove-label/action.yml
+++ b/.github/actions/remove-label/action.yml
@@ -1,5 +1,5 @@
 name: Remove Label
-description: Remove a label to the issue or pull request
+description: Remove\ a label to the issue or pull request
 inputs:
   issue_number:
     description: 'The issue number to associate with. Defaults to the current issue or pull request number used to trigger the action.'
@@ -35,9 +35,22 @@ runs:
       uses: actions/github-script@v6
       with:
         script: |
-          github.rest.issues.removeLabel({
-            issue_number: ${{ steps.resolve_issue_number.outputs.issue }},
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            name: ['${{ inputs.label }}']
-          })
+          async function removeLabel() {
+            try {
+              await github.rest.issues.removeLabel({
+                issue_number: ${{ steps.resolve_issue_number.outputs.issue }},
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: '${{ inputs.label }}'
+              });
+            } catch (error) {
+              // Log the error if it's about the label not being present.
+              if (error.status === 404) {
+                console.log(`The label '${{ inputs.label }}' does not exist on the issue.`);
+              } else {
+                console.error('Unexpected error:', error);
+              }
+            }
+          }
+
+          removeLabel();


### PR DESCRIPTION

#1466 introduced a regression where if label is not present, `./.github/actions/remove-label` will exit w/ status code 1. This is problematic since in `packages.yml`, we *always* try to remove the label (see [this](https://github.com/synapsecns/sanguine/actions/runs/6590910981/job/17908432632?pr=1472) failure on #472 for example):

<img width="1041" alt="image" src="https://github.com/synapsecns/sanguine/assets/83933037/5373021e-1a1c-4a7f-a0d5-8c2ffdf2e40b">

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

- Chore: Enhanced the "Remove a label" action in our GitHub workflow. This update improves the system's feedback mechanism by providing more detailed information when a label is not found on an issue or pull request. It also strengthens error handling, making the process more reliable and user-friendly. This change is part of our ongoing efforts to streamline our workflow and improve user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->