### PR TITLE
Add block height endpoint to explorer api

### DIFF
--- a/services/explorer/api/resolver_test.go
+++ b/services/explorer/api/resolver_test.go
@@ -4,6 +4,7 @@ import (
 	gosql "database/sql"
 	"fmt"
 	"github.com/ethereum/go-ethereum/crypto"
+	. "github.com/stretchr/testify/assert"
 	"github.com/synapsecns/sanguine/services/explorer/graphql/server/graph/model"
 	"math"
 	"math/big"
@@ -12,7 +13,6 @@ import (
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/ethereum/go-ethereum/common"
-	. "github.com/stretchr/testify/assert"
 	"github.com/synapsecns/sanguine/services/explorer/db/sql"
 )
 
@@ -723,4 +723,43 @@ func (g APISuite) TestAmountStatistic() {
 	Nil(g.T(), err)
 	NotNil(g.T(), result)
 	Equal(g.T(), "1.000000", *result.Response.Value)
+}
+
+func (g APISuite) TestGetBlockHeight() {
+	chainID1 := 1
+	chainID2 := 56
+
+	type1 := model.ContractTypeCctp
+	type2 := model.ContractTypeBridge
+
+	contract1 := g.config.Chains[uint32(chainID1)].Contracts.CCTP
+	contract2 := g.config.Chains[uint32(chainID2)].Contracts.Bridge
+
+	block1 := uint64(3)
+	block2 := uint64(4)
+
+	contracts := []*model.ContractQuery{
+		{
+			ChainID: &chainID1,
+			Type:    &type1,
+		},
+		{
+			ChainID: &chainID2,
+			Type:    &type2,
+		},
+	}
+
+	// Store blocks in the database.
+	err := g.db.StoreLastBlock(g.GetTestContext(), uint32(chainID1), block1, contract1)
+	Nil(g.T(), err)
+
+	err = g.db.StoreLastBlock(g.GetTestContext(), uint32(chainID2), block2, contract2)
+	Nil(g.T(), err)
+
+	results, err := g.client.GetBlockHeight(g.GetTestContext(), contracts)
+	Nil(g.T(), err)
+	Equal(g.T(), 2, len(results.Response))
+	Equal(g.T(), int(block1), *results.Response[0].BlockNumber)
+	Equal(g.T(), int(block2), *results.Response[1].BlockNumber)
+
 }

--- a/services/explorer/api/suite_test.go
+++ b/services/explorer/api/suite_test.go
@@ -174,6 +174,7 @@ type APISuite struct {
 	chainIDs        []uint32
 	scribeMetrics   metrics.Handler
 	explorerMetrics metrics.Handler
+	config          serverConfig.Config
 }
 
 // NewTestSuite creates a new test suite and performs some basic checks afterward.
@@ -282,6 +283,7 @@ func (g *APISuite) SetupTest() {
 			},
 		},
 	}
+	g.config = config
 	go func() {
 		Nil(g.T(), api.Start(g.GetTestContext(), config, g.explorerMetrics))
 	}()

--- a/services/explorer/db/consumerinterface.go
+++ b/services/explorer/db/consumerinterface.go
@@ -9,6 +9,9 @@ import (
 	"gorm.io/gorm"
 )
 
+// TODO simplify these interfaces so that there is one generic read function using an interface to accept a pointer from
+// the caller so that the query's results are scanned into that pointer.
+
 // ConsumerDBWriter is the interface for writing to the ConsumerDB.
 type ConsumerDBWriter interface {
 	// StoreEvent stores an event.
@@ -72,6 +75,8 @@ type ConsumerDBReader interface {
 	GetLeaderboard(ctx context.Context, query string) ([]*model.Leaderboard, error)
 	// GetPendingByChain gets the pending txs by chain.
 	GetPendingByChain(ctx context.Context) (res *immutable.Map[int, int], err error)
+	// GetBlockHeights gets the block heights for a given chain and contract.
+	GetBlockHeights(ctx context.Context, query string, contractTypeMap map[string]*model.ContractType) ([]*model.BlockHeight, error)
 }
 
 // ConsumerDB is the interface for the ConsumerDB.

--- a/services/explorer/db/sql/reader.go
+++ b/services/explorer/db/sql/reader.go
@@ -282,3 +282,27 @@ func (s *Store) GetPendingByChain(ctx context.Context) (res *immutable.Map[int, 
 
 	return builder.Map(), nil
 }
+
+func (s *Store) GetBlockHeights(ctx context.Context, query string, contractTypeMap map[string]*model.ContractType) ([]*model.BlockHeight, error) {
+	var res []*LastBlock
+	dbTx := s.db.WithContext(ctx).Raw(query).Scan(&res)
+	if dbTx.Error != nil {
+		return nil, fmt.Errorf("failed to get block heights: %w", dbTx.Error)
+	}
+	if len(res) == 0 {
+		return nil, nil
+	}
+
+	var formatted []*model.BlockHeight
+	for _, block := range res {
+		chainID := int(block.ChainID)
+		blockNumber := int(block.BlockNumber)
+		formatted = append(formatted, &model.BlockHeight{
+			ChainID:     &chainID,
+			Type:        contractTypeMap[block.ContractAddress],
+			BlockNumber: &blockNumber,
+		})
+	}
+
+	return formatted, nil
+}

--- a/services/explorer/graphql/client/client.go
+++ b/services/explorer/graphql/client/client.go
@@ -31,6 +31,7 @@ type Query struct {
 	Leaderboard            []*model.Leaderboard            "json:\"leaderboard\" graphql:\"leaderboard\""
 	GetOriginBridgeTx      *model.BridgeWatcherTx          "json:\"getOriginBridgeTx\" graphql:\"getOriginBridgeTx\""
 	GetDestinationBridgeTx *model.BridgeWatcherTx          "json:\"getDestinationBridgeTx\" graphql:\"getDestinationBridgeTx\""
+	GetBlockHeight         []*model.BlockHeight            "json:\"getBlockHeight\" graphql:\"getBlockHeight\""
 }
 type GetBridgeTransactions struct {
 	Response []*struct {
@@ -89,6 +90,13 @@ type GetRankedChainIDsByVolume struct {
 	Response []*struct {
 		ChainID *int     "json:\"chainID\" graphql:\"chainID\""
 		Total   *float64 "json:\"total\" graphql:\"total\""
+	} "json:\"response\" graphql:\"response\""
+}
+type GetBlockHeight struct {
+	Response []*struct {
+		ChainID     *int                "json:\"chainID\" graphql:\"chainID\""
+		Type        *model.ContractType "json:\"type\" graphql:\"type\""
+		BlockNumber *int                "json:\"blockNumber\" graphql:\"blockNumber\""
 	} "json:\"response\" graphql:\"response\""
 }
 type GetAmountStatistic struct {
@@ -412,6 +420,28 @@ func (c *Client) GetRankedChainIDsByVolume(ctx context.Context, duration *model.
 
 	var res GetRankedChainIDsByVolume
 	if err := c.Client.Post(ctx, "GetRankedChainIDsByVolume", GetRankedChainIDsByVolumeDocument, &res, vars, httpRequestOptions...); err != nil {
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+const GetBlockHeightDocument = `query GetBlockHeight ($contracts: [ContractQuery]) {
+	response: getBlockHeight(contracts: $contracts) {
+		chainID
+		type
+		blockNumber
+	}
+}
+`
+
+func (c *Client) GetBlockHeight(ctx context.Context, contracts []*model.ContractQuery, httpRequestOptions ...client.HTTPRequestOption) (*GetBlockHeight, error) {
+	vars := map[string]interface{}{
+		"contracts": contracts,
+	}
+
+	var res GetBlockHeight
+	if err := c.Client.Post(ctx, "GetBlockHeight", GetBlockHeightDocument, &res, vars, httpRequestOptions...); err != nil {
 		return nil, err
 	}
 

--- a/services/explorer/graphql/client/queries/queries.graphql
+++ b/services/explorer/graphql/client/queries/queries.graphql
@@ -97,6 +97,17 @@ query GetRankedChainIDsByVolume($duration: Duration) {
   }
 }
 
+query GetBlockHeight($contracts: [ContractQuery]) {
+  response: getBlockHeight(
+    contracts: $contracts
+  ) {
+    chainID
+    type
+    blockNumber
+  }
+}
+
+
 
 
 

--- a/services/explorer/graphql/server/graph/model/models_gen.go
+++ b/services/explorer/graphql/server/graph/model/models_gen.go
@@ -42,6 +42,12 @@ type AddressRanking struct {
 	Count   *int    `json:"count,omitempty"`
 }
 
+type BlockHeight struct {
+	ChainID     *int          `json:"chainID,omitempty"`
+	Type        *ContractType `json:"type,omitempty"`
+	BlockNumber *int          `json:"blockNumber,omitempty"`
+}
+
 // BridgeTransaction represents an entire bridge transaction, including both
 // to and from transactions. If a `from` transaction does not have a corresponding
 // `to` transaction, `pending` will be true.
@@ -60,6 +66,11 @@ type BridgeWatcherTx struct {
 	Type        *BridgeTxType `json:"type,omitempty"`
 	Kappa       *string       `json:"kappa,omitempty"`
 	KappaStatus *KappaStatus  `json:"kappaStatus,omitempty"`
+}
+
+type ContractQuery struct {
+	ChainID *int          `json:"chainID,omitempty"`
+	Type    *ContractType `json:"type,omitempty"`
 }
 
 // DateResult is a given statistic for a given date.
@@ -279,6 +290,47 @@ func (e *BridgeType) UnmarshalGQL(v interface{}) error {
 }
 
 func (e BridgeType) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+type ContractType string
+
+const (
+	ContractTypeBridge ContractType = "BRIDGE"
+	ContractTypeCctp   ContractType = "CCTP"
+)
+
+var AllContractType = []ContractType{
+	ContractTypeBridge,
+	ContractTypeCctp,
+}
+
+func (e ContractType) IsValid() bool {
+	switch e {
+	case ContractTypeBridge, ContractTypeCctp:
+		return true
+	}
+	return false
+}
+
+func (e ContractType) String() string {
+	return string(e)
+}
+
+func (e *ContractType) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = ContractType(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid ContractType", str)
+	}
+	return nil
+}
+
+func (e ContractType) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 

--- a/services/explorer/graphql/server/graph/queries.resolvers.go
+++ b/services/explorer/graphql/server/graph/queries.resolvers.go
@@ -427,6 +427,35 @@ func (r *queryResolver) GetDestinationBridgeTx(ctx context.Context, chainID int,
 	return results, nil
 }
 
+// GetBlockHeight is the resolver for the getBlockHeight field.
+func (r *queryResolver) GetBlockHeight(ctx context.Context, contracts []*model.ContractQuery) ([]*model.BlockHeight, error) {
+	// Generate string for right side of IN clause
+	var contractString string
+	contractTypeMap := make(map[string]*model.ContractType)
+	for i, contract := range contracts {
+		if contract.ChainID == nil || contract.Type == nil {
+			return nil, fmt.Errorf("chainID and type must be set")
+		}
+		contractAddr, err := r.getContractAddressFromType(uint32(*contract.ChainID), *contract.Type)
+		if err != nil {
+			return nil, fmt.Errorf("could not get contract address from type %s, %w", contract.Type, err)
+		}
+		contractTypeMap[contractAddr] = contract.Type
+		if i == 0 {
+			contractString += fmt.Sprintf("('%s', %d)", contractAddr, *contract.ChainID)
+		} else {
+			contractString += fmt.Sprintf(", ('%s', %d)", contractAddr, *contract.ChainID)
+		}
+	}
+
+	query := fmt.Sprintf("SELECT contract_address, chain_id, block_number FROM last_blocks WHERE (contract_address, chain_id) IN (%s) ORDER BY block_number", contractString)
+	results, err := r.DB.GetBlockHeights(ctx, query, contractTypeMap)
+	if err != nil {
+		return nil, fmt.Errorf("could not get block heights from database %w", err)
+	}
+	return results, nil
+}
+
 // Query returns resolvers.QueryResolver implementation.
 func (r *Resolver) Query() resolvers.QueryResolver { return &queryResolver{r} }
 

--- a/services/explorer/graphql/server/graph/queryutils.go
+++ b/services/explorer/graphql/server/graph/queryutils.go
@@ -1835,3 +1835,14 @@ func (r *queryResolver) checkIfChainIDExists(chainIDNeeded uint32, bridgeType mo
 	}
 	return exists
 }
+
+func (r *queryResolver) getContractAddressFromType(chainID uint32, contractType model.ContractType) (string, error) {
+	switch contractType {
+	case model.ContractTypeBridge:
+		return r.Config.Chains[chainID].Contracts.Bridge, nil
+	case model.ContractTypeCctp:
+		return r.Config.Chains[chainID].Contracts.CCTP, nil
+	default:
+		return "", fmt.Errorf("contract type not supported")
+	}
+}

--- a/services/explorer/graphql/server/graph/resolver/server.go
+++ b/services/explorer/graphql/server/graph/resolver/server.go
@@ -72,6 +72,12 @@ type ComplexityRoot struct {
 		Count   func(childComplexity int) int
 	}
 
+	BlockHeight struct {
+		BlockNumber func(childComplexity int) int
+		ChainID     func(childComplexity int) int
+		Type        func(childComplexity int) int
+	}
+
 	BridgeTransaction struct {
 		FromInfo    func(childComplexity int) int
 		Kappa       func(childComplexity int) int
@@ -190,6 +196,7 @@ type ComplexityRoot struct {
 		CountByChainID         func(childComplexity int, chainID *int, address *string, direction *model.Direction, hours *int) int
 		CountByTokenAddress    func(childComplexity int, chainID *int, address *string, direction *model.Direction, hours *int) int
 		DailyStatisticsByChain func(childComplexity int, chainID *int, typeArg *model.DailyStatisticType, platform *model.Platform, duration *model.Duration, useCache *bool, useMv *bool) int
+		GetBlockHeight         func(childComplexity int, contracts []*model.ContractQuery) int
 		GetDestinationBridgeTx func(childComplexity int, chainID int, address string, kappa string, timestamp int, bridgeType model.BridgeType, historical *bool) int
 		GetOriginBridgeTx      func(childComplexity int, chainID int, txnHash string, bridgeType model.BridgeType) int
 		Leaderboard            func(childComplexity int, duration *model.Duration, chainID *int, useMv *bool, page *int) int
@@ -240,6 +247,7 @@ type QueryResolver interface {
 	Leaderboard(ctx context.Context, duration *model.Duration, chainID *int, useMv *bool, page *int) ([]*model.Leaderboard, error)
 	GetOriginBridgeTx(ctx context.Context, chainID int, txnHash string, bridgeType model.BridgeType) (*model.BridgeWatcherTx, error)
 	GetDestinationBridgeTx(ctx context.Context, chainID int, address string, kappa string, timestamp int, bridgeType model.BridgeType, historical *bool) (*model.BridgeWatcherTx, error)
+	GetBlockHeight(ctx context.Context, contracts []*model.ContractQuery) ([]*model.BlockHeight, error)
 }
 
 type executableSchema struct {
@@ -375,6 +383,27 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.AddressRanking.Count(childComplexity), true
+
+	case "BlockHeight.blockNumber":
+		if e.complexity.BlockHeight.BlockNumber == nil {
+			break
+		}
+
+		return e.complexity.BlockHeight.BlockNumber(childComplexity), true
+
+	case "BlockHeight.chainID":
+		if e.complexity.BlockHeight.ChainID == nil {
+			break
+		}
+
+		return e.complexity.BlockHeight.ChainID(childComplexity), true
+
+	case "BlockHeight.type":
+		if e.complexity.BlockHeight.Type == nil {
+			break
+		}
+
+		return e.complexity.BlockHeight.Type(childComplexity), true
 
 	case "BridgeTransaction.fromInfo":
 		if e.complexity.BridgeTransaction.FromInfo == nil {
@@ -999,6 +1028,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.DailyStatisticsByChain(childComplexity, args["chainID"].(*int), args["type"].(*model.DailyStatisticType), args["platform"].(*model.Platform), args["duration"].(*model.Duration), args["useCache"].(*bool), args["useMv"].(*bool)), true
 
+	case "Query.getBlockHeight":
+		if e.complexity.Query.GetBlockHeight == nil {
+			break
+		}
+
+		args, err := ec.field_Query_getBlockHeight_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.GetBlockHeight(childComplexity, args["contracts"].([]*model.ContractQuery)), true
+
 	case "Query.getDestinationBridgeTx":
 		if e.complexity.Query.GetDestinationBridgeTx == nil {
 			break
@@ -1143,7 +1184,9 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	rc := graphql.GetOperationContext(ctx)
 	ec := executionContext{rc, e, 0, 0, make(chan graphql.DeferredResult)}
-	inputUnmarshalMap := graphql.BuildUnmarshalerMap()
+	inputUnmarshalMap := graphql.BuildUnmarshalerMap(
+		ec.unmarshalInputContractQuery,
+	)
 	first := true
 
 	switch rc.Operation.Operation {
@@ -1404,6 +1447,13 @@ Ranked chainIDs by volume
     historical:  Boolean = false
   ): BridgeWatcherTx
 
+
+  """
+  GetBlockHeight gets block heights from the current bridge.
+  """
+  getBlockHeight(
+    contracts: [ContractQuery]
+  ): [BlockHeight]
 }
 
 
@@ -1624,7 +1674,6 @@ type Leaderboard {
   rank: Int
   avgVolumeUSD: Float
 }
-
 enum BridgeType{
   BRIDGE
   CCTP
@@ -1635,6 +1684,24 @@ enum KappaStatus{
   PENDING
   UNKNOWN
 }
+
+input ContractQuery {
+  chainID: Int
+  type: ContractType
+}
+
+enum ContractType{
+  BRIDGE
+  CCTP
+}
+
+type BlockHeight {
+  chainID: Int
+  type: ContractType
+  blockNumber: Int
+}
+
+
 `, BuiltIn: false},
 }
 var parsedSchema = gqlparser.MustLoadSchema(sources...)
@@ -2075,6 +2142,21 @@ func (ec *executionContext) field_Query_dailyStatisticsByChain_args(ctx context.
 		}
 	}
 	args["useMv"] = arg5
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_getBlockHeight_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 []*model.ContractQuery
+	if tmp, ok := rawArgs["contracts"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("contracts"))
+		arg0, err = ec.unmarshalOContractQuery2ᚕᚖgithubᚗcomᚋsynapsecnsᚋsanguineᚋservicesᚋexplorerᚋgraphqlᚋserverᚋgraphᚋmodelᚐContractQuery(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["contracts"] = arg0
 	return args, nil
 }
 
@@ -3063,6 +3145,129 @@ func (ec *executionContext) _AddressRanking_count(ctx context.Context, field gra
 func (ec *executionContext) fieldContext_AddressRanking_count(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "AddressRanking",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _BlockHeight_chainID(ctx context.Context, field graphql.CollectedField, obj *model.BlockHeight) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_BlockHeight_chainID(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ChainID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int)
+	fc.Result = res
+	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_BlockHeight_chainID(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "BlockHeight",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _BlockHeight_type(ctx context.Context, field graphql.CollectedField, obj *model.BlockHeight) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_BlockHeight_type(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Type, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.ContractType)
+	fc.Result = res
+	return ec.marshalOContractType2ᚖgithubᚗcomᚋsynapsecnsᚋsanguineᚋservicesᚋexplorerᚋgraphqlᚋserverᚋgraphᚋmodelᚐContractType(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_BlockHeight_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "BlockHeight",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ContractType does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _BlockHeight_blockNumber(ctx context.Context, field graphql.CollectedField, obj *model.BlockHeight) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_BlockHeight_blockNumber(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.BlockNumber, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int)
+	fc.Result = res
+	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_BlockHeight_blockNumber(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "BlockHeight",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -7173,6 +7378,66 @@ func (ec *executionContext) fieldContext_Query_getDestinationBridgeTx(ctx contex
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_getBlockHeight(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_getBlockHeight(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().GetBlockHeight(rctx, fc.Args["contracts"].([]*model.ContractQuery))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]*model.BlockHeight)
+	fc.Result = res
+	return ec.marshalOBlockHeight2ᚕᚖgithubᚗcomᚋsynapsecnsᚋsanguineᚋservicesᚋexplorerᚋgraphqlᚋserverᚋgraphᚋmodelᚐBlockHeight(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_getBlockHeight(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "chainID":
+				return ec.fieldContext_BlockHeight_chainID(ctx, field)
+			case "type":
+				return ec.fieldContext_BlockHeight_type(ctx, field)
+			case "blockNumber":
+				return ec.fieldContext_BlockHeight_blockNumber(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type BlockHeight", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_getBlockHeight_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query___type(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query___type(ctx, field)
 	if err != nil {
@@ -9535,6 +9800,44 @@ func (ec *executionContext) fieldContext___Type_specifiedByURL(ctx context.Conte
 
 // region    **************************** input.gotpl *****************************
 
+func (ec *executionContext) unmarshalInputContractQuery(ctx context.Context, obj interface{}) (model.ContractQuery, error) {
+	var it model.ContractQuery
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"chainID", "type"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "chainID":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("chainID"))
+			data, err := ec.unmarshalOInt2ᚖint(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ChainID = data
+		case "type":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("type"))
+			data, err := ec.unmarshalOContractType2ᚖgithubᚗcomᚋsynapsecnsᚋsanguineᚋservicesᚋexplorerᚋgraphqlᚋserverᚋgraphᚋmodelᚐContractType(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Type = data
+		}
+	}
+
+	return it, nil
+}
+
 // endregion **************************** input.gotpl *****************************
 
 // region    ************************** interface.gotpl ***************************
@@ -9727,6 +10030,46 @@ func (ec *executionContext) _AddressRanking(ctx context.Context, sel ast.Selecti
 			out.Values[i] = ec._AddressRanking_address(ctx, field, obj)
 		case "count":
 			out.Values[i] = ec._AddressRanking_count(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var blockHeightImplementors = []string{"BlockHeight"}
+
+func (ec *executionContext) _BlockHeight(ctx context.Context, sel ast.SelectionSet, obj *model.BlockHeight) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, blockHeightImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("BlockHeight")
+		case "chainID":
+			out.Values[i] = ec._BlockHeight_chainID(ctx, field, obj)
+		case "type":
+			out.Values[i] = ec._BlockHeight_type(ctx, field, obj)
+		case "blockNumber":
+			out.Values[i] = ec._BlockHeight_blockNumber(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -10531,6 +10874,25 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_getDestinationBridgeTx(ctx, field)
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "getBlockHeight":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_getBlockHeight(ctx, field)
 				return res
 			}
 
@@ -11601,6 +11963,54 @@ func (ec *executionContext) marshalOAddressRanking2ᚖgithubᚗcomᚋsynapsecns�
 	return ec._AddressRanking(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalOBlockHeight2ᚕᚖgithubᚗcomᚋsynapsecnsᚋsanguineᚋservicesᚋexplorerᚋgraphqlᚋserverᚋgraphᚋmodelᚐBlockHeight(ctx context.Context, sel ast.SelectionSet, v []*model.BlockHeight) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalOBlockHeight2ᚖgithubᚗcomᚋsynapsecnsᚋsanguineᚋservicesᚋexplorerᚋgraphqlᚋserverᚋgraphᚋmodelᚐBlockHeight(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	return ret
+}
+
+func (ec *executionContext) marshalOBlockHeight2ᚖgithubᚗcomᚋsynapsecnsᚋsanguineᚋservicesᚋexplorerᚋgraphqlᚋserverᚋgraphᚋmodelᚐBlockHeight(ctx context.Context, sel ast.SelectionSet, v *model.BlockHeight) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._BlockHeight(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalOBoolean2bool(ctx context.Context, v interface{}) (bool, error) {
 	res, err := graphql.UnmarshalBoolean(v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -11696,6 +12106,50 @@ func (ec *executionContext) marshalOBridgeWatcherTx2ᚖgithubᚗcomᚋsynapsecns
 		return graphql.Null
 	}
 	return ec._BridgeWatcherTx(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalOContractQuery2ᚕᚖgithubᚗcomᚋsynapsecnsᚋsanguineᚋservicesᚋexplorerᚋgraphqlᚋserverᚋgraphᚋmodelᚐContractQuery(ctx context.Context, v interface{}) ([]*model.ContractQuery, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]*model.ContractQuery, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalOContractQuery2ᚖgithubᚗcomᚋsynapsecnsᚋsanguineᚋservicesᚋexplorerᚋgraphqlᚋserverᚋgraphᚋmodelᚐContractQuery(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) unmarshalOContractQuery2ᚖgithubᚗcomᚋsynapsecnsᚋsanguineᚋservicesᚋexplorerᚋgraphqlᚋserverᚋgraphᚋmodelᚐContractQuery(ctx context.Context, v interface{}) (*model.ContractQuery, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputContractQuery(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalOContractType2ᚖgithubᚗcomᚋsynapsecnsᚋsanguineᚋservicesᚋexplorerᚋgraphqlᚋserverᚋgraphᚋmodelᚐContractType(ctx context.Context, v interface{}) (*model.ContractType, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var res = new(model.ContractType)
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOContractType2ᚖgithubᚗcomᚋsynapsecnsᚋsanguineᚋservicesᚋexplorerᚋgraphqlᚋserverᚋgraphᚋmodelᚐContractType(ctx context.Context, sel ast.SelectionSet, v *model.ContractType) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return v
 }
 
 func (ec *executionContext) unmarshalODailyStatisticType2ᚖgithubᚗcomᚋsynapsecnsᚋsanguineᚋservicesᚋexplorerᚋgraphqlᚋserverᚋgraphᚋmodelᚐDailyStatisticType(ctx context.Context, v interface{}) (*model.DailyStatisticType, error) {

--- a/services/explorer/graphql/server/graph/schema/queries.graphql
+++ b/services/explorer/graphql/server/graph/schema/queries.graphql
@@ -145,6 +145,13 @@ Ranked chainIDs by volume
     historical:  Boolean = false
   ): BridgeWatcherTx
 
+
+  """
+  GetBlockHeight gets block heights from the current bridge. Returns results in an array of increased block heights.
+  """
+  getBlockHeight(
+    contracts: [ContractQuery]
+  ): [BlockHeight]
 }
 
 

--- a/services/explorer/graphql/server/graph/schema/types.graphql
+++ b/services/explorer/graphql/server/graph/schema/types.graphql
@@ -214,7 +214,6 @@ type Leaderboard {
   rank: Int
   avgVolumeUSD: Float
 }
-
 enum BridgeType{
   BRIDGE
   CCTP
@@ -225,3 +224,21 @@ enum KappaStatus{
   PENDING
   UNKNOWN
 }
+
+input ContractQuery {
+  chainID: Int
+  type: ContractType
+}
+
+enum ContractType{
+  BRIDGE
+  CCTP
+}
+
+type BlockHeight {
+  chainID: Int
+  type: ContractType
+  blockNumber: Int
+}
+
+


### PR DESCRIPTION
**Description**
Provides a new api endpoint that returns the current block height status for contracts in the explorer data base.

Takes an array of objects of the following type
```
type ContractQuery {
  chainID: Int
  type: ContractType (Enum of string BRIDGE or CCTP)
}
```
 
 and returns an array of objects in of the following type in ascending block height order
 
 ```
 type BlockHeight {
  chainID: Int
  type: ContractType (Enum of string BRIDGE or CCTP)
  blockNumber: Int
}
```
 
 


