### PR TITLE
Make agents tests faster

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -183,7 +183,7 @@ jobs:
       - name: Test
         run: |
           set -e
-          max_num_retries=5
+          max_num_retries=3
           echo "mode: atomic" > coverage.txt
 
           # Loop through each package and run tests, with package level retries
@@ -192,7 +192,7 @@ jobs:
             retries=0
 
             while [ $retries -lt $max_num_retries ]; do
-              if $PYROSCOPE_PATH exec --apiKey=${{ secrets.PYROSCOPE_CLOUD_TOKEN }} -- gotestsum --rerun-fails=5 --packages="$pkg" --format standard-verbose -- -v -coverpkg="$pkg" -coverprofile=profile.cov $pkg; then
+              if $PYROSCOPE_PATH exec --apiKey=${{ secrets.PYROSCOPE_CLOUD_TOKEN }} -- gotestsum --rerun-fails=3 --packages="$pkg" --format standard-verbose -- -v -coverpkg="$pkg" -coverprofile=profile.cov $pkg; then
                 break
               else
                 retries=$((retries+1))
@@ -502,7 +502,6 @@ jobs:
         uses: ./.github/actions/remove-label
         with:
           label: 'needs-go-generate-${{matrix.package}}'
-
 
   check-generation:
     name: Go Generate (Module Changes)

--- a/agents/testutil/simulated_backends_suite.go
+++ b/agents/testutil/simulated_backends_suite.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/brianvoe/gofakeit"
 	"github.com/synapsecns/sanguine/core"
@@ -373,18 +374,21 @@ func (a *SimulatedBackendsTestSuite) SetupTest() {
 		defer wg.Done()
 		anvilOptsOrigin := anvil.NewAnvilOptionBuilder()
 		anvilOptsOrigin.SetChainID(uint64(params.RinkebyChainConfig.ChainID.Int64()))
+		anvilOptsOrigin.SetBlockTime(1 * time.Second)
 		a.TestBackendOrigin = anvil.NewAnvilBackend(a.GetTestContext(), a.T(), anvilOptsOrigin)
 	}()
 	go func() {
 		defer wg.Done()
 		anvilOptsDestination := anvil.NewAnvilOptionBuilder()
 		anvilOptsDestination.SetChainID(uint64(client.ChapelChainConfig.ChainID.Int64()))
+		anvilOptsDestination.SetBlockTime(1 * time.Second)
 		a.TestBackendDestination = anvil.NewAnvilBackend(a.GetTestContext(), a.T(), anvilOptsDestination)
 	}()
 	go func() {
 		defer wg.Done()
 		anvilOptsSummit := anvil.NewAnvilOptionBuilder()
 		anvilOptsSummit.SetChainID(uint64(10))
+		anvilOptsSummit.SetBlockTime(1 * time.Second)
 		a.TestBackendSummit = anvil.NewAnvilBackend(a.GetTestContext(), a.T(), anvilOptsSummit)
 	}()
 	wg.Wait()


### PR DESCRIPTION

**Description**
Set anvil block time to 1 second which should make event processing more robust (instead of having to rely on bumping blocks with dummy events).

**Additional context**
Decrease amount of retries in CI to notify faster if an agents test has actually broken.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

- Test Improvement: Reduced the maximum number of retries for test execution from 5 to 3, enhancing the efficiency of our testing process.
- Consistency Enhancement: Ensured uniform block time across different instances in our testing suite, leading to more reliable and consistent test results.

These changes primarily improve our internal testing procedures, making them more efficient and reliable. While these updates may not directly impact end-users, they help us deliver higher quality software more quickly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->