### PR TITLE
[explorer] add required params to gql server

### DIFF
--- a/contrib/promexporter/internal/gql/explorer/models.gen.go
+++ b/contrib/promexporter/internal/gql/explorer/models.gen.go
@@ -69,8 +69,8 @@ type BridgeWatcherTx struct {
 }
 
 type ContractQuery struct {
-	ChainID *int64        `json:"chainID,omitempty"`
-	Type    *ContractType `json:"type,omitempty"`
+	ChainID int64        `json:"chainID"`
+	Type    ContractType `json:"type"`
 }
 
 // DateResult is a given statistic for a given date.

--- a/services/explorer/api/resolver_test.go
+++ b/services/explorer/api/resolver_test.go
@@ -740,12 +740,12 @@ func (g APISuite) TestGetBlockHeight() {
 
 	contracts := []*model.ContractQuery{
 		{
-			ChainID: &chainID1,
-			Type:    &type1,
+			ChainID: chainID1,
+			Type:    type1,
 		},
 		{
-			ChainID: &chainID2,
-			Type:    &type2,
+			ChainID: chainID2,
+			Type:    type2,
 		},
 	}
 

--- a/services/explorer/db/consumerinterface.go
+++ b/services/explorer/db/consumerinterface.go
@@ -76,7 +76,7 @@ type ConsumerDBReader interface {
 	// GetPendingByChain gets the pending txs by chain.
 	GetPendingByChain(ctx context.Context) (res *immutable.Map[int, int], err error)
 	// GetBlockHeights gets the block heights for a given chain and contract.
-	GetBlockHeights(ctx context.Context, query string, contractTypeMap map[string]*model.ContractType) ([]*model.BlockHeight, error)
+	GetBlockHeights(ctx context.Context, query string, contractTypeMap map[string]model.ContractType) ([]*model.BlockHeight, error)
 }
 
 // ConsumerDB is the interface for the ConsumerDB.

--- a/services/explorer/db/consumerinterface.go
+++ b/services/explorer/db/consumerinterface.go
@@ -24,7 +24,7 @@ type ConsumerDBWriter interface {
 	StoreTokenIndex(ctx context.Context, chainID uint32, tokenIndex uint8, tokenAddress string, contractAddress string) error
 	// StoreSwapFee stores the swap fee data.
 	StoreSwapFee(ctx context.Context, chainID uint32, timestamp uint64, contractAddress string, fee uint64, feeType string) error
-	// UNSAFE_DB gets the underlying gorm db. This is not intended for use in production.
+	// UNSAFE_DB gets the underlying gorm db. This is for testing only and not intended for use in production.
 	//
 	//nolint:golint
 	UNSAFE_DB() *gorm.DB
@@ -75,7 +75,7 @@ type ConsumerDBReader interface {
 	GetLeaderboard(ctx context.Context, query string) ([]*model.Leaderboard, error)
 	// GetPendingByChain gets the pending txs by chain.
 	GetPendingByChain(ctx context.Context) (res *immutable.Map[int, int], err error)
-	// GetBlockHeights gets the block heights for a given chain and contract.
+	// GetBlockHeights gets the block heights for a given chain and contract type.
 	GetBlockHeights(ctx context.Context, query string, contractTypeMap map[string]model.ContractType) ([]*model.BlockHeight, error)
 }
 

--- a/services/explorer/db/mocks/consumer_db.go
+++ b/services/explorer/db/mocks/consumer_db.go
@@ -172,11 +172,11 @@ func (_m *ConsumerDB) GetAllMessageBusEvents(ctx context.Context, query string) 
 }
 
 // GetBlockHeights provides a mock function with given fields: ctx, query, contractTypeMap
-func (_m *ConsumerDB) GetBlockHeights(ctx context.Context, query string, contractTypeMap map[string]*model.ContractType) ([]*model.BlockHeight, error) {
+func (_m *ConsumerDB) GetBlockHeights(ctx context.Context, query string, contractTypeMap map[string]model.ContractType) ([]*model.BlockHeight, error) {
 	ret := _m.Called(ctx, query, contractTypeMap)
 
 	var r0 []*model.BlockHeight
-	if rf, ok := ret.Get(0).(func(context.Context, string, map[string]*model.ContractType) []*model.BlockHeight); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, map[string]model.ContractType) []*model.BlockHeight); ok {
 		r0 = rf(ctx, query, contractTypeMap)
 	} else {
 		if ret.Get(0) != nil {
@@ -185,7 +185,7 @@ func (_m *ConsumerDB) GetBlockHeights(ctx context.Context, query string, contrac
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, string, map[string]*model.ContractType) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, string, map[string]model.ContractType) error); ok {
 		r1 = rf(ctx, query, contractTypeMap)
 	} else {
 		r1 = ret.Error(1)

--- a/services/explorer/db/sql/reader.go
+++ b/services/explorer/db/sql/reader.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/benbjohnson/immutable"
+	"github.com/synapsecns/sanguine/core"
 	"github.com/synapsecns/sanguine/services/explorer/graphql/server/graph/model"
 )
 
@@ -283,7 +284,7 @@ func (s *Store) GetPendingByChain(ctx context.Context) (res *immutable.Map[int, 
 	return builder.Map(), nil
 }
 
-func (s *Store) GetBlockHeights(ctx context.Context, query string, contractTypeMap map[string]*model.ContractType) ([]*model.BlockHeight, error) {
+func (s *Store) GetBlockHeights(ctx context.Context, query string, contractTypeMap map[string]model.ContractType) ([]*model.BlockHeight, error) {
 	var res []*LastBlock
 	dbTx := s.db.WithContext(ctx).Raw(query).Scan(&res)
 	if dbTx.Error != nil {
@@ -299,7 +300,7 @@ func (s *Store) GetBlockHeights(ctx context.Context, query string, contractTypeM
 		blockNumber := int(block.BlockNumber)
 		formatted = append(formatted, &model.BlockHeight{
 			ChainID:     &chainID,
-			Type:        contractTypeMap[block.ContractAddress],
+			Type:        core.PtrTo(contractTypeMap[block.ContractAddress]),
 			BlockNumber: &blockNumber,
 		})
 	}

--- a/services/explorer/graphql/server/graph/model/models_gen.go
+++ b/services/explorer/graphql/server/graph/model/models_gen.go
@@ -69,8 +69,8 @@ type BridgeWatcherTx struct {
 }
 
 type ContractQuery struct {
-	ChainID *int          `json:"chainID,omitempty"`
-	Type    *ContractType `json:"type,omitempty"`
+	ChainID int          `json:"chainID"`
+	Type    ContractType `json:"type"`
 }
 
 // DateResult is a given statistic for a given date.

--- a/services/explorer/graphql/server/graph/queries.resolvers.go
+++ b/services/explorer/graphql/server/graph/queries.resolvers.go
@@ -431,20 +431,17 @@ func (r *queryResolver) GetDestinationBridgeTx(ctx context.Context, chainID int,
 func (r *queryResolver) GetBlockHeight(ctx context.Context, contracts []*model.ContractQuery) ([]*model.BlockHeight, error) {
 	// Generate string for right side of IN clause
 	var contractString string
-	contractTypeMap := make(map[string]*model.ContractType)
+	contractTypeMap := make(map[string]model.ContractType)
 	for i, contract := range contracts {
-		if contract.ChainID == nil || contract.Type == nil {
-			return nil, fmt.Errorf("chainID and type must be set")
-		}
-		contractAddr, err := r.getContractAddressFromType(uint32(*contract.ChainID), *contract.Type)
+		contractAddr, err := r.getContractAddressFromType(uint32(contract.ChainID), contract.Type)
 		if err != nil {
 			return nil, fmt.Errorf("could not get contract address from type %s, %w", contract.Type, err)
 		}
 		contractTypeMap[contractAddr] = contract.Type
 		if i == 0 {
-			contractString += fmt.Sprintf("('%s', %d)", contractAddr, *contract.ChainID)
+			contractString += fmt.Sprintf("('%s', %d)", contractAddr, contract.ChainID)
 		} else {
-			contractString += fmt.Sprintf(", ('%s', %d)", contractAddr, *contract.ChainID)
+			contractString += fmt.Sprintf(", ('%s', %d)", contractAddr, contract.ChainID)
 		}
 	}
 

--- a/services/explorer/graphql/server/graph/resolver/server.go
+++ b/services/explorer/graphql/server/graph/resolver/server.go
@@ -1686,8 +1686,8 @@ enum KappaStatus{
 }
 
 input ContractQuery {
-  chainID: Int
-  type: ContractType
+  chainID: Int!
+  type: ContractType!
 }
 
 enum ContractType{
@@ -9818,7 +9818,7 @@ func (ec *executionContext) unmarshalInputContractQuery(ctx context.Context, obj
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("chainID"))
-			data, err := ec.unmarshalOInt2ᚖint(ctx, v)
+			data, err := ec.unmarshalNInt2int(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -9827,7 +9827,7 @@ func (ec *executionContext) unmarshalInputContractQuery(ctx context.Context, obj
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("type"))
-			data, err := ec.unmarshalOContractType2ᚖgithubᚗcomᚋsynapsecnsᚋsanguineᚋservicesᚋexplorerᚋgraphqlᚋserverᚋgraphᚋmodelᚐContractType(ctx, v)
+			data, err := ec.unmarshalNContractType2githubᚗcomᚋsynapsecnsᚋsanguineᚋservicesᚋexplorerᚋgraphqlᚋserverᚋgraphᚋmodelᚐContractType(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -11516,6 +11516,16 @@ func (ec *executionContext) unmarshalNBridgeType2githubᚗcomᚋsynapsecnsᚋsan
 }
 
 func (ec *executionContext) marshalNBridgeType2githubᚗcomᚋsynapsecnsᚋsanguineᚋservicesᚋexplorerᚋgraphqlᚋserverᚋgraphᚋmodelᚐBridgeType(ctx context.Context, sel ast.SelectionSet, v model.BridgeType) graphql.Marshaler {
+	return v
+}
+
+func (ec *executionContext) unmarshalNContractType2githubᚗcomᚋsynapsecnsᚋsanguineᚋservicesᚋexplorerᚋgraphqlᚋserverᚋgraphᚋmodelᚐContractType(ctx context.Context, v interface{}) (model.ContractType, error) {
+	var res model.ContractType
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNContractType2githubᚗcomᚋsynapsecnsᚋsanguineᚋservicesᚋexplorerᚋgraphqlᚋserverᚋgraphᚋmodelᚐContractType(ctx context.Context, sel ast.SelectionSet, v model.ContractType) graphql.Marshaler {
 	return v
 }
 

--- a/services/explorer/graphql/server/graph/schema/types.graphql
+++ b/services/explorer/graphql/server/graph/schema/types.graphql
@@ -226,8 +226,8 @@ enum KappaStatus{
 }
 
 input ContractQuery {
-  chainID: Int
-  type: ContractType
+  chainID: Int!
+  type: ContractType!
 }
 
 enum ContractType{


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**

Use server side form-field validation to require both fields. Makes this api less confusing to consumers & decreases potential for nil reference errors.

Targets #1475
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

- Refactor: Updated the `ContractQuery` structure to make `ChainID` and `Type` fields mandatory, enhancing data consistency and reducing potential errors.
- Refactor: Simplified the `GetBlockHeight` function by removing unnecessary null checks, improving code readability and maintainability.
- Test: Clarified the use of `UNSAFE_DB` function in testing, ensuring it's not used in production environments, thereby enhancing application security.
- Refactor: Updated the `GetBlockHeights` function to handle non-pointer `ContractType`, streamlining data handling and improving performance.

These changes improve the robustness and clarity of the code, making it easier to maintain and less prone to errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->