### PR TITLE
Fix: ToB-20 (missing events)

### DIFF
--- a/packages/contracts-core/contracts/GasOracle.sol
+++ b/packages/contracts-core/contracts/GasOracle.sol
@@ -90,7 +90,7 @@ contract GasOracle is MessagingBase, GasOracleEvents, InterfaceGasOracle {
     function setSummitTip(uint256 summitTipWei_) external onlyOwner {
         if (summitTipWei_ > MAX_SUMMIT_TIP) revert SummitTipTooHigh();
         summitTipWei = summitTipWei_;
-        // TODO: emit event
+        emit SummitTipUpdated(summitTipWei_);
     }
 
     /// @inheritdoc InterfaceGasOracle

--- a/packages/contracts-core/contracts/Origin.sol
+++ b/packages/contracts-core/contracts/Origin.sol
@@ -107,6 +107,7 @@ contract Origin is StateHub, OriginEvents, InterfaceOrigin {
         if (address(this).balance < amount) revert InsufficientEthBalance();
         (bool success,) = recipient.call{value: amount}("");
         if (!success) revert EthTransferFailed();
+        emit TipWithdrawalCompleted(recipient, amount);
     }
 
     // ═══════════════════════════════════════════════════ VIEWS ═══════════════════════════════════════════════════════

--- a/packages/contracts-core/contracts/Summit.sol
+++ b/packages/contracts-core/contracts/Summit.sol
@@ -178,6 +178,7 @@ contract Summit is SnapshotHub, SummitEvents, InterfaceSummit {
         // Guaranteed to fit into uint128, as the sum is lower than `earned`
         actorTips[msg.sender][origin].claimed = uint128(tips.claimed + amount);
         InterfaceBondingManager(address(agentManager)).withdrawTips(msg.sender, origin, amount);
+        emit TipWithdrawalInitiated(msg.sender, origin, amount);
     }
 
     // ═══════════════════════════════════════════════════ VIEWS ═══════════════════════════════════════════════════════

--- a/packages/contracts-core/contracts/events/GasOracleEvents.sol
+++ b/packages/contracts-core/contracts/events/GasOracleEvents.sol
@@ -9,4 +9,10 @@ abstract contract GasOracleEvents {
      * @param paddedGasData Padded encoded gas data
      */
     event GasDataUpdated(uint32 domain, uint256 paddedGasData);
+
+    /**
+     * @notice Emitted when the value of the summit tip is updated
+     * @param summitTipWei  The new value of the summit tip in Mainnet wei
+     */
+    event SummitTipUpdated(uint256 summitTipWei);
 }

--- a/packages/contracts-core/contracts/events/OriginEvents.sol
+++ b/packages/contracts-core/contracts/events/OriginEvents.sol
@@ -11,4 +11,11 @@ abstract contract OriginEvents {
      * @param message       Raw bytes of message
      */
     event Sent(bytes32 indexed messageHash, uint32 indexed nonce, uint32 indexed destination, bytes message);
+
+    /**
+     * @notice Emitted when a tip withdrawal is completed.
+     * @param actor     Actor address
+     * @param tip       Tip value, denominated in local domain's wei
+     */
+    event TipWithdrawalCompleted(address actor, uint256 tip);
 }

--- a/packages/contracts-core/contracts/events/SummitEvents.sol
+++ b/packages/contracts-core/contracts/events/SummitEvents.sol
@@ -10,4 +10,12 @@ abstract contract SummitEvents {
      * @param tip       Tip value, denominated in domain's wei
      */
     event TipAwarded(address actor, uint32 origin, uint256 tip);
+
+    /**
+     * @notice Emitted when a tip withdrawal is initiated by the actor.
+     * @param actor     Actor address
+     * @param origin    Domain where tips were originally paid
+     * @param tip       Tip value, denominated in domain's wei
+     */
+    event TipWithdrawalInitiated(address actor, uint32 origin, uint256 tip);
 }

--- a/packages/contracts-core/test/suite/GasOracle.GasData.t.sol
+++ b/packages/contracts-core/test/suite/GasOracle.GasData.t.sol
@@ -30,6 +30,12 @@ contract GasOracleGasDataTest is GasOracleTest {
         assertEq(GasOracle(gasOracle).summitTipWei(), 0.01 ether);
     }
 
+    function test_setSummitTip_emitsEvent() public {
+        vm.expectEmit(gasOracle);
+        emit SummitTipUpdated(1337);
+        GasOracle(gasOracle).setSummitTip(1337);
+    }
+
     function test_setSummitTip_revert_higherThanUpperBound() public {
         vm.expectRevert(SummitTipTooHigh.selector);
         GasOracle(gasOracle).setSummitTip(0.01 ether + 1 wei);

--- a/packages/contracts-core/test/suite/Origin.t.sol
+++ b/packages/contracts-core/test/suite/Origin.t.sol
@@ -428,6 +428,8 @@ contract OriginTest is AgentSecuredTest {
 
     function test_withdrawTips(uint256 amount) public {
         vm.deal(origin, amount);
+        vm.expectEmit(origin);
+        emit TipWithdrawalCompleted(recipient, amount);
         vm.prank(address(lightManager));
         InterfaceOrigin(origin).withdrawTips(recipient, amount);
         assertEq(recipient.balance, amount);

--- a/packages/contracts-core/test/suite/SummitTips.t.sol
+++ b/packages/contracts-core/test/suite/SummitTips.t.sol
@@ -524,6 +524,8 @@ contract SummitTipsTest is AgentSecuredTest {
         SummitCheats(summit).setActorTips(actor, domain, earned, claimed);
         bytes memory expectedCall = abi.encodeWithSelector(bondingManager.withdrawTips.selector, actor, domain, amount);
         vm.expectCall(address(bondingManager), expectedCall);
+        vm.expectEmit(summit);
+        emit TipWithdrawalInitiated(actor, domain, amount);
         vm.prank(actor);
         InterfaceSummit(summit).withdrawTips(domain, amount);
         (uint128 earned_, uint128 claimed_) = InterfaceSummit(summit).actorTips(actor, domain);

--- a/packages/contracts-core/test/utils/events/ProductionEvents.t.sol
+++ b/packages/contracts-core/test/utils/events/ProductionEvents.t.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.17;
 import {AgentManagerEvents} from "../../../contracts/events/AgentManagerEvents.sol";
 import {DestinationEvents} from "../../../contracts/events/DestinationEvents.sol";
 import {ExecutionHubEvents} from "../../../contracts/events/ExecutionHubEvents.sol";
+import {GasOracleEvents} from "../../../contracts/events/GasOracleEvents.sol";
 import {InboxEvents} from "../../../contracts/events/InboxEvents.sol";
 import {OriginEvents} from "../../../contracts/events/OriginEvents.sol";
 import {SnapshotHubEvents} from "../../../contracts/events/SnapshotHubEvents.sol";
@@ -15,6 +16,7 @@ abstract contract ProductionEvents is
     AgentManagerEvents,
     DestinationEvents,
     ExecutionHubEvents,
+    GasOracleEvents,
     InboxEvents,
     OriginEvents,
     SnapshotHubEvents,


### PR DESCRIPTION
**Description**
- Fixed ToB-20 by adding following events:
  - `GasOracle` now emits event when the summit tip value is updated.
  - `Summit` now emits event whenever the actor requests a tip withdrawal (either for Synapse or remote chain).
  - `Origin` now emits event whenever the tip withdrawal procedure is completed for the actor.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->


### Summary by CodeRabbit

- New Feature: Enhanced tracking of tip transactions in the system. This includes:
  - Event notifications when the summit tip is updated, providing real-time updates on changes.
  - Event notifications when a tip withdrawal is initiated, allowing users to track their transactions.
  - Event notifications when a tip withdrawal is completed, confirming successful transactions.
- Test: Added new tests to ensure the correct emission of events during tip transactions.
- Chore: Integrated the `GasOracleEvents` contract into the `ProductionEvents` contract for better event management. 

These updates improve the transparency and traceability of tip transactions, enhancing user trust and experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->