### PR TITLE
Escape SQL in non-paramaterized queries at resolver level

### DIFF
--- a/core/dbcommon/escape.go
+++ b/core/dbcommon/escape.go
@@ -1,0 +1,45 @@
+package dbcommon
+
+import (
+	"strings"
+)
+
+// MysqlRealEscapeString mimics the behavior of the PHP function
+// mysql_real_escape_string, which is used to escape special characters in a
+// string before sending it to a MySQL database. This can help prevent SQL
+// injection attacks.
+//
+// The PHP function itself has a checkered history. While its primary intention
+// was to make strings safe for MySQL, relying solely on it is considered bad
+// practice. This is because the best way to prevent SQL injection is by using
+// prepared statements or parameterized queries, which don't require manual
+// string escaping. Additionally, mysql_real_escape_string in PHP relies on the
+// current character set, and without the proper character set, it can fail to
+// protect against SQL injection.
+//
+// It's worth noting that using this Go implementation is, in a way, an
+// acknowledgement of an anti-pattern from PHP. While it can escape some
+// characters and may prevent some naive SQL injection attempts, it is not a
+// substitute for  prepared statements or parameterized queries.
+// This implementation is provided as a convenience for some legacy code and
+// should not be considered a robust security solution. Furthermore, it is only used on blockchain
+// data which is all public. Do not use this in any situation where you are dealing w/ private data.
+//
+// Deprecated: Use prepared statements or parameterized queries instead going forward.
+func MysqlRealEscapeString(value string) string {
+	var sb strings.Builder
+	for i := 0; i < len(value); i++ {
+		c := value[i]
+		switch c {
+		case '\\', 0, '\n', '\r', '\'', '"':
+			sb.WriteByte('\\')
+			sb.WriteByte(c)
+		case '\032':
+			sb.WriteByte('\\')
+			sb.WriteByte('Z')
+		default:
+			sb.WriteByte(c)
+		}
+	}
+	return sb.String()
+}

--- a/core/dbcommon/escape_test.go
+++ b/core/dbcommon/escape_test.go
@@ -1,0 +1,36 @@
+package dbcommon
+
+import (
+	"testing"
+)
+
+func TestMysqlRealEscapeString(t *testing.T) {
+	// ' to \\'
+	// " to \\"
+	// \r to \\r
+	// \n to \\n
+	// \\ to \\\\
+	// \x00 (null byte) to \\x00
+	// \x1a (substitute character) to \\Z
+	tests := []struct {
+		input  string
+		expect string
+	}{
+		{"hello", "hello"},
+		{"he'llo", "he\\'llo"},
+		{"he\"llo", "he\\\"llo"},
+		{"he\nllo", "he\\\nllo"},
+		{"he\rllo", "he\\\rllo"},
+		{"hello\\world", "hello\\\\world"},
+		{"he\x00llo", "he\\\x00llo"},
+		{"he\x1allo", "he\\Zllo"},
+	}
+
+	for i, tt := range tests {
+		_ = i
+		result := MysqlRealEscapeString(tt.input)
+		if result != tt.expect {
+			t.Errorf("For input '%s', expected '%s' but got '%s'", tt.input, tt.expect, result)
+		}
+	}
+}

--- a/core/dbcommon/escape_test.go
+++ b/core/dbcommon/escape_test.go
@@ -26,8 +26,7 @@ func TestMysqlRealEscapeString(t *testing.T) {
 		{"he\x1allo", "he\\Zllo"},
 	}
 
-	for i, tt := range tests {
-		_ = i
+	for _, tt := range tests {
 		result := MysqlRealEscapeString(tt.input)
 		if result != tt.expect {
 			t.Errorf("For input '%s', expected '%s' but got '%s'", tt.input, tt.expect, result)

--- a/make/go.Makefile
+++ b/make/go.Makefile
@@ -6,7 +6,7 @@ default: help
 # set variables
 GIT_ROOT := $(shell git rev-parse --show-toplevel)
 CURRENT_PATH := $(shell pwd)
-RELPATH := $(shell realpath --relative-to="$(GIT_ROOT)" "$(CURRENT_PATH)")
+RELPATH := $(shell perl -e 'use Cwd "abs_path"; use File::Spec; print File::Spec->abs2rel("$(shell pwd)", "$(GIT_ROOT)")')
 
 
 help: ## This help dialog.
@@ -29,7 +29,7 @@ lint: ## Run golangci-lint and go fmt ./...
 	cd $(CURRENT_PATH)
 	# Note: when we upgrade, we can use either the brew version (needs to stay at latest). If we decide to stay with docker, we can use gomemlimit instead of a constant heap size.
 	# TODO: investigate why this is so much slower than local install
-	docker run -t --rm -v $(go env GOCACHE):/cache/go -v ${GOPATH}/pkg:/go/pkg -e GOGC=2000  -e GOCACHE=/cache/go -v ~/.cache/golangci-lint/:/root/.cache -v "$(GIT_ROOT)":/app -w "/app/$(RELPATH)" golangci/golangci-lint:v1.48.0 golangci-lint run -v --fix
+	docker run -t --rm -v $(shell go env GOCACHE):/cache/go -v ${GOPATH}/pkg:/go/pkg -e GOGC=2000  -e GOCACHE=/cache/go -v ~/.cache/golangci-lint/:/root/.cache -v "$(GIT_ROOT)":/app -w "/app/$(RELPATH)" golangci/golangci-lint:v1.48.0 golangci-lint run -v --fix
 
 docker-clean: ## stops and removes all containers at once
 	docker ps -aq | xargs docker stop | xargs docker rm

--- a/services/explorer/graphql/server/gin.go
+++ b/services/explorer/graphql/server/gin.go
@@ -16,6 +16,7 @@ import (
 	"github.com/synapsecns/sanguine/services/explorer/contracts/swap"
 	"github.com/synapsecns/sanguine/services/explorer/db"
 	"github.com/synapsecns/sanguine/services/explorer/graphql/server/graph"
+	"github.com/synapsecns/sanguine/services/explorer/graphql/server/graph/interceptor"
 	resolvers "github.com/synapsecns/sanguine/services/explorer/graphql/server/graph/resolver"
 	"github.com/synapsecns/sanguine/services/explorer/types"
 	"time"
@@ -46,6 +47,7 @@ func EnableGraphql(engine *gin.Engine, consumerDB db.ConsumerDB, fetcher fetcher
 	)
 	// TODO; investigate WithCreateSpanFromFields(predicate)
 	server.Use(otelgqlgen.Middleware(otelgqlgen.WithTracerProvider(handler.GetTracerProvider())))
+	server.Use(interceptor.SqlSanitizerMiddleware())
 
 	engine.GET(GraphqlEndpoint, graphqlHandler(server))
 	engine.POST(GraphqlEndpoint, graphqlHandler(server))

--- a/services/explorer/graphql/server/graph/interceptor/doc.go
+++ b/services/explorer/graphql/server/graph/interceptor/doc.go
@@ -1,0 +1,3 @@
+// Package interceptor contains a santizier for the graphql server
+// It santitizes strings uing MysqlRealEscapeString. This will be removed in a future version.
+package interceptor

--- a/services/explorer/graphql/server/graph/interceptor/intercept.go
+++ b/services/explorer/graphql/server/graph/interceptor/intercept.go
@@ -1,0 +1,50 @@
+package interceptor
+
+import (
+	"context"
+	"github.com/99designs/gqlgen/graphql"
+	"github.com/synapsecns/sanguine/core/dbcommon"
+)
+
+type sqlSanitizerImpl struct {
+}
+
+func (s sqlSanitizerImpl) ExtensionName() string {
+	return "sqlsanitizer"
+}
+
+func (s sqlSanitizerImpl) Validate(schema graphql.ExecutableSchema) error {
+	return nil
+}
+
+// SqlSanitizer is a middleware that sanitizes SQL queries.
+type SqlSanitizer interface {
+	graphql.ResponseInterceptor
+	graphql.HandlerExtension
+}
+
+// InterceptResponse intercepts the incoming request.
+func (s sqlSanitizerImpl) InterceptResponse(ctx context.Context, next graphql.ResponseHandler) *graphql.Response {
+	if !graphql.HasOperationContext(ctx) {
+		return next(ctx)
+	}
+
+	oc := graphql.GetOperationContext(ctx)
+	// key validation is handled by schema validator already
+	for key, val := range oc.Variables {
+		switch marshalledVal := val.(type) {
+		case string:
+			oc.Variables[key] = dbcommon.MysqlRealEscapeString(marshalledVal)
+		}
+
+	}
+	graphql.WithOperationContext(ctx, oc)
+
+	return next(ctx)
+}
+
+// SqlSanitizerMiddleware returns a new SqlSanitizer middleware. This is a workaround
+// until we have better support for paramaterized queries.
+func SqlSanitizerMiddleware() SqlSanitizer {
+	return sqlSanitizerImpl{}
+}


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**

Idea here is a quick and dirty sql sanitizer baed on `mysql_real_escape_string`. My first attempt #1484 failed because of subqueries:

![image](https://github.com/synapsecns/sanguine/assets/83933037/fef51bbf-020a-4a36-9608-adb27e634623)


So it became clear whatever we did had to be done above the query level. This introduced a middleware that sanitizes fields before they even hit the query resolver.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

- New Feature: Introduced a new `dbcommon` package with a function for escaping special characters in strings before sending them to a MySQL database, enhancing data security.
- Test: Added comprehensive tests for the new escaping function, ensuring its reliability and correctness.
- Refactor: Improved the portability and compatibility of the Makefile, making it easier to use across different environments.
- New Feature: Implemented a new `interceptor` package in the GraphQL server, which includes a middleware function for SQL sanitization. This feature enhances the security of incoming requests by preventing SQL injection attacks.
- Documentation: Added documentation for the new `interceptor` package, providing clarity on its purpose and usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->