### PR TITLE
Adds missing chainId

### DIFF
--- a/packages/synapse-interface/constants/tokens/sushiMaster.ts
+++ b/packages/synapse-interface/constants/tokens/sushiMaster.ts
@@ -16,6 +16,7 @@ export const SYN_ETH_SUSHI_TOKEN = new Token({
   poolType: 'EXTERNAL_LP',
   description: 'The SYN/ETH Sushiswap LP Token',
   priorityRank: 6,
+  chainId: CHAINS.ETH.id,
 })
 
 export const ETH_USDC_SUSHI_TOKEN = new Token({
@@ -31,4 +32,5 @@ export const ETH_USDC_SUSHI_TOKEN = new Token({
   poolType: 'EXTERNAL_LP',
   description: 'The ETH/USDC Sushiswap LP Token',
   priorityRank: 6,
+  chainId: CHAINS.ETH.id,
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->


### Summary by CodeRabbit

- New Feature: Enhanced token information with the addition of 'chainId' for 'SYN_ETH_SUSHI_TOKEN' and 'ETH_USDC_SUSHI_TOKEN'. This update provides users with more detailed information about the blockchain network associated with these tokens, improving transparency and aiding in token management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
82489ce1216a0a78e736adadc622984459d8e24f: [synapse-interface preview link ](https://sanguine-synapse-interface-l50hvarkj-synapsecns.vercel.app)