### PR TITLE
SDK: support for CCTP on Base

### DIFF
--- a/packages/sdk-router/src/constants/chainIds.ts
+++ b/packages/sdk-router/src/constants/chainIds.ts
@@ -28,13 +28,14 @@ export const SUPPORTED_CHAIN_IDS: number[] = Object.values(SupportedChainId)
   .filter((chainId) => !isNaN(chainId))
 
 /**
- * List of chain ids where SynapseCCTP is deployed.
+ * List of chain ids where SynapseCCTP is deployed, ordered by CCTP's domain:
+ * https://developers.circle.com/stablecoin/docs/cctp-protocol-contract#mainnet-contract-addresses
  *
  * Note: This is a subset of SUPPORTED_CHAIN_IDS.
  */
 export const CCTP_SUPPORTED_CHAIN_IDS: number[] = [
   SupportedChainId.ETH,
-  SupportedChainId.ARBITRUM,
   SupportedChainId.AVALANCHE,
   SupportedChainId.OPTIMISM,
+  SupportedChainId.ARBITRUM,
 ]

--- a/packages/sdk-router/src/constants/chainIds.ts
+++ b/packages/sdk-router/src/constants/chainIds.ts
@@ -38,4 +38,5 @@ export const CCTP_SUPPORTED_CHAIN_IDS: number[] = [
   SupportedChainId.AVALANCHE,
   SupportedChainId.OPTIMISM,
   SupportedChainId.ARBITRUM,
+  SupportedChainId.BASE,
 ]


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**
Adds support for Base CCTP in the Router SDK.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->


### Summary by CodeRabbit

- New Feature: We've expanded our blockchain compatibility to include `Arbitrum` and `Base` chains. This update aligns with the deployment of SynapseCCTP on these chains, broadening our reach and enhancing the versatility of our platform. Users can now interact with our software across a wider range of blockchain networks, providing more flexibility and options for their transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->