### PR TITLE
SDK: return estimated bridge time along with the quotes

### DIFF
--- a/packages/sdk-router/src/constants/index.ts
+++ b/packages/sdk-router/src/constants/index.ts
@@ -3,6 +3,7 @@ import { BigNumber } from '@ethersproject/bignumber'
 
 export * from './addresses'
 export * from './chainIds'
+export * from './medianTime'
 export * from './testValues'
 
 // exports for external consumption

--- a/packages/sdk-router/src/constants/medianTime.ts
+++ b/packages/sdk-router/src/constants/medianTime.ts
@@ -1,5 +1,9 @@
 import { SupportedChainId } from './chainIds'
 
+/**
+ * Median time (in seconds) for a SynapseBridge transaction to be completed,
+ * when the transaction is sent from a given chain.
+ */
 export const MEDIAN_TIME_BRIDGE = {
   [SupportedChainId.ETH]: 420,
   [SupportedChainId.OPTIMISM]: 1290,
@@ -22,6 +26,10 @@ export const MEDIAN_TIME_BRIDGE = {
   [SupportedChainId.HARMONY]: 30,
 }
 
+/**
+ * Median time (in seconds) for a SynapseCCTP transaction to be completed,
+ * when the transaction is sent from a given chain.
+ */
 export const MEDIAN_TIME_CCTP = {
   [SupportedChainId.ETH]: 1020,
   [SupportedChainId.OPTIMISM]: 1170,

--- a/packages/sdk-router/src/constants/medianTime.ts
+++ b/packages/sdk-router/src/constants/medianTime.ts
@@ -1,0 +1,31 @@
+import { SupportedChainId } from './chainIds'
+
+export const MEDIAN_TIME_BRIDGE = {
+  [SupportedChainId.ETH]: 420,
+  [SupportedChainId.OPTIMISM]: 1290,
+  [SupportedChainId.CRONOS]: 30,
+  [SupportedChainId.BSC]: 60,
+  [SupportedChainId.POLYGON]: 300,
+  [SupportedChainId.FANTOM]: 90,
+  [SupportedChainId.BOBA]: 180,
+  [SupportedChainId.METIS]: 60,
+  [SupportedChainId.MOONBEAM]: 90,
+  [SupportedChainId.MOONRIVER]: 45,
+  [SupportedChainId.DOGECHAIN]: 15,
+  [SupportedChainId.CANTO]: 150,
+  [SupportedChainId.KLAYTN]: 15,
+  [SupportedChainId.BASE]: 1230,
+  [SupportedChainId.ARBITRUM]: 30,
+  [SupportedChainId.AVALANCHE]: 30,
+  [SupportedChainId.DFK]: 30,
+  [SupportedChainId.AURORA]: 30,
+  [SupportedChainId.HARMONY]: 30,
+}
+
+export const MEDIAN_TIME_CCTP = {
+  [SupportedChainId.ETH]: 1020,
+  [SupportedChainId.OPTIMISM]: 1170,
+  [SupportedChainId.BASE]: 1170,
+  [SupportedChainId.ARBITRUM]: 1170,
+  [SupportedChainId.AVALANCHE]: 30,
+}

--- a/packages/sdk-router/src/operations/bridge.ts
+++ b/packages/sdk-router/src/operations/bridge.ts
@@ -118,6 +118,30 @@ export async function bridgeQuote(
 }
 
 /**
+ * Returns the estimated time for a bridge operation from a given origin chain using a given router.
+ * This will be the estimated time for the bridge operation to be completed regardless of the destination chain,
+ * or the bridge token.
+ *
+ * @param originChainId - The ID of the origin chain.
+ * @param routerAddress - The address of the router deployed on the origin chain.
+ * @returns - The estimated time for a bridge operation.
+ * @throws - Will throw an error if the router address is unknown for the given chain.
+ */
+export function getEstimatedTime(
+  this: SynapseSDK,
+  originChainId: number,
+  routerAddress: string
+): number {
+  if (this.synapseRouterSet.getRouter(originChainId, routerAddress)) {
+    return this.synapseRouterSet.getEstimatedTime(originChainId)
+  }
+  if (this.synapseCCTPRouterSet.getRouter(originChainId, routerAddress)) {
+    return this.synapseCCTPRouterSet.getEstimatedTime(originChainId)
+  }
+  throw new Error('Unknown router address')
+}
+
+/**
  * Gets the chain gas amount for the Synapse bridge.
  *
  * @param chainId The chain ID

--- a/packages/sdk-router/src/operations/bridge.ts
+++ b/packages/sdk-router/src/operations/bridge.ts
@@ -124,7 +124,7 @@ export async function bridgeQuote(
  *
  * @param originChainId - The ID of the origin chain.
  * @param routerAddress - The address of the router deployed on the origin chain.
- * @returns - The estimated time for a bridge operation.
+ * @returns - The estimated time for a bridge operation, in seconds.
  * @throws - Will throw an error if the router address is unknown for the given chain.
  */
 export function getEstimatedTime(

--- a/packages/sdk-router/src/router/routerSet.ts
+++ b/packages/sdk-router/src/router/routerSet.ts
@@ -197,6 +197,7 @@ export abstract class RouterSet {
       originQuery.minAmountOut,
       hasComplexBridgeAction(destQuery)
     )
+    const estimatedTime = this.getEstimatedTime(bridgeRoute.originChainId)
     return {
       feeAmount,
       feeConfig,
@@ -204,6 +205,7 @@ export abstract class RouterSet {
       maxAmountOut: destQuery.minAmountOut,
       originQuery,
       destQuery,
+      estimatedTime,
     }
   }
 }

--- a/packages/sdk-router/src/router/routerSet.ts
+++ b/packages/sdk-router/src/router/routerSet.ts
@@ -61,6 +61,16 @@ export abstract class RouterSet {
   }
 
   /**
+   * Returns the estimated time for a bridge transaction to be completed,
+   * when the transaction is sent from the given chain.
+   *
+   * @param chainId - The ID of the origin chain.
+   * @returns The estimated time in seconds.
+   * @throws Will throw an error if the chain ID is not supported.
+   */
+  abstract getEstimatedTime(chainId: number): number
+
+  /**
    * Returns the existing Router instance for the given address on the given chain.
    * If the router address is not valid, it will return undefined.
    *

--- a/packages/sdk-router/src/router/synapseCCTPRouterSet.test.ts
+++ b/packages/sdk-router/src/router/synapseCCTPRouterSet.test.ts
@@ -5,6 +5,8 @@ import {
   PUBLIC_PROVIDER_URLS,
   ROUTER_ADDRESS_MAP,
   CCTP_ROUTER_ADDRESS_MAP,
+  MEDIAN_TIME_CCTP,
+  CCTP_SUPPORTED_CHAIN_IDS,
   SupportedChainId,
 } from '../constants'
 import { ChainProvider } from './routerSet'
@@ -63,6 +65,29 @@ describe('SynapseCCTPRouterSet', () => {
 
     it('Does not create SynapseCCTPRouter instances for chains without providers', () => {
       expect(routerSet.routers[SupportedChainId.AVALANCHE]).toBeUndefined()
+    })
+  })
+
+  describe('getEstimatedTime', () => {
+    it('Returns the correct estimated time for all supported chains', () => {
+      CCTP_SUPPORTED_CHAIN_IDS.forEach((chainId) => {
+        expect(routerSet.getEstimatedTime(Number(chainId))).toEqual(
+          MEDIAN_TIME_CCTP[chainId as keyof typeof MEDIAN_TIME_CCTP]
+        )
+      })
+    })
+
+    it('Throws error for unsupported chain with a provider', () => {
+      expect(() =>
+        routerSet.getEstimatedTime(SupportedChainId.MOONBEAM)
+      ).toThrow('No estimated time for chain 1284')
+    })
+
+    it('Throws error for unsupported chain without a provider', () => {
+      // 5 is the chain ID for Goerli testnet
+      expect(() => routerSet.getEstimatedTime(5)).toThrow(
+        'No estimated time for chain 5'
+      )
     })
   })
 

--- a/packages/sdk-router/src/router/synapseCCTPRouterSet.ts
+++ b/packages/sdk-router/src/router/synapseCCTPRouterSet.ts
@@ -2,7 +2,7 @@ import invariant from 'tiny-invariant'
 
 import { SynapseCCTPRouter } from './synapseCCTPRouter'
 import { ChainProvider, RouterSet } from './routerSet'
-import { CCTP_ROUTER_ADDRESS_MAP } from '../constants'
+import { CCTP_ROUTER_ADDRESS_MAP, MEDIAN_TIME_CCTP } from '../constants'
 
 /**
  * Wrapper class for interacting with a SynapseCCTPRouter contracts deployed on multiple chains.
@@ -12,6 +12,16 @@ export class SynapseCCTPRouterSet extends RouterSet {
 
   constructor(chains: ChainProvider[]) {
     super(chains, CCTP_ROUTER_ADDRESS_MAP, SynapseCCTPRouter)
+  }
+
+  /**
+   * @inheritdoc RouterSet.getOriginAmountOut
+   */
+  public getEstimatedTime(chainId: number): number {
+    const medianTime =
+      MEDIAN_TIME_CCTP[chainId as keyof typeof MEDIAN_TIME_CCTP]
+    invariant(medianTime, `No estimated time for chain ${chainId}`)
+    return medianTime
   }
 
   /**

--- a/packages/sdk-router/src/router/synapseRouterSet.test.ts
+++ b/packages/sdk-router/src/router/synapseRouterSet.test.ts
@@ -5,6 +5,8 @@ import {
   PUBLIC_PROVIDER_URLS,
   ROUTER_ADDRESS_MAP,
   CCTP_ROUTER_ADDRESS_MAP,
+  MEDIAN_TIME_BRIDGE,
+  SUPPORTED_CHAIN_IDS,
   SupportedChainId,
 } from '../constants'
 import { ChainProvider } from './routerSet'
@@ -50,6 +52,23 @@ describe('SynapseRouterSet', () => {
 
     it('Does not create SynapseRouter instances for chains without providers', () => {
       expect(routerSet.routers[SupportedChainId.AVALANCHE]).toBeUndefined()
+    })
+  })
+
+  describe('getEstimatedTime', () => {
+    it('Returns the correct estimated time for all supported chains', () => {
+      SUPPORTED_CHAIN_IDS.forEach((chainId) => {
+        expect(routerSet.getEstimatedTime(Number(chainId))).toEqual(
+          MEDIAN_TIME_BRIDGE[chainId as keyof typeof MEDIAN_TIME_BRIDGE]
+        )
+      })
+    })
+
+    it('Throws error for unsupported chain', () => {
+      // 5 is the chain ID for Goerli testnet
+      expect(() => routerSet.getEstimatedTime(5)).toThrow(
+        'No estimated time for chain 5'
+      )
     })
   })
 

--- a/packages/sdk-router/src/router/synapseRouterSet.ts
+++ b/packages/sdk-router/src/router/synapseRouterSet.ts
@@ -2,7 +2,7 @@ import invariant from 'tiny-invariant'
 
 import { SynapseRouter } from './synapseRouter'
 import { ChainProvider, RouterSet } from './routerSet'
-import { ROUTER_ADDRESS_MAP } from '../constants'
+import { MEDIAN_TIME_BRIDGE, ROUTER_ADDRESS_MAP } from '../constants'
 
 /**
  * Wrapper class for interacting with a SynapseRouter contracts deployed on multiple chains.
@@ -12,6 +12,16 @@ export class SynapseRouterSet extends RouterSet {
 
   constructor(chains: ChainProvider[]) {
     super(chains, ROUTER_ADDRESS_MAP, SynapseRouter)
+  }
+
+  /**
+   * @inheritdoc RouterSet.getOriginAmountOut
+   */
+  public getEstimatedTime(chainId: number): number {
+    const medianTime =
+      MEDIAN_TIME_BRIDGE[chainId as keyof typeof MEDIAN_TIME_BRIDGE]
+    invariant(medianTime, `No estimated time for chain ${chainId}`)
+    return medianTime
   }
 
   /**

--- a/packages/sdk-router/src/router/types.ts
+++ b/packages/sdk-router/src/router/types.ts
@@ -70,6 +70,7 @@ export type BridgeQuote = {
   maxAmountOut: BigNumber
   originQuery: Query
   destQuery: Query
+  estimatedTime: number
 }
 
 /**

--- a/packages/sdk-router/src/sdk.test.ts
+++ b/packages/sdk-router/src/sdk.test.ts
@@ -684,6 +684,74 @@ describe('SynapseSDK', () => {
     )
   })
 
+  describe('getEstimatedTime', () => {
+    const synapse = new SynapseSDK(
+      [
+        SupportedChainId.ETH,
+        SupportedChainId.ARBITRUM,
+        SupportedChainId.MOONBEAM,
+      ],
+      [ethProvider, arbProvider, moonbeamProvider]
+    )
+
+    it('Returns estimated time for SynapseBridge', () => {
+      expect(
+        synapse.getEstimatedTime(
+          SupportedChainId.ETH,
+          ROUTER_ADDRESS_MAP[SupportedChainId.ETH]
+        )
+      ).toEqual(MEDIAN_TIME_BRIDGE[SupportedChainId.ETH])
+
+      expect(
+        synapse.getEstimatedTime(
+          SupportedChainId.ARBITRUM,
+          ROUTER_ADDRESS_MAP[SupportedChainId.ARBITRUM]
+        )
+      ).toEqual(MEDIAN_TIME_BRIDGE[SupportedChainId.ARBITRUM])
+
+      expect(
+        synapse.getEstimatedTime(
+          SupportedChainId.MOONBEAM,
+          ROUTER_ADDRESS_MAP[SupportedChainId.MOONBEAM]
+        )
+      ).toEqual(MEDIAN_TIME_BRIDGE[SupportedChainId.MOONBEAM])
+    })
+
+    it('Returns estimated time for SynapseCCTP', () => {
+      expect(
+        synapse.getEstimatedTime(
+          SupportedChainId.ETH,
+          CCTP_ROUTER_ADDRESS_MAP[SupportedChainId.ETH]
+        )
+      ).toEqual(MEDIAN_TIME_CCTP[SupportedChainId.ETH])
+
+      expect(
+        synapse.getEstimatedTime(
+          SupportedChainId.ARBITRUM,
+          CCTP_ROUTER_ADDRESS_MAP[SupportedChainId.ARBITRUM]
+        )
+      ).toEqual(MEDIAN_TIME_CCTP[SupportedChainId.ARBITRUM])
+    })
+
+    it('Throws for chain without a provider', () => {
+      expect(() =>
+        synapse.getEstimatedTime(
+          SupportedChainId.AVALANCHE,
+          ROUTER_ADDRESS_MAP[SupportedChainId.AVALANCHE]
+        )
+      ).toThrow('Unknown router address')
+    })
+
+    it('Throws for unknown router address', () => {
+      expect(() =>
+        synapse.getEstimatedTime(
+          SupportedChainId.MOONBEAM,
+          CCTP_ROUTER_ADDRESS_MAP[SupportedChainId.ETH]
+        )
+      ).toThrow('Unknown router address')
+    })
+  })
+
   describe('Get bridge gas', () => {
     const synapse = new SynapseSDK(
       [SupportedChainId.ETH, SupportedChainId.ARBITRUM],

--- a/packages/sdk-router/src/sdk.test.ts
+++ b/packages/sdk-router/src/sdk.test.ts
@@ -424,6 +424,157 @@ describe('SynapseSDK', () => {
     })
   })
 
+  describe('Bridging: ARB -> ETH', () => {
+    const synapse = new SynapseSDK(
+      [SupportedChainId.ETH, SupportedChainId.ARBITRUM],
+      [ethProvider, arbProvider]
+    )
+
+    describe('ARB USDC -> ETH USDC (using Bridge)', () => {
+      const amount = BigNumber.from(10).pow(12).add(1)
+      const resultPromise: Promise<BridgeQuote> = synapse.bridgeQuote(
+        SupportedChainId.ARBITRUM,
+        SupportedChainId.ETH,
+        ARB_USDC,
+        ETH_USDC,
+        amount
+      )
+
+      createBridgeQuoteTests(
+        synapse,
+        SupportedChainId.ETH,
+        SupportedChainId.ARBITRUM,
+        ETH_USDC,
+        amount,
+        resultPromise
+      )
+
+      it('Fetches a Synapse bridge quote', async () => {
+        resultPromise.then((result) => {
+          expect(result.routerAddress).toEqual(
+            ROUTER_ADDRESS_MAP[SupportedChainId.ARBITRUM]
+          )
+          // SynapseRouterQuery has swapAdapter property
+          expect(result.originQuery.swapAdapter).toBeDefined()
+          // Estimated time must match the SynapseBridge median time
+          expect(result.estimatedTime).toEqual(
+            MEDIAN_TIME_BRIDGE[SupportedChainId.ARBITRUM]
+          )
+        })
+      })
+    })
+
+    describe('ARB USDC -> ETH USDC (using CCTP)', () => {
+      const amount = BigNumber.from(10).pow(12)
+      const resultPromise: Promise<BridgeQuote> = synapse.bridgeQuote(
+        SupportedChainId.ARBITRUM,
+        SupportedChainId.ETH,
+        ARB_USDC,
+        ETH_USDC,
+        amount
+      )
+
+      createBridgeQuoteTests(
+        synapse,
+        SupportedChainId.ETH,
+        SupportedChainId.ARBITRUM,
+        ETH_USDC,
+        amount,
+        resultPromise
+      )
+
+      it('Fetches a CCTP bridge quote', async () => {
+        resultPromise.then((result) => {
+          expect(result.routerAddress).toEqual(
+            CCTP_ROUTER_ADDRESS_MAP[SupportedChainId.ARBITRUM]
+          )
+          // SynapseCCTPRouterQuery has routerAdapter property
+          expect(result.originQuery.routerAdapter).toBeDefined()
+          // Estimated time must match the SynapseCCTP median time
+          expect(result.estimatedTime).toEqual(
+            MEDIAN_TIME_CCTP[SupportedChainId.ARBITRUM]
+          )
+        })
+      })
+    })
+  })
+
+  describe('Bridging: BSC -> AVAX', () => {
+    const synapse = new SynapseSDK(
+      [SupportedChainId.AVALANCHE, SupportedChainId.BSC],
+      [avaxProvider, bscProvider]
+    )
+
+    describe('BSC USDC -> AVAX USDC.e', () => {
+      // USDC has 18 decimals on BSC. Don't ask me why.
+      const amount = BigNumber.from(10).pow(21)
+      const resultPromise: Promise<BridgeQuote> = synapse.bridgeQuote(
+        SupportedChainId.BSC,
+        SupportedChainId.AVALANCHE,
+        BSC_USDC,
+        AVAX_USDC_E,
+        amount
+      )
+
+      createBridgeQuoteTests(
+        synapse,
+        SupportedChainId.AVALANCHE,
+        SupportedChainId.BSC,
+        AVAX_USDC_E,
+        amount,
+        resultPromise
+      )
+
+      it('Fetches a Synapse bridge quote', async () => {
+        resultPromise.then((result) => {
+          expect(result.routerAddress).toEqual(
+            ROUTER_ADDRESS_MAP[SupportedChainId.BSC]
+          )
+          // SynapseRouterQuery has swapAdapter property
+          expect(result.originQuery.swapAdapter).toBeDefined()
+          // Estimated time must match the SynapseBridge median time
+          expect(result.estimatedTime).toEqual(
+            MEDIAN_TIME_BRIDGE[SupportedChainId.BSC]
+          )
+        })
+      })
+    })
+
+    describe('BSC gOHM -> AVAX gOHM', () => {
+      const amount = BigNumber.from(10).pow(21)
+      const resultPromise: Promise<BridgeQuote> = synapse.bridgeQuote(
+        SupportedChainId.BSC,
+        SupportedChainId.AVALANCHE,
+        BSC_GOHM,
+        AVAX_GOHM,
+        amount
+      )
+
+      createBridgeQuoteTests(
+        synapse,
+        SupportedChainId.AVALANCHE,
+        SupportedChainId.BSC,
+        AVAX_GOHM,
+        amount,
+        resultPromise
+      )
+
+      it('Fetches a Synapse bridge quote', async () => {
+        resultPromise.then((result) => {
+          expect(result.routerAddress).toEqual(
+            ROUTER_ADDRESS_MAP[SupportedChainId.BSC]
+          )
+          // SynapseRouterQuery has swapAdapter property
+          expect(result.originQuery.swapAdapter).toBeDefined()
+          // Estimated time must match the SynapseBridge median time
+          expect(result.estimatedTime).toEqual(
+            MEDIAN_TIME_BRIDGE[SupportedChainId.BSC]
+          )
+        })
+      })
+    })
+  })
+
   describe('Errors', () => {
     const synapse = new SynapseSDK(
       [SupportedChainId.ETH, SupportedChainId.BSC],

--- a/packages/sdk-router/src/sdk.test.ts
+++ b/packages/sdk-router/src/sdk.test.ts
@@ -22,6 +22,8 @@ import {
   ETH_POOL_NUSD,
   ETH_USDC,
   ETH_USDT,
+  MEDIAN_TIME_BRIDGE,
+  MEDIAN_TIME_CCTP,
   PUBLIC_PROVIDER_URLS,
   ROUTER_ADDRESS_MAP,
   SupportedChainId,
@@ -262,6 +264,10 @@ describe('SynapseSDK', () => {
           )
           // SynapseCCTPRouterQuery has routerAdapter property
           expect(result.originQuery.routerAdapter).toBeDefined()
+          // Estimated time must match the SynapseCCTP median time
+          expect(result.estimatedTime).toEqual(
+            MEDIAN_TIME_CCTP[SupportedChainId.ETH]
+          )
         })
       })
     })
@@ -296,6 +302,10 @@ describe('SynapseSDK', () => {
           )
           // SynapseCCTPRouterQuery has routerAdapter property
           expect(result.originQuery.routerAdapter).toBeDefined()
+          // Estimated time must match the SynapseCCTP median time
+          expect(result.estimatedTime).toEqual(
+            MEDIAN_TIME_CCTP[SupportedChainId.ETH]
+          )
         })
       })
     })
@@ -330,6 +340,10 @@ describe('SynapseSDK', () => {
           )
           // SynapseRouterQuery has swapAdapter property
           expect(result.originQuery.swapAdapter).toBeDefined()
+          // Estimated time must match the SynapseBridge median time
+          expect(result.estimatedTime).toEqual(
+            MEDIAN_TIME_BRIDGE[SupportedChainId.ETH]
+          )
         })
       })
     })
@@ -359,6 +373,20 @@ describe('SynapseSDK', () => {
         amount,
         resultPromise
       )
+
+      it('Fetches a Synapse bridge quote', async () => {
+        resultPromise.then((result) => {
+          expect(result.routerAddress).toEqual(
+            ROUTER_ADDRESS_MAP[SupportedChainId.AVALANCHE]
+          )
+          // SynapseRouterQuery has swapAdapter property
+          expect(result.originQuery.swapAdapter).toBeDefined()
+          // Estimated time must match the SynapseBridge median time
+          expect(result.estimatedTime).toEqual(
+            MEDIAN_TIME_BRIDGE[SupportedChainId.AVALANCHE]
+          )
+        })
+      })
     })
 
     describe('AVAX gOHM -> BSC gOHM', () => {
@@ -379,6 +407,20 @@ describe('SynapseSDK', () => {
         amount,
         resultPromise
       )
+
+      it('Fetches a Synapse bridge quote', async () => {
+        resultPromise.then((result) => {
+          expect(result.routerAddress).toEqual(
+            ROUTER_ADDRESS_MAP[SupportedChainId.AVALANCHE]
+          )
+          // SynapseRouterQuery has swapAdapter property
+          expect(result.originQuery.swapAdapter).toBeDefined()
+          // Estimated time must match the SynapseBridge median time
+          expect(result.estimatedTime).toEqual(
+            MEDIAN_TIME_BRIDGE[SupportedChainId.AVALANCHE]
+          )
+        })
+      })
     })
   })
 

--- a/packages/sdk-router/src/sdk.ts
+++ b/packages/sdk-router/src/sdk.ts
@@ -46,6 +46,7 @@ class SynapseSDK {
   // Define Bridge operations
   public bridge = operations.bridge
   public bridgeQuote = operations.bridgeQuote
+  public getEstimatedTime = operations.getEstimatedTime
 
   public getBridgeGas = operations.getBridgeGas
 


### PR DESCRIPTION
**Description**
- Added the median time from the explorer statistics as estimated bridging time for both SynapseBridge and SynapseCCTP.
- This estimated time is now returned in `bridgeQuote()` alongside other quote data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

New Features:
- Introduced `getEstimatedTime` function to `RouterSet`, `SynapseCCTPRouterSet`, and `SynapseRouterSet` classes, providing estimated transaction completion times for various blockchain chains.
- Added `estimatedTime` property to the `BridgeQuote` interface, enhancing transaction information with estimated completion times.

Tests:
- Added comprehensive tests for the new `getEstimatedTime` function across supported and unsupported chains.
- Expanded bridge quote test cases to include the new `estimatedTime` property.

Chores:
- Updated exports and global data structures to support the new `getEstimatedTime` function and `estimatedTime` property.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->