### PR TITLE
Replaces Snowtrace with Avascan

### DIFF
--- a/packages/explorer-ui/constants/networks.ts
+++ b/packages/explorer-ui/constants/networks.ts
@@ -293,7 +293,7 @@ export const CHAIN_EXPLORER_URLS = {
   [ChainId.MOONRIVER]: 'https://moonriver.moonscan.io',
   [ChainId.ARBITRUM]: 'https://arbiscan.io',
   [ChainId.OPTIMISM]: 'https://optimistic.etherscan.io',
-  [ChainId.AVALANCHE]: 'https://snowtrace.io',
+  [ChainId.AVALANCHE]: 'https://avascan.info/',
   [ChainId.DFK]:
     'https://subnets.avax.network/defi-kingdoms/dfk-chain/explorer',
   [ChainId.FANTOM]: 'https://ftmscan.com',

--- a/packages/synapse-interface/constants/chains/master.tsx
+++ b/packages/synapse-interface/constants/chains/master.tsx
@@ -119,8 +119,8 @@ export const AVALANCHE: Chain = {
     fallback: 'https://1rpc.io/avax/c',
   },
   nativeCurrency: { name: 'Avax', symbol: 'AVAX', decimals: 18 },
-  explorerUrl: 'https://snowtrace.io',
-  explorerName: 'Snowtrace',
+  explorerUrl: 'https://avascan.info/',
+  explorerName: 'Avascan',
   explorerImg: avalancheExplorerImg,
   color: 'red',
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Chores:
- Updated the blockchain explorer URL for Avalanche network from 'Snowtrace' to 'Avascan'. This change is reflected in both the explorer UI and synapse interface packages. This update will direct users to the new explorer site when interacting with the Avalanche network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
45aa87209cd968e666702bbdf572e54dd32aeb2a: [explorer-ui preview link ](https://sanguine-im2h6pcyk-synapsecns.vercel.app)
45aa87209cd968e666702bbdf572e54dd32aeb2a: [synapse-interface preview link ](https://sanguine-synapse-interface-6zf61i97s-synapsecns.vercel.app)