### PR TITLE
Scribe: Add get log range ascending to API

### DIFF
--- a/contrib/promexporter/internal/gql/dfk/client.gen.go
+++ b/contrib/promexporter/internal/gql/dfk/client.gen.go
@@ -33,12 +33,18 @@ type Query struct {
 	BazaarOrder        *BazaarOrder         "json:\"bazaarOrder\" graphql:\"bazaarOrder\""
 	BazaarOrders       []*BazaarOrder       "json:\"bazaarOrders\" graphql:\"bazaarOrders\""
 	BazaarTransactions []*BazaarTransaction "json:\"bazaarTransactions\" graphql:\"bazaarTransactions\""
-	Weapon             *Weapon              "json:\"weapon\" graphql:\"weapon\""
-	Weapons            []*Weapon            "json:\"weapons\" graphql:\"weapons\""
-	Armor              *Armor               "json:\"armor\" graphql:\"armor\""
-	Armors             []*Armor             "json:\"armors\" graphql:\"armors\""
 	Accessory          *Accessory           "json:\"accessory\" graphql:\"accessory\""
 	Accessories        []*Accessory         "json:\"accessories\" graphql:\"accessories\""
+	AccessoryAuction   *AccessoryAuction    "json:\"accessoryAuction\" graphql:\"accessoryAuction\""
+	AccessoryAuctions  []*AccessoryAuction  "json:\"accessoryAuctions\" graphql:\"accessoryAuctions\""
+	Armor              *Armor               "json:\"armor\" graphql:\"armor\""
+	Armors             []*Armor             "json:\"armors\" graphql:\"armors\""
+	ArmorAuction       *ArmorAuction        "json:\"armorAuction\" graphql:\"armorAuction\""
+	ArmorAuctions      []*ArmorAuction      "json:\"armorAuctions\" graphql:\"armorAuctions\""
+	Weapon             *Weapon              "json:\"weapon\" graphql:\"weapon\""
+	Weapons            []*Weapon            "json:\"weapons\" graphql:\"weapons\""
+	WeaponAuction      *WeaponAuction       "json:\"weaponAuction\" graphql:\"weaponAuction\""
+	WeaponAuctions     []*WeaponAuction     "json:\"weaponAuctions\" graphql:\"weaponAuctions\""
 }
 type StuckHeroes struct {
 	Heroes []*struct {

--- a/contrib/promexporter/internal/gql/dfk/models.gen.go
+++ b/contrib/promexporter/internal/gql/dfk/models.gen.go
@@ -9,45 +9,60 @@ import (
 )
 
 type Accessory struct {
-	ID                    *string  `json:"id,omitempty"`
-	NormalizedID          *int64   `json:"normalizedId,omitempty"`
-	Owner                 *Profile `json:"owner,omitempty"`
-	EquippableAt          *int64   `json:"equippableAt,omitempty"`
-	EquippedTo            *Hero    `json:"equippedTo,omitempty"`
-	CurrentRealm          *string  `json:"currentRealm,omitempty"`
-	OriginRealm           *string  `json:"originRealm,omitempty"`
-	CreatedAt             int64    `json:"createdAt"`
-	CraftedBy             *string  `json:"craftedBy,omitempty"`
-	SalePrice             *string  `json:"salePrice,omitempty"`
-	PrivateAuctionProfile *Profile `json:"privateAuctionProfile,omitempty"`
-	DisplayID             *int64   `json:"displayId,omitempty"`
-	Rarity                *int64   `json:"rarity,omitempty"`
-	Dye1                  *int64   `json:"dye1,omitempty"`
-	Dye2                  *int64   `json:"dye2,omitempty"`
-	MaxDurability         *int64   `json:"maxDurability,omitempty"`
-	Durability            *int64   `json:"durability,omitempty"`
-	MaxRepairs            *int64   `json:"maxRepairs,omitempty"`
-	RemainingRepairs      *int64   `json:"remainingRepairs,omitempty"`
-	Bonus1                *int64   `json:"bonus1,omitempty"`
-	Bonus2                *int64   `json:"bonus2,omitempty"`
-	Bonus3                *int64   `json:"bonus3,omitempty"`
-	Bonus4                *int64   `json:"bonus4,omitempty"`
-	Bonus5                *int64   `json:"bonus5,omitempty"`
-	BonusScalar1          *int64   `json:"bonusScalar1,omitempty"`
-	BonusScalar2          *int64   `json:"bonusScalar2,omitempty"`
-	BonusScalar3          *int64   `json:"bonusScalar3,omitempty"`
-	BonusScalar4          *int64   `json:"bonusScalar4,omitempty"`
-	BonusScalar5          *int64   `json:"bonusScalar5,omitempty"`
-	EnchantmentScalar1    *int64   `json:"enchantmentScalar1,omitempty"`
-	EnchantmentScalar2    *int64   `json:"enchantmentScalar2,omitempty"`
-	EnchantmentScalar3    *int64   `json:"enchantmentScalar3,omitempty"`
-	EnchantmentType1      *int64   `json:"enchantmentType1,omitempty"`
-	EnchantmentType2      *int64   `json:"enchantmentType2,omitempty"`
-	EnchantmentType3      *int64   `json:"enchantmentType3,omitempty"`
-	EquipRequirement      *int64   `json:"equipRequirement,omitempty"`
-	EquipmentType         *int64   `json:"equipmentType,omitempty"`
-	UniqueSettings        *int64   `json:"uniqueSettings,omitempty"`
-	RestorationCount      *int64   `json:"restorationCount,omitempty"`
+	ID                    *string           `json:"id,omitempty"`
+	NormalizedID          *int64            `json:"normalizedId,omitempty"`
+	Owner                 *Profile          `json:"owner,omitempty"`
+	EquippableAt          *int64            `json:"equippableAt,omitempty"`
+	EquippedTo            *Hero             `json:"equippedTo,omitempty"`
+	CurrentRealm          *string           `json:"currentRealm,omitempty"`
+	OriginRealm           *string           `json:"originRealm,omitempty"`
+	CreatedAt             int64             `json:"createdAt"`
+	CraftedBy             *string           `json:"craftedBy,omitempty"`
+	SaleAuction           *AccessoryAuction `json:"saleAuction,omitempty"`
+	SalePrice             *string           `json:"salePrice,omitempty"`
+	PrivateAuctionProfile *Profile          `json:"privateAuctionProfile,omitempty"`
+	DisplayID             *int64            `json:"displayId,omitempty"`
+	Rarity                *int64            `json:"rarity,omitempty"`
+	Dye1                  *int64            `json:"dye1,omitempty"`
+	Dye2                  *int64            `json:"dye2,omitempty"`
+	MaxDurability         *int64            `json:"maxDurability,omitempty"`
+	Durability            *int64            `json:"durability,omitempty"`
+	MaxRepairs            *int64            `json:"maxRepairs,omitempty"`
+	RemainingRepairs      *int64            `json:"remainingRepairs,omitempty"`
+	Bonus1                *int64            `json:"bonus1,omitempty"`
+	Bonus2                *int64            `json:"bonus2,omitempty"`
+	Bonus3                *int64            `json:"bonus3,omitempty"`
+	Bonus4                *int64            `json:"bonus4,omitempty"`
+	Bonus5                *int64            `json:"bonus5,omitempty"`
+	BonusScalar1          *int64            `json:"bonusScalar1,omitempty"`
+	BonusScalar2          *int64            `json:"bonusScalar2,omitempty"`
+	BonusScalar3          *int64            `json:"bonusScalar3,omitempty"`
+	BonusScalar4          *int64            `json:"bonusScalar4,omitempty"`
+	BonusScalar5          *int64            `json:"bonusScalar5,omitempty"`
+	EnchantmentScalar1    *int64            `json:"enchantmentScalar1,omitempty"`
+	EnchantmentScalar2    *int64            `json:"enchantmentScalar2,omitempty"`
+	EnchantmentScalar3    *int64            `json:"enchantmentScalar3,omitempty"`
+	EnchantmentType1      *int64            `json:"enchantmentType1,omitempty"`
+	EnchantmentType2      *int64            `json:"enchantmentType2,omitempty"`
+	EnchantmentType3      *int64            `json:"enchantmentType3,omitempty"`
+	EquipRequirement      *int64            `json:"equipRequirement,omitempty"`
+	EquipmentType         *int64            `json:"equipmentType,omitempty"`
+	UniqueSettings        *int64            `json:"uniqueSettings,omitempty"`
+	RestorationCount      *int64            `json:"restorationCount,omitempty"`
+}
+
+type AccessoryAuction struct {
+	ID            *string    `json:"id,omitempty"`
+	Seller        *Profile   `json:"seller,omitempty"`
+	TokenID       *Accessory `json:"tokenId,omitempty"`
+	StartingPrice *string    `json:"startingPrice,omitempty"`
+	EndingPrice   *string    `json:"endingPrice,omitempty"`
+	Duration      *int64     `json:"duration,omitempty"`
+	StartedAt     *int64     `json:"startedAt,omitempty"`
+	Winner        *Profile   `json:"winner,omitempty"`
+	EndedAt       *int64     `json:"endedAt,omitempty"`
+	Open          bool       `json:"open"`
+	PurchasePrice *string    `json:"purchasePrice,omitempty"`
 }
 
 type AccessoryFilter struct {
@@ -109,6 +124,8 @@ type AccessoryFilter struct {
 	CraftedByLt                        *string   `json:"craftedBy_lt,omitempty"`
 	CraftedByIn                        []*string `json:"craftedBy_in,omitempty"`
 	CraftedByNotIn                     []*string `json:"craftedBy_not_in,omitempty"`
+	SaleAuction                        *string   `json:"saleAuction,omitempty"`
+	SaleAuctionNot                     *string   `json:"saleAuction_not,omitempty"`
 	SalePrice                          *string   `json:"salePrice,omitempty"`
 	SalePriceNot                       *string   `json:"salePrice_not,omitempty"`
 	SalePriceGt                        *string   `json:"salePrice_gt,omitempty"`
@@ -354,58 +371,73 @@ type AccessoryFilter struct {
 }
 
 type Armor struct {
-	ID                    *string  `json:"id,omitempty"`
-	NormalizedID          *int64   `json:"normalizedId,omitempty"`
-	Owner                 *Profile `json:"owner,omitempty"`
-	EquippableAt          *int64   `json:"equippableAt,omitempty"`
-	EquippedTo            *Hero    `json:"equippedTo,omitempty"`
-	CurrentRealm          *string  `json:"currentRealm,omitempty"`
-	OriginRealm           *string  `json:"originRealm,omitempty"`
-	CreatedAt             int64    `json:"createdAt"`
-	CraftedBy             *string  `json:"craftedBy,omitempty"`
-	SalePrice             *string  `json:"salePrice,omitempty"`
-	PrivateAuctionProfile *Profile `json:"privateAuctionProfile,omitempty"`
-	DisplayID             *int64   `json:"displayId,omitempty"`
-	Rarity                *int64   `json:"rarity,omitempty"`
-	Dye1                  *int64   `json:"dye1,omitempty"`
-	Dye2                  *int64   `json:"dye2,omitempty"`
-	MaxDurability         *int64   `json:"maxDurability,omitempty"`
-	Durability            *int64   `json:"durability,omitempty"`
-	MaxRepairs            *int64   `json:"maxRepairs,omitempty"`
-	RemainingRepairs      *int64   `json:"remainingRepairs,omitempty"`
-	Bonus1                *int64   `json:"bonus1,omitempty"`
-	Bonus2                *int64   `json:"bonus2,omitempty"`
-	Bonus3                *int64   `json:"bonus3,omitempty"`
-	Bonus4                *int64   `json:"bonus4,omitempty"`
-	Bonus5                *int64   `json:"bonus5,omitempty"`
-	BonusScalar1          *int64   `json:"bonusScalar1,omitempty"`
-	BonusScalar2          *int64   `json:"bonusScalar2,omitempty"`
-	BonusScalar3          *int64   `json:"bonusScalar3,omitempty"`
-	BonusScalar4          *int64   `json:"bonusScalar4,omitempty"`
-	BonusScalar5          *int64   `json:"bonusScalar5,omitempty"`
-	EnchantmentScalar1    *int64   `json:"enchantmentScalar1,omitempty"`
-	EnchantmentScalar2    *int64   `json:"enchantmentScalar2,omitempty"`
-	EnchantmentScalar3    *int64   `json:"enchantmentScalar3,omitempty"`
-	EnchantmentType1      *int64   `json:"enchantmentType1,omitempty"`
-	EnchantmentType2      *int64   `json:"enchantmentType2,omitempty"`
-	EnchantmentType3      *int64   `json:"enchantmentType3,omitempty"`
-	EquipRequirement      *int64   `json:"equipRequirement,omitempty"`
-	ArmorType             *int64   `json:"armorType,omitempty"`
-	RawPhysDefense        *int64   `json:"rawPhysDefense,omitempty"`
-	PhysDefScalar         *int64   `json:"physDefScalar,omitempty"`
-	PDefScalarMax         *int64   `json:"pDefScalarMax,omitempty"`
-	RawMagicDefense       *int64   `json:"rawMagicDefense,omitempty"`
-	MagicDefScalar        *int64   `json:"magicDefScalar,omitempty"`
-	MDefScalarMax         *int64   `json:"mDefScalarMax,omitempty"`
-	Evasion               *int64   `json:"evasion,omitempty"`
-	UniqueSettings        *int64   `json:"uniqueSettings,omitempty"`
-	Spare1                *int64   `json:"spare1,omitempty"`
-	Spare2                *int64   `json:"spare2,omitempty"`
-	RestorationCount      *int64   `json:"restorationCount,omitempty"`
-	Misc1                 *int64   `json:"misc1,omitempty"`
-	Misc2                 *int64   `json:"misc2,omitempty"`
-	Misc3                 *int64   `json:"misc3,omitempty"`
-	Misc4                 *int64   `json:"misc4,omitempty"`
+	ID                    *string       `json:"id,omitempty"`
+	NormalizedID          *int64        `json:"normalizedId,omitempty"`
+	Owner                 *Profile      `json:"owner,omitempty"`
+	EquippableAt          *int64        `json:"equippableAt,omitempty"`
+	EquippedTo            *Hero         `json:"equippedTo,omitempty"`
+	CurrentRealm          *string       `json:"currentRealm,omitempty"`
+	OriginRealm           *string       `json:"originRealm,omitempty"`
+	CreatedAt             int64         `json:"createdAt"`
+	CraftedBy             *string       `json:"craftedBy,omitempty"`
+	SaleAuction           *ArmorAuction `json:"saleAuction,omitempty"`
+	SalePrice             *string       `json:"salePrice,omitempty"`
+	PrivateAuctionProfile *Profile      `json:"privateAuctionProfile,omitempty"`
+	DisplayID             *int64        `json:"displayId,omitempty"`
+	Rarity                *int64        `json:"rarity,omitempty"`
+	Dye1                  *int64        `json:"dye1,omitempty"`
+	Dye2                  *int64        `json:"dye2,omitempty"`
+	MaxDurability         *int64        `json:"maxDurability,omitempty"`
+	Durability            *int64        `json:"durability,omitempty"`
+	MaxRepairs            *int64        `json:"maxRepairs,omitempty"`
+	RemainingRepairs      *int64        `json:"remainingRepairs,omitempty"`
+	Bonus1                *int64        `json:"bonus1,omitempty"`
+	Bonus2                *int64        `json:"bonus2,omitempty"`
+	Bonus3                *int64        `json:"bonus3,omitempty"`
+	Bonus4                *int64        `json:"bonus4,omitempty"`
+	Bonus5                *int64        `json:"bonus5,omitempty"`
+	BonusScalar1          *int64        `json:"bonusScalar1,omitempty"`
+	BonusScalar2          *int64        `json:"bonusScalar2,omitempty"`
+	BonusScalar3          *int64        `json:"bonusScalar3,omitempty"`
+	BonusScalar4          *int64        `json:"bonusScalar4,omitempty"`
+	BonusScalar5          *int64        `json:"bonusScalar5,omitempty"`
+	EnchantmentScalar1    *int64        `json:"enchantmentScalar1,omitempty"`
+	EnchantmentScalar2    *int64        `json:"enchantmentScalar2,omitempty"`
+	EnchantmentScalar3    *int64        `json:"enchantmentScalar3,omitempty"`
+	EnchantmentType1      *int64        `json:"enchantmentType1,omitempty"`
+	EnchantmentType2      *int64        `json:"enchantmentType2,omitempty"`
+	EnchantmentType3      *int64        `json:"enchantmentType3,omitempty"`
+	EquipRequirement      *int64        `json:"equipRequirement,omitempty"`
+	ArmorType             *int64        `json:"armorType,omitempty"`
+	RawPhysDefense        *int64        `json:"rawPhysDefense,omitempty"`
+	PhysDefScalar         *int64        `json:"physDefScalar,omitempty"`
+	PDefScalarMax         *int64        `json:"pDefScalarMax,omitempty"`
+	RawMagicDefense       *int64        `json:"rawMagicDefense,omitempty"`
+	MagicDefScalar        *int64        `json:"magicDefScalar,omitempty"`
+	MDefScalarMax         *int64        `json:"mDefScalarMax,omitempty"`
+	Evasion               *int64        `json:"evasion,omitempty"`
+	UniqueSettings        *int64        `json:"uniqueSettings,omitempty"`
+	Spare1                *int64        `json:"spare1,omitempty"`
+	Spare2                *int64        `json:"spare2,omitempty"`
+	RestorationCount      *int64        `json:"restorationCount,omitempty"`
+	Misc1                 *int64        `json:"misc1,omitempty"`
+	Misc2                 *int64        `json:"misc2,omitempty"`
+	Misc3                 *int64        `json:"misc3,omitempty"`
+	Misc4                 *int64        `json:"misc4,omitempty"`
+}
+
+type ArmorAuction struct {
+	ID            *string  `json:"id,omitempty"`
+	Seller        *Profile `json:"seller,omitempty"`
+	TokenID       *Armor   `json:"tokenId,omitempty"`
+	StartingPrice *string  `json:"startingPrice,omitempty"`
+	EndingPrice   *string  `json:"endingPrice,omitempty"`
+	Duration      *int64   `json:"duration,omitempty"`
+	StartedAt     *int64   `json:"startedAt,omitempty"`
+	Winner        *Profile `json:"winner,omitempty"`
+	EndedAt       *int64   `json:"endedAt,omitempty"`
+	Open          bool     `json:"open"`
+	PurchasePrice *string  `json:"purchasePrice,omitempty"`
 }
 
 type ArmorFilter struct {
@@ -467,6 +499,8 @@ type ArmorFilter struct {
 	CraftedByLt                        *string   `json:"craftedBy_lt,omitempty"`
 	CraftedByIn                        []*string `json:"craftedBy_in,omitempty"`
 	CraftedByNotIn                     []*string `json:"craftedBy_not_in,omitempty"`
+	SaleAuction                        *string   `json:"saleAuction,omitempty"`
+	SaleAuctionNot                     *string   `json:"saleAuction_not,omitempty"`
 	SalePrice                          *string   `json:"salePrice,omitempty"`
 	SalePriceNot                       *string   `json:"salePrice_not,omitempty"`
 	SalePriceGt                        *string   `json:"salePrice_gt,omitempty"`
@@ -2743,66 +2777,81 @@ type ProfileFilter struct {
 }
 
 type Weapon struct {
-	ID                     *string  `json:"id,omitempty"`
-	NormalizedID           int64    `json:"normalizedId"`
-	Owner                  *Profile `json:"owner,omitempty"`
-	EquippableAt           int64    `json:"equippableAt"`
-	EquippedTo             *Hero    `json:"equippedTo,omitempty"`
-	CurrentRealm           *string  `json:"currentRealm,omitempty"`
-	OriginRealm            *string  `json:"originRealm,omitempty"`
-	CreatedAt              int64    `json:"createdAt"`
-	CraftedBy              *string  `json:"craftedBy,omitempty"`
-	SalePrice              *string  `json:"salePrice,omitempty"`
-	PrivateAuctionProfile  *Profile `json:"privateAuctionProfile,omitempty"`
-	DisplayID              *int64   `json:"displayId,omitempty"`
-	Rarity                 *int64   `json:"rarity,omitempty"`
-	Dye1                   *int64   `json:"dye1,omitempty"`
-	Dye2                   *int64   `json:"dye2,omitempty"`
-	MaxDurability          *int64   `json:"maxDurability,omitempty"`
-	Durability             *int64   `json:"durability,omitempty"`
-	MaxRepairs             *int64   `json:"maxRepairs,omitempty"`
-	RemainingRepairs       *int64   `json:"remainingRepairs,omitempty"`
-	Bonus1                 *int64   `json:"bonus1,omitempty"`
-	Bonus2                 *int64   `json:"bonus2,omitempty"`
-	Bonus3                 *int64   `json:"bonus3,omitempty"`
-	Bonus4                 *int64   `json:"bonus4,omitempty"`
-	BonusScalar1           *int64   `json:"bonusScalar1,omitempty"`
-	BonusScalar2           *int64   `json:"bonusScalar2,omitempty"`
-	BonusScalar3           *int64   `json:"bonusScalar3,omitempty"`
-	BonusScalar4           *int64   `json:"bonusScalar4,omitempty"`
-	EnchantmentScalar1     *int64   `json:"enchantmentScalar1,omitempty"`
-	EnchantmentScalar2     *int64   `json:"enchantmentScalar2,omitempty"`
-	EnchantmentScalar3     *int64   `json:"enchantmentScalar3,omitempty"`
-	EnchantmentType1       *int64   `json:"enchantmentType1,omitempty"`
-	EnchantmentType2       *int64   `json:"enchantmentType2,omitempty"`
-	EnchantmentType3       *int64   `json:"enchantmentType3,omitempty"`
-	EquipRequirement       *int64   `json:"equipRequirement,omitempty"`
-	WeaponType             *int64   `json:"weaponType,omitempty"`
-	BasePotency            *int64   `json:"basePotency,omitempty"`
-	FocusRequirement       *int64   `json:"focusRequirement,omitempty"`
-	MAccuracyAtRequirement *int64   `json:"mAccuracyAtRequirement,omitempty"`
-	MScalarStat1           *int64   `json:"mScalarStat1,omitempty"`
-	MScalarStat2           *int64   `json:"mScalarStat2,omitempty"`
-	MScalarStat3           *int64   `json:"mScalarStat3,omitempty"`
-	MScalarValue1          *int64   `json:"mScalarValue1,omitempty"`
-	MScalarValue2          *int64   `json:"mScalarValue2,omitempty"`
-	MScalarValue3          *int64   `json:"mScalarValue3,omitempty"`
-	MScalarMax1            *int64   `json:"mScalarMax1,omitempty"`
-	MScalarMax2            *int64   `json:"mScalarMax2,omitempty"`
-	MScalarMax3            *int64   `json:"mScalarMax3,omitempty"`
-	RestorationCount       *int64   `json:"restorationCount,omitempty"`
-	BaseDamage             *int64   `json:"baseDamage,omitempty"`
-	AccuracyRequirement    *int64   `json:"accuracyRequirement,omitempty"`
-	PAccuracyAtRequirement *int64   `json:"pAccuracyAtRequirement,omitempty"`
-	PScalarStat1           *int64   `json:"pScalarStat1,omitempty"`
-	PScalarStat2           *int64   `json:"pScalarStat2,omitempty"`
-	PScalarStat3           *int64   `json:"pScalarStat3,omitempty"`
-	PScalarValue1          *int64   `json:"pScalarValue1,omitempty"`
-	PScalarValue2          *int64   `json:"pScalarValue2,omitempty"`
-	PScalarValue3          *int64   `json:"pScalarValue3,omitempty"`
-	PScalarMax1            *int64   `json:"pScalarMax1,omitempty"`
-	PScalarMax2            *int64   `json:"pScalarMax2,omitempty"`
-	PScalarMax3            *int64   `json:"pScalarMax3,omitempty"`
+	ID                     *string        `json:"id,omitempty"`
+	NormalizedID           int64          `json:"normalizedId"`
+	Owner                  *Profile       `json:"owner,omitempty"`
+	EquippableAt           int64          `json:"equippableAt"`
+	EquippedTo             *Hero          `json:"equippedTo,omitempty"`
+	CurrentRealm           *string        `json:"currentRealm,omitempty"`
+	OriginRealm            *string        `json:"originRealm,omitempty"`
+	CreatedAt              int64          `json:"createdAt"`
+	CraftedBy              *string        `json:"craftedBy,omitempty"`
+	SaleAuction            *WeaponAuction `json:"saleAuction,omitempty"`
+	SalePrice              *string        `json:"salePrice,omitempty"`
+	PrivateAuctionProfile  *Profile       `json:"privateAuctionProfile,omitempty"`
+	DisplayID              *int64         `json:"displayId,omitempty"`
+	Rarity                 *int64         `json:"rarity,omitempty"`
+	Dye1                   *int64         `json:"dye1,omitempty"`
+	Dye2                   *int64         `json:"dye2,omitempty"`
+	MaxDurability          *int64         `json:"maxDurability,omitempty"`
+	Durability             *int64         `json:"durability,omitempty"`
+	MaxRepairs             *int64         `json:"maxRepairs,omitempty"`
+	RemainingRepairs       *int64         `json:"remainingRepairs,omitempty"`
+	Bonus1                 *int64         `json:"bonus1,omitempty"`
+	Bonus2                 *int64         `json:"bonus2,omitempty"`
+	Bonus3                 *int64         `json:"bonus3,omitempty"`
+	Bonus4                 *int64         `json:"bonus4,omitempty"`
+	BonusScalar1           *int64         `json:"bonusScalar1,omitempty"`
+	BonusScalar2           *int64         `json:"bonusScalar2,omitempty"`
+	BonusScalar3           *int64         `json:"bonusScalar3,omitempty"`
+	BonusScalar4           *int64         `json:"bonusScalar4,omitempty"`
+	EnchantmentScalar1     *int64         `json:"enchantmentScalar1,omitempty"`
+	EnchantmentScalar2     *int64         `json:"enchantmentScalar2,omitempty"`
+	EnchantmentScalar3     *int64         `json:"enchantmentScalar3,omitempty"`
+	EnchantmentType1       *int64         `json:"enchantmentType1,omitempty"`
+	EnchantmentType2       *int64         `json:"enchantmentType2,omitempty"`
+	EnchantmentType3       *int64         `json:"enchantmentType3,omitempty"`
+	EquipRequirement       *int64         `json:"equipRequirement,omitempty"`
+	WeaponType             *int64         `json:"weaponType,omitempty"`
+	BasePotency            *int64         `json:"basePotency,omitempty"`
+	FocusRequirement       *int64         `json:"focusRequirement,omitempty"`
+	MAccuracyAtRequirement *int64         `json:"mAccuracyAtRequirement,omitempty"`
+	MScalarStat1           *int64         `json:"mScalarStat1,omitempty"`
+	MScalarStat2           *int64         `json:"mScalarStat2,omitempty"`
+	MScalarStat3           *int64         `json:"mScalarStat3,omitempty"`
+	MScalarValue1          *int64         `json:"mScalarValue1,omitempty"`
+	MScalarValue2          *int64         `json:"mScalarValue2,omitempty"`
+	MScalarValue3          *int64         `json:"mScalarValue3,omitempty"`
+	MScalarMax1            *int64         `json:"mScalarMax1,omitempty"`
+	MScalarMax2            *int64         `json:"mScalarMax2,omitempty"`
+	MScalarMax3            *int64         `json:"mScalarMax3,omitempty"`
+	RestorationCount       *int64         `json:"restorationCount,omitempty"`
+	BaseDamage             *int64         `json:"baseDamage,omitempty"`
+	AccuracyRequirement    *int64         `json:"accuracyRequirement,omitempty"`
+	PAccuracyAtRequirement *int64         `json:"pAccuracyAtRequirement,omitempty"`
+	PScalarStat1           *int64         `json:"pScalarStat1,omitempty"`
+	PScalarStat2           *int64         `json:"pScalarStat2,omitempty"`
+	PScalarStat3           *int64         `json:"pScalarStat3,omitempty"`
+	PScalarValue1          *int64         `json:"pScalarValue1,omitempty"`
+	PScalarValue2          *int64         `json:"pScalarValue2,omitempty"`
+	PScalarValue3          *int64         `json:"pScalarValue3,omitempty"`
+	PScalarMax1            *int64         `json:"pScalarMax1,omitempty"`
+	PScalarMax2            *int64         `json:"pScalarMax2,omitempty"`
+	PScalarMax3            *int64         `json:"pScalarMax3,omitempty"`
+}
+
+type WeaponAuction struct {
+	ID            *string  `json:"id,omitempty"`
+	Seller        *Profile `json:"seller,omitempty"`
+	TokenID       *Weapon  `json:"tokenId,omitempty"`
+	StartingPrice *string  `json:"startingPrice,omitempty"`
+	EndingPrice   *string  `json:"endingPrice,omitempty"`
+	Duration      *int64   `json:"duration,omitempty"`
+	StartedAt     *int64   `json:"startedAt,omitempty"`
+	Winner        *Profile `json:"winner,omitempty"`
+	EndedAt       *int64   `json:"endedAt,omitempty"`
+	Open          bool     `json:"open"`
+	PurchasePrice *string  `json:"purchasePrice,omitempty"`
 }
 
 type WeaponFilter struct {
@@ -2864,6 +2913,8 @@ type WeaponFilter struct {
 	CraftedByLt                        *string   `json:"craftedBy_lt,omitempty"`
 	CraftedByIn                        []*string `json:"craftedBy_in,omitempty"`
 	CraftedByNotIn                     []*string `json:"craftedBy_not_in,omitempty"`
+	SaleAuction                        *string   `json:"saleAuction,omitempty"`
+	SaleAuctionNot                     *string   `json:"saleAuction_not,omitempty"`
 	SalePrice                          *string   `json:"salePrice,omitempty"`
 	SalePriceNot                       *string   `json:"salePrice_not,omitempty"`
 	SalePriceGt                        *string   `json:"salePrice_gt,omitempty"`

--- a/services/explorer/consumer/client/resolver-client/server.go
+++ b/services/explorer/consumer/client/resolver-client/server.go
@@ -80,7 +80,7 @@ type ComplexityRoot struct {
 		LogCount                 func(childComplexity int, contractAddress string, chainID int) int
 		Logs                     func(childComplexity int, contractAddress *string, chainID int, blockNumber *int, txHash *string, txIndex *int, blockHash *string, index *int, confirmed *bool, page int) int
 		LogsAtHeadRange          func(childComplexity int, contractAddress *string, chainID int, blockNumber *int, txHash *string, txIndex *int, blockHash *string, index *int, confirmed *bool, startBlock int, endBlock int, page int) int
-		LogsRange                func(childComplexity int, contractAddress *string, chainID int, blockNumber *int, txHash *string, txIndex *int, blockHash *string, index *int, confirmed *bool, startBlock int, endBlock int, page int) int
+		LogsRange                func(childComplexity int, contractAddress *string, chainID int, blockNumber *int, txHash *string, txIndex *int, blockHash *string, index *int, confirmed *bool, startBlock int, endBlock int, page int, asc *bool) int
 		ReceiptCount             func(childComplexity int, chainID int) int
 		Receipts                 func(childComplexity int, chainID int, txHash *string, contractAddress *string, blockHash *string, blockNumber *int, txIndex *int, confirmed *bool, page int) int
 		ReceiptsAtHeadRange      func(childComplexity int, chainID int, txHash *string, contractAddress *string, blockHash *string, blockNumber *int, txIndex *int, confirmed *bool, startBlock int, endBlock int, page int) int
@@ -138,7 +138,7 @@ type LogResolver interface {
 }
 type QueryResolver interface {
 	Logs(ctx context.Context, contractAddress *string, chainID int, blockNumber *int, txHash *string, txIndex *int, blockHash *string, index *int, confirmed *bool, page int) ([]*model.Log, error)
-	LogsRange(ctx context.Context, contractAddress *string, chainID int, blockNumber *int, txHash *string, txIndex *int, blockHash *string, index *int, confirmed *bool, startBlock int, endBlock int, page int) ([]*model.Log, error)
+	LogsRange(ctx context.Context, contractAddress *string, chainID int, blockNumber *int, txHash *string, txIndex *int, blockHash *string, index *int, confirmed *bool, startBlock int, endBlock int, page int, asc *bool) ([]*model.Log, error)
 	Receipts(ctx context.Context, chainID int, txHash *string, contractAddress *string, blockHash *string, blockNumber *int, txIndex *int, confirmed *bool, page int) ([]*model.Receipt, error)
 	ReceiptsRange(ctx context.Context, chainID int, txHash *string, contractAddress *string, blockHash *string, blockNumber *int, txIndex *int, confirmed *bool, startBlock int, endBlock int, page int) ([]*model.Receipt, error)
 	Transactions(ctx context.Context, txHash *string, chainID int, blockNumber *int, blockHash *string, confirmed *bool, page int) ([]*model.Transaction, error)
@@ -419,7 +419,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.LogsRange(childComplexity, args["contract_address"].(*string), args["chain_id"].(int), args["block_number"].(*int), args["tx_hash"].(*string), args["tx_index"].(*int), args["block_hash"].(*string), args["index"].(*int), args["confirmed"].(*bool), args["start_block"].(int), args["end_block"].(int), args["page"].(int)), true
+		return e.complexity.Query.LogsRange(childComplexity, args["contract_address"].(*string), args["chain_id"].(int), args["block_number"].(*int), args["tx_hash"].(*string), args["tx_index"].(*int), args["block_hash"].(*string), args["index"].(*int), args["confirmed"].(*bool), args["start_block"].(int), args["end_block"].(int), args["page"].(int), args["asc"].(*bool)), true
 
 	case "Query.receiptCount":
 		if e.complexity.Query.ReceiptCount == nil {
@@ -873,6 +873,7 @@ directive @goField(forceResolver: Boolean, name: String) on INPUT_FIELD_DEFINITI
     start_block: Int!
     end_block: Int!
     page: Int!
+    asc: Boolean = False
   ): [Log]
   # returns all receipts that match the given filter
   receipts(
@@ -1427,6 +1428,15 @@ func (ec *executionContext) field_Query_logsRange_args(ctx context.Context, rawA
 		}
 	}
 	args["page"] = arg10
+	var arg11 *bool
+	if tmp, ok := rawArgs["asc"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("asc"))
+		arg11, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["asc"] = arg11
 	return args, nil
 }
 
@@ -3003,7 +3013,7 @@ func (ec *executionContext) _Query_logsRange(ctx context.Context, field graphql.
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().LogsRange(rctx, fc.Args["contract_address"].(*string), fc.Args["chain_id"].(int), fc.Args["block_number"].(*int), fc.Args["tx_hash"].(*string), fc.Args["tx_index"].(*int), fc.Args["block_hash"].(*string), fc.Args["index"].(*int), fc.Args["confirmed"].(*bool), fc.Args["start_block"].(int), fc.Args["end_block"].(int), fc.Args["page"].(int))
+		return ec.resolvers.Query().LogsRange(rctx, fc.Args["contract_address"].(*string), fc.Args["chain_id"].(int), fc.Args["block_number"].(*int), fc.Args["tx_hash"].(*string), fc.Args["tx_index"].(*int), fc.Args["block_hash"].(*string), fc.Args["index"].(*int), fc.Args["confirmed"].(*bool), fc.Args["start_block"].(int), fc.Args["end_block"].(int), fc.Args["page"].(int), fc.Args["asc"].(*bool))
 	})
 	if err != nil {
 		ec.Error(ctx, err)

--- a/services/scribe/api/data_test.go
+++ b/services/scribe/api/data_test.go
@@ -50,11 +50,17 @@ func (g APISuite) TestRetrieveData() {
 	logs, err := g.gqlClient.GetLogs(g.GetTestContext(), int(chainID), 1)
 	Nil(g.T(), err)
 	// there were 20 logs created (2 per loop, in a loop of 10)
-	Equal(g.T(), len(logs.Response), 20)
+	Equal(g.T(), 20, len(logs.Response))
 	logsRange, err := g.gqlClient.GetLogsRange(g.GetTestContext(), int(chainID), 2, 5, 1)
 	Nil(g.T(), err)
 	// from 2-5, there were 8 logs created (2 per loop, in a range of 4)
-	Equal(g.T(), len(logsRange.Response), 8)
+	Equal(g.T(), 8, len(logsRange.Response))
+
+	// Test getting logs in a range in ascending order.
+	logsRangeAsc, err := g.gqlClient.GetLogsRange(g.GetTestContext(), int(chainID), 5, 2, 1)
+	Nil(g.T(), err)
+	Equal(g.T(), 8, len(logsRangeAsc.Response))
+	Equal(g.T(), 2, logsRangeAsc.Response[0].BlockNumber)
 
 	// test get logs and get logs in a range (GRPC)
 	grpcLogs, res, err := g.grpcRestClient.ScribeServiceApi.ScribeServiceFilterLogs(g.GetTestContext(), rest.V1FilterLogsRequest{
@@ -213,17 +219,17 @@ func (g APISuite) TestBlockTimeDataEquality() {
 	Nil(g.T(), err)
 
 	// check that the data is equal
-	Equal(g.T(), *retrievedBlockTime.Response, int(blockTime))
+	Equal(g.T(), int(blockTime), *retrievedBlockTime.Response)
 
 	// check that the last stored block is correct
 	lastBlock, err := g.gqlClient.GetLastStoredBlockNumber(g.GetTestContext(), int(chainID))
 	Nil(g.T(), err)
-	Equal(g.T(), *lastBlock.Response, int(blockNumber))
+	Equal(g.T(), int(blockNumber), *lastBlock.Response)
 
 	// check that the first stored block is correct
 	firstBlock, err := g.gqlClient.GetFirstStoredBlockNumber(g.GetTestContext(), int(chainID))
 	Nil(g.T(), err)
-	Equal(g.T(), *firstBlock.Response, int(blockNumber))
+	Equal(g.T(), int(blockNumber), *firstBlock.Response)
 }
 
 func (g *APISuite) buildLog(contractAddress common.Address, blockNumber uint64) types.Log {
@@ -291,7 +297,7 @@ func (g APISuite) TestLastContractIndexed() {
 	Nil(g.T(), err)
 
 	// check that the data is equal
-	Equal(g.T(), *retrievedBlockTime.Response, int(blockNumber))
+	Equal(g.T(), int(blockNumber), *retrievedBlockTime.Response)
 }
 
 // nolint:dupl
@@ -390,7 +396,7 @@ func (g APISuite) TestLastConfirmedBlock() {
 	Nil(g.T(), err)
 
 	// check that the data is equal
-	Equal(g.T(), *retrievedBlockTime.Response, int(blockNumber))
+	Equal(g.T(), int(blockNumber), *retrievedBlockTime.Response)
 }
 
 // nolint:dupl

--- a/services/scribe/api/data_test.go
+++ b/services/scribe/api/data_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	. "github.com/stretchr/testify/assert"
+	"github.com/synapsecns/sanguine/core"
 	"github.com/synapsecns/sanguine/services/scribe/db"
 	"github.com/synapsecns/sanguine/services/scribe/graphql"
 	"github.com/synapsecns/sanguine/services/scribe/grpc/client/rest"
@@ -51,13 +52,13 @@ func (g APISuite) TestRetrieveData() {
 	Nil(g.T(), err)
 	// there were 20 logs created (2 per loop, in a loop of 10)
 	Equal(g.T(), 20, len(logs.Response))
-	logsRange, err := g.gqlClient.GetLogsRange(g.GetTestContext(), int(chainID), 2, 5, 1)
+	logsRange, err := g.gqlClient.GetLogsRange(g.GetTestContext(), int(chainID), 2, 5, 1, nil)
 	Nil(g.T(), err)
 	// from 2-5, there were 8 logs created (2 per loop, in a range of 4)
 	Equal(g.T(), 8, len(logsRange.Response))
 
 	// Test getting logs in a range in ascending order.
-	logsRangeAsc, err := g.gqlClient.GetLogsRange(g.GetTestContext(), int(chainID), 5, 2, 1)
+	logsRangeAsc, err := g.gqlClient.GetLogsRange(g.GetTestContext(), int(chainID), 2, 5, 1, core.PtrTo(true))
 	Nil(g.T(), err)
 	Equal(g.T(), 8, len(logsRangeAsc.Response))
 	Equal(g.T(), 2, logsRangeAsc.Response[0].BlockNumber)

--- a/services/scribe/cmd/cmd.md
+++ b/services/scribe/cmd/cmd.md
@@ -5,7 +5,7 @@
 Scribe is a multi-chain indexing service. Scribe is designed to take a list of contracts specified by chain id and store logs, receipts, and txs for every event, past to present, in a mysql database.
 
 Use cases
-- Analytics for on chain events
+- Analytics for on-chain events
 - Stream events occurring across chains
 - Monitor activity on your contracts
 

--- a/services/scribe/cmd/cmd.md
+++ b/services/scribe/cmd/cmd.md
@@ -2,7 +2,7 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/synapsecns/sanguine/services/scribe.svg)](https://pkg.go.dev/github.com/synapsecns/sanguine/services/scribe)
 [![Go Report Card](https://goreportcard.com/badge/github.com/synapsecns/sanguine/services/scribe)](https://goreportcard.com/report/github.com/synapsecns/sanguine/services/scribe)
 
-Scribe is a multi chain indexing service. Scribe is designed to take a list of contracts specified by chain id and store logs, receipts, and txs for every event, past to present, in a mysql database.
+Scribe is a multi-chain indexing service. Scribe is designed to take a list of contracts specified by chain id and store logs, receipts, and txs for every event, past to present, in a mysql database.
 
 Use cases
 - Analytics for on chain events

--- a/services/scribe/graphql/client/client.go
+++ b/services/scribe/graphql/client/client.go
@@ -327,8 +327,8 @@ func (c *Client) GetLogs(ctx context.Context, chainID int, page int, httpRequest
 	return &res, nil
 }
 
-const GetLogsRangeDocument = `query GetLogsRange ($chain_id: Int!, $start_block: Int!, $end_block: Int!, $page: Int!) {
-	response: logsRange(chain_id: $chain_id, start_block: $start_block, end_block: $end_block, page: $page) {
+const GetLogsRangeDocument = `query GetLogsRange ($chain_id: Int!, $start_block: Int!, $end_block: Int!, $page: Int!, $asc: Boolean = false) {
+	response: logsRange(chain_id: $chain_id, start_block: $start_block, end_block: $end_block, page: $page, asc: $asc) {
 		contract_address
 		chain_id
 		topics
@@ -343,12 +343,13 @@ const GetLogsRangeDocument = `query GetLogsRange ($chain_id: Int!, $start_block:
 }
 `
 
-func (c *Client) GetLogsRange(ctx context.Context, chainID int, startBlock int, endBlock int, page int, httpRequestOptions ...client.HTTPRequestOption) (*GetLogsRange, error) {
+func (c *Client) GetLogsRange(ctx context.Context, chainID int, startBlock int, endBlock int, page int, asc *bool, httpRequestOptions ...client.HTTPRequestOption) (*GetLogsRange, error) {
 	vars := map[string]interface{}{
 		"chain_id":    chainID,
 		"start_block": startBlock,
 		"end_block":   endBlock,
 		"page":        page,
+		"asc":         asc,
 	}
 
 	var res GetLogsRange

--- a/services/scribe/graphql/client/queries/queries.graphql
+++ b/services/scribe/graphql/client/queries/queries.graphql
@@ -13,8 +13,8 @@ query GetLogs ($chain_id: Int!, $page: Int!) {
     }
 }
 
-query GetLogsRange ($chain_id: Int!, $start_block: Int!, $end_block: Int!, $page: Int!) {
-    response: logsRange (chain_id: $chain_id, start_block: $start_block, end_block: $end_block, page: $page) {
+query GetLogsRange ($chain_id: Int!, $start_block: Int!, $end_block: Int!, $page: Int!, $asc: Boolean = false) {
+    response: logsRange (chain_id: $chain_id, start_block: $start_block, end_block: $end_block, page: $page,asc: $asc) {
         contract_address
         chain_id
         topics

--- a/services/scribe/graphql/server/graph/queries.resolvers.go
+++ b/services/scribe/graphql/server/graph/queries.resolvers.go
@@ -31,14 +31,14 @@ func (r *queryResolver) Logs(ctx context.Context, contractAddress *string, chain
 }
 
 // LogsRange is the resolver for the logsRange field.
-func (r *queryResolver) LogsRange(ctx context.Context, contractAddress *string, chainID int, blockNumber *int, txHash *string, txIndex *int, blockHash *string, index *int, confirmed *bool, startBlock int, endBlock int, page int) ([]*model.Log, error) {
+func (r *queryResolver) LogsRange(ctx context.Context, contractAddress *string, chainID int, blockNumber *int, txHash *string, txIndex *int, blockHash *string, index *int, confirmed *bool, startBlock int, endBlock int, page int, asc *bool) ([]*model.Log, error) {
 	logsFilter := db.BuildLogFilter(contractAddress, blockNumber, txHash, txIndex, blockHash, index, confirmed)
 	logsFilter.ChainID = uint32(chainID)
 	var logs []*types.Log
 	var err error
 	// Get logs in ascending order if startBlock > endBlock
-	if startBlock > endBlock {
-		logs, err = r.DB.RetrieveLogsInRangeAsc(ctx, logsFilter, uint64(endBlock), uint64(startBlock), page)
+	if asc != nil && *asc {
+		logs, err = r.DB.RetrieveLogsInRangeAsc(ctx, logsFilter, uint64(startBlock), uint64(endBlock), page)
 	} else {
 		logs, err = r.DB.RetrieveLogsInRange(ctx, logsFilter, uint64(startBlock), uint64(endBlock), page)
 	}

--- a/services/scribe/graphql/server/graph/queries.resolvers.go
+++ b/services/scribe/graphql/server/graph/queries.resolvers.go
@@ -36,7 +36,7 @@ func (r *queryResolver) LogsRange(ctx context.Context, contractAddress *string, 
 	logsFilter.ChainID = uint32(chainID)
 	var logs []*types.Log
 	var err error
-	// Get logs in ascending order if asc is true.
+	// Get logs in ascending order if asc is set to true.
 	if asc != nil && *asc {
 		logs, err = r.DB.RetrieveLogsInRangeAsc(ctx, logsFilter, uint64(startBlock), uint64(endBlock), page)
 	} else {

--- a/services/scribe/graphql/server/graph/queries.resolvers.go
+++ b/services/scribe/graphql/server/graph/queries.resolvers.go
@@ -34,7 +34,14 @@ func (r *queryResolver) Logs(ctx context.Context, contractAddress *string, chain
 func (r *queryResolver) LogsRange(ctx context.Context, contractAddress *string, chainID int, blockNumber *int, txHash *string, txIndex *int, blockHash *string, index *int, confirmed *bool, startBlock int, endBlock int, page int) ([]*model.Log, error) {
 	logsFilter := db.BuildLogFilter(contractAddress, blockNumber, txHash, txIndex, blockHash, index, confirmed)
 	logsFilter.ChainID = uint32(chainID)
-	logs, err := r.DB.RetrieveLogsInRange(ctx, logsFilter, uint64(startBlock), uint64(endBlock), page)
+	var logs []*types.Log
+	var err error
+	// Get logs in ascending order if startBlock > endBlock
+	if startBlock > endBlock {
+		logs, err = r.DB.RetrieveLogsInRangeAsc(ctx, logsFilter, uint64(endBlock), uint64(startBlock), page)
+	} else {
+		logs, err = r.DB.RetrieveLogsInRange(ctx, logsFilter, uint64(startBlock), uint64(endBlock), page)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving logs: %w", err)
 	}

--- a/services/scribe/graphql/server/graph/queries.resolvers.go
+++ b/services/scribe/graphql/server/graph/queries.resolvers.go
@@ -36,7 +36,7 @@ func (r *queryResolver) LogsRange(ctx context.Context, contractAddress *string, 
 	logsFilter.ChainID = uint32(chainID)
 	var logs []*types.Log
 	var err error
-	// Get logs in ascending order if startBlock > endBlock
+	// Get logs in ascending order if asc is true.
 	if asc != nil && *asc {
 		logs, err = r.DB.RetrieveLogsInRangeAsc(ctx, logsFilter, uint64(startBlock), uint64(endBlock), page)
 	} else {

--- a/services/scribe/graphql/server/graph/resolver/server.go
+++ b/services/scribe/graphql/server/graph/resolver/server.go
@@ -80,7 +80,7 @@ type ComplexityRoot struct {
 		LogCount                 func(childComplexity int, contractAddress string, chainID int) int
 		Logs                     func(childComplexity int, contractAddress *string, chainID int, blockNumber *int, txHash *string, txIndex *int, blockHash *string, index *int, confirmed *bool, page int) int
 		LogsAtHeadRange          func(childComplexity int, contractAddress *string, chainID int, blockNumber *int, txHash *string, txIndex *int, blockHash *string, index *int, confirmed *bool, startBlock int, endBlock int, page int) int
-		LogsRange                func(childComplexity int, contractAddress *string, chainID int, blockNumber *int, txHash *string, txIndex *int, blockHash *string, index *int, confirmed *bool, startBlock int, endBlock int, page int) int
+		LogsRange                func(childComplexity int, contractAddress *string, chainID int, blockNumber *int, txHash *string, txIndex *int, blockHash *string, index *int, confirmed *bool, startBlock int, endBlock int, page int, asc *bool) int
 		ReceiptCount             func(childComplexity int, chainID int) int
 		Receipts                 func(childComplexity int, chainID int, txHash *string, contractAddress *string, blockHash *string, blockNumber *int, txIndex *int, confirmed *bool, page int) int
 		ReceiptsAtHeadRange      func(childComplexity int, chainID int, txHash *string, contractAddress *string, blockHash *string, blockNumber *int, txIndex *int, confirmed *bool, startBlock int, endBlock int, page int) int
@@ -138,7 +138,7 @@ type LogResolver interface {
 }
 type QueryResolver interface {
 	Logs(ctx context.Context, contractAddress *string, chainID int, blockNumber *int, txHash *string, txIndex *int, blockHash *string, index *int, confirmed *bool, page int) ([]*model.Log, error)
-	LogsRange(ctx context.Context, contractAddress *string, chainID int, blockNumber *int, txHash *string, txIndex *int, blockHash *string, index *int, confirmed *bool, startBlock int, endBlock int, page int) ([]*model.Log, error)
+	LogsRange(ctx context.Context, contractAddress *string, chainID int, blockNumber *int, txHash *string, txIndex *int, blockHash *string, index *int, confirmed *bool, startBlock int, endBlock int, page int, asc *bool) ([]*model.Log, error)
 	Receipts(ctx context.Context, chainID int, txHash *string, contractAddress *string, blockHash *string, blockNumber *int, txIndex *int, confirmed *bool, page int) ([]*model.Receipt, error)
 	ReceiptsRange(ctx context.Context, chainID int, txHash *string, contractAddress *string, blockHash *string, blockNumber *int, txIndex *int, confirmed *bool, startBlock int, endBlock int, page int) ([]*model.Receipt, error)
 	Transactions(ctx context.Context, txHash *string, chainID int, blockNumber *int, blockHash *string, confirmed *bool, page int) ([]*model.Transaction, error)
@@ -419,7 +419,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.LogsRange(childComplexity, args["contract_address"].(*string), args["chain_id"].(int), args["block_number"].(*int), args["tx_hash"].(*string), args["tx_index"].(*int), args["block_hash"].(*string), args["index"].(*int), args["confirmed"].(*bool), args["start_block"].(int), args["end_block"].(int), args["page"].(int)), true
+		return e.complexity.Query.LogsRange(childComplexity, args["contract_address"].(*string), args["chain_id"].(int), args["block_number"].(*int), args["tx_hash"].(*string), args["tx_index"].(*int), args["block_hash"].(*string), args["index"].(*int), args["confirmed"].(*bool), args["start_block"].(int), args["end_block"].(int), args["page"].(int), args["asc"].(*bool)), true
 
 	case "Query.receiptCount":
 		if e.complexity.Query.ReceiptCount == nil {
@@ -873,6 +873,7 @@ directive @goField(forceResolver: Boolean, name: String) on INPUT_FIELD_DEFINITI
     start_block: Int!
     end_block: Int!
     page: Int!
+    asc: Boolean = False
   ): [Log]
   # returns all receipts that match the given filter
   receipts(
@@ -1427,6 +1428,15 @@ func (ec *executionContext) field_Query_logsRange_args(ctx context.Context, rawA
 		}
 	}
 	args["page"] = arg10
+	var arg11 *bool
+	if tmp, ok := rawArgs["asc"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("asc"))
+		arg11, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["asc"] = arg11
 	return args, nil
 }
 
@@ -3003,7 +3013,7 @@ func (ec *executionContext) _Query_logsRange(ctx context.Context, field graphql.
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().LogsRange(rctx, fc.Args["contract_address"].(*string), fc.Args["chain_id"].(int), fc.Args["block_number"].(*int), fc.Args["tx_hash"].(*string), fc.Args["tx_index"].(*int), fc.Args["block_hash"].(*string), fc.Args["index"].(*int), fc.Args["confirmed"].(*bool), fc.Args["start_block"].(int), fc.Args["end_block"].(int), fc.Args["page"].(int))
+		return ec.resolvers.Query().LogsRange(rctx, fc.Args["contract_address"].(*string), fc.Args["chain_id"].(int), fc.Args["block_number"].(*int), fc.Args["tx_hash"].(*string), fc.Args["tx_index"].(*int), fc.Args["block_hash"].(*string), fc.Args["index"].(*int), fc.Args["confirmed"].(*bool), fc.Args["start_block"].(int), fc.Args["end_block"].(int), fc.Args["page"].(int), fc.Args["asc"].(*bool))
 	})
 	if err != nil {
 		ec.Error(ctx, err)

--- a/services/scribe/graphql/server/graph/schema/queries.graphql
+++ b/services/scribe/graphql/server/graph/schema/queries.graphql
@@ -24,6 +24,7 @@ type Query {
     start_block: Int!
     end_block: Int!
     page: Int!
+    asc: Boolean = False
   ): [Log]
   # returns all receipts that match the given filter
   receipts(

--- a/services/scribe/service/indexer/indexer_test.go
+++ b/services/scribe/service/indexer/indexer_test.go
@@ -467,7 +467,7 @@ func (x *IndexerSuite) TestTxTypeNotSupported() {
 	}
 
 	var backendClient backend.ScribeBackend
-	omnirpcURL := "https://rpc.interoperability.institute/confirmations/1/rpc/42161"
+	omnirpcURL := "https://arbitrum.llamarpc.com"
 	backendClient, err := backend.DialBackend(x.GetTestContext(), omnirpcURL, x.metrics)
 	Nil(x.T(), err)
 


### PR DESCRIPTION
**Description**
Handle returning logs in ascending order. Fixed some syntax in tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

New Features:
- Enhanced the Scribe service to support multi-chain indexing, improving analytics for on-chain events.
- Added flexibility in retrieving logs within a specified range in both ascending and descending order, improving data accessibility.
- Updated the GraphQL schema to include a new field `asc` allowing clients to specify the sorting order of the results.

Refactor:
- Modified the order of arguments in various function calls to improve code readability and consistency.

Tests:
- Added a new test case to verify the retrieval of logs in a range in ascending order.

Documentation:
- Improved the description of the Scribe service in the documentation for better clarity.

Chores:
- Updated the backend client URL in the indexer test.

Style:
- Improved the phrasing in the documentation for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->