### PR TITLE
[WIP - do not merge] Fe/estimated time update

### DIFF
--- a/packages/synapse-interface/constants/bridge.ts
+++ b/packages/synapse-interface/constants/bridge.ts
@@ -13,6 +13,7 @@ export const EMPTY_BRIDGE_QUOTE = {
   feeAmount: 0n,
   delta: 0n,
   quotes: { originQuery: null, destQuery: null },
+  estimatedTime: null,
 }
 
 export const EMPTY_BRIDGE_QUOTE_ZERO = {

--- a/packages/synapse-interface/constants/bridge.ts
+++ b/packages/synapse-interface/constants/bridge.ts
@@ -24,6 +24,7 @@ export const EMPTY_BRIDGE_QUOTE_ZERO = {
   feeAmount: 0n,
   delta: 0n,
   quotes: { originQuery: null, destQuery: null },
+  estimatedTime: null,
 }
 /**
  * ETH Only Bridge Config used to calculate swap fees

--- a/packages/synapse-interface/pages/state-managed-bridge/index.tsx
+++ b/packages/synapse-interface/pages/state-managed-bridge/index.tsx
@@ -193,6 +193,7 @@ const StateManagedBridge = () => {
         stringToBigInt(debouncedFromValue, fromToken.decimals[fromChainId])
       )
 
+      console.log('estimatedTime:', estimatedTime)
       // console.log(`[getAndSetQuote] fromChainId`, fromChainId)
       // console.log(`[getAndSetQuote] toChainId`, toChainId)
       // console.log(`[getAndSetQuote] fromToken.symbol`, fromToken.symbol)

--- a/packages/synapse-interface/pages/state-managed-bridge/index.tsx
+++ b/packages/synapse-interface/pages/state-managed-bridge/index.tsx
@@ -178,14 +178,20 @@ const StateManagedBridge = () => {
     try {
       dispatch(setIsLoading(true))
 
-      const { feeAmount, routerAddress, maxAmountOut, originQuery, destQuery } =
-        await synapseSDK.bridgeQuote(
-          fromChainId,
-          toChainId,
-          fromToken.addresses[fromChainId],
-          toToken.addresses[toChainId],
-          stringToBigInt(debouncedFromValue, fromToken.decimals[fromChainId])
-        )
+      const {
+        feeAmount,
+        routerAddress,
+        maxAmountOut,
+        originQuery,
+        destQuery,
+        estimatedTime,
+      } = await synapseSDK.bridgeQuote(
+        fromChainId,
+        toChainId,
+        fromToken.addresses[fromChainId],
+        toToken.addresses[toChainId],
+        stringToBigInt(debouncedFromValue, fromToken.decimals[fromChainId])
+      )
 
       // console.log(`[getAndSetQuote] fromChainId`, fromChainId)
       // console.log(`[getAndSetQuote] toChainId`, toChainId)
@@ -279,6 +285,7 @@ const StateManagedBridge = () => {
               originQuery: newOriginQuery,
               destQuery: newDestQuery,
             },
+            estimatedTime: estimatedTime,
           })
         )
 

--- a/packages/synapse-interface/utils/actions/fetchBridgeQuotes.tsx
+++ b/packages/synapse-interface/utils/actions/fetchBridgeQuotes.tsx
@@ -37,14 +37,20 @@ export async function fetchBridgeQuote(
         destinationToken,
         amount,
       }: BridgeQuoteRequest = request
-      const { feeAmount, routerAddress, maxAmountOut, originQuery, destQuery } =
-        await synapseSDK.bridgeQuote(
-          originChainId,
-          destinationChainId,
-          originToken.addresses[originChainId],
-          destinationTokenAddress,
-          amount
-        )
+      const {
+        feeAmount,
+        routerAddress,
+        maxAmountOut,
+        originQuery,
+        destQuery,
+        estimatedTime,
+      } = await synapseSDK.bridgeQuote(
+        originChainId,
+        destinationChainId,
+        originToken.addresses[originChainId],
+        destinationTokenAddress,
+        amount
+      )
 
       const toValueBigInt: bigint = BigInt(maxAmountOut.toString()) ?? 0n
       const originTokenDecimals: number = originToken.decimals[originChainId]
@@ -95,6 +101,7 @@ export async function fetchBridgeQuote(
         },
         destinationToken: request.destinationToken,
         destinationChainId: destinationChainId,
+        estimatedTime: estimatedTime,
       }
     } catch (error) {
       console.error('Error fetching bridge quote:', error)

--- a/packages/synapse-interface/utils/types/index.tsx
+++ b/packages/synapse-interface/utils/types/index.tsx
@@ -60,6 +60,7 @@ export type BridgeQuote = {
   feeAmount: bigint
   delta: bigint
   quotes: { originQuery: any; destQuery: any }
+  estimatedTime: number
 }
 interface TokensByChain {
   [cID: string]: Token[]


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**
A clear and concise description of the features you're adding in this pull request.

**Additional context**
Add any other context about the problem you're solving.

**Metadata**
- Fixes #[Link to Issue]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

New Features:
- Added an `estimatedTime` property to the `BridgeQuote` interface, providing users with an estimated time for the bridge quote.
- Updated the `fetchBridgeQuote` function to include `estimatedTime` in the returned object, enhancing the information available to users.
- Included `estimatedTime` in the state object in the `state-managed-bridge` page, improving the user interface with additional information.
- Added a console log statement for `estimatedTime` for better debugging and tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
b3f3e593d893f019846145053c97277ffc623e5d: [synapse-interface preview link ](https://sanguine-synapse-interface-8cf61a094-synapsecns.vercel.app)