### PR TITLE
Sdk: bridge module naming

### DIFF
--- a/packages/sdk-router/src/operations/bridge.ts
+++ b/packages/sdk-router/src/operations/bridge.ts
@@ -118,27 +118,27 @@ export async function bridgeQuote(
 }
 
 /**
- * Returns the estimated time for a bridge operation from a given origin chain using a given router.
+ * Returns the estimated time for a bridge operation from a given origin chain using a given bridge module.
  * This will be the estimated time for the bridge operation to be completed regardless of the destination chain,
  * or the bridge token.
  *
  * @param originChainId - The ID of the origin chain.
- * @param routerAddress - The address of the router deployed on the origin chain.
+ * @param bridgeNoduleName - The name of the bridge module.
  * @returns - The estimated time for a bridge operation, in seconds.
- * @throws - Will throw an error if the router address is unknown for the given chain.
+ * @throws - Will throw an error if the bridge module is unknown for the given chain.
  */
 export function getEstimatedTime(
   this: SynapseSDK,
   originChainId: number,
-  routerAddress: string
+  bridgeNoduleName: string
 ): number {
-  if (this.synapseRouterSet.getRouter(originChainId, routerAddress)) {
+  if (this.synapseRouterSet.bridgeModuleName === bridgeNoduleName) {
     return this.synapseRouterSet.getEstimatedTime(originChainId)
   }
-  if (this.synapseCCTPRouterSet.getRouter(originChainId, routerAddress)) {
+  if (this.synapseCCTPRouterSet.bridgeModuleName === bridgeNoduleName) {
     return this.synapseCCTPRouterSet.getEstimatedTime(originChainId)
   }
-  throw new Error('Unknown router address')
+  throw new Error('Unknown bridge module')
 }
 
 /**

--- a/packages/sdk-router/src/operations/bridge.ts
+++ b/packages/sdk-router/src/operations/bridge.ts
@@ -118,6 +118,26 @@ export async function bridgeQuote(
 }
 
 /**
+ * Returns the name of the bridge module that emits the given event.
+ * This will be either SynapseBridge or SynapseCCTP.
+ *
+ * @param eventName - The name of the event.
+ * @returns - The name of the bridge module.
+ */
+export function getBridgeModuleName(
+  this: SynapseSDK,
+  eventName: string
+): string {
+  if (this.synapseRouterSet.allEvents.includes(eventName)) {
+    return this.synapseRouterSet.bridgeModuleName
+  }
+  if (this.synapseCCTPRouterSet.allEvents.includes(eventName)) {
+    return this.synapseCCTPRouterSet.bridgeModuleName
+  }
+  throw new Error('Unknown event')
+}
+
+/**
  * Returns the estimated time for a bridge operation from a given origin chain using a given bridge module.
  * This will be the estimated time for the bridge operation to be completed regardless of the destination chain,
  * or the bridge token.

--- a/packages/sdk-router/src/router/routerSet.ts
+++ b/packages/sdk-router/src/router/routerSet.ts
@@ -31,6 +31,7 @@ export type RouterConstructor = new (
  */
 export abstract class RouterSet {
   abstract readonly bridgeModuleName: string
+  abstract readonly allEvents: string[]
 
   public routers: {
     [chainId: number]: Router

--- a/packages/sdk-router/src/router/routerSet.ts
+++ b/packages/sdk-router/src/router/routerSet.ts
@@ -25,12 +25,12 @@ export type RouterConstructor = new (
  *
  * The class children should provide the router addresses for each chain, as well as the Router constructor.
  *
- * @property routerName The name of the router set.
+ * @property bridgeModuleName The name of the bridge module used by the routers.
  * @property routers Collection of Router instances indexed by chainId.
  * @property providers Collection of Provider instances indexed by chainId.
  */
 export abstract class RouterSet {
-  abstract readonly routerName: string
+  abstract readonly bridgeModuleName: string
 
   public routers: {
     [chainId: number]: Router

--- a/packages/sdk-router/src/router/routerSet.ts
+++ b/packages/sdk-router/src/router/routerSet.ts
@@ -206,6 +206,7 @@ export abstract class RouterSet {
       originQuery,
       destQuery,
       estimatedTime,
+      bridgeModuleName: this.bridgeModuleName,
     }
   }
 }

--- a/packages/sdk-router/src/router/synapseCCTPRouterSet.test.ts
+++ b/packages/sdk-router/src/router/synapseCCTPRouterSet.test.ts
@@ -66,6 +66,10 @@ describe('SynapseCCTPRouterSet', () => {
     it('Does not create SynapseCCTPRouter instances for chains without providers', () => {
       expect(routerSet.routers[SupportedChainId.AVALANCHE]).toBeUndefined()
     })
+
+    it('Correct bridge module name', () => {
+      expect(routerSet.bridgeModuleName).toEqual('SynapseCCTP')
+    })
   })
 
   describe('getEstimatedTime', () => {

--- a/packages/sdk-router/src/router/synapseCCTPRouterSet.ts
+++ b/packages/sdk-router/src/router/synapseCCTPRouterSet.ts
@@ -9,6 +9,10 @@ import { CCTP_ROUTER_ADDRESS_MAP, MEDIAN_TIME_CCTP } from '../constants'
  */
 export class SynapseCCTPRouterSet extends RouterSet {
   public readonly bridgeModuleName = 'SynapseCCTP'
+  public readonly allEvents = [
+    'CircleRequestSentEvent',
+    'CircleRequestFulfilledEvent',
+  ]
 
   constructor(chains: ChainProvider[]) {
     super(chains, CCTP_ROUTER_ADDRESS_MAP, SynapseCCTPRouter)

--- a/packages/sdk-router/src/router/synapseCCTPRouterSet.ts
+++ b/packages/sdk-router/src/router/synapseCCTPRouterSet.ts
@@ -8,7 +8,7 @@ import { CCTP_ROUTER_ADDRESS_MAP, MEDIAN_TIME_CCTP } from '../constants'
  * Wrapper class for interacting with a SynapseCCTPRouter contracts deployed on multiple chains.
  */
 export class SynapseCCTPRouterSet extends RouterSet {
-  public readonly routerName = 'SynapseCCTPRouter'
+  public readonly bridgeModuleName = 'SynapseCCTP'
 
   constructor(chains: ChainProvider[]) {
     super(chains, CCTP_ROUTER_ADDRESS_MAP, SynapseCCTPRouter)

--- a/packages/sdk-router/src/router/synapseRouterSet.test.ts
+++ b/packages/sdk-router/src/router/synapseRouterSet.test.ts
@@ -53,6 +53,10 @@ describe('SynapseRouterSet', () => {
     it('Does not create SynapseRouter instances for chains without providers', () => {
       expect(routerSet.routers[SupportedChainId.AVALANCHE]).toBeUndefined()
     })
+
+    it('Correct bridge module name', () => {
+      expect(routerSet.bridgeModuleName).toEqual('SynapseBridge')
+    })
   })
 
   describe('getEstimatedTime', () => {

--- a/packages/sdk-router/src/router/synapseRouterSet.ts
+++ b/packages/sdk-router/src/router/synapseRouterSet.ts
@@ -8,7 +8,7 @@ import { MEDIAN_TIME_BRIDGE, ROUTER_ADDRESS_MAP } from '../constants'
  * Wrapper class for interacting with a SynapseRouter contracts deployed on multiple chains.
  */
 export class SynapseRouterSet extends RouterSet {
-  public readonly routerName = 'SynapseRouter'
+  public readonly bridgeModuleName = 'SynapseBridge'
 
   constructor(chains: ChainProvider[]) {
     super(chains, ROUTER_ADDRESS_MAP, SynapseRouter)

--- a/packages/sdk-router/src/router/synapseRouterSet.ts
+++ b/packages/sdk-router/src/router/synapseRouterSet.ts
@@ -9,6 +9,18 @@ import { MEDIAN_TIME_BRIDGE, ROUTER_ADDRESS_MAP } from '../constants'
  */
 export class SynapseRouterSet extends RouterSet {
   public readonly bridgeModuleName = 'SynapseBridge'
+  public readonly allEvents = [
+    'DepositEvent',
+    'RedeemEvent',
+    'WithdrawEvent',
+    'MintEvent',
+    'DepositAndSwapEvent',
+    'MintAndSwapEvent',
+    'RedeemAndSwapEvent',
+    'RedeemAndRemoveEvent',
+    'WithdrawAndRemoveEvent',
+    'RedeemV2Event',
+  ]
 
   constructor(chains: ChainProvider[]) {
     super(chains, ROUTER_ADDRESS_MAP, SynapseRouter)

--- a/packages/sdk-router/src/router/types.ts
+++ b/packages/sdk-router/src/router/types.ts
@@ -71,6 +71,7 @@ export type BridgeQuote = {
   originQuery: Query
   destQuery: Query
   estimatedTime: number
+  bridgeModuleName: string
 }
 
 /**

--- a/packages/sdk-router/src/sdk.test.ts
+++ b/packages/sdk-router/src/sdk.test.ts
@@ -695,69 +695,64 @@ describe('SynapseSDK', () => {
 
   describe('getEstimatedTime', () => {
     const synapse = new SynapseSDK(
-      [
-        SupportedChainId.ETH,
-        SupportedChainId.ARBITRUM,
-        SupportedChainId.MOONBEAM,
-      ],
-      [ethProvider, arbProvider, moonbeamProvider]
+      [SupportedChainId.ETH, SupportedChainId.MOONBEAM],
+      [ethProvider, moonbeamProvider]
     )
 
-    it('Returns estimated time for SynapseBridge', () => {
-      expect(
-        synapse.getEstimatedTime(
-          SupportedChainId.ETH,
-          ROUTER_ADDRESS_MAP[SupportedChainId.ETH]
-        )
-      ).toEqual(MEDIAN_TIME_BRIDGE[SupportedChainId.ETH])
+    describe('Chain with a provider', () => {
+      it('Returns estimated time for SynapseBridge', () => {
+        expect(
+          synapse.getEstimatedTime(SupportedChainId.ETH, 'SynapseBridge')
+        ).toEqual(MEDIAN_TIME_BRIDGE[SupportedChainId.ETH])
 
-      expect(
-        synapse.getEstimatedTime(
-          SupportedChainId.ARBITRUM,
-          ROUTER_ADDRESS_MAP[SupportedChainId.ARBITRUM]
-        )
-      ).toEqual(MEDIAN_TIME_BRIDGE[SupportedChainId.ARBITRUM])
+        expect(
+          synapse.getEstimatedTime(SupportedChainId.MOONBEAM, 'SynapseBridge')
+        ).toEqual(MEDIAN_TIME_BRIDGE[SupportedChainId.MOONBEAM])
+      })
 
-      expect(
-        synapse.getEstimatedTime(
-          SupportedChainId.MOONBEAM,
-          ROUTER_ADDRESS_MAP[SupportedChainId.MOONBEAM]
-        )
-      ).toEqual(MEDIAN_TIME_BRIDGE[SupportedChainId.MOONBEAM])
+      it('Returns estimated time for SynapseCCTP', () => {
+        expect(
+          synapse.getEstimatedTime(SupportedChainId.ETH, 'SynapseCCTP')
+        ).toEqual(MEDIAN_TIME_CCTP[SupportedChainId.ETH])
+      })
+
+      it('Throws when bridge module does not exist on a chain', () => {
+        expect(() =>
+          synapse.getEstimatedTime(SupportedChainId.MOONBEAM, 'SynapseCCTP')
+        ).toThrow('No estimated time for chain 1284')
+      })
+
+      it('Throws when bridge module name is invalid', () => {
+        expect(() =>
+          synapse.getEstimatedTime(SupportedChainId.ETH, 'SynapseSynapse')
+        ).toThrow('Unknown bridge module')
+      })
     })
 
-    it('Returns estimated time for SynapseCCTP', () => {
-      expect(
-        synapse.getEstimatedTime(
-          SupportedChainId.ETH,
-          CCTP_ROUTER_ADDRESS_MAP[SupportedChainId.ETH]
-        )
-      ).toEqual(MEDIAN_TIME_CCTP[SupportedChainId.ETH])
+    describe('Chain without a provider', () => {
+      it('Returns estimated time for SynapseBridge', () => {
+        expect(
+          synapse.getEstimatedTime(SupportedChainId.BSC, 'SynapseBridge')
+        ).toEqual(MEDIAN_TIME_BRIDGE[SupportedChainId.BSC])
+      })
 
-      expect(
-        synapse.getEstimatedTime(
-          SupportedChainId.ARBITRUM,
-          CCTP_ROUTER_ADDRESS_MAP[SupportedChainId.ARBITRUM]
-        )
-      ).toEqual(MEDIAN_TIME_CCTP[SupportedChainId.ARBITRUM])
-    })
+      it('Returns estimated time for SynapseCCTP', () => {
+        expect(
+          synapse.getEstimatedTime(SupportedChainId.ARBITRUM, 'SynapseCCTP')
+        ).toEqual(MEDIAN_TIME_CCTP[SupportedChainId.ARBITRUM])
+      })
 
-    it('Throws for chain without a provider', () => {
-      expect(() =>
-        synapse.getEstimatedTime(
-          SupportedChainId.AVALANCHE,
-          ROUTER_ADDRESS_MAP[SupportedChainId.AVALANCHE]
-        )
-      ).toThrow('Unknown router address')
-    })
+      it('Throws when bridge module does not exist on a chain', () => {
+        expect(() =>
+          synapse.getEstimatedTime(SupportedChainId.DOGECHAIN, 'SynapseCCTP')
+        ).toThrow('No estimated time for chain 2000')
+      })
 
-    it('Throws for unknown router address', () => {
-      expect(() =>
-        synapse.getEstimatedTime(
-          SupportedChainId.MOONBEAM,
-          CCTP_ROUTER_ADDRESS_MAP[SupportedChainId.ETH]
-        )
-      ).toThrow('Unknown router address')
+      it('Throws when bridge module name is invalid', () => {
+        expect(() =>
+          synapse.getEstimatedTime(SupportedChainId.BSC, 'SynapseSynapse')
+        ).toThrow('Unknown bridge module')
+      })
     })
   })
 

--- a/packages/sdk-router/src/sdk.test.ts
+++ b/packages/sdk-router/src/sdk.test.ts
@@ -698,7 +698,7 @@ describe('SynapseSDK', () => {
 
     // https://github.com/synapsecns/synapse-contracts/blob/3f592a879baa4487a62ca8d2cfd44d329bc22e62/contracts/bridge/SynapseBridge.sol#L63-L121
     describe('SynapseBridge events', () => {
-      const eventNames = [
+      const contractEvents = [
         'TokenDeposit',
         'TokenRedeem',
         'TokenWithdraw',
@@ -711,11 +711,12 @@ describe('SynapseSDK', () => {
         'TokenRedeemV2',
       ]
 
-      eventNames.forEach((eventName) => {
-        it(eventName, () => {
+      contractEvents.forEach((contractEvent) => {
+        it(contractEvent, () => {
+          // Event naming in contract and explorer is a bit different
           // schema: TokenDeposit => DepositEvent
-          const explorerEventName = `${eventName.slice(5)}Event`
-          expect(synapse.getBridgeModuleName(explorerEventName)).toEqual(
+          const explorerEvent = `${contractEvent.slice(5)}Event`
+          expect(synapse.getBridgeModuleName(explorerEvent)).toEqual(
             'SynapseBridge'
           )
         })
@@ -724,13 +725,14 @@ describe('SynapseSDK', () => {
 
     // https://github.com/synapsecns/synapse-contracts/blob/3f592a879baa4487a62ca8d2cfd44d329bc22e62/contracts/cctp/events/SynapseCCTPEvents.sol#L5-L45
     describe('SynapseCCTP events', () => {
-      const eventNames = ['CircleRequestSent', 'CircleRequestFulfilled']
+      const contractEvents = ['CircleRequestSent', 'CircleRequestFulfilled']
 
-      eventNames.forEach((eventName) => {
-        it(eventName, () => {
+      contractEvents.forEach((contractEvent) => {
+        it(contractEvent, () => {
+          // Event naming in contract and explorer is a bit different
           // schema: CircleRequestSent => CircleRequestSentEvent
-          const explorerEventName = `${eventName}Event`
-          expect(synapse.getBridgeModuleName(explorerEventName)).toEqual(
+          const explorerEvent = `${contractEvent}Event`
+          expect(synapse.getBridgeModuleName(explorerEvent)).toEqual(
             'SynapseCCTP'
           )
         })

--- a/packages/sdk-router/src/sdk.test.ts
+++ b/packages/sdk-router/src/sdk.test.ts
@@ -268,6 +268,7 @@ describe('SynapseSDK', () => {
           expect(result.estimatedTime).toEqual(
             MEDIAN_TIME_CCTP[SupportedChainId.ETH]
           )
+          expect(result.bridgeModuleName).toEqual('SynapseCCTP')
         })
       })
     })
@@ -306,6 +307,7 @@ describe('SynapseSDK', () => {
           expect(result.estimatedTime).toEqual(
             MEDIAN_TIME_CCTP[SupportedChainId.ETH]
           )
+          expect(result.bridgeModuleName).toEqual('SynapseCCTP')
         })
       })
     })
@@ -344,6 +346,7 @@ describe('SynapseSDK', () => {
           expect(result.estimatedTime).toEqual(
             MEDIAN_TIME_BRIDGE[SupportedChainId.ETH]
           )
+          expect(result.bridgeModuleName).toEqual('SynapseBridge')
         })
       })
     })
@@ -385,6 +388,7 @@ describe('SynapseSDK', () => {
           expect(result.estimatedTime).toEqual(
             MEDIAN_TIME_BRIDGE[SupportedChainId.AVALANCHE]
           )
+          expect(result.bridgeModuleName).toEqual('SynapseBridge')
         })
       })
     })
@@ -419,6 +423,7 @@ describe('SynapseSDK', () => {
           expect(result.estimatedTime).toEqual(
             MEDIAN_TIME_BRIDGE[SupportedChainId.AVALANCHE]
           )
+          expect(result.bridgeModuleName).toEqual('SynapseBridge')
         })
       })
     })
@@ -460,6 +465,7 @@ describe('SynapseSDK', () => {
           expect(result.estimatedTime).toEqual(
             MEDIAN_TIME_BRIDGE[SupportedChainId.ARBITRUM]
           )
+          expect(result.bridgeModuleName).toEqual('SynapseBridge')
         })
       })
     })
@@ -494,6 +500,7 @@ describe('SynapseSDK', () => {
           expect(result.estimatedTime).toEqual(
             MEDIAN_TIME_CCTP[SupportedChainId.ARBITRUM]
           )
+          expect(result.bridgeModuleName).toEqual('SynapseCCTP')
         })
       })
     })
@@ -536,6 +543,7 @@ describe('SynapseSDK', () => {
           expect(result.estimatedTime).toEqual(
             MEDIAN_TIME_BRIDGE[SupportedChainId.BSC]
           )
+          expect(result.bridgeModuleName).toEqual('SynapseBridge')
         })
       })
     })
@@ -570,6 +578,7 @@ describe('SynapseSDK', () => {
           expect(result.estimatedTime).toEqual(
             MEDIAN_TIME_BRIDGE[SupportedChainId.BSC]
           )
+          expect(result.bridgeModuleName).toEqual('SynapseBridge')
         })
       })
     })

--- a/packages/sdk-router/src/sdk.test.ts
+++ b/packages/sdk-router/src/sdk.test.ts
@@ -693,6 +693,120 @@ describe('SynapseSDK', () => {
     )
   })
 
+  describe('getBridgeModuleName', () => {
+    const synapse = new SynapseSDK([], [])
+
+    // https://github.com/synapsecns/synapse-contracts/blob/3f592a879baa4487a62ca8d2cfd44d329bc22e62/contracts/bridge/SynapseBridge.sol#L63-L121
+    describe('SynapseBridge events', () => {
+      // schema: TokenDeposit => DepositEvent
+      const transformBridgeEventName = (contractEventName: string) => {
+        // Remove 'Token' prefix, then add 'Event' suffix
+        return `${contractEventName.slice(5)}Event`
+      }
+
+      it('TokenDeposit', () => {
+        expect(
+          synapse.getBridgeModuleName(transformBridgeEventName('TokenDeposit'))
+        ).toEqual('SynapseBridge')
+      })
+
+      it('TokenRedeem', () => {
+        expect(
+          synapse.getBridgeModuleName(transformBridgeEventName('TokenRedeem'))
+        ).toEqual('SynapseBridge')
+      })
+
+      it('TokenWithdraw', () => {
+        expect(
+          synapse.getBridgeModuleName(transformBridgeEventName('TokenWithdraw'))
+        ).toEqual('SynapseBridge')
+      })
+
+      it('TokenMint', () => {
+        expect(
+          synapse.getBridgeModuleName(transformBridgeEventName('TokenMint'))
+        ).toEqual('SynapseBridge')
+      })
+
+      it('TokenDepositAndSwap', () => {
+        expect(
+          synapse.getBridgeModuleName(
+            transformBridgeEventName('TokenDepositAndSwap')
+          )
+        ).toEqual('SynapseBridge')
+      })
+
+      it('TokenMintAndSwap', () => {
+        expect(
+          synapse.getBridgeModuleName(
+            transformBridgeEventName('TokenMintAndSwap')
+          )
+        ).toEqual('SynapseBridge')
+      })
+
+      it('TokenRedeemAndSwap', () => {
+        expect(
+          synapse.getBridgeModuleName(
+            transformBridgeEventName('TokenRedeemAndSwap')
+          )
+        ).toEqual('SynapseBridge')
+      })
+
+      it('TokenRedeemAndRemove', () => {
+        expect(
+          synapse.getBridgeModuleName(
+            transformBridgeEventName('TokenRedeemAndRemove')
+          )
+        ).toEqual('SynapseBridge')
+      })
+
+      it('TokenWithdrawAndRemove', () => {
+        expect(
+          synapse.getBridgeModuleName(
+            transformBridgeEventName('TokenWithdrawAndRemove')
+          )
+        ).toEqual('SynapseBridge')
+      })
+
+      it('TokenRedeemV2', () => {
+        expect(
+          synapse.getBridgeModuleName(transformBridgeEventName('TokenRedeemV2'))
+        ).toEqual('SynapseBridge')
+      })
+    })
+
+    // https://github.com/synapsecns/synapse-contracts/blob/3f592a879baa4487a62ca8d2cfd44d329bc22e62/contracts/cctp/events/SynapseCCTPEvents.sol#L5-L45
+    describe('SynapseCCTP events', () => {
+      // schema: CircleRequestSent => CircleRequestSentEvent
+      const transformCCTPEventName = (contractEventName: string) => {
+        // Add 'Event' suffix
+        return `${contractEventName}Event`
+      }
+
+      it('CircleRequestSent', () => {
+        expect(
+          synapse.getBridgeModuleName(
+            transformCCTPEventName('CircleRequestSent')
+          )
+        ).toEqual('SynapseCCTP')
+      })
+
+      it('CircleRequestFulfilled', () => {
+        expect(
+          synapse.getBridgeModuleName(
+            transformCCTPEventName('CircleRequestFulfilled')
+          )
+        ).toEqual('SynapseCCTP')
+      })
+    })
+
+    it('Throws when event name is unknown', () => {
+      expect(() => synapse.getBridgeModuleName('SomeUnknownEvent')).toThrow(
+        'Unknown event'
+      )
+    })
+  })
+
   describe('getEstimatedTime', () => {
     const synapse = new SynapseSDK(
       [SupportedChainId.ETH, SupportedChainId.MOONBEAM],

--- a/packages/sdk-router/src/sdk.test.ts
+++ b/packages/sdk-router/src/sdk.test.ts
@@ -698,105 +698,42 @@ describe('SynapseSDK', () => {
 
     // https://github.com/synapsecns/synapse-contracts/blob/3f592a879baa4487a62ca8d2cfd44d329bc22e62/contracts/bridge/SynapseBridge.sol#L63-L121
     describe('SynapseBridge events', () => {
-      // schema: TokenDeposit => DepositEvent
-      const transformBridgeEventName = (contractEventName: string) => {
-        // Remove 'Token' prefix, then add 'Event' suffix
-        return `${contractEventName.slice(5)}Event`
-      }
+      const eventNames = [
+        'TokenDeposit',
+        'TokenRedeem',
+        'TokenWithdraw',
+        'TokenMint',
+        'TokenDepositAndSwap',
+        'TokenMintAndSwap',
+        'TokenRedeemAndSwap',
+        'TokenRedeemAndRemove',
+        'TokenWithdrawAndRemove',
+        'TokenRedeemV2',
+      ]
 
-      it('TokenDeposit', () => {
-        expect(
-          synapse.getBridgeModuleName(transformBridgeEventName('TokenDeposit'))
-        ).toEqual('SynapseBridge')
-      })
-
-      it('TokenRedeem', () => {
-        expect(
-          synapse.getBridgeModuleName(transformBridgeEventName('TokenRedeem'))
-        ).toEqual('SynapseBridge')
-      })
-
-      it('TokenWithdraw', () => {
-        expect(
-          synapse.getBridgeModuleName(transformBridgeEventName('TokenWithdraw'))
-        ).toEqual('SynapseBridge')
-      })
-
-      it('TokenMint', () => {
-        expect(
-          synapse.getBridgeModuleName(transformBridgeEventName('TokenMint'))
-        ).toEqual('SynapseBridge')
-      })
-
-      it('TokenDepositAndSwap', () => {
-        expect(
-          synapse.getBridgeModuleName(
-            transformBridgeEventName('TokenDepositAndSwap')
+      eventNames.forEach((eventName) => {
+        it(eventName, () => {
+          // schema: TokenDeposit => DepositEvent
+          const explorerEventName = `${eventName.slice(5)}Event`
+          expect(synapse.getBridgeModuleName(explorerEventName)).toEqual(
+            'SynapseBridge'
           )
-        ).toEqual('SynapseBridge')
-      })
-
-      it('TokenMintAndSwap', () => {
-        expect(
-          synapse.getBridgeModuleName(
-            transformBridgeEventName('TokenMintAndSwap')
-          )
-        ).toEqual('SynapseBridge')
-      })
-
-      it('TokenRedeemAndSwap', () => {
-        expect(
-          synapse.getBridgeModuleName(
-            transformBridgeEventName('TokenRedeemAndSwap')
-          )
-        ).toEqual('SynapseBridge')
-      })
-
-      it('TokenRedeemAndRemove', () => {
-        expect(
-          synapse.getBridgeModuleName(
-            transformBridgeEventName('TokenRedeemAndRemove')
-          )
-        ).toEqual('SynapseBridge')
-      })
-
-      it('TokenWithdrawAndRemove', () => {
-        expect(
-          synapse.getBridgeModuleName(
-            transformBridgeEventName('TokenWithdrawAndRemove')
-          )
-        ).toEqual('SynapseBridge')
-      })
-
-      it('TokenRedeemV2', () => {
-        expect(
-          synapse.getBridgeModuleName(transformBridgeEventName('TokenRedeemV2'))
-        ).toEqual('SynapseBridge')
+        })
       })
     })
 
     // https://github.com/synapsecns/synapse-contracts/blob/3f592a879baa4487a62ca8d2cfd44d329bc22e62/contracts/cctp/events/SynapseCCTPEvents.sol#L5-L45
     describe('SynapseCCTP events', () => {
-      // schema: CircleRequestSent => CircleRequestSentEvent
-      const transformCCTPEventName = (contractEventName: string) => {
-        // Add 'Event' suffix
-        return `${contractEventName}Event`
-      }
+      const eventNames = ['CircleRequestSent', 'CircleRequestFulfilled']
 
-      it('CircleRequestSent', () => {
-        expect(
-          synapse.getBridgeModuleName(
-            transformCCTPEventName('CircleRequestSent')
+      eventNames.forEach((eventName) => {
+        it(eventName, () => {
+          // schema: CircleRequestSent => CircleRequestSentEvent
+          const explorerEventName = `${eventName}Event`
+          expect(synapse.getBridgeModuleName(explorerEventName)).toEqual(
+            'SynapseCCTP'
           )
-        ).toEqual('SynapseCCTP')
-      })
-
-      it('CircleRequestFulfilled', () => {
-        expect(
-          synapse.getBridgeModuleName(
-            transformCCTPEventName('CircleRequestFulfilled')
-          )
-        ).toEqual('SynapseCCTP')
+        })
       })
     })
 

--- a/packages/sdk-router/src/sdk.ts
+++ b/packages/sdk-router/src/sdk.ts
@@ -46,6 +46,7 @@ class SynapseSDK {
   // Define Bridge operations
   public bridge = operations.bridge
   public bridgeQuote = operations.bridgeQuote
+  public getBridgeModuleName = operations.getBridgeModuleName
   public getEstimatedTime = operations.getEstimatedTime
 
   public getBridgeGas = operations.getBridgeGas


### PR DESCRIPTION
**Description**
This PR introduces the concept of bridge module naming, with the currently supported values being SynapseBridge and SynapseCCTP. The bridge module name is returned along with the bridge quote, and could potentially be used in the future to retrieve the estimated completion time.

In addition, a mapping from event name to bridge module name has been implemented. This allows for the front-end update to proceed without requiring changes to the explorer API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

New Features:
- Added `getBridgeModuleName` and `getEstimatedTime` functions to enhance bridge operation handling in the SDK.
- Introduced `bridgeModuleName` property to `RouterSet` and `BridgeQuote` for better module identification.

Refactor:
- Renamed `routerName` to `bridgeModuleName` in `RouterSet` for consistency.
- Added `allEvents` property to `RouterSet` classes to list all event names.

Tests:
- Added test cases for `bridgeModuleName` in `SynapseCCTPRouterSet` and `SynapseRouterSet` to ensure correct module identification.
- Updated `SynapseSDK` tests to cover new functions and changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->