### PR TITLE
Fixes destructure typing mismatch on using prepareWriteContract

### DIFF
--- a/packages/synapse-interface/actions/harvestLpPool.ts
+++ b/packages/synapse-interface/actions/harvestLpPool.ts
@@ -19,7 +19,7 @@ export const harvestLpPool = async ({
   poolId: number
   lpAddress: Address
 }) => {
-  const config = await prepareWriteContract({
+  const { request } = await prepareWriteContract({
     chainId,
     address: lpAddress,
     abi: MINICHEF_ABI,
@@ -27,7 +27,7 @@ export const harvestLpPool = async ({
     args: [poolId, address],
   })
 
-  const { hash } = await writeContract({ config })
+  const { hash } = await writeContract(request)
   const txReceipt: TransactionReceipt = await waitForTransaction({ hash })
 
   return txReceipt

--- a/packages/synapse-interface/actions/stakeLpToken.ts
+++ b/packages/synapse-interface/actions/stakeLpToken.ts
@@ -21,7 +21,7 @@ export const stakeLpToken = async ({
   amount: bigint
   lpAddress: Address
 }) => {
-  const config = await prepareWriteContract({
+  const { request } = await prepareWriteContract({
     chainId,
     address: lpAddress,
     abi: MINICHEF_ABI,
@@ -29,7 +29,7 @@ export const stakeLpToken = async ({
     args: [poolId, amount, address],
   })
 
-  const { hash } = await writeContract({ config })
+  const { hash } = await writeContract(request)
   const txReceipt: TransactionReceipt = await waitForTransaction({ hash })
 
   return txReceipt

--- a/packages/synapse-interface/actions/swapPoolAddLiquidity.ts
+++ b/packages/synapse-interface/actions/swapPoolAddLiquidity.ts
@@ -42,9 +42,9 @@ export const swapPoolAddLiquidity = async ({
     pwcConfig = pwcBaseConfig
   }
 
-  const config = await prepareWriteContract(pwcConfig)
+  const { request } = await prepareWriteContract(pwcConfig)
 
-  const { hash } = await writeContract({ config })
+  const { hash } = await writeContract(request)
   const txReceipt: TransactionReceipt = await waitForTransaction({ hash })
 
   return txReceipt

--- a/packages/synapse-interface/actions/swapPoolRemoveLiquidity.ts
+++ b/packages/synapse-interface/actions/swapPoolRemoveLiquidity.ts
@@ -26,7 +26,7 @@ export const swapPoolRemoveLiquidity = async ({
 }) => {
   const { abi, poolAddress } = getSwapDepositContractFields(pool, chainId)
 
-  const config = await prepareWriteContract({
+  const { request } = await prepareWriteContract({
     chainId,
     address: poolAddress,
     abi,
@@ -44,7 +44,7 @@ export const swapPoolRemoveLiquidity = async ({
     ],
   })
 
-  const { hash } = await writeContract({ config })
+  const { hash } = await writeContract(request)
   const txReceipt: TransactionReceipt = await waitForTransaction({ hash })
 
   return txReceipt

--- a/packages/synapse-interface/actions/swapPoolRemoveLiquidityOneToken.ts
+++ b/packages/synapse-interface/actions/swapPoolRemoveLiquidityOneToken.ts
@@ -28,7 +28,7 @@ export const swapPoolRemoveLiquidityOneToken = async ({
 }) => {
   const { abi, poolAddress } = getSwapDepositContractFields(pool, chainId)
 
-  const config = await prepareWriteContract({
+  const { request } = await prepareWriteContract({
     chainId,
     address: poolAddress,
     abi,
@@ -45,7 +45,7 @@ export const swapPoolRemoveLiquidityOneToken = async ({
     ],
   })
 
-  const { hash } = await writeContract({ config })
+  const { hash } = await writeContract(request)
   const txReceipt: TransactionReceipt = await waitForTransaction({ hash })
 
   return txReceipt

--- a/packages/synapse-interface/actions/unstakeLpToken.ts
+++ b/packages/synapse-interface/actions/unstakeLpToken.ts
@@ -21,7 +21,7 @@ export const unstakeLpToken = async ({
   amount: bigint
   lpAddress: Address
 }) => {
-  const config = await prepareWriteContract({
+  const { request } = await prepareWriteContract({
     chainId,
     address: lpAddress,
     abi: MINICHEF_ABI,
@@ -29,7 +29,7 @@ export const unstakeLpToken = async ({
     args: [poolId, amount, address],
   })
 
-  const { hash } = await writeContract({ config })
+  const { hash } = await writeContract(request)
   const txReceipt: TransactionReceipt = await waitForTransaction({ hash })
 
   return txReceipt


### PR DESCRIPTION
- Fixes destructuring issue related to viem/wagmi upgrade. `prepareWriteContract` require a particular format of `const { request } = await prepareWriteContract({...})` where `writeContract` expects its input to be named `request`.

From docs: https://wagmi.sh/core/actions/prepareWriteContract

add67bec5fff5360016610803ff0cd080425ba3d: [synapse-interface preview link ](https://sanguine-synapse-interface-ma0onamvo-synapsecns.vercel.app)