### PR TITLE
Read raw `value`

### DIFF
--- a/packages/synapse-interface/components/Portfolio/Transaction/MostRecentTransaction.tsx
+++ b/packages/synapse-interface/components/Portfolio/Transaction/MostRecentTransaction.tsx
@@ -179,7 +179,7 @@ export const MostRecentTransaction = () => {
             startedTimestamp={transaction?.fromInfo?.time as number}
             transactionHash={transaction?.fromInfo?.txnHash as string}
             transactionType={TransactionType.PENDING}
-            originValue={transaction?.fromInfo?.formattedValue as number}
+            originValue={transaction?.fromInfo?.value as number}
             originChain={CHAINS_BY_ID[transaction?.fromInfo?.chainID] as Chain}
             destinationChain={
               CHAINS_BY_ID[transaction?.fromInfo?.destinationChainID] as Chain
@@ -225,8 +225,8 @@ export const MostRecentTransaction = () => {
             transactionHash={transaction?.fromInfo?.txnHash as string}
             kappa={transaction?.kappa as string}
             transactionType={TransactionType.PENDING}
-            originValue={transaction?.fromInfo?.formattedValue as number}
-            destinationValue={transaction?.toInfo?.formattedValue as number}
+            originValue={transaction?.fromInfo?.value as number}
+            destinationValue={transaction?.toInfo?.value as number}
             originChain={CHAINS_BY_ID[transaction?.fromInfo?.chainID] as Chain}
             destinationChain={
               CHAINS_BY_ID[transaction?.fromInfo?.destinationChainID] as Chain


### PR DESCRIPTION
Utilize `BridgeTransaction.fromInfo.value` (raw value) so fallback queries can show accurate values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the 'Most Recent Transaction' component to display accurate transaction values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
6c922332356a200cdd814c0bdb09134450571162: [synapse-interface preview link ](https://sanguine-synapse-interface-jpaxjxdyo-synapsecns.vercel.app)