### PR TITLE
Fe/move pending bridge transactions

### DIFF
--- a/packages/synapse-interface/components/Portfolio/Activity.tsx
+++ b/packages/synapse-interface/components/Portfolio/Activity.tsx
@@ -10,8 +10,6 @@ import { tokenAddressToToken } from '@/constants/tokens'
 import { TransactionsState } from '@/slices/transactions/reducer'
 import { PortfolioState } from '@/slices/portfolio/reducer'
 import { PendingBridgeTransaction } from '@/slices/transactions/actions'
-import { BridgeState } from '@/slices/bridge/reducer'
-import { useBridgeState } from '@/slices/bridge/hooks'
 import { Transaction, TransactionType } from './Transaction/Transaction'
 import { PendingTransaction } from './Transaction/PendingTransaction'
 import { UserExplorerLink } from './Transaction/components/TransactionExplorerLink'
@@ -328,7 +326,8 @@ export const Activity = ({ visibility }: { visibility: boolean }) => {
 
 export const PendingTransactionAwaitingIndexing = () => {
   const { address } = useAccount()
-  const { pendingBridgeTransactions }: BridgeState = useBridgeState()
+  const { pendingBridgeTransactions }: TransactionsState =
+    useTransactionsState()
   return (
     <>
       {pendingBridgeTransactions.map(

--- a/packages/synapse-interface/components/Portfolio/Activity.tsx
+++ b/packages/synapse-interface/components/Portfolio/Activity.tsx
@@ -9,7 +9,7 @@ import { Chain, Token } from '@/utils/types'
 import { tokenAddressToToken } from '@/constants/tokens'
 import { TransactionsState } from '@/slices/transactions/reducer'
 import { PortfolioState } from '@/slices/portfolio/reducer'
-import { PendingBridgeTransaction } from '@/slices/bridge/actions'
+import { PendingBridgeTransaction } from '@/slices/transactions/actions'
 import { BridgeState } from '@/slices/bridge/reducer'
 import { useBridgeState } from '@/slices/bridge/hooks'
 import { Transaction, TransactionType } from './Transaction/Transaction'
@@ -27,8 +27,8 @@ export const Activity = ({ visibility }: { visibility: boolean }) => {
     pendingAwaitingCompletionTransactions,
     fallbackQueryPendingTransactions,
     fallbackQueryHistoricalTransactions,
+    pendingBridgeTransactions,
   }: TransactionsState = useTransactionsState()
-  const { pendingBridgeTransactions }: BridgeState = useBridgeState()
   const { searchInput, searchedBalancesAndAllowances }: PortfolioState =
     usePortfolioState()
 

--- a/packages/synapse-interface/components/Portfolio/Portfolio.tsx
+++ b/packages/synapse-interface/components/Portfolio/Portfolio.tsx
@@ -24,11 +24,11 @@ import { resetTransactionsState } from '@/slices/transactions/actions'
 import { PortfolioState } from '@/slices/portfolio/reducer'
 import { useBridgeState } from '@/slices/bridge/hooks'
 import { BridgeState } from '@/slices/bridge/reducer'
-import { isValidAddress } from '@/utils/isValidAddress'
-import { Activity } from './Activity'
-import { ViewSearchAddressBanner } from './SearchBar'
 import { resetBridgeInputs } from '@/slices/bridge/actions'
 import { resetReduxCache } from '@/slices/application/actions'
+import { isValidAddress } from '@/utils/isValidAddress'
+import { ViewSearchAddressBanner } from './SearchBar'
+import { Activity } from './Activity'
 
 export const Portfolio = () => {
   const dispatch = useAppDispatch()

--- a/packages/synapse-interface/components/Portfolio/Transaction/MostRecentTransaction.tsx
+++ b/packages/synapse-interface/components/Portfolio/Transaction/MostRecentTransaction.tsx
@@ -1,13 +1,11 @@
 import { useState, useEffect, useMemo } from 'react'
 import { useAccount, Address } from 'wagmi'
 import { Chain, Token } from '@/utils/types'
-import { useBridgeState } from '@/slices/bridge/hooks'
 import { useTransactionsState } from '@/slices/transactions/hooks'
 import { usePortfolioState } from '@/slices/portfolio/hooks'
 import { PortfolioState } from '@/slices/portfolio/reducer'
-import { BridgeState } from '@/slices/bridge/reducer'
 import { TransactionsState } from '@/slices/transactions/reducer'
-import { PendingBridgeTransaction } from '@/slices/bridge/actions'
+import { PendingBridgeTransaction } from '@/slices/transactions/actions'
 import { BridgeTransaction } from '@/slices/api/generated'
 import { getTimeMinutesBeforeNow } from '@/utils/time'
 import { TransactionType } from './Transaction'
@@ -18,7 +16,6 @@ import { checkTransactionsExist } from '@/utils/checkTransactionsExist'
 
 export const MostRecentTransaction = () => {
   const { address } = useAccount()
-  const { pendingBridgeTransactions }: BridgeState = useBridgeState()
   const {
     userHistoricalTransactions,
     isUserHistoricalTransactionsLoading,
@@ -27,6 +24,7 @@ export const MostRecentTransaction = () => {
     pendingAwaitingCompletionTransactions,
     fallbackQueryHistoricalTransactions,
     fallbackQueryPendingTransactions,
+    pendingBridgeTransactions,
   }: TransactionsState = useTransactionsState()
   const { searchInput, searchedBalancesAndAllowances }: PortfolioState =
     usePortfolioState()

--- a/packages/synapse-interface/components/Portfolio/Transaction/PendingTransaction.tsx
+++ b/packages/synapse-interface/components/Portfolio/Transaction/PendingTransaction.tsx
@@ -5,7 +5,7 @@ import { useAppDispatch } from '@/store/hooks'
 import {
   removePendingBridgeTransaction,
   updatePendingBridgeTransaction,
-} from '@/slices/bridge/actions'
+} from '@/slices/transactions/actions'
 import { BridgeType } from '@/slices/api/generated'
 import { getTimeMinutesFromNow } from '@/utils/time'
 import { ARBITRUM, ETH } from '@/constants/chains/master'

--- a/packages/synapse-interface/pages/state-managed-bridge/index.tsx
+++ b/packages/synapse-interface/pages/state-managed-bridge/index.tsx
@@ -56,26 +56,21 @@ import { Address, zeroAddress } from 'viem'
 import { stringToBigInt } from '@/utils/bigint/format'
 import { Warning } from '@/components/Warning'
 import { useAppDispatch } from '@/store/hooks'
-import { NetworkTokenBalancesAndAllowances } from '@/utils/actions/fetchPortfolioBalances'
 import {
   fetchAndStoreSingleTokenAllowance,
-  fetchAndStoreSingleTokenBalance,
   useFetchPortfolioBalances,
 } from '@/slices/portfolio/hooks'
 import {
   updatePendingBridgeTransaction,
   addPendingBridgeTransaction,
   removePendingBridgeTransaction,
-  PendingBridgeTransaction,
-} from '@/slices/bridge/actions'
+} from '@/slices/transactions/actions'
 import { getTimeMinutesFromNow } from '@/utils/time'
-import { FetchState } from '@/slices/portfolio/actions'
 import { updateSingleTokenAllowance } from '@/slices/portfolio/actions'
 import { FromChainListOverlay } from '@/components/StateManagedBridge/FromChainListOverlay'
 import { ToChainListOverlay } from '@/components/StateManagedBridge/ToChainListOverlay'
 import { FromTokenListOverlay } from '@/components/StateManagedBridge/FromTokenListOverlay'
 import { ToTokenListOverlay } from '@/components/StateManagedBridge/ToTokenListOverlay'
-import { checkTransactionsExist } from '@/utils/checkTransactionsExist'
 
 const StateManagedBridge = () => {
   const { address } = useAccount()
@@ -102,9 +97,7 @@ const StateManagedBridge = () => {
     toChainIds,
     fromTokens,
     toTokens,
-    pendingBridgeTransactions,
   }: BridgeState = useBridgeState()
-
   const {
     showSettingsSlideOver,
     showDestinationAddress,

--- a/packages/synapse-interface/slices/bridge/actions.ts
+++ b/packages/synapse-interface/slices/bridge/actions.ts
@@ -1,42 +1,12 @@
 import { createAction } from '@reduxjs/toolkit'
 
-// import { Chain, Token } from '@/utils/types'
-
-// export interface PendingBridgeTransaction {
-//   id: number
-//   originChain: Chain
-//   originToken: Token
-//   originValue: string
-//   destinationChain: Chain
-//   destinationToken: Token
-//   transactionHash?: string
-//   timestamp: number
-//   isSubmitted: boolean
-//   estimatedTime: number
-//   bridgeModuleName: string
-// }
-
-// export const addPendingBridgeTransaction =
-//   createAction<PendingBridgeTransaction>('bridge/addPendingBridgeTransaction')
-// export const updatePendingBridgeTransaction = createAction<{
-//   id: number
-//   timestamp: number
-//   transactionHash: string
-//   isSubmitted: boolean
-// }>('bridge/updatePendingBridgeTransaction')
-// export const removePendingBridgeTransaction = createAction<number>(
-//   'bridge/removePendingBridgeTransaction'
-// )
-// export const updatePendingBridgeTransactions = createAction<
-//   PendingBridgeTransaction[]
-// >('bridge/updatePendingBridgeTransactions')
-export const resetBridgeInputs = createAction<void>('bridge/resetBridgeInputs')
-export const resetFetchedBridgeQuotes = createAction<void>(
-  'bridge/resetFetchedBridgeQuotes'
-)
 export const updateDebouncedFromValue = createAction<string>(
   'bridge/updateDebouncedFromValue'
 )
 export const updateDebouncedToTokensFromValue = createAction<string>(
   'bridge/updateDebouncedToTokensFromValue'
+)
+export const resetBridgeInputs = createAction<void>('bridge/resetBridgeInputs')
+export const resetFetchedBridgeQuotes = createAction<void>(
+  'bridge/resetFetchedBridgeQuotes'
 )

--- a/packages/synapse-interface/slices/bridge/actions.ts
+++ b/packages/synapse-interface/slices/bridge/actions.ts
@@ -1,35 +1,35 @@
 import { createAction } from '@reduxjs/toolkit'
 
-import { Chain, Token } from '@/utils/types'
+// import { Chain, Token } from '@/utils/types'
 
-export interface PendingBridgeTransaction {
-  id: number
-  originChain: Chain
-  originToken: Token
-  originValue: string
-  destinationChain: Chain
-  destinationToken: Token
-  transactionHash?: string
-  timestamp: number
-  isSubmitted: boolean
-  estimatedTime: number
-  bridgeModuleName: string
-}
+// export interface PendingBridgeTransaction {
+//   id: number
+//   originChain: Chain
+//   originToken: Token
+//   originValue: string
+//   destinationChain: Chain
+//   destinationToken: Token
+//   transactionHash?: string
+//   timestamp: number
+//   isSubmitted: boolean
+//   estimatedTime: number
+//   bridgeModuleName: string
+// }
 
-export const addPendingBridgeTransaction =
-  createAction<PendingBridgeTransaction>('bridge/addPendingBridgeTransaction')
-export const updatePendingBridgeTransaction = createAction<{
-  id: number
-  timestamp: number
-  transactionHash: string
-  isSubmitted: boolean
-}>('bridge/updatePendingBridgeTransaction')
-export const removePendingBridgeTransaction = createAction<number>(
-  'bridge/removePendingBridgeTransaction'
-)
-export const updatePendingBridgeTransactions = createAction<
-  PendingBridgeTransaction[]
->('bridge/updatePendingBridgeTransactions')
+// export const addPendingBridgeTransaction =
+//   createAction<PendingBridgeTransaction>('bridge/addPendingBridgeTransaction')
+// export const updatePendingBridgeTransaction = createAction<{
+//   id: number
+//   timestamp: number
+//   transactionHash: string
+//   isSubmitted: boolean
+// }>('bridge/updatePendingBridgeTransaction')
+// export const removePendingBridgeTransaction = createAction<number>(
+//   'bridge/removePendingBridgeTransaction'
+// )
+// export const updatePendingBridgeTransactions = createAction<
+//   PendingBridgeTransaction[]
+// >('bridge/updatePendingBridgeTransactions')
 export const resetBridgeInputs = createAction<void>('bridge/resetBridgeInputs')
 export const resetFetchedBridgeQuotes = createAction<void>(
   'bridge/resetFetchedBridgeQuotes'

--- a/packages/synapse-interface/slices/bridge/reducer.ts
+++ b/packages/synapse-interface/slices/bridge/reducer.ts
@@ -47,7 +47,7 @@ export interface BridgeState {
   isLoading: boolean
   deadlineMinutes: number | null
   destinationAddress: Address | null
-  pendingBridgeTransactions: PendingBridgeTransaction[]
+  // pendingBridgeTransactions: PendingBridgeTransaction[]
 }
 
 const {
@@ -85,7 +85,7 @@ export const initialState: BridgeState = {
   isLoading: false,
   deadlineMinutes: null,
   destinationAddress: null,
-  pendingBridgeTransactions: [],
+  // pendingBridgeTransactions: [],
 }
 
 export const bridgeSlice = createSlice({

--- a/packages/synapse-interface/slices/bridge/reducer.ts
+++ b/packages/synapse-interface/slices/bridge/reducer.ts
@@ -13,12 +13,12 @@ import { getToChainIds } from '@/utils/routeMaker/getToChainIds'
 import { getToTokens } from '@/utils/routeMaker/getToTokens'
 import { findTokenByRouteSymbol } from '@/utils/findTokenByRouteSymbol'
 import {
-  PendingBridgeTransaction,
-  addPendingBridgeTransaction,
-  removePendingBridgeTransaction,
+  // PendingBridgeTransaction,
+  // addPendingBridgeTransaction,
+  // removePendingBridgeTransaction,
+  // updatePendingBridgeTransaction,
+  // updatePendingBridgeTransactions,
   resetFetchedBridgeQuotes,
-  updatePendingBridgeTransaction,
-  updatePendingBridgeTransactions,
   resetBridgeInputs,
   updateDebouncedFromValue,
   updateDebouncedToTokensFromValue,

--- a/packages/synapse-interface/slices/bridge/reducer.ts
+++ b/packages/synapse-interface/slices/bridge/reducer.ts
@@ -13,11 +13,6 @@ import { getToChainIds } from '@/utils/routeMaker/getToChainIds'
 import { getToTokens } from '@/utils/routeMaker/getToTokens'
 import { findTokenByRouteSymbol } from '@/utils/findTokenByRouteSymbol'
 import {
-  // PendingBridgeTransaction,
-  // addPendingBridgeTransaction,
-  // removePendingBridgeTransaction,
-  // updatePendingBridgeTransaction,
-  // updatePendingBridgeTransactions,
   resetFetchedBridgeQuotes,
   resetBridgeInputs,
   updateDebouncedFromValue,
@@ -47,7 +42,6 @@ export interface BridgeState {
   isLoading: boolean
   deadlineMinutes: number | null
   destinationAddress: Address | null
-  // pendingBridgeTransactions: PendingBridgeTransaction[]
 }
 
 const {
@@ -85,7 +79,6 @@ export const initialState: BridgeState = {
   isLoading: false,
   deadlineMinutes: null,
   destinationAddress: null,
-  // pendingBridgeTransactions: [],
 }
 
 export const bridgeSlice = createSlice({
@@ -481,57 +474,6 @@ export const bridgeSlice = createSlice({
           state.debouncedToTokensFromValue = action.payload
         }
       )
-      // .addCase(
-      //   addPendingBridgeTransaction,
-      //   (state, action: PayloadAction<PendingBridgeTransaction>) => {
-      //     state.pendingBridgeTransactions = [
-      //       action.payload,
-      //       ...state.pendingBridgeTransactions,
-      //     ]
-      //   }
-      // )
-      // .addCase(
-      //   updatePendingBridgeTransaction,
-      //   (
-      //     state,
-      //     action: PayloadAction<{
-      //       id: number
-      //       timestamp: number
-      //       transactionHash: string
-      //       isSubmitted: boolean
-      //     }>
-      //   ) => {
-      //     const { id, timestamp, transactionHash, isSubmitted } = action.payload
-      //     const transactionIndex = state.pendingBridgeTransactions.findIndex(
-      //       (transaction) => transaction.id === id
-      //     )
-
-      //     if (transactionIndex !== -1) {
-      //       state.pendingBridgeTransactions =
-      //         state.pendingBridgeTransactions.map((transaction, index) =>
-      //           index === transactionIndex
-      //             ? { ...transaction, transactionHash, isSubmitted, timestamp }
-      //             : transaction
-      //         )
-      //     }
-      //   }
-      // )
-      // .addCase(
-      //   removePendingBridgeTransaction,
-      //   (state, action: PayloadAction<number>) => {
-      //     const idTimestampToRemove = action.payload
-      //     state.pendingBridgeTransactions =
-      //       state.pendingBridgeTransactions.filter(
-      //         (transaction) => transaction.id !== idTimestampToRemove
-      //       )
-      //   }
-      // )
-      // .addCase(
-      //   updatePendingBridgeTransactions,
-      //   (state, action: PayloadAction<PendingBridgeTransaction[]>) => {
-      //     state.pendingBridgeTransactions = action.payload
-      //   }
-      // )
       .addCase(resetBridgeInputs, (state) => {
         state.fromChainId = initialState.fromChainId
         state.fromToken = initialState.fromToken

--- a/packages/synapse-interface/slices/bridge/reducer.ts
+++ b/packages/synapse-interface/slices/bridge/reducer.ts
@@ -481,57 +481,57 @@ export const bridgeSlice = createSlice({
           state.debouncedToTokensFromValue = action.payload
         }
       )
-      .addCase(
-        addPendingBridgeTransaction,
-        (state, action: PayloadAction<PendingBridgeTransaction>) => {
-          state.pendingBridgeTransactions = [
-            action.payload,
-            ...state.pendingBridgeTransactions,
-          ]
-        }
-      )
-      .addCase(
-        updatePendingBridgeTransaction,
-        (
-          state,
-          action: PayloadAction<{
-            id: number
-            timestamp: number
-            transactionHash: string
-            isSubmitted: boolean
-          }>
-        ) => {
-          const { id, timestamp, transactionHash, isSubmitted } = action.payload
-          const transactionIndex = state.pendingBridgeTransactions.findIndex(
-            (transaction) => transaction.id === id
-          )
+      // .addCase(
+      //   addPendingBridgeTransaction,
+      //   (state, action: PayloadAction<PendingBridgeTransaction>) => {
+      //     state.pendingBridgeTransactions = [
+      //       action.payload,
+      //       ...state.pendingBridgeTransactions,
+      //     ]
+      //   }
+      // )
+      // .addCase(
+      //   updatePendingBridgeTransaction,
+      //   (
+      //     state,
+      //     action: PayloadAction<{
+      //       id: number
+      //       timestamp: number
+      //       transactionHash: string
+      //       isSubmitted: boolean
+      //     }>
+      //   ) => {
+      //     const { id, timestamp, transactionHash, isSubmitted } = action.payload
+      //     const transactionIndex = state.pendingBridgeTransactions.findIndex(
+      //       (transaction) => transaction.id === id
+      //     )
 
-          if (transactionIndex !== -1) {
-            state.pendingBridgeTransactions =
-              state.pendingBridgeTransactions.map((transaction, index) =>
-                index === transactionIndex
-                  ? { ...transaction, transactionHash, isSubmitted, timestamp }
-                  : transaction
-              )
-          }
-        }
-      )
-      .addCase(
-        removePendingBridgeTransaction,
-        (state, action: PayloadAction<number>) => {
-          const idTimestampToRemove = action.payload
-          state.pendingBridgeTransactions =
-            state.pendingBridgeTransactions.filter(
-              (transaction) => transaction.id !== idTimestampToRemove
-            )
-        }
-      )
-      .addCase(
-        updatePendingBridgeTransactions,
-        (state, action: PayloadAction<PendingBridgeTransaction[]>) => {
-          state.pendingBridgeTransactions = action.payload
-        }
-      )
+      //     if (transactionIndex !== -1) {
+      //       state.pendingBridgeTransactions =
+      //         state.pendingBridgeTransactions.map((transaction, index) =>
+      //           index === transactionIndex
+      //             ? { ...transaction, transactionHash, isSubmitted, timestamp }
+      //             : transaction
+      //         )
+      //     }
+      //   }
+      // )
+      // .addCase(
+      //   removePendingBridgeTransaction,
+      //   (state, action: PayloadAction<number>) => {
+      //     const idTimestampToRemove = action.payload
+      //     state.pendingBridgeTransactions =
+      //       state.pendingBridgeTransactions.filter(
+      //         (transaction) => transaction.id !== idTimestampToRemove
+      //       )
+      //   }
+      // )
+      // .addCase(
+      //   updatePendingBridgeTransactions,
+      //   (state, action: PayloadAction<PendingBridgeTransaction[]>) => {
+      //     state.pendingBridgeTransactions = action.payload
+      //   }
+      // )
       .addCase(resetBridgeInputs, (state) => {
         state.fromChainId = initialState.fromChainId
         state.fromToken = initialState.fromToken

--- a/packages/synapse-interface/slices/portfolio/updater.tsx
+++ b/packages/synapse-interface/slices/portfolio/updater.tsx
@@ -1,25 +1,18 @@
 import { useEffect } from 'react'
+import { useAccount } from 'wagmi'
 import { Address } from '@wagmi/core'
-import { watchPendingTransactions, waitForTransaction } from '@wagmi/core'
 import { useAppDispatch } from '@/store/hooks'
-import { useBridgeState } from '../bridge/hooks'
 import { useTransactionsState } from '../transactions/hooks'
 import { TransactionsState } from '../transactions/reducer'
-import { BridgeState } from '../bridge/reducer'
 import { fetchAndStoreSingleNetworkPortfolioBalances } from './hooks'
-
-import { useAccount } from 'wagmi'
-import {
-  PendingBridgeTransaction,
-  updatePendingBridgeTransaction,
-} from '../bridge/actions'
+import { PendingBridgeTransaction } from '../transactions/actions'
 import { BridgeTransaction } from '../api/generated'
 
 export default function Updater(): null {
   const dispatch = useAppDispatch()
   const { address } = useAccount()
-  const { pendingBridgeTransactions }: BridgeState = useBridgeState()
   const {
+    pendingBridgeTransactions,
     userHistoricalTransactions,
     isUserHistoricalTransactionsLoading,
   }: TransactionsState = useTransactionsState()

--- a/packages/synapse-interface/slices/transactions/actions.ts
+++ b/packages/synapse-interface/slices/transactions/actions.ts
@@ -1,6 +1,36 @@
 import { createAction } from '@reduxjs/toolkit'
 
 import { BridgeTransaction } from '../api/generated'
+import { Chain, Token } from '@/utils/types'
+
+export interface PendingBridgeTransaction {
+  id: number
+  originChain: Chain
+  originToken: Token
+  originValue: string
+  destinationChain: Chain
+  destinationToken: Token
+  transactionHash?: string
+  timestamp: number
+  isSubmitted: boolean
+  estimatedTime: number
+  bridgeModuleName: string
+}
+
+export const addPendingBridgeTransaction =
+  createAction<PendingBridgeTransaction>('bridge/addPendingBridgeTransaction')
+export const updatePendingBridgeTransaction = createAction<{
+  id: number
+  timestamp: number
+  transactionHash: string
+  isSubmitted: boolean
+}>('bridge/updatePendingBridgeTransaction')
+export const removePendingBridgeTransaction = createAction<number>(
+  'bridge/removePendingBridgeTransaction'
+)
+export const updatePendingBridgeTransactions = createAction<
+  PendingBridgeTransaction[]
+>('bridge/updatePendingBridgeTransactions')
 
 export const updateUserHistoricalTransactions = createAction<
   BridgeTransaction[]

--- a/packages/synapse-interface/slices/transactions/actions.ts
+++ b/packages/synapse-interface/slices/transactions/actions.ts
@@ -18,19 +18,21 @@ export interface PendingBridgeTransaction {
 }
 
 export const addPendingBridgeTransaction =
-  createAction<PendingBridgeTransaction>('bridge/addPendingBridgeTransaction')
+  createAction<PendingBridgeTransaction>(
+    'transactions/addPendingBridgeTransaction'
+  )
 export const updatePendingBridgeTransaction = createAction<{
   id: number
   timestamp: number
   transactionHash: string
   isSubmitted: boolean
-}>('bridge/updatePendingBridgeTransaction')
+}>('transactions/updatePendingBridgeTransaction')
 export const removePendingBridgeTransaction = createAction<number>(
-  'bridge/removePendingBridgeTransaction'
+  'transactions/removePendingBridgeTransaction'
 )
 export const updatePendingBridgeTransactions = createAction<
   PendingBridgeTransaction[]
->('bridge/updatePendingBridgeTransactions')
+>('transactions/updatePendingBridgeTransactions')
 
 export const updateUserHistoricalTransactions = createAction<
   BridgeTransaction[]

--- a/packages/synapse-interface/slices/transactions/reducer.ts
+++ b/packages/synapse-interface/slices/transactions/reducer.ts
@@ -1,6 +1,11 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
 import {
+  PendingBridgeTransaction,
+  addPendingBridgeTransaction,
+  removePendingBridgeTransaction,
+  updatePendingBridgeTransaction,
+  updatePendingBridgeTransactions,
   updateUserHistoricalTransactions,
   updateIsUserHistoricalTransactionsLoading,
   updateUserPendingTransactions,
@@ -26,6 +31,7 @@ export interface TransactionsState {
   pendingAwaitingCompletionTransactions: BridgeTransaction[]
   fallbackQueryPendingTransactions: BridgeTransaction[]
   fallbackQueryHistoricalTransactions: BridgeTransaction[]
+  pendingBridgeTransactions: PendingBridgeTransaction[]
 }
 
 const initialState: TransactionsState = {
@@ -37,6 +43,7 @@ const initialState: TransactionsState = {
   pendingAwaitingCompletionTransactions: [],
   fallbackQueryPendingTransactions: [],
   fallbackQueryHistoricalTransactions: [],
+  pendingBridgeTransactions: [],
 }
 
 export const transactionsSlice = createSlice({
@@ -45,6 +52,57 @@ export const transactionsSlice = createSlice({
   reducers: {},
   extraReducers: (builder) => {
     builder
+      .addCase(
+        addPendingBridgeTransaction,
+        (state, action: PayloadAction<PendingBridgeTransaction>) => {
+          state.pendingBridgeTransactions = [
+            action.payload,
+            ...state.pendingBridgeTransactions,
+          ]
+        }
+      )
+      .addCase(
+        updatePendingBridgeTransaction,
+        (
+          state,
+          action: PayloadAction<{
+            id: number
+            timestamp: number
+            transactionHash: string
+            isSubmitted: boolean
+          }>
+        ) => {
+          const { id, timestamp, transactionHash, isSubmitted } = action.payload
+          const transactionIndex = state.pendingBridgeTransactions.findIndex(
+            (transaction) => transaction.id === id
+          )
+
+          if (transactionIndex !== -1) {
+            state.pendingBridgeTransactions =
+              state.pendingBridgeTransactions.map((transaction, index) =>
+                index === transactionIndex
+                  ? { ...transaction, transactionHash, isSubmitted, timestamp }
+                  : transaction
+              )
+          }
+        }
+      )
+      .addCase(
+        removePendingBridgeTransaction,
+        (state, action: PayloadAction<number>) => {
+          const idTimestampToRemove = action.payload
+          state.pendingBridgeTransactions =
+            state.pendingBridgeTransactions.filter(
+              (transaction) => transaction.id !== idTimestampToRemove
+            )
+        }
+      )
+      .addCase(
+        updatePendingBridgeTransactions,
+        (state, action: PayloadAction<PendingBridgeTransaction[]>) => {
+          state.pendingBridgeTransactions = action.payload
+        }
+      )
       .addCase(
         updateUserHistoricalTransactions,
         (state, action: PayloadAction<BridgeTransaction[]>) => {

--- a/packages/synapse-interface/slices/transactions/reducer.ts
+++ b/packages/synapse-interface/slices/transactions/reducer.ts
@@ -226,6 +226,7 @@ export const transactionsSlice = createSlice({
         }
       )
       .addCase(resetTransactionsState, (state) => {
+        state.pendingBridgeTransactions = initialState.pendingBridgeTransactions
         state.userHistoricalTransactions =
           initialState.userHistoricalTransactions
         state.isUserHistoricalTransactionsLoading =
@@ -237,6 +238,8 @@ export const transactionsSlice = createSlice({
           initialState.pendingAwaitingCompletionTransactions
         state.fallbackQueryPendingTransactions =
           initialState.fallbackQueryPendingTransactions
+        state.fallbackQueryHistoricalTransactions =
+          initialState.fallbackQueryHistoricalTransactions
       })
   },
 })

--- a/packages/synapse-interface/slices/transactions/updater.tsx
+++ b/packages/synapse-interface/slices/transactions/updater.tsx
@@ -175,7 +175,7 @@ export default function Updater(): null {
   useEffect(() => {
     const matchingTransactionHashes = new Set(
       pendingBridgeTransactions
-        .filter(
+        ?.filter(
           (recentTx) =>
             (userPendingTransactions &&
               userPendingTransactions.some(

--- a/packages/synapse-interface/slices/transactions/updater.tsx
+++ b/packages/synapse-interface/slices/transactions/updater.tsx
@@ -27,8 +27,6 @@ import {
   updateUserHistoricalTransactions,
   updateUserPendingTransactions,
 } from './actions'
-import { useBridgeState } from '../bridge/hooks'
-import { BridgeState } from '../bridge/reducer'
 import { PortfolioState } from '../portfolio/reducer'
 import { usePortfolioState } from '../portfolio/hooks'
 import { PortfolioTabs } from '../portfolio/actions'
@@ -36,7 +34,7 @@ import {
   updatePendingBridgeTransactions,
   removePendingBridgeTransaction,
   PendingBridgeTransaction,
-} from '../bridge/actions'
+} from '../transactions/actions'
 import {
   addSeenHistoricalTransaction,
   addPendingAwaitingCompletionTransaction,
@@ -44,7 +42,6 @@ import {
 } from './actions'
 import { getValidAddress } from '@/utils/isValidAddress'
 import { checkTransactionsExist } from '@/utils/checkTransactionsExist'
-import { getTimeMinutesFromNow } from '@/utils/time'
 
 const queryHistoricalTime: number = getTimeMinutesBeforeNow(oneMonthInMinutes)
 const queryPendingTime: number = getTimeMinutesBeforeNow(oneDayInMinutes)
@@ -60,8 +57,8 @@ export default function Updater(): null {
     pendingAwaitingCompletionTransactions,
     fallbackQueryPendingTransactions,
     fallbackQueryHistoricalTransactions,
+    pendingBridgeTransactions,
   }: TransactionsState = useTransactionsState()
-  const { pendingBridgeTransactions }: BridgeState = useBridgeState()
   const {
     activeTab,
     searchInput,

--- a/packages/synapse-interface/slices/transactions/updater.tsx
+++ b/packages/synapse-interface/slices/transactions/updater.tsx
@@ -1,4 +1,3 @@
-import useWindowFocus from 'use-window-focus'
 import { useEffect, useMemo } from 'react'
 import { useAppDispatch } from '@/store/hooks'
 import { useAccount, Address } from 'wagmi'
@@ -16,30 +15,24 @@ import {
   oneDayInMinutes,
 } from '@/utils/time'
 import {
+  updatePendingBridgeTransactions,
+  removePendingBridgeTransaction,
+  PendingBridgeTransaction,
   addFallbackQueryHistoricalTransaction,
   removeFallbackQueryHistoricalTransaction,
   removeFallbackQueryPendingTransaction,
   resetTransactionsState,
   updateIsUserPendingTransactionsLoading,
-} from './actions'
-import {
   updateIsUserHistoricalTransactionsLoading,
   updateUserHistoricalTransactions,
   updateUserPendingTransactions,
-} from './actions'
-import { PortfolioState } from '../portfolio/reducer'
-import { usePortfolioState } from '../portfolio/hooks'
-import { PortfolioTabs } from '../portfolio/actions'
-import {
-  updatePendingBridgeTransactions,
-  removePendingBridgeTransaction,
-  PendingBridgeTransaction,
-} from '../transactions/actions'
-import {
   addSeenHistoricalTransaction,
   addPendingAwaitingCompletionTransaction,
   removePendingAwaitingCompletionTransaction,
 } from './actions'
+import { PortfolioState } from '../portfolio/reducer'
+import { usePortfolioState } from '../portfolio/hooks'
+import { PortfolioTabs } from '../portfolio/actions'
 import { getValidAddress } from '@/utils/isValidAddress'
 import { checkTransactionsExist } from '@/utils/checkTransactionsExist'
 

--- a/packages/synapse-interface/store/reducer.ts
+++ b/packages/synapse-interface/store/reducer.ts
@@ -19,7 +19,6 @@ import { RootActions } from '@/slices/application/actions'
 
 const persistedReducers = {
   application,
-  bridge,
   transactions,
 }
 
@@ -33,6 +32,7 @@ export const persistConfig: PersistConfig<AppState> = {
 }
 
 export const appReducer = combineReducers({
+  bridge,
   portfolio,
   swap,
   bridgeDisplay,

--- a/packages/synapse-interface/store/reducer.ts
+++ b/packages/synapse-interface/store/reducer.ts
@@ -25,7 +25,7 @@ const persistedReducers = {
 export const storageKey: string = 'synapse-interface'
 
 export const persistConfig: PersistConfig<AppState> = {
-  version: 1, // upgrade to reset cache
+  version: 1, // upgrade to reset cache when updated data structures throw errors
   key: storageKey,
   storage,
   whitelist: Object.keys(persistedReducers),

--- a/packages/synapse-interface/store/reducer.ts
+++ b/packages/synapse-interface/store/reducer.ts
@@ -26,7 +26,7 @@ const persistedReducers = {
 export const storageKey: string = 'synapse-interface'
 
 export const persistConfig: PersistConfig<AppState> = {
-  version: 0, // upgrade to reset cache
+  version: 1, // upgrade to reset cache
   key: storageKey,
   storage,
   whitelist: Object.keys(persistedReducers),


### PR DESCRIPTION
Moving `pendingBridgeTransactions` state and related actions/reducers from `bridge` to `transactions` slice

Remove `bridge` slice from `persistedReducers`, only track `application` and `transactions` in local storage

Upgrade redux persist version to reset client side storage to prevent errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Reorganized bridge transactions functionality to improve code structure and efficiency.
- **New Features**
	- Introduced new actions and interfaces for managing pending bridge transactions.
- **Bug Fixes**
	- Updated the `persistConfig` version to reset cache and fix data structure errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
7203a92a48330af13bc5c8a4114451029a8ec212: [synapse-interface preview link ](https://sanguine-synapse-interface-nwn5gtzkj-synapsecns.vercel.app)
f560cb2788268c92168f9568f12ee3b9248ea22e: [synapse-interface preview link ](https://sanguine-synapse-interface-a1vwq6h72-synapsecns.vercel.app)
c667e2f5d51853ab1987efcf5d980b79255aec54: [synapse-interface preview link ](https://sanguine-synapse-interface-8pae1gzdk-synapsecns.vercel.app)