### PR TITLE
Adds spender address to eth syn sushi token

### DIFF
--- a/packages/synapse-interface/constants/tokens/poolMaster.ts
+++ b/packages/synapse-interface/constants/tokens/poolMaster.ts
@@ -48,7 +48,7 @@ export const ETH_POOL_SWAP_TOKEN = new Token({
   logo: synapseLogo,
   poolName: 'Ethereum Stableswap Pool',
   routerIndex: 'eth3pool',
-  poolId: 0, // 420
+  poolId: 420,
   poolType: 'USD',
   swapAddresses: {
     [CHAINS.ETH.id]: '0x1116898DdA4015eD8dDefb84b6e8Bc24528Af2d8',

--- a/packages/synapse-interface/constants/tokens/sushiMaster.ts
+++ b/packages/synapse-interface/constants/tokens/sushiMaster.ts
@@ -2,6 +2,7 @@ import sushiLogo from '@assets/icons/sushi.svg'
 import * as CHAINS from '@constants/chains/master'
 
 import { Token } from '@/utils/types'
+import { MINICHEF_ADDRESSES } from '../minichef'
 
 export const SYN_ETH_SUSHI_TOKEN = new Token({
   addresses: {
@@ -17,6 +18,7 @@ export const SYN_ETH_SUSHI_TOKEN = new Token({
   description: 'The SYN/ETH Sushiswap LP Token',
   priorityRank: 6,
   chainId: CHAINS.ETH.id,
+  miniChefAddress: MINICHEF_ADDRESSES[CHAINS.ETH.id],
 })
 
 export const ETH_USDC_SUSHI_TOKEN = new Token({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the initialization of the `SYN_ETH_SUSHI_TOKEN` to include the `miniChefAddress` property.
- **Bug Fixes**
	- Adjusted the `poolId` value in the `ETH_POOL_SWAP_TOKEN` configuration for the Ethereum Stableswap Pool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
a27602c4e174a5edc96f147fe20c7086baabf710: [synapse-interface preview link ](https://sanguine-synapse-interface-cuxpa8auk-synapsecns.vercel.app)
fe8d4668f1e20b8a2c48a5c96b99526e88d78738: [synapse-interface preview link ](https://sanguine-synapse-interface-8fawtdejn-synapsecns.vercel.app)