### PR TITLE
Fix: submitter should always call `updateOldTxStatuses()`

### DIFF
--- a/ethergo/submitter/chain_queue.go
+++ b/ethergo/submitter/chain_queue.go
@@ -83,9 +83,9 @@ func (t *txSubmitterImpl) chainPendingQueue(parentCtx context.Context, chainID *
 			continue
 		}
 
-		cq.updateOldTxStatuses(gCtx)
 		cq.bumpTX(gCtx, tx)
 	}
+    cq.updateOldTxStatuses(gCtx)
 
 	err = cq.g.Wait()
 	if err != nil {


### PR DESCRIPTION
**Description**
Addresses an edge case where the all pending transactions in a batch are "confirmed" (tx nonce < current nonce) and we never mark the transactions as complete in the database.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the efficiency of updating old transaction statuses by modifying the execution order of function calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->