### PR TITLE
Add templating to scribe configmap

### DIFF
--- a/charts/agents/Chart.lock
+++ b/charts/agents/Chart.lock
@@ -4,12 +4,12 @@ dependencies:
   version: 9.3.2
 - name: omnirpc
   repository: file://../omnirpc/
-  version: 0.2.91
+  version: 0.2.92
 - name: scribe
   repository: file://../scribe/
   version: 0.2.16
 - name: jaeger
   repository: https://jaegertracing.github.io/helm-charts
   version: 0.69.1
-digest: sha256:4d984e64a67528903ae3e8be7733e10a3a4a6fc3e901e338cf25ec6cf164d84d
-generated: "2023-11-14T21:26:04.007449-06:00"
+digest: sha256:9f69403329ddaea21c35c9e75b4e555237c1e1ced342b82a517db142713af709
+generated: "2023-11-14T22:07:00.422311-06:00"

--- a/charts/agents/Chart.lock
+++ b/charts/agents/Chart.lock
@@ -7,9 +7,9 @@ dependencies:
   version: 0.2.91
 - name: scribe
   repository: file://../scribe/
-  version: 0.2.15
+  version: 0.2.16
 - name: jaeger
   repository: https://jaegertracing.github.io/helm-charts
   version: 0.69.1
-digest: sha256:7b9ac6625ebd1bbb31b539dda69c5399b3285ad05287fba122e355e57a434bed
-generated: "2023-11-01T00:44:48.396983-05:00"
+digest: sha256:4d984e64a67528903ae3e8be7733e10a3a4a6fc3e901e338cf25ec6cf164d84d
+generated: "2023-11-14T21:26:04.007449-06:00"

--- a/charts/agents/Chart.yaml
+++ b/charts/agents/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.29
+version: 0.1.30
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/agents/Chart.yaml
+++ b/charts/agents/Chart.yaml
@@ -29,7 +29,7 @@ dependencies:
     repository: "https://charts.bitnami.com/bitnami"
     condition: mysql.enabled
   - name: omnirpc
-    version: "0.2.91"
+    version: "0.2.92"
     repository: "file://../omnirpc/"
     condition: omnirpc.enabled
   - name: scribe

--- a/charts/agents/Chart.yaml
+++ b/charts/agents/Chart.yaml
@@ -33,7 +33,7 @@ dependencies:
     repository: "file://../omnirpc/"
     condition: omnirpc.enabled
   - name: scribe
-    version: "0.2.15"
+    version: "0.2.16"
     repository: "file://../scribe/"
     condition: scribe.enabled
   - name: jaeger

--- a/charts/explorer/Chart.lock
+++ b/charts/explorer/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: omnirpc
   repository: file://../omnirpc/
-  version: 0.2.91
+  version: 0.2.92
 - name: clickhouse
   repository: https://sentry-kubernetes.github.io/charts
   version: 3.1.3
-digest: sha256:c3f0ef19b6724eb840c4d77f3a343901da44f3d2ca336187a52cc1ee0f5470a5
-generated: "2023-11-01T00:44:53.090052-05:00"
+digest: sha256:d41e7713f0f1e6b9e17f8a30cc38497a76fb9c2fdb9b884682ebe55234816444
+generated: "2023-11-14T22:07:32.395834-06:00"

--- a/charts/explorer/Chart.yaml
+++ b/charts/explorer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.15
+version: 0.2.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/explorer/Chart.yaml
+++ b/charts/explorer/Chart.yaml
@@ -21,11 +21,11 @@ version: 0.2.15
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.16.0"
+appVersion: "1.17.0"
 
 dependencies:
   - name: omnirpc
-    version: "0.2.91"
+    version: "0.2.92"
     repository: "file://../omnirpc/"
     condition: omnirpc.enabled
   - name: clickhouse

--- a/charts/omnirpc/Chart.yaml
+++ b/charts/omnirpc/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.91
+version: 0.2.92
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/omnirpc/values.yaml
+++ b/charts/omnirpc/values.yaml
@@ -98,35 +98,9 @@ files:
   config.yml: |-
     client_type: resty
     chains:
-      11155111:
+      1:
         rpcs:
-          - rpc: https://ethereum-sepolia.publicnode.com
-            rpc_type: atable
-          - rpc: https://rpc.sepolia.org
-            rpc_type: auxiliary
-          - rpc: https://endpoints.omniatech.io/v1/eth/sepolia/public
-            rpc_type: auxiliary
-        confirmations: 1
-      421614:
-        rpcs:
-          - rpc: https://arbitrum-sepolia.blockpi.network/v1/rpc/public
-            rpc_type: stable
-          - rpc: https://sepolia-rollup.arbitrum.io/rpc
-            rpc_type: auxiliary
-        confirmations: 1
-      444:
-        rpcs:
-          - rpc: https://l2-synapse-sepolia-testnet-1mdqkm651f.t.conduit.xyz
-            rpc_type: stable
-        confirmations: 1
-      43113:
-        rpcs:
-          - rpc: https://api.avax-test.network/ext/bc/C/rpc
-            rpc_type: stable
-          - rpc: https://avalanche-fuji.blockpi.network/v1/rpc/public
-            rpc_type: auxiliary
-          - rpc: https://endpoints.omniatech.io/v1/avax/fuji/public
-            rpc_type: auxiliary
+          - https://eth.llamarpc.com
         confirmations: 1
 
 env:

--- a/charts/scribe/Chart.lock
+++ b/charts/scribe/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 9.3.2
 - name: omnirpc
   repository: file://../omnirpc/
-  version: 0.2.91
-digest: sha256:7996a0999644426256ef1218066ed3dc408004204324cd94f4d8e044fa57374b
-generated: "2023-11-01T00:44:55.324185-05:00"
+  version: 0.2.92
+digest: sha256:72a2b51d01b7b6a2d9c6ee3938fcad62214315e7f321468ac54b54bfa7ba78df
+generated: "2023-11-14T22:07:43.630566-06:00"

--- a/charts/scribe/Chart.yaml
+++ b/charts/scribe/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.15
+version: 0.2.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/scribe/Chart.yaml
+++ b/charts/scribe/Chart.yaml
@@ -29,6 +29,6 @@ dependencies:
     repository: "https://charts.bitnami.com/bitnami"
     condition: mysql.enabled
   - name: omnirpc
-    version: "0.2.91"
+    version: "0.2.92"
     repository: "file://../omnirpc/"
     condition: omnirpc.enabled

--- a/charts/scribe/templates/configmap.yaml
+++ b/charts/scribe/templates/configmap.yaml
@@ -9,5 +9,5 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-{{ toYaml .Values.files | indent 2 }}
+{{ tpl (toYaml .Values.files) . | indent 2 }}
 {{- end }}


### PR DESCRIPTION
**Description**
Allows us to use templating to clean up helm charts for scribe deployments.