### PR TITLE
Add sequential factory for messaging deployments

### DIFF
--- a/.github/workflows/solidity.yml
+++ b/.github/workflows/solidity.yml
@@ -21,8 +21,6 @@ jobs:
       NODE_ENV: 'production'
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
       - name: Setup NodeJS
         uses: ./.github/actions/setup-nodejs
         with:

--- a/.github/workflows/solidity.yml
+++ b/.github/workflows/solidity.yml
@@ -21,6 +21,8 @@ jobs:
       NODE_ENV: 'production'
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - name: Setup NodeJS
         uses: ./.github/actions/setup-nodejs
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -14,3 +14,7 @@
 [submodule "packages/contracts-core/lib/create3-factory"]
 	path = packages/contracts-core/lib/create3-factory
 	url = https://github.com/zeframlou/create3-factory
+[submodule "packages/contracts-core/lib/solmate"]
+	path = packages/contracts-core/lib/solmate
+	url = https://github.com/transmissions11/solmate.git
+	branch = v7

--- a/packages/contracts-core/contracts/factory/SequentialFactory.sol
+++ b/packages/contracts-core/contracts/factory/SequentialFactory.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+// ═════════════════════════════ INTERNAL IMPORTS ══════════════════════════════
+import {ISequentialFactory} from "../interfaces/ISequentialFactory.sol";
+// ═════════════════════════════ EXTERNAL IMPORTS ══════════════════════════════
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+contract SequentialFactory is Ownable, ISequentialFactory {
+    error SequentialFactory__DeploymentFailed(uint256 nonce);
+    error SequentialFactory__InvalidNonce(uint256 nonce, uint256 expectedNonce);
+
+    constructor(address owner_) {
+        transferOwnership(owner_);
+    }
+
+    /// @inheritdoc ISequentialFactory
+    function deploy(uint256 nonce, bytes memory code) external onlyOwner returns (address deployedAt) {}
+
+    /// @inheritdoc ISequentialFactory
+    function getNonce() external view returns (uint256 nonce) {}
+
+    /// @inheritdoc ISequentialFactory
+    function predictDeployment(uint256 nonce) external view returns (address deployedAt) {}
+
+    /// @inheritdoc ISequentialFactory
+    function predictNextDeployment() external view returns (address deployedAt) {}
+}

--- a/packages/contracts-core/contracts/factory/SequentialFactory.sol
+++ b/packages/contracts-core/contracts/factory/SequentialFactory.sol
@@ -10,19 +10,43 @@ contract SequentialFactory is Ownable, ISequentialFactory {
     error SequentialFactory__DeploymentFailed(uint256 nonce);
     error SequentialFactory__InvalidNonce(uint256 nonce, uint256 expectedNonce);
 
+    /// @dev Tracks the nonce of the factory. This is required because address(this).nonce does not exist.
+    uint256 internal _nonce;
+
     constructor(address owner_) {
         transferOwnership(owner_);
+        // Nonce of the smart contract starts at 1, see EIP-161
+        // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md
+        _nonce = 1;
     }
 
     /// @inheritdoc ISequentialFactory
-    function deploy(uint256 nonce, bytes memory code) external onlyOwner returns (address deployedAt) {}
+    function deploy(uint256 nonce, bytes memory code) external onlyOwner returns (address deployedAt) {
+        uint256 expectedNonce = getNonce();
+        if (nonce != expectedNonce) revert SequentialFactory__InvalidNonce(nonce, expectedNonce);
+        ++_nonce;
+        // Use assembly to deploy the contract
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            // Add 0x20 to skip the length field of code
+            deployedAt := create(0, add(code, 0x20), mload(code))
+        }
+        // CREATE opcode returns 0 on deployment failure
+        if (deployedAt == address(0)) revert SequentialFactory__DeploymentFailed(nonce);
+    }
 
     /// @inheritdoc ISequentialFactory
-    function getNonce() external view returns (uint256 nonce) {}
+    function getNonce() public view returns (uint256 nonce) {
+        return _nonce;
+    }
 
     /// @inheritdoc ISequentialFactory
-    function predictDeployment(uint256 nonce) external view returns (address deployedAt) {}
+    function predictDeployment(uint256 nonce) public view returns (address deployedAt) {
+        // TODO: complete
+    }
 
     /// @inheritdoc ISequentialFactory
-    function predictNextDeployment() external view returns (address deployedAt) {}
+    function predictNextDeployment() external view returns (address deployedAt) {
+        return predictDeployment(getNonce());
+    }
 }

--- a/packages/contracts-core/contracts/factory/SequentialFactory.sol
+++ b/packages/contracts-core/contracts/factory/SequentialFactory.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.17;
 // ═════════════════════════════ INTERNAL IMPORTS ══════════════════════════════
 import {ISequentialFactory} from "../interfaces/ISequentialFactory.sol";
 // ═════════════════════════════ EXTERNAL IMPORTS ══════════════════════════════
+import {LibRLP} from "solmate/utils/LibRLP.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 contract SequentialFactory is Ownable, ISequentialFactory {
@@ -42,7 +43,7 @@ contract SequentialFactory is Ownable, ISequentialFactory {
 
     /// @inheritdoc ISequentialFactory
     function predictDeployment(uint256 nonce) public view returns (address deployedAt) {
-        // TODO: complete
+        return LibRLP.computeAddress(address(this), nonce);
     }
 
     /// @inheritdoc ISequentialFactory

--- a/packages/contracts-core/contracts/interfaces/ISequentialFactory.sol
+++ b/packages/contracts-core/contracts/interfaces/ISequentialFactory.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+interface ISequentialFactory {
+    /**
+     * @notice Deploys an arbitrary contract at the predicted address. The predicted address is
+     * calculated using the nonce of the factory and the address of the factory itself.
+     * The context of `code` does not influence the address of the deployment.
+     * @dev Will revert if nonce is not equal to the nonce of the factory.
+     * This is done to enable a multi-transaction deployment, where one unsuccessful deployment
+     * will lead to the nonce not being incremented and the next deployments will also fail.
+     * This guarantees the sequentiality of the deployments, and that one failed deployment will
+     * not lead to the predicted address being occupied by a different contract.
+     * Only the contract owner can deploy.
+     * @param nonce     The nonce of the factory
+     * @param code      The bytecode of the contract to deploy
+     */
+    function deploy(uint256 nonce, bytes memory code) external returns (address deployedAt);
+
+    /**
+     * @notice Returns the nonce of the factory. Using this value for the next deployment will
+     * guarantee the successful deployment.
+     */
+    function getNonce() external view returns (uint256 nonce);
+
+    /**
+     * @notice Returns the address of the contract that would be deployed using `deploy(nonce, *)`
+     * regardless of the `code` passed.
+     * @param nonce     The nonce of the factory
+     */
+    function predictDeployment(uint256 nonce) external view returns (address deployedAt);
+
+    /**
+     * @notice Returns the next address of the contract that would be deployed using `deploy(getNonce())`
+     * regardless of the `code` passed.
+     */
+    function predictNextDeployment() external view returns (address deployedAt);
+}

--- a/packages/contracts-core/remappings.txt
+++ b/packages/contracts-core/remappings.txt
@@ -1,3 +1,4 @@
 forge-std=lib/forge-std/src
 ds-test=lib/forge-std/lib/ds-test/src
 create3=lib/create3-factory/src
+solmate=lib/solmate/src

--- a/packages/contracts-core/test/suite/factory/Contracts.sol
+++ b/packages/contracts-core/test/suite/factory/Contracts.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+contract A {
+    uint256 public value;
+
+    constructor() {
+        value = 1337;
+    }
+}
+
+contract B {
+    uint256 public value;
+
+    constructor(uint256 value_) {
+        value = value_;
+    }
+}
+
+contract UnDeployable {
+    constructor() {
+        revert("GM, I don't feel so good...");
+    }
+}

--- a/packages/contracts-core/test/suite/factory/SequentialFactory.t.sol
+++ b/packages/contracts-core/test/suite/factory/SequentialFactory.t.sol
@@ -53,47 +53,47 @@ contract SequentialFactoryTest is Test {
 
     // ═══════════════════════════════════════ HAPPY PATH: FIRST DEPLOYMENT ════════════════════════════════════════════
 
-    function test_deploy_contractA_nonceOne_correctContract() public {
+    function test_deploy_nonce01_contractA_correctContract() public {
         address deployedAt = deploy(type(A).creationCode);
         A a = A(deployedAt);
         assertEq(a.value(), 1337);
     }
 
-    function test_deploy_contractA_nonceOne_incrementsNonce() public {
+    function test_deploy_nonce01_contractA_incrementsNonce() public {
         deploy(type(A).creationCode);
         assertEq(factory.getNonce(), 2);
     }
 
-    function test_deploy_contractA_nonceOne_predictDeployment() public {
+    function test_deploy_nonce01_contractA_predictDeployment() public {
         address predicted = factory.predictDeployment(1);
         address deployedAt = deploy(type(A).creationCode);
         assertEq(predicted, deployedAt);
     }
 
-    function test_deploy_contractA_nonceOne_predictNextDeployment() public {
+    function test_deploy_nonce01_contractA_predictNextDeployment() public {
         address predicted = factory.predictNextDeployment();
         address deployedAt = deploy(type(A).creationCode);
         assertEq(predicted, deployedAt);
     }
 
-    function test_deploy_contractB_nonceOne_correctContract() public {
+    function test_deploy_nonce01_contractB_correctContract() public {
         address deployedAt = deploy(getOneArgCode(42));
         B b = B(deployedAt);
         assertEq(b.value(), 42);
     }
 
-    function test_deploy_contractB_nonceOne_incrementsNonce() public {
+    function test_deploy_nonce01_contractB_incrementsNonce() public {
         deploy(getOneArgCode(42));
         assertEq(factory.getNonce(), 2);
     }
 
-    function test_deploy_contractB_nonceOne_predictDeployment() public {
+    function test_deploy_nonce01_contractB_predictDeployment() public {
         address predicted = factory.predictDeployment(1);
         address deployedAt = deploy(getOneArgCode(42));
         assertEq(predicted, deployedAt);
     }
 
-    function test_deploy_contractB_nonceOne_predictNextDeployment() public {
+    function test_deploy_nonce01_contractB_predictNextDeployment() public {
         address predicted = factory.predictNextDeployment();
         address deployedAt = deploy(getOneArgCode(42));
         assertEq(predicted, deployedAt);
@@ -101,54 +101,54 @@ contract SequentialFactoryTest is Test {
 
     // ═════════════════════════════════════ HAPPY PATH: NON-FIRST DEPLOYMENT ══════════════════════════════════════════
 
-    function test_deploy_contractA_nonceEleven_correctContract() public {
+    function test_deploy_nonce11_contractA_correctContract() public {
         deployTenContracts();
         address deployedAt = deploy(type(A).creationCode);
         A a = A(deployedAt);
         assertEq(a.value(), 1337);
     }
 
-    function test_deploy_contractA_nonceEleven_incrementsNonce() public {
+    function test_deploy_nonce11_contractA_incrementsNonce() public {
         deployTenContracts();
         deploy(type(A).creationCode);
         assertEq(factory.getNonce(), 12);
     }
 
-    function test_deploy_contractA_nonceEleven_predictDeployment() public {
+    function test_deploy_nonce11_contractA_predictDeployment() public {
         deployTenContracts();
         address predicted = factory.predictDeployment(11);
         address deployedAt = deploy(type(A).creationCode);
         assertEq(predicted, deployedAt);
     }
 
-    function test_deploy_contractA_nonceEleven_predictNextDeployment() public {
+    function test_deploy_nonce11_contractA_predictNextDeployment() public {
         deployTenContracts();
         address predicted = factory.predictNextDeployment();
         address deployedAt = deploy(type(A).creationCode);
         assertEq(predicted, deployedAt);
     }
 
-    function test_deploy_contractB_nonceEleven_correctContract() public {
+    function test_deploy_nonce11_contractB_correctContract() public {
         deployTenContracts();
         address deployedAt = deploy(getOneArgCode(42));
         B b = B(deployedAt);
         assertEq(b.value(), 42);
     }
 
-    function test_deploy_contractB_nonceEleven_incrementsNonce() public {
+    function test_deploy_nonce11_contractB_incrementsNonce() public {
         deployTenContracts();
         deploy(getOneArgCode(42));
         assertEq(factory.getNonce(), 12);
     }
 
-    function test_deploy_contractB_nonceEleven_predictDeployment() public {
+    function test_deploy_nonce11_contractB_predictDeployment() public {
         deployTenContracts();
         address predicted = factory.predictDeployment(11);
         address deployedAt = deploy(getOneArgCode(42));
         assertEq(predicted, deployedAt);
     }
 
-    function test_deploy_contractB_nonceEleven_predictNextDeployment() public {
+    function test_deploy_nonce11_contractB_predictNextDeployment() public {
         deployTenContracts();
         address predicted = factory.predictNextDeployment();
         address deployedAt = deploy(getOneArgCode(42));
@@ -175,52 +175,52 @@ contract SequentialFactoryTest is Test {
 
     // ══════════════════════════════════════════════════ REVERTS ══════════════════════════════════════════════════════
 
-    function test_deploy_nonceOne_reverts_whenCallerNotOwner() public {
+    function test_deploy_nonce01_reverts_whenCallerNotOwner() public {
         vm.expectRevert("Ownable: caller is not the owner");
         vm.prank(attacker);
         factory.deploy(1, type(A).creationCode);
     }
 
-    function test_deploy_nonceEleven_reverts_whenCallerNotOwner() public {
+    function test_deploy_nonce11_reverts_whenCallerNotOwner() public {
         deployTenContracts();
         vm.expectRevert("Ownable: caller is not the owner");
         vm.prank(attacker);
         factory.deploy(11, type(A).creationCode);
     }
 
-    function test_deploy_nonceOne_reverts_whenNonceIsLower() public {
+    function test_deploy_nonce01_reverts_whenNonceIsLower() public {
         vm.expectRevert(abi.encodeWithSelector(SequentialFactory.SequentialFactory__InvalidNonce.selector, 0, 1));
         vm.prank(owner);
         factory.deploy(0, type(A).creationCode);
     }
 
-    function test_deploy_nonceOne_reverts_whenNonceIsHigher() public {
+    function test_deploy_nonce01_reverts_whenNonceIsHigher() public {
         vm.expectRevert(abi.encodeWithSelector(SequentialFactory.SequentialFactory__InvalidNonce.selector, 2, 1));
         vm.prank(owner);
         factory.deploy(2, type(A).creationCode);
     }
 
-    function test_deploy_nonceEleven_reverts_whenNonceIsLower() public {
+    function test_deploy_nonce11_reverts_whenNonceIsLower() public {
         deployTenContracts();
         vm.expectRevert(abi.encodeWithSelector(SequentialFactory.SequentialFactory__InvalidNonce.selector, 10, 11));
         vm.prank(owner);
         factory.deploy(10, type(A).creationCode);
     }
 
-    function test_deploy_nonceEleven_reverts_whenNonceIsHigher() public {
+    function test_deploy_nonce11_reverts_whenNonceIsHigher() public {
         deployTenContracts();
         vm.expectRevert(abi.encodeWithSelector(SequentialFactory.SequentialFactory__InvalidNonce.selector, 12, 11));
         vm.prank(owner);
         factory.deploy(12, type(A).creationCode);
     }
 
-    function test_deploy_nonceOne_revert_whenDeploymentFails() public {
+    function test_deploy_nonce01_reverts_whenDeploymentFails() public {
         vm.expectRevert(abi.encodeWithSelector(SequentialFactory.SequentialFactory__DeploymentFailed.selector, 1));
         vm.prank(owner);
         factory.deploy(1, type(UnDeployable).creationCode);
     }
 
-    function test_deploy_nonceEleven_revert_whenDeploymentFails() public {
+    function test_deploy_nonce11_reverts_whenDeploymentFails() public {
         deployTenContracts();
         vm.expectRevert(abi.encodeWithSelector(SequentialFactory.SequentialFactory__DeploymentFailed.selector, 11));
         vm.prank(owner);

--- a/packages/contracts-core/test/suite/factory/SequentialFactory.t.sol
+++ b/packages/contracts-core/test/suite/factory/SequentialFactory.t.sol
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {SequentialFactory} from "../../../contracts/factory/SequentialFactory.sol";
+
+import {A, B, UnDeployable} from "./Contracts.sol";
+
+import {Test} from "forge-std/Test.sol";
+
+contract SequentialFactoryTest is Test {
+    SequentialFactory public factory;
+    address public owner;
+
+    function setUp() public {
+        owner = makeAddr("Owner");
+        factory = new SequentialFactory(owner);
+    }
+
+    function testSetup() public {
+        assertEq(address(factory.owner()), owner);
+        // Nonce starts at 1
+        assertEq(factory.getNonce(), 1);
+    }
+
+    // ═════════════════════════════════════════════ DEFINE TEST CASES ═════════════════════════════════════════════════
+
+    function getOneArgCode(uint256 value) internal pure returns (bytes memory code) {
+        return abi.encodePacked(type(B).creationCode, abi.encode(value));
+    }
+
+    function getCodeTenDeployments(uint256 index) internal pure returns (bytes memory code) {
+        // First 10 deployments are A, B, A, B, A, B, A, B, A, B
+        if (index % 2 == 0) {
+            return type(A).creationCode;
+        } else {
+            return getOneArgCode(index);
+        }
+    }
+
+    function deploy(bytes memory code) internal returns (address deployedAt) {
+        uint256 nonce = factory.getNonce();
+        vm.prank(owner);
+        return factory.deploy(nonce, code);
+    }
+
+    function deployTenContracts() internal {
+        for (uint256 i = 0; i < 10; i++) {
+            deploy(getCodeTenDeployments(i));
+        }
+    }
+
+    // ═══════════════════════════════════════ HAPPY PATH: FIRST DEPLOYMENT ════════════════════════════════════════════
+
+    function test_deploy_contractA_nonceOne_correctContract() public {
+        address deployedAt = deploy(type(A).creationCode);
+        A a = A(deployedAt);
+        assertEq(a.value(), 1337);
+    }
+
+    function test_deploy_contractA_nonceOne_incrementsNonce() public {
+        deploy(type(A).creationCode);
+        assertEq(factory.getNonce(), 2);
+    }
+
+    function test_deploy_contractA_nonceOne_predictDeployment() public {
+        address predicted = factory.predictDeployment(1);
+        address deployedAt = deploy(type(A).creationCode);
+        assertEq(predicted, deployedAt);
+    }
+
+    function test_deploy_contractA_nonceOne_predictNextDeployment() public {
+        address predicted = factory.predictNextDeployment();
+        address deployedAt = deploy(type(A).creationCode);
+        assertEq(predicted, deployedAt);
+    }
+
+    function test_deploy_contractB_nonceOne_correctContract() public {
+        address deployedAt = deploy(getOneArgCode(42));
+        B b = B(deployedAt);
+        assertEq(b.value(), 42);
+    }
+
+    function test_deploy_contractB_nonceOne_incrementsNonce() public {
+        deploy(getOneArgCode(42));
+        assertEq(factory.getNonce(), 2);
+    }
+
+    function test_deploy_contractB_nonceOne_predictDeployment() public {
+        address predicted = factory.predictDeployment(1);
+        address deployedAt = deploy(getOneArgCode(42));
+        assertEq(predicted, deployedAt);
+    }
+
+    function test_deploy_contractB_nonceOne_predictNextDeployment() public {
+        address predicted = factory.predictNextDeployment();
+        address deployedAt = deploy(getOneArgCode(42));
+        assertEq(predicted, deployedAt);
+    }
+
+    // ═════════════════════════════════════ HAPPY PATH: NON-FIRST DEPLOYMENT ══════════════════════════════════════════
+
+    function test_deploy_contractA_nonceEleven_correctContract() public {
+        deployTenContracts();
+        address deployedAt = deploy(type(A).creationCode);
+        A a = A(deployedAt);
+        assertEq(a.value(), 1337);
+    }
+
+    function test_deploy_contractA_nonceEleven_incrementsNonce() public {
+        deployTenContracts();
+        deploy(type(A).creationCode);
+        assertEq(factory.getNonce(), 12);
+    }
+
+    function test_deploy_contractA_nonceEleven_predictDeployment() public {
+        deployTenContracts();
+        address predicted = factory.predictDeployment(11);
+        address deployedAt = deploy(type(A).creationCode);
+        assertEq(predicted, deployedAt);
+    }
+
+    function test_deploy_contractA_nonceEleven_predictNextDeployment() public {
+        deployTenContracts();
+        address predicted = factory.predictNextDeployment();
+        address deployedAt = deploy(type(A).creationCode);
+        assertEq(predicted, deployedAt);
+    }
+
+    function test_deploy_contractB_nonceEleven_correctContract() public {
+        deployTenContracts();
+        address deployedAt = deploy(getOneArgCode(42));
+        B b = B(deployedAt);
+        assertEq(b.value(), 42);
+    }
+
+    function test_deploy_contractB_nonceEleven_incrementsNonce() public {
+        deployTenContracts();
+        deploy(getOneArgCode(42));
+        assertEq(factory.getNonce(), 12);
+    }
+
+    function test_deploy_contractB_nonceEleven_predictDeployment() public {
+        deployTenContracts();
+        address predicted = factory.predictDeployment(11);
+        address deployedAt = deploy(getOneArgCode(42));
+        assertEq(predicted, deployedAt);
+    }
+
+    function test_deploy_contractB_nonceEleven_predictNextDeployment() public {
+        deployTenContracts();
+        address predicted = factory.predictNextDeployment();
+        address deployedAt = deploy(getOneArgCode(42));
+        assertEq(predicted, deployedAt);
+    }
+
+    // ════════════════════════════════════════ PREDICT DEPLOYMENT ADDRESS ═════════════════════════════════════════════
+
+    function test_predictDeployment_tenContracts() public {
+        for (uint256 i = 0; i < 10; i++) {
+            address predicted = factory.predictDeployment(i + 1);
+            address deployedAt = deploy(getCodeTenDeployments(i));
+            assertEq(predicted, deployedAt);
+        }
+    }
+
+    function test_predictNextDeployment_tenContracts() public {
+        for (uint256 i = 0; i < 10; i++) {
+            address predicted = factory.predictNextDeployment();
+            address deployedAt = deploy(getCodeTenDeployments(i));
+            assertEq(predicted, deployedAt);
+        }
+    }
+}


### PR DESCRIPTION
**Description**
Adds a factory for back-to-back deployments with predictable addresses.

This is helpful if you need to deploy contracts A, B and C and pass:
- Address of B and C to A during construction
- Address of A and B to C during construction

This allows us to get rid of the Create3Factory dependency later on. `SequentialFactory` itself could be created using create2, if needed, to guarantee the consistent cross-chain addresses.

**Additional context**
Add any other context about the problem you're solving.

**Metadata**
- Fixes #[Link to Issue]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new `SequentialFactory` contract for deploying contracts and managing deployments.
  - Added a new `ISequentialFactory` interface to define the contract deployment process.
  - Integrated the "solmate" library as a submodule for enhanced contract functionality.

- **Documentation**
  - Updated workflow documentation to specify a fixed version of the Foundry toolchain.

- **Tests**
  - Added a comprehensive test suite for the `SequentialFactory` contract to ensure correct functionality.

- **Chores**
  - Updated remappings to include the new "solmate" library path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->