### PR TITLE
Messaging: support factory deployment

### DIFF
--- a/packages/contracts-core/contracts/Destination.sol
+++ b/packages/contracts-core/contracts/Destination.sol
@@ -69,11 +69,10 @@ contract Destination is ExecutionHub, DestinationEvents, InterfaceDestination {
     {} // solhint-disable-line no-empty-blocks
 
     /// @notice Initializes Destination contract:
-    /// - msg.sender is set as contract owner
-    function initialize(bytes32 agentRoot) external initializer {
-        // Initialize Ownable: msg.sender is set as "owner"
-        __Ownable2Step_init();
-        // Initialize ReeentrancyGuard
+    /// - `owner_` is set as contract owner
+    /// - `agentRoot` is set as the initial Agent Merkle Root in LightManager (if not on Synapse Chain)
+    function initialize(bytes32 agentRoot, address owner_) external initializer {
+        __MessagingBase_init(owner_);
         __ReentrancyGuard_init();
         // Set Agent Merkle Root in Light Manager
         if (localDomain != synapseDomain) {

--- a/packages/contracts-core/contracts/GasOracle.sol
+++ b/packages/contracts-core/contracts/GasOracle.sol
@@ -57,10 +57,9 @@ contract GasOracle is MessagingBase, GasOracleEvents, InterfaceGasOracle {
     }
 
     /// @notice Initializes GasOracle contract:
-    /// - msg.sender is set as contract owner
-    function initialize() external initializer {
-        // Initialize Ownable: msg.sender is set as "owner"
-        __Ownable2Step_init();
+    /// - `owner_` is set as contract owner
+    function initialize(address owner_) external initializer {
+        __MessagingBase_init(owner_);
     }
 
     /// @notice MVP function to set the gas data for the given domain.

--- a/packages/contracts-core/contracts/Origin.sol
+++ b/packages/contracts-core/contracts/Origin.sol
@@ -55,11 +55,10 @@ contract Origin is StateHub, OriginEvents, InterfaceOrigin {
     }
 
     /// @notice Initializes Origin contract:
-    /// - msg.sender is set as contract owner
+    /// - `owner_` is set as contract owner
     /// - State of "empty merkle tree" is saved
-    function initialize() external initializer {
-        // Initialize Ownable: msg.sender is set as "owner"
-        __Ownable2Step_init();
+    function initialize(address owner_) external initializer {
+        __MessagingBase_init(owner_);
         // Initialize "states": state of an "empty merkle tree" is saved
         _initializeStates();
     }

--- a/packages/contracts-core/contracts/Summit.sol
+++ b/packages/contracts-core/contracts/Summit.sol
@@ -101,9 +101,11 @@ contract Summit is SnapshotHub, SummitEvents, InterfaceSummit {
         if (localDomain != synapseDomain) revert MustBeSynapseDomain();
     }
 
-    function initialize() external initializer {
-        // Initialize Ownable: msg.sender is set as "owner"
-        __Ownable2Step_init();
+    /// @notice Initializes Summit contract:
+    /// - `owner_` is set as contract owner
+    /// - Empty snapshot and attestation are saved, so that the attestation nonce starts from 1
+    function initialize(address owner_) external initializer {
+        __MessagingBase_init(owner_);
         _initializeAttestations();
     }
 

--- a/packages/contracts-core/contracts/base/MessagingBase.sol
+++ b/packages/contracts-core/contracts/base/MessagingBase.sol
@@ -33,6 +33,10 @@ abstract contract MessagingBase is MultiCallable, Versioned, Ownable2StepUpgrade
         synapseDomain = synapseDomain_;
     }
 
+    function __MessagingBase_init(address owner_) internal onlyInitializing {
+        _transferOwnership(owner_);
+    }
+
     // TODO: Implement pausing
 
     /**

--- a/packages/contracts-core/contracts/inbox/Inbox.sol
+++ b/packages/contracts-core/contracts/inbox/Inbox.sol
@@ -58,13 +58,13 @@ contract Inbox is StatementInbox, InboxEvents, InterfaceInbox {
     }
 
     /// @notice Initializes `Inbox` contract:
-    /// - Sets `msg.sender` as the owner of the contract
+    /// - Sets `owner_` as the owner of the contract
     /// - Sets `agentManager`, `origin`, `destination` and `summit` addresses
-    function initialize(address agentManager_, address origin_, address destination_, address summit_)
+    function initialize(address agentManager_, address origin_, address destination_, address summit_, address owner_)
         external
         initializer
     {
-        __StatementInbox_init(agentManager_, origin_, destination_);
+        __StatementInbox_init(agentManager_, origin_, destination_, owner_);
         summit = summit_;
     }
 

--- a/packages/contracts-core/contracts/inbox/LightInbox.sol
+++ b/packages/contracts-core/contracts/inbox/LightInbox.sol
@@ -27,10 +27,13 @@ contract LightInbox is StatementInbox, InterfaceLightInbox {
     }
 
     /// @notice Initializes `LightInbox` contract:
-    /// - Sets `msg.sender` as the owner of the contract
+    /// - Sets `owner_` as the owner of the contract
     /// - Sets `agentManager`, `origin` and `destination` addresses
-    function initialize(address agentManager_, address origin_, address destination_) external initializer {
-        __StatementInbox_init(agentManager_, origin_, destination_);
+    function initialize(address agentManager_, address origin_, address destination_, address owner_)
+        external
+        initializer
+    {
+        __StatementInbox_init(agentManager_, origin_, destination_, owner_);
     }
 
     // ══════════════════════════════════════════ SUBMIT AGENT STATEMENTS ══════════════════════════════════════════════

--- a/packages/contracts-core/contracts/inbox/StatementInbox.sol
+++ b/packages/contracts-core/contracts/inbox/StatementInbox.sol
@@ -61,17 +61,17 @@ abstract contract StatementInbox is MessagingBase, StatementInboxEvents, IStatem
     // ════════════════════════════════════════════════ INITIALIZER ════════════════════════════════════════════════════
 
     /// @dev Initializes the contract:
-    /// - Sets up `msg.sender` as the owner of the contract.
+    /// - Sets up `owner_` as the owner of the contract.
     /// - Sets up `agentManager`, `origin`, and `destination`.
     // solhint-disable-next-line func-name-mixedcase
-    function __StatementInbox_init(address agentManager_, address origin_, address destination_)
+    function __StatementInbox_init(address agentManager_, address origin_, address destination_, address owner_)
         internal
         onlyInitializing
     {
+        __MessagingBase_init(owner_);
         agentManager = agentManager_;
         origin = origin_;
         destination = destination_;
-        __Ownable2Step_init();
     }
 
     // ══════════════════════════════════════════ SUBMIT AGENT STATEMENTS ══════════════════════════════════════════════

--- a/packages/contracts-core/contracts/manager/AgentManager.sol
+++ b/packages/contracts-core/contracts/manager/AgentManager.sol
@@ -74,7 +74,11 @@ abstract contract AgentManager is MessagingBase, AgentManagerEvents, IAgentManag
     // ════════════════════════════════════════════════ INITIALIZER ════════════════════════════════════════════════════
 
     // solhint-disable-next-line func-name-mixedcase
-    function __AgentManager_init(address origin_, address destination_, address inbox_) internal onlyInitializing {
+    function __AgentManager_init(address origin_, address destination_, address inbox_, address owner_)
+        internal
+        onlyInitializing
+    {
+        __MessagingBase_init(owner_);
         origin = origin_;
         destination = destination_;
         inbox = inbox_;

--- a/packages/contracts-core/contracts/manager/BondingManager.sol
+++ b/packages/contracts-core/contracts/manager/BondingManager.sol
@@ -69,10 +69,12 @@ contract BondingManager is AgentManager, InterfaceBondingManager {
         if (localDomain != synapseDomain) revert MustBeSynapseDomain();
     }
 
-    function initialize(address origin_, address destination_, address inbox_, address summit_) external initializer {
-        __AgentManager_init(origin_, destination_, inbox_);
+    function initialize(address origin_, address destination_, address inbox_, address summit_, address owner_)
+        external
+        initializer
+    {
+        __AgentManager_init(origin_, destination_, inbox_, owner_);
         summit = summit_;
-        __Ownable2Step_init();
         // Insert a zero address to make indexes for Agents start from 1.
         // Zeroed index is supposed to be used as a sentinel value meaning "no agent".
         _agents.push(address(0));

--- a/packages/contracts-core/contracts/manager/LightManager.sol
+++ b/packages/contracts-core/contracts/manager/LightManager.sol
@@ -64,9 +64,8 @@ contract LightManager is AgentManager, InterfaceLightManager {
         if (localDomain == synapseDomain_) revert SynapseDomainForbidden();
     }
 
-    function initialize(address origin_, address destination_, address inbox_) external initializer {
-        __AgentManager_init(origin_, destination_, inbox_);
-        __Ownable2Step_init();
+    function initialize(address origin_, address destination_, address inbox_, address owner_) external initializer {
+        __AgentManager_init(origin_, destination_, inbox_, owner_);
     }
 
     // ════════════════════════════════════════════════ OWNER ONLY ═════════════════════════════════════════════════════

--- a/packages/contracts-core/script/DeployMessaging003Base.s.sol
+++ b/packages/contracts-core/script/DeployMessaging003Base.s.sol
@@ -162,7 +162,7 @@ abstract contract DeployMessaging003BaseScript is DeployerUtils {
     function _initializeDestination(address deployment) internal {
         if (Destination(deployment).owner() == address(0)) {
             console.log("   %s: initializing", DESTINATION);
-            Destination(deployment).initialize(_getInitialAgentRoot());
+            Destination(deployment).initialize(_getInitialAgentRoot(), broadcasterAddress);
         } else {
             console.log("   %s: already initialized", DESTINATION);
         }
@@ -181,7 +181,7 @@ abstract contract DeployMessaging003BaseScript is DeployerUtils {
     function _initializeGasOracle(address deployment) internal {
         if (GasOracle(deployment).owner() == address(0)) {
             console.log("   %s: initializing", GAS_ORACLE);
-            GasOracle(deployment).initialize();
+            GasOracle(deployment).initialize(broadcasterAddress);
         } else {
             console.log("   %s: already initialized", GAS_ORACLE);
         }
@@ -202,7 +202,7 @@ abstract contract DeployMessaging003BaseScript is DeployerUtils {
     function _initializeOrigin(address deployment) internal {
         if (Origin(deployment).owner() == address(0)) {
             console.log("   %s: initializing", ORIGIN);
-            Origin(deployment).initialize();
+            Origin(deployment).initialize(broadcasterAddress);
         } else {
             console.log("   %s: already initialized", ORIGIN);
         }
@@ -222,7 +222,7 @@ abstract contract DeployMessaging003BaseScript is DeployerUtils {
     function _initializeSummit(address deployment) internal {
         if (Summit(deployment).owner() == address(0)) {
             console.log("   %s: initializing", SUMMIT);
-            Summit(deployment).initialize();
+            Summit(deployment).initialize(broadcasterAddress);
         } else {
             console.log("   %s: already initialized", SUMMIT);
         }

--- a/packages/contracts-core/script/DeployMessaging003LightChain.s.sol
+++ b/packages/contracts-core/script/DeployMessaging003LightChain.s.sol
@@ -32,7 +32,12 @@ contract DeployMessaging003LightChainScript is DeployMessaging003BaseScript {
     function _initializeAgentManager(address deployment) internal override {
         if (LightManager(deployment).owner() == address(0)) {
             console.log("   %s: initializing", agentManagerName());
-            LightManager(deployment).initialize({origin_: origin, destination_: destination, inbox_: statementInbox});
+            LightManager(deployment).initialize({
+                origin_: origin,
+                destination_: destination,
+                inbox_: statementInbox,
+                owner_: broadcasterAddress
+            });
         } else {
             console.log("   %s: already initialized", agentManagerName());
         }
@@ -53,7 +58,12 @@ contract DeployMessaging003LightChainScript is DeployMessaging003BaseScript {
     function _initializeStatementInbox(address deployment) internal override {
         if (LightInbox(deployment).owner() == address(0)) {
             console.log("   %s: initializing", statementInboxName());
-            LightInbox(deployment).initialize({agentManager_: agentManager, origin_: origin, destination_: destination});
+            LightInbox(deployment).initialize({
+                agentManager_: agentManager,
+                origin_: origin,
+                destination_: destination,
+                owner_: broadcasterAddress
+            });
         } else {
             console.log("   %s: already initialized", statementInboxName());
         }

--- a/packages/contracts-core/script/DeployMessaging003SynChain.s.sol
+++ b/packages/contracts-core/script/DeployMessaging003SynChain.s.sol
@@ -37,7 +37,8 @@ contract DeployMessaging003SynChainScript is DeployMessaging003BaseScript {
                 origin_: origin,
                 destination_: destination,
                 inbox_: statementInbox,
-                summit_: summit
+                summit_: summit,
+                owner_: broadcasterAddress
             });
         } else {
             console.log("   %s: already initialized", agentManagerName());
@@ -64,7 +65,8 @@ contract DeployMessaging003SynChainScript is DeployMessaging003BaseScript {
                 agentManager_: agentManager,
                 origin_: origin,
                 destination_: destination,
-                summit_: summit
+                summit_: summit,
+                owner_: broadcasterAddress
             });
         } else {
             console.log("   %s: already initialized", statementInboxName());

--- a/packages/contracts-core/test/suite/Destination.t.sol
+++ b/packages/contracts-core/test/suite/Destination.t.sol
@@ -59,11 +59,12 @@ contract DestinationTest is ExecutionHubTest {
         LightManager agentManager = new LightManager(DOMAIN_SYNAPSE);
         address inbox_ = random.nextAddress();
         bytes32 agentRoot = random.next();
+        address owner_ = random.nextAddress();
         Destination cleanContract = new Destination(DOMAIN_SYNAPSE, address(agentManager), inbox_);
-        agentManager.initialize(address(0), address(cleanContract), inbox_);
+        agentManager.initialize(address(0), address(cleanContract), inbox_, owner_);
         vm.prank(caller);
-        cleanContract.initialize(agentRoot);
-        assertEq(cleanContract.owner(), caller, "!owner");
+        cleanContract.initialize(agentRoot, owner_);
+        assertEq(cleanContract.owner(), owner_, "!owner");
         assertEq(cleanContract.localDomain(), domain, "!localDomain");
         assertEq(cleanContract.agentManager(), address(agentManager), "!agentManager");
         assertEq(cleanContract.inbox(), inbox_, "!inbox");
@@ -71,7 +72,7 @@ contract DestinationTest is ExecutionHubTest {
     }
 
     function initializeLocalContract() public override {
-        Destination(localContract()).initialize(0);
+        Destination(localContract()).initialize(0, address(0));
     }
 
     // ════════════════════════════════════════════════ OTHER TESTS ════════════════════════════════════════════════════

--- a/packages/contracts-core/test/suite/DestinationSynapse.t.sol
+++ b/packages/contracts-core/test/suite/DestinationSynapse.t.sol
@@ -44,12 +44,13 @@ contract DestinationSynapseTest is ExecutionHubTest {
         BondingManager manager = new BondingManager(domain);
         address inbox_ = random.nextAddress();
         bytes32 agentRoot = random.next();
+        address owner_ = random.nextAddress();
         Destination cleanContract = new Destination(DOMAIN_SYNAPSE, address(manager), inbox_);
-        manager.initialize(address(0), address(cleanContract), inbox_, address(0));
+        manager.initialize(address(0), address(cleanContract), inbox_, address(0), owner_);
         // agentRoot should be ignored on Synapse Chain
         vm.prank(caller);
-        cleanContract.initialize(agentRoot);
-        assertEq(cleanContract.owner(), caller, "!owner");
+        cleanContract.initialize(agentRoot, owner_);
+        assertEq(cleanContract.owner(), owner_, "!owner");
         assertEq(cleanContract.localDomain(), domain, "!localDomain");
         assertEq(cleanContract.agentManager(), address(manager), "!agentManager");
         assertEq(cleanContract.inbox(), inbox_, "!inbox");
@@ -57,7 +58,7 @@ contract DestinationSynapseTest is ExecutionHubTest {
     }
 
     function initializeLocalContract() public override {
-        Destination(localContract()).initialize(0);
+        Destination(localContract()).initialize(0, address(0));
     }
 
     function test_getAttestation(Random memory random) public {

--- a/packages/contracts-core/test/suite/GasOracle.t.sol
+++ b/packages/contracts-core/test/suite/GasOracle.t.sol
@@ -18,10 +18,11 @@ contract GasOracleTest is MessagingBaseTest {
         vm.chainId(domain);
         address caller = random.nextAddress();
         address destination_ = random.nextAddress();
+        address owner_ = random.nextAddress();
         GasOracle cleanContract = new GasOracle(DOMAIN_SYNAPSE, destination_);
         vm.prank(caller);
-        cleanContract.initialize();
-        assertEq(cleanContract.owner(), caller, "!owner");
+        cleanContract.initialize(owner_);
+        assertEq(cleanContract.owner(), owner_, "!owner");
         assertEq(cleanContract.localDomain(), domain, "!localDomain");
         assertEq(cleanContract.destination(), destination_, "!destination");
     }
@@ -33,7 +34,7 @@ contract GasOracleTest is MessagingBaseTest {
     }
 
     function initializeLocalContract() public override {
-        testedGO().initialize();
+        testedGO().initialize(address(0));
     }
 
     // ══════════════════════════════════════════════════ HELPERS ══════════════════════════════════════════════════════

--- a/packages/contracts-core/test/suite/Origin.t.sol
+++ b/packages/contracts-core/test/suite/Origin.t.sol
@@ -75,11 +75,12 @@ contract OriginTest is AgentSecuredTest {
         address agentManager = random.nextAddress();
         address inbox_ = random.nextAddress();
         address gasOracle_ = address(new GasOracle(DOMAIN_SYNAPSE, random.nextAddress()));
+        address owner_ = random.nextAddress();
 
         Origin cleanContract = new Origin(DOMAIN_SYNAPSE, agentManager, inbox_, gasOracle_);
         vm.prank(caller);
-        cleanContract.initialize();
-        assertEq(cleanContract.owner(), caller, "!owner");
+        cleanContract.initialize(owner_);
+        assertEq(cleanContract.owner(), owner_, "!owner");
         assertEq(cleanContract.localDomain(), domain, "!localDomain");
         assertEq(cleanContract.agentManager(), agentManager, "!agentManager");
         assertEq(cleanContract.inbox(), inbox_, "!inbox");
@@ -88,7 +89,7 @@ contract OriginTest is AgentSecuredTest {
     }
 
     function initializeLocalContract() public override {
-        Origin(localContract()).initialize();
+        Origin(localContract()).initialize(address(0));
     }
 
     function test_sendBaseMessage_revert_blockTimestampOverflow() public {

--- a/packages/contracts-core/test/suite/Summit.t.sol
+++ b/packages/contracts-core/test/suite/Summit.t.sol
@@ -80,17 +80,18 @@ contract SummitTest is AgentSecuredTest {
         address agentManager = random.nextAddress();
         address inbox_ = random.nextAddress();
         address caller = random.nextAddress();
+        address owner_ = random.nextAddress();
         Summit cleanContract = new Summit(domain, agentManager, inbox_);
         vm.prank(caller);
-        cleanContract.initialize();
-        assertEq(cleanContract.owner(), caller, "!owner");
+        cleanContract.initialize(owner_);
+        assertEq(cleanContract.owner(), owner_, "!owner");
         assertEq(cleanContract.agentManager(), agentManager, "!agentManager");
         assertEq(cleanContract.inbox(), inbox_, "!inbox");
         assertEq(cleanContract.localDomain(), domain, "!localDomain");
     }
 
     function initializeLocalContract() public override {
-        Summit(localContract()).initialize();
+        Summit(localContract()).initialize(address(0));
     }
 
     function test_acceptGuardSnapshot_revert_notInbox(address caller) public {

--- a/packages/contracts-core/test/suite/SummitTips.t.sol
+++ b/packages/contracts-core/test/suite/SummitTips.t.sol
@@ -114,17 +114,18 @@ contract SummitTipsTest is AgentSecuredTest {
         address agentManager = random.nextAddress();
         address inbox_ = random.nextAddress();
         address caller = random.nextAddress();
+        address owner_ = random.nextAddress();
         Summit cleanContract = new Summit(domain, agentManager, inbox_);
         vm.prank(caller);
-        cleanContract.initialize();
-        assertEq(cleanContract.owner(), caller, "!owner");
+        cleanContract.initialize(owner_);
+        assertEq(cleanContract.owner(), owner_, "!owner");
         assertEq(cleanContract.agentManager(), agentManager, "!agentManager");
         assertEq(cleanContract.inbox(), inbox_, "!inbox");
         assertEq(cleanContract.localDomain(), domain, "!localDomain");
     }
 
     function initializeLocalContract() public override {
-        Summit(localContract()).initialize();
+        Summit(localContract()).initialize(address(0));
     }
 
     function prepareNotaryInDisputeTest() internal {

--- a/packages/contracts-core/test/suite/inbox/Inbox.t.sol
+++ b/packages/contracts-core/test/suite/inbox/Inbox.t.sol
@@ -43,10 +43,11 @@ contract InboxTest is StatementInboxTest {
         address origin_ = random.nextAddress();
         address destination_ = random.nextAddress();
         address summit_ = random.nextAddress();
+        address owner_ = random.nextAddress();
         Inbox inbox_ = new Inbox(domain);
         vm.prank(caller);
-        inbox_.initialize(agentManager, origin_, destination_, summit_);
-        assertEq(inbox_.owner(), caller);
+        inbox_.initialize(agentManager, origin_, destination_, summit_, owner_);
+        assertEq(inbox_.owner(), owner_);
         assertEq(inbox_.localDomain(), domain);
         assertEq(inbox_.origin(), origin_);
         assertEq(inbox_.destination(), destination_);
@@ -74,7 +75,7 @@ contract InboxTest is StatementInboxTest {
     }
 
     function initializeLocalContract() public override {
-        Inbox(localContract()).initialize(address(0), address(0), address(0), address(0));
+        Inbox(localContract()).initialize(address(0), address(0), address(0), address(0), address(0));
     }
 
     // ══════════════════════════════════════════ TEST: SUBMIT STATEMENTS ══════════════════════════════════════════════

--- a/packages/contracts-core/test/suite/inbox/LightInbox.t.sol
+++ b/packages/contracts-core/test/suite/inbox/LightInbox.t.sol
@@ -36,10 +36,11 @@ contract LightInboxTest is StatementInboxTest {
         address agentManager = random.nextAddress();
         address origin_ = random.nextAddress();
         address destination_ = random.nextAddress();
+        address owner_ = random.nextAddress();
         LightInbox lightInbox_ = new LightInbox(DOMAIN_SYNAPSE);
         vm.prank(caller);
-        lightInbox_.initialize(agentManager, origin_, destination_);
-        assertEq(lightInbox_.owner(), caller);
+        lightInbox_.initialize(agentManager, origin_, destination_, owner_);
+        assertEq(lightInbox_.owner(), owner_);
         assertEq(lightInbox_.localDomain(), domain);
         assertEq(lightInbox_.origin(), origin_);
         assertEq(lightInbox_.destination(), destination_);
@@ -64,7 +65,7 @@ contract LightInboxTest is StatementInboxTest {
     }
 
     function initializeLocalContract() public override {
-        LightInbox(lightInbox).initialize(address(0), address(0), address(0));
+        LightInbox(lightInbox).initialize(address(0), address(0), address(0), address(0));
     }
 
     // ══════════════════════════════════════════ TEST: SUBMIT STATEMENTS ══════════════════════════════════════════════

--- a/packages/contracts-core/test/suite/manager/BondingManager.t.sol
+++ b/packages/contracts-core/test/suite/manager/BondingManager.t.sol
@@ -42,11 +42,12 @@ contract BondingManagerTest is AgentManagerTest {
         address destination_ = random.nextAddress();
         address summit_ = random.nextAddress();
         address inbox_ = random.nextAddress();
+        address owner_ = random.nextAddress();
         BondingManager cleanContract = new BondingManager(domain);
         vm.prank(caller);
-        cleanContract.initialize(origin_, destination_, inbox_, summit_);
+        cleanContract.initialize(origin_, destination_, inbox_, summit_, owner_);
         assertEq(cleanContract.localDomain(), domain);
-        assertEq(cleanContract.owner(), caller);
+        assertEq(cleanContract.owner(), owner_);
         assertEq(cleanContract.origin(), origin_);
         assertEq(cleanContract.destination(), destination_);
         assertEq(cleanContract.inbox(), inbox_);
@@ -55,7 +56,7 @@ contract BondingManagerTest is AgentManagerTest {
     }
 
     function initializeLocalContract() public override {
-        BondingManager(localContract()).initialize(address(0), address(0), address(0), address(0));
+        BondingManager(localContract()).initialize(address(0), address(0), address(0), address(0), address(0));
     }
 
     function test_constructor_revert_notOnSynapseChain(uint32 domain) public {
@@ -174,7 +175,7 @@ contract BondingManagerTest is AgentManagerTest {
         // Deploy fresh instance of BondingManager
         vm.chainId(DOMAIN_SYNAPSE);
         bondingManager = new BondingManagerHarness(DOMAIN_SYNAPSE);
-        bondingManager.initialize(originSynapse, destinationSynapse, address(inbox), summit);
+        bondingManager.initialize(originSynapse, destinationSynapse, address(inbox), summit, address(this));
         // Try to add all agents one by one
         for (uint256 d = 0; d < allDomains.length; ++d) {
             uint32 domain = allDomains[d];

--- a/packages/contracts-core/test/suite/manager/LightManager.t.sol
+++ b/packages/contracts-core/test/suite/manager/LightManager.t.sol
@@ -36,18 +36,19 @@ contract LightManagerTest is AgentManagerTest {
         address origin_ = random.nextAddress();
         address destination_ = random.nextAddress();
         address inbox_ = random.nextAddress();
+        address owner_ = random.nextAddress();
         LightManager cleanContract = new LightManager(DOMAIN_SYNAPSE);
         vm.prank(caller);
-        cleanContract.initialize(origin_, destination_, inbox_);
+        cleanContract.initialize(origin_, destination_, inbox_, owner_);
         assertEq(cleanContract.localDomain(), domain);
-        assertEq(cleanContract.owner(), caller);
+        assertEq(cleanContract.owner(), owner_);
         assertEq(cleanContract.origin(), origin_);
         assertEq(cleanContract.destination(), destination_);
         assertEq(cleanContract.inbox(), inbox_);
     }
 
     function initializeLocalContract() public override {
-        LightManager(localContract()).initialize(address(0), address(0), address(0));
+        LightManager(localContract()).initialize(address(0), address(0), address(0), address(0));
     }
 
     function test_constructor_revert_chainIdOverflow() public {

--- a/packages/contracts-core/test/utils/SynapseTest.t.sol
+++ b/packages/contracts-core/test/utils/SynapseTest.t.sol
@@ -93,7 +93,7 @@ abstract contract SynapseTest is ProductionEvents, SuiteEvents, SynapseAgents, S
     function setupAgentsLM() public virtual {
         if (deployMask & DEPLOY_MASK_DESTINATION == DEPLOY_PROD_DESTINATION) {
             // Set initial agent merkle root via production Destination
-            Destination(destination).initialize(getAgentRoot());
+            Destination(destination).initialize(getAgentRoot(), address(this));
         } else {
             // Mock a call from destination instead
             bytes32 root = getAgentRoot();
@@ -118,7 +118,7 @@ abstract contract SynapseTest is ProductionEvents, SuiteEvents, SynapseAgents, S
     }
 
     function initLightManager() public virtual {
-        lightManager.initialize(origin, destination, address(lightInbox));
+        lightManager.initialize(origin, destination, address(lightInbox), address(this));
     }
 
     function deployBondingManager() public virtual {
@@ -128,7 +128,7 @@ abstract contract SynapseTest is ProductionEvents, SuiteEvents, SynapseAgents, S
     }
 
     function initBondingManager() public virtual {
-        bondingManager.initialize(originSynapse, destinationSynapse, address(inbox), summit);
+        bondingManager.initialize(originSynapse, destinationSynapse, address(inbox), summit, address(this));
     }
 
     function deployLightInbox() public virtual {
@@ -137,7 +137,7 @@ abstract contract SynapseTest is ProductionEvents, SuiteEvents, SynapseAgents, S
     }
 
     function initLightInbox() public virtual {
-        LightInbox(lightInbox).initialize(address(lightManager), origin, destination);
+        LightInbox(lightInbox).initialize(address(lightManager), origin, destination, address(this));
     }
 
     function deployInbox() public virtual {
@@ -146,7 +146,7 @@ abstract contract SynapseTest is ProductionEvents, SuiteEvents, SynapseAgents, S
     }
 
     function initInbox() public virtual {
-        Inbox(inbox).initialize(address(bondingManager), originSynapse, destinationSynapse, summit);
+        Inbox(inbox).initialize(address(bondingManager), originSynapse, destinationSynapse, summit, address(this));
     }
 
     function deployGasOracle() public virtual {
@@ -155,7 +155,7 @@ abstract contract SynapseTest is ProductionEvents, SuiteEvents, SynapseAgents, S
             gasOracle = address(new GasOracleMock());
         } else if (option == DEPLOY_PROD_GAS_ORACLE) {
             gasOracle = address(new GasOracle(DOMAIN_SYNAPSE, destination));
-            GasOracle(gasOracle).initialize();
+            GasOracle(gasOracle).initialize(address(this));
         } else {
             revert("Unknown option: GasOracle");
         }
@@ -181,7 +181,7 @@ abstract contract SynapseTest is ProductionEvents, SuiteEvents, SynapseAgents, S
             origin = address(new OriginMock());
         } else if (option == DEPLOY_PROD_ORIGIN) {
             origin = address(new Origin(DOMAIN_SYNAPSE, address(lightManager), address(lightInbox), gasOracle));
-            Origin(origin).initialize();
+            Origin(origin).initialize(address(this));
         } else {
             revert("Unknown option: Origin");
         }
@@ -194,7 +194,7 @@ abstract contract SynapseTest is ProductionEvents, SuiteEvents, SynapseAgents, S
             gasOracleSynapse = address(new GasOracleMock());
         } else if (option == DEPLOY_PROD_GAS_ORACLE_SYNAPSE) {
             gasOracleSynapse = address(new GasOracle(DOMAIN_SYNAPSE, destinationSynapse));
-            GasOracle(gasOracleSynapse).initialize();
+            GasOracle(gasOracleSynapse).initialize(address(this));
         } else {
             revert("Unknown option: GasOracle");
         }
@@ -207,7 +207,7 @@ abstract contract SynapseTest is ProductionEvents, SuiteEvents, SynapseAgents, S
             destinationSynapse = address(new DestinationMock());
         } else if (option == DEPLOY_PROD_DESTINATION_SYNAPSE) {
             destinationSynapse = address(new Destination(DOMAIN_SYNAPSE, address(bondingManager), address(inbox)));
-            Destination(destinationSynapse).initialize(0);
+            Destination(destinationSynapse).initialize(0, address(this));
         } else {
             revert("Unknown option: Destination");
         }
@@ -221,7 +221,7 @@ abstract contract SynapseTest is ProductionEvents, SuiteEvents, SynapseAgents, S
         } else if (option == DEPLOY_PROD_ORIGIN_SYNAPSE) {
             originSynapse =
                 address(new Origin(DOMAIN_SYNAPSE, address(bondingManager), address(inbox), gasOracleSynapse));
-            Origin(originSynapse).initialize();
+            Origin(originSynapse).initialize(address(this));
         } else {
             revert("Unknown option: Origin");
         }
@@ -236,7 +236,7 @@ abstract contract SynapseTest is ProductionEvents, SuiteEvents, SynapseAgents, S
             summit = address(new SummitMock());
         } else if (option == DEPLOY_PROD_SUMMIT) {
             summit = address(new Summit(DOMAIN_SYNAPSE, address(bondingManager), address(inbox)));
-            Summit(summit).initialize();
+            Summit(summit).initialize(address(this));
         } else {
             revert("Unknown option: Summit");
         }


### PR DESCRIPTION
**Description**
Changes the contracts to use arbitrary address as owner in the initializer (rather than `msg.sender`). This will allow to use any factory for contract deployments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Implemented a new initialization process across various contracts to include an `owner` parameter, enhancing the control and security of contract ownership.

- **Refactor**
  - Updated initialization functions in multiple contracts to standardize the ownership setup.
  - Streamlined deployment scripts to accommodate the new initialization parameters.

- **Tests**
  - Modified test suites to align with the updated contract initialization processes, ensuring consistency and reliability of the ownership feature.

- **Documentation**
  - Updated comments and documentation to reflect the changes in the initialization parameters and ownership configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->