### PR TITLE
Fix: exclude unclaimed admin fees from pool's displayed reserves

### DIFF
--- a/packages/synapse-interface/utils/actions/getPoolData.ts
+++ b/packages/synapse-interface/utils/actions/getPoolData.ts
@@ -34,7 +34,7 @@ export const getBalanceData = async ({
 
   multicallInputs.push(one)
 
-  tokens.forEach((token, index) => {
+  tokens?.forEach((token, index) => {
     const isLP = token.addresses[chainId] === lpTokenAddress
     // Use pool's getTokenBalance for pool tokens, if the address is the pool itself
     // to exclude the unclaimed admin fees

--- a/packages/synapse-interface/utils/actions/getPoolData.ts
+++ b/packages/synapse-interface/utils/actions/getPoolData.ts
@@ -18,7 +18,7 @@ export const getBalanceData = async ({
   address: string
   lpTokenAddress: string
 }) => {
-  const tokens: Token[] = [...pool.poolTokens, pool]
+  const tokens: Token[] = [...pool?.poolTokens, pool]
   const tokenBalances = []
   let poolTokenSum = 0n
   let lpTokenBalance = 1n

--- a/packages/synapse-interface/utils/actions/getPoolData.ts
+++ b/packages/synapse-interface/utils/actions/getPoolData.ts
@@ -34,15 +34,28 @@ export const getBalanceData = async ({
 
   multicallInputs.push(one)
 
-  for (const token of tokens) {
-    multicallInputs.push({
-      address: token.addresses[chainId],
-      abi: erc20ABI,
-      functionName: 'balanceOf',
-      chainId,
-      args: [address],
-    })
-  }
+  tokens.forEach((token, index) => {
+    const isLP = token.addresses[chainId] === lpTokenAddress
+    // Use pool's getTokenBalance for pool tokens, if the address is the pool itself
+    // to exclude the unclaimed admin fees
+    if (address === pool.swapAddresses[chainId] && !isLP) {
+      multicallInputs.push({
+        address: pool.swapAddresses[chainId],
+        abi: SWAP_ABI,
+        functionName: 'getTokenBalance',
+        chainId,
+        args: [index],
+      })
+    } else {
+      multicallInputs.push({
+        address: token.addresses[chainId],
+        abi: erc20ABI,
+        functionName: 'balanceOf',
+        chainId,
+        args: [address],
+      })
+    }
+  })
   const two = {
     address: pool.swapAddresses[chainId],
     abi: SWAP_ABI,


### PR DESCRIPTION
**Description**
**Currency Reserves** component on the pool page is currently using treating pool's token balances as the available reserves, when in fact this number includes the unclaimed admin fees. Pool's ABI exposes a separate function `getTokenBalance`, which is used to get the pool's reserves in this PR.

 `getBalanceData` is used both for retrieving pool's internal balances, as well as user's balances of pool's tokens, so the logic was slightly adjusted to accommodate this flow.
1ee2a66b965b5b3346c1b61f7806fab9fe2ed13c: [synapse-interface preview link ](https://sanguine-synapse-interface-92b7ifedn-synapsecns.vercel.app)
194fe693478f123e528060e609c439a34bc9e78c: [synapse-interface preview link ](https://sanguine-synapse-interface-dru1jowzg-synapsecns.vercel.app)
9e4a05c86ac09bd3d8b6763fc1495486d63cd95d: [synapse-interface preview link ](https://sanguine-synapse-interface-64y9e7mqa-synapsecns.vercel.app)