### PR TITLE
Typo fix, rename to Liquity

### DIFF
--- a/packages/explorer-ui/constants/tokens/basic.ts
+++ b/packages/explorer-ui/constants/tokens/basic.ts
@@ -305,7 +305,7 @@ export const LUSD = new Token({
   },
   decimals: 18,
   symbol: 'LUSD',
-  name: 'Liquidity USD',
+  name: 'Liquity USD',
   logo: lusdLogo,
   swapableType: 'USD',
 })

--- a/packages/synapse-interface/constants/tokens/bridgeable.ts
+++ b/packages/synapse-interface/constants/tokens/bridgeable.ts
@@ -1217,7 +1217,7 @@ export const LUSD = new Token({
   decimals: 18,
   swapExceptions: {},
   symbol: 'LUSD',
-  name: 'Liquidity USD',
+  name: 'Liquity USD',
   logo: lusdLogo,
   swapableType: 'USD',
   swapableOn: [],


### PR DESCRIPTION
null
b8ba8d7c7f5a161b4d3d745642a58fb2a52a7539: [synapse-interface preview link ](https://sanguine-synapse-interface-4rjjtk2ql-synapsecns.vercel.app)
827629daca42cb9373dee93390227846796e4790: [explorer-ui preview link ](https://sanguine-8s167f5qs-synapsecns.vercel.app)
827629daca42cb9373dee93390227846796e4790: [synapse-interface preview link ](https://sanguine-synapse-interface-mfmq0e04h-synapsecns.vercel.app)