### PR TITLE
Fixes gasdrop to null when toChain is Eth

### DIFF
--- a/packages/synapse-interface/components/StateManagedBridge/BridgeExchangeRateInfo.tsx
+++ b/packages/synapse-interface/components/StateManagedBridge/BridgeExchangeRateInfo.tsx
@@ -51,6 +51,7 @@ const BridgeExchangeRateInfo = ({ showGasDrop }: { showGasDrop: boolean }) => {
   }, [toChainId, isGasDropped])
 
   const memoizedGasDropLabel = useMemo(() => {
+    if (toChainId === CHAINS.ETH.id) return null
     if (!isGasDropped || !(toChainId == gasDropChainId)) return null
     if (loading) return null
     return <GasDropLabel gasDropAmount={gasDropAmount} toChainId={toChainId} />


### PR DESCRIPTION
null
ec3787a99613dd6e23806300a169a29e16d21246: [synapse-interface preview link ](https://sanguine-synapse-interface-7yskdv5bs-synapsecns.vercel.app)