### PR TITLE
remove eip-155 considerations from arbitrary data signing

### DIFF
--- a/ethergo/signer/signer/localsigner/signer.go
+++ b/ethergo/signer/signer/localsigner/signer.go
@@ -56,7 +56,7 @@ func decodeSignature(sig []byte) signer.Signature {
 	if len(sig) != crypto.SignatureLength {
 		panic(fmt.Sprintf("wrong size for signature: got %d, want %d", len(sig), crypto.SignatureLength))
 	}
-	v := new(big.Int).SetBytes([]byte{sig[64] + 27})
+	v := new(big.Int).SetBytes([]byte{sig[64]})
 	r := new(big.Int).SetBytes(sig[:32])
 	s := new(big.Int).SetBytes(sig[32:64])
 

--- a/ethergo/signer/signer/signer.go
+++ b/ethergo/signer/signer/signer.go
@@ -85,7 +85,7 @@ func DecodeSignature(sig []byte) Signature {
 	}
 	r := new(big.Int).SetBytes(sig[:32])
 	s := new(big.Int).SetBytes(sig[32:64])
-	v := new(big.Int).SetBytes([]byte{sig[64] + 27})
+	v := new(big.Int).SetBytes([]byte{sig[64]})
 	return NewSignature(v, r, s)
 }
 


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

Replaces #1632

Removes eip-155 consideration in decoding which shouldn't be there. This was a bug found in #1625 which won't end up getting merged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the signature decoding process to ensure accurate validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->