### PR TITLE
Remove relayer logging 'unknown topic'

### DIFF
--- a/services/cctp-relayer/relayer/relayer.go
+++ b/services/cctp-relayer/relayer/relayer.go
@@ -456,7 +456,6 @@ func (c *CCTPRelayer) handleLog(ctx context.Context, log *types.Log, chainID uin
 		}
 		return nil
 	default:
-		logger.Warnf("unknown topic %s", log.Topics[0])
 		return nil
 	}
 }


### PR DESCRIPTION
Replaces #1620 after master acidentally deleted

**Description**
No need to warn about 'unknown topic' now that there are more CCTP events in the contracts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined logging by removing unnecessary "unknown topic" warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->