### PR TITLE
Scribe Variable OmniRPC Confirmations

### DIFF
--- a/services/scribe/cmd/cmd.md
+++ b/services/scribe/cmd/cmd.md
@@ -145,7 +145,7 @@ Scribe
 ├── <a href="./grpc">grpc</a>: The gRPC client implementation for Scribe
 ├── <a href="./internal">internal</a>: Internal packages for Scribe
 ├── <a href="./logger">logger</a>: Handles logging for various events in Scribe.
-├── <a href="./metadata">metadata</a>: Provides metadata for building .
+├── <a href="./metadata">metadata</a>: Provides metadata for building.
 ├── <a href="./scripts">scripts</a>: Scripts for Scribe
 ├── <a href="./service">service</a>: Service holds Scribe indexer code (Fetcher, Indexer, ChainIndexer)
 ├── <a href="./testhelper">testhelper</a>: Assists testing in downstream services.

--- a/services/scribe/cmd/commands.go
+++ b/services/scribe/cmd/commands.go
@@ -23,7 +23,7 @@ import (
 var help string
 
 // MaxConfirmations is the maximum number of confirmations.
-var MaxConfirmations = 3
+const MaxConfirmations = 3
 
 // infoCommand gets info about using the scribe service.
 var infoCommand = &cli.Command{
@@ -75,7 +75,11 @@ func createScribeParameters(c *cli.Context) (eventDB db.EventDB, clients map[uin
 
 	clients = make(map[uint32][]backend.ScribeBackend)
 	for _, client := range scribeConfig.Chains {
-		for confNum := 1; confNum <= MaxConfirmations; confNum++ {
+		minConf := client.OmniRPCConfirmations
+		if minConf == 0 {
+			minConf = 1
+		}
+		for confNum := minConf; confNum <= MaxConfirmations; confNum++ {
 			backendClient, err := backend.DialBackend(c.Context, fmt.Sprintf("%s/%d/rpc/%d", scribeConfig.RPCURL, confNum, client.ChainID), metrics.Get())
 			if err != nil {
 				return nil, nil, scribeConfig, fmt.Errorf("could not start client for %s", fmt.Sprintf("%s/1/rpc/%d", scribeConfig.RPCURL, client.ChainID))

--- a/services/scribe/config/chain.go
+++ b/services/scribe/config/chain.go
@@ -32,6 +32,8 @@ type ChainConfig struct {
 	LivefillRange uint64 `yaml:"livefill_range"`
 	// LivefillFlushInterval is how long to wait before flushing the livefill indexer db (in seconds)
 	LivefillFlushInterval uint64 `yaml:"livefill_flush_interval"`
+	// OmniRPCConfirmations is the OmniRPC URL.
+	OmniRPCConfirmations uint `yaml:"omnirpc_confirmations"`
 }
 
 // ChainConfigs contains an array of ChainConfigs.

--- a/services/scribe/logger/handler.go
+++ b/services/scribe/logger/handler.go
@@ -54,6 +54,8 @@ const (
 	BackfillCompleted
 	// BeginBackfillIndexing is returned when a backfill is beginning.
 	BeginBackfillIndexing
+	// StoringLogs is returned when logs are being stored.
+	StoringLogs
 )
 
 // ErrorType is a type of error.
@@ -140,9 +142,15 @@ func ReportScribeState(chainID uint32, block uint64, addresses []common.Address,
 		logger.Warnf("Flushing logs at head on chain %d", chainID)
 	case CreatingSQLStore:
 		logger.Warnf("Creating SQL store")
+
 	default:
 		logger.Warnf("Event on chain %d on block %d while interacting with contract %s", chainID, block, dumpAddresses(addresses))
 	}
+}
+
+// LogEventLogStore records when a log has been seen and will be stored. Used for debugging BSC missing txs.
+func LogEventLogStore(chainID uint32, block uint64, txHash string) {
+	logger.Warnf("Log seen: ChainID: %d | Block %d | TxHash %s", chainID, block, txHash)
 }
 
 func unpackIndexerConfig(indexerData scribeTypes.IndexerConfig) string {

--- a/services/scribe/service/indexer/indexer.go
+++ b/services/scribe/service/indexer/indexer.go
@@ -277,6 +277,7 @@ func (x *Indexer) store(parentCtx context.Context, log types.Log) (err error) {
 		attribute.String("tx", log.TxHash.Hex()),
 		attribute.String("block", fmt.Sprintf("%d", log.BlockNumber)),
 	))
+	logger.LogEventLogStore(x.indexerConfig.ChainID, log.BlockNumber, log.TxHash.String())
 
 	defer func() {
 		metrics.EndSpanWithErr(span, err)


### PR DESCRIPTION
Replaces #1607 after master acidentally deleted

**Description**
Allow different changes to request various ranges of Confirmations from OmniRPC.


**Additional context**
Addressing an occurrence of a missing tx found during indexing BSC testnet.
