### PR TITLE
Sdk: expose bridge tx status

### DIFF
--- a/packages/sdk-router/src/abi/SynapseCCTP.json
+++ b/packages/sdk-router/src/abi/SynapseCCTP.json
@@ -1,0 +1,767 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "contract ITokenMessenger",
+        "name": "tokenMessenger_",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  { "inputs": [], "name": "CCTPGasRescueFailed", "type": "error" },
+  { "inputs": [], "name": "CCTPIncorrectChainId", "type": "error" },
+  { "inputs": [], "name": "CCTPIncorrectConfig", "type": "error" },
+  { "inputs": [], "name": "CCTPIncorrectDomain", "type": "error" },
+  { "inputs": [], "name": "CCTPIncorrectGasAmount", "type": "error" },
+  { "inputs": [], "name": "CCTPIncorrectProtocolFee", "type": "error" },
+  { "inputs": [], "name": "CCTPIncorrectTokenAmount", "type": "error" },
+  { "inputs": [], "name": "CCTPInsufficientAmount", "type": "error" },
+  { "inputs": [], "name": "CCTPMessageNotReceived", "type": "error" },
+  { "inputs": [], "name": "CCTPSymbolAlreadyAdded", "type": "error" },
+  { "inputs": [], "name": "CCTPSymbolIncorrect", "type": "error" },
+  { "inputs": [], "name": "CCTPTokenAlreadyAdded", "type": "error" },
+  { "inputs": [], "name": "CCTPTokenNotFound", "type": "error" },
+  { "inputs": [], "name": "CCTPZeroAddress", "type": "error" },
+  { "inputs": [], "name": "CCTPZeroAmount", "type": "error" },
+  { "inputs": [], "name": "CastOverflow", "type": "error" },
+  { "inputs": [], "name": "ForwarderDeploymentFailed", "type": "error" },
+  { "inputs": [], "name": "IncorrectRequestLength", "type": "error" },
+  { "inputs": [], "name": "RemoteCCTPDeploymentNotSet", "type": "error" },
+  { "inputs": [], "name": "UnknownRequestVersion", "type": "error" },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "ChainGasAirdropped",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "chainGasAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "ChainGasAmountUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "originDomain",
+        "type": "uint32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "mintToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "fee",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "requestID",
+        "type": "bytes32"
+      }
+    ],
+    "name": "CircleRequestFulfilled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "chainId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "nonce",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "requestVersion",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "formattedRequest",
+        "type": "bytes"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "requestID",
+        "type": "bytes32"
+      }
+    ],
+    "name": "CircleRequestSent",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "CircleTokenPoolSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "feeCollector",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "relayerFeeAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "protocolFeeAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "FeeCollected",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "relayer",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "oldFeeCollector",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newFeeCollector",
+        "type": "address"
+      }
+    ],
+    "name": "FeeCollectorUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "FeesWithdrawn",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Paused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newProtocolFee",
+        "type": "uint256"
+      }
+    ],
+    "name": "ProtocolFeeUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "remoteChainId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "remoteDomain",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "remoteSynapseCCTP",
+        "type": "address"
+      }
+    ],
+    "name": "RemoteDomainConfigSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "symbol",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "TokenAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "relayerFee",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "minBaseFee",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "minSwapFee",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "maxFee",
+        "type": "uint256"
+      }
+    ],
+    "name": "TokenFeeSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "symbol",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "TokenRemoved",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Unpaused",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "", "type": "address" },
+      { "internalType": "address", "name": "", "type": "address" }
+    ],
+    "name": "accumulatedFees",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "string", "name": "symbol", "type": "string" },
+      { "internalType": "address", "name": "token", "type": "address" },
+      { "internalType": "uint256", "name": "relayerFee", "type": "uint256" },
+      { "internalType": "uint256", "name": "minBaseFee", "type": "uint256" },
+      { "internalType": "uint256", "name": "minSwapFee", "type": "uint256" },
+      { "internalType": "uint256", "name": "maxFee", "type": "uint256" }
+    ],
+    "name": "addToken",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "token", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" },
+      { "internalType": "bool", "name": "isSwap", "type": "bool" }
+    ],
+    "name": "calculateFeeAmount",
+    "outputs": [
+      { "internalType": "uint256", "name": "fee", "type": "uint256" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "chainGasAmount",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "circleTokenPool",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "feeStructures",
+    "outputs": [
+      { "internalType": "uint40", "name": "relayerFee", "type": "uint40" },
+      { "internalType": "uint72", "name": "minBaseFee", "type": "uint72" },
+      { "internalType": "uint72", "name": "minSwapFee", "type": "uint72" },
+      { "internalType": "uint72", "name": "maxFee", "type": "uint72" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getBridgeTokens",
+    "outputs": [
+      {
+        "components": [
+          { "internalType": "string", "name": "symbol", "type": "string" },
+          { "internalType": "address", "name": "token", "type": "address" }
+        ],
+        "internalType": "struct BridgeToken[]",
+        "name": "bridgeTokens",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint32", "name": "remoteDomain", "type": "uint32" },
+      { "internalType": "address", "name": "remoteToken", "type": "address" }
+    ],
+    "name": "getLocalToken",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "owner_", "type": "address" }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "requestID", "type": "bytes32" }
+    ],
+    "name": "isRequestFulfilled",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "localDomain",
+    "outputs": [{ "internalType": "uint32", "name": "", "type": "uint32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "messageTransmitter",
+    "outputs": [
+      {
+        "internalType": "contract IMessageTransmitter",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pauseSending",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "paused",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "protocolFee",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes", "name": "message", "type": "bytes" },
+      { "internalType": "bytes", "name": "signature", "type": "bytes" },
+      { "internalType": "uint32", "name": "requestVersion", "type": "uint32" },
+      { "internalType": "bytes", "name": "formattedRequest", "type": "bytes" }
+    ],
+    "name": "receiveCircleToken",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "relayerFeeCollectors",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "name": "remoteDomainConfig",
+    "outputs": [
+      { "internalType": "uint32", "name": "domain", "type": "uint32" },
+      { "internalType": "address", "name": "synapseCCTP", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "token", "type": "address" }
+    ],
+    "name": "removeToken",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "rescueGas",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "recipient", "type": "address" },
+      { "internalType": "uint256", "name": "chainId", "type": "uint256" },
+      { "internalType": "address", "name": "burnToken", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" },
+      { "internalType": "uint32", "name": "requestVersion", "type": "uint32" },
+      { "internalType": "bytes", "name": "swapParams", "type": "bytes" }
+    ],
+    "name": "sendCircleToken",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "newChainGasAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "setChainGasAmount",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "circleToken", "type": "address" },
+      { "internalType": "address", "name": "pool", "type": "address" }
+    ],
+    "name": "setCircleTokenPool",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "feeCollector", "type": "address" }
+    ],
+    "name": "setFeeCollector",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "newProtocolFee", "type": "uint256" }
+    ],
+    "name": "setProtocolFee",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "remoteChainId", "type": "uint256" },
+      { "internalType": "uint32", "name": "remoteDomain", "type": "uint32" },
+      {
+        "internalType": "address",
+        "name": "remoteSynapseCCTP",
+        "type": "address"
+      }
+    ],
+    "name": "setRemoteDomainConfig",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "token", "type": "address" },
+      { "internalType": "uint256", "name": "relayerFee", "type": "uint256" },
+      { "internalType": "uint256", "name": "minBaseFee", "type": "uint256" },
+      { "internalType": "uint256", "name": "minSwapFee", "type": "uint256" },
+      { "internalType": "uint256", "name": "maxFee", "type": "uint256" }
+    ],
+    "name": "setTokenFee",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "name": "symbolToToken",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "tokenMessenger",
+    "outputs": [
+      {
+        "internalType": "contract ITokenMessenger",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "tokenToSymbol",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "newOwner", "type": "address" }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "unpauseSending",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "token", "type": "address" }
+    ],
+    "name": "withdrawProtocolFees",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "token", "type": "address" }
+    ],
+    "name": "withdrawRelayerFees",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/packages/sdk-router/src/operations/bridge.ts
+++ b/packages/sdk-router/src/operations/bridge.ts
@@ -133,8 +133,9 @@ export async function getBridgeID(
   bridgeModuleName: string,
   txHash: string
 ): Promise<string> {
-  // Placeholder logic
-  return originChainId + bridgeModuleName + txHash
+  return getRouterSet
+    .call(this, bridgeModuleName)
+    .getBridgeID(originChainId, txHash)
 }
 
 /**
@@ -151,8 +152,9 @@ export async function getBridgeTxStatus(
   bridgeModuleName: string,
   bridgeID: string
 ): Promise<boolean> {
-  // Placeholder logic
-  return (destChainId + bridgeModuleName + bridgeID).length % 2 === 0
+  return getRouterSet
+    .call(this, bridgeModuleName)
+    .getBridgeTxStatus(destChainId, bridgeID)
 }
 
 /**

--- a/packages/sdk-router/src/operations/bridge.ts
+++ b/packages/sdk-router/src/operations/bridge.ts
@@ -118,6 +118,44 @@ export async function bridgeQuote(
 }
 
 /**
+ * Gets the unique bridge ID for a bridge operation that happened within a given transaction.
+ * Bridge ID is known as "kappa" for SynapseBridge contract and "requestID" for SynapseCCTP contract.
+ * This function is meant to abstract away the differences between the two bridge modules.
+ *
+ * @param originChainId - The ID of the origin chain.
+ * @param bridgeModuleName - The name of the bridge module.
+ * @param txHash - The transaction hash of the bridge operation on the origin chain.
+ * @returns A promise that resolves to the unique bridge ID of the bridge operation.
+ */
+export async function getBridgeID(
+  this: SynapseSDK,
+  originChainId: number,
+  bridgeModuleName: string,
+  txHash: string
+): Promise<string> {
+  // Placeholder logic
+  return originChainId + bridgeModuleName + txHash
+}
+
+/**
+ * Checks whether a bridge operation has been completed on the destination chain.
+ *
+ * @param destChainId - The ID of the destination chain.
+ * @param bridgeModuleName - The name of the bridge module.
+ * @param bridgeID - The unique bridge ID of the bridge operation.
+ * @returns A promise that resolves to a boolean indicating whether the bridge operation has been completed.
+ */
+export async function getBridgeTxStatus(
+  this: SynapseSDK,
+  destChainId: number,
+  bridgeModuleName: string,
+  bridgeID: string
+): Promise<boolean> {
+  // Placeholder logic
+  return (destChainId + bridgeModuleName + bridgeID).length % 2 === 0
+}
+
+/**
  * Returns the name of the bridge module that emits the given event.
  * This will be either SynapseBridge or SynapseCCTP.
  *

--- a/packages/sdk-router/src/operations/bridge.ts
+++ b/packages/sdk-router/src/operations/bridge.ts
@@ -181,19 +181,19 @@ export function getBridgeModuleName(
  * or the bridge token.
  *
  * @param originChainId - The ID of the origin chain.
- * @param bridgeNoduleName - The name of the bridge module.
+ * @param bridgeModuleName - The name of the bridge module.
  * @returns - The estimated time for a bridge operation, in seconds.
  * @throws - Will throw an error if the bridge module is unknown for the given chain.
  */
 export function getEstimatedTime(
   this: SynapseSDK,
   originChainId: number,
-  bridgeNoduleName: string
+  bridgeModuleName: string
 ): number {
-  if (this.synapseRouterSet.bridgeModuleName === bridgeNoduleName) {
+  if (this.synapseRouterSet.bridgeModuleName === bridgeModuleName) {
     return this.synapseRouterSet.getEstimatedTime(originChainId)
   }
-  if (this.synapseCCTPRouterSet.bridgeModuleName === bridgeNoduleName) {
+  if (this.synapseCCTPRouterSet.bridgeModuleName === bridgeModuleName) {
     return this.synapseCCTPRouterSet.getEstimatedTime(originChainId)
   }
   throw new Error('Unknown bridge module')

--- a/packages/sdk-router/src/operations/bridge.ts
+++ b/packages/sdk-router/src/operations/bridge.ts
@@ -190,13 +190,9 @@ export function getEstimatedTime(
   originChainId: number,
   bridgeModuleName: string
 ): number {
-  if (this.synapseRouterSet.bridgeModuleName === bridgeModuleName) {
-    return this.synapseRouterSet.getEstimatedTime(originChainId)
-  }
-  if (this.synapseCCTPRouterSet.bridgeModuleName === bridgeModuleName) {
-    return this.synapseCCTPRouterSet.getEstimatedTime(originChainId)
-  }
-  throw new Error('Unknown bridge module')
+  return getRouterSet
+    .call(this, bridgeModuleName)
+    .getEstimatedTime(originChainId)
 }
 
 /**
@@ -211,4 +207,14 @@ export async function getBridgeGas(
   chainId: number
 ): Promise<BigNumber> {
   return this.synapseRouterSet.getSynapseRouter(chainId).chainGasAmount()
+}
+
+function getRouterSet(this: SynapseSDK, bridgeModuleName: string): RouterSet {
+  if (this.synapseRouterSet.bridgeModuleName === bridgeModuleName) {
+    return this.synapseRouterSet
+  }
+  if (this.synapseCCTPRouterSet.bridgeModuleName === bridgeModuleName) {
+    return this.synapseCCTPRouterSet
+  }
+  throw new Error('Unknown bridge module')
 }

--- a/packages/sdk-router/src/operations/bridge.ts
+++ b/packages/sdk-router/src/operations/bridge.ts
@@ -118,16 +118,16 @@ export async function bridgeQuote(
 }
 
 /**
- * Gets the unique bridge ID for a bridge operation that happened within a given transaction.
- * Bridge ID is known as "kappa" for SynapseBridge contract and "requestID" for SynapseCCTP contract.
+ * Gets the unique Synapse txId for a bridge operation that happened within a given transaction.
+ * Synapse txId is known as "kappa" for SynapseBridge contract and "requestID" for SynapseCCTP contract.
  * This function is meant to abstract away the differences between the two bridge modules.
  *
  * @param originChainId - The ID of the origin chain.
  * @param bridgeModuleName - The name of the bridge module.
  * @param txHash - The transaction hash of the bridge operation on the origin chain.
- * @returns A promise that resolves to the unique bridge ID of the bridge operation.
+ * @returns A promise that resolves to the unique Synapse txId of the bridge operation.
  */
-export async function getBridgeID(
+export async function getSynapseTxId(
   this: SynapseSDK,
   originChainId: number,
   bridgeModuleName: string,
@@ -135,7 +135,7 @@ export async function getBridgeID(
 ): Promise<string> {
   return getRouterSet
     .call(this, bridgeModuleName)
-    .getBridgeID(originChainId, txHash)
+    .getSynapseTxId(originChainId, txHash)
 }
 
 /**
@@ -143,18 +143,18 @@ export async function getBridgeID(
  *
  * @param destChainId - The ID of the destination chain.
  * @param bridgeModuleName - The name of the bridge module.
- * @param bridgeID - The unique bridge ID of the bridge operation.
+ * @param synapseTxId - The unique Synapse txId of the bridge operation.
  * @returns A promise that resolves to a boolean indicating whether the bridge operation has been completed.
  */
 export async function getBridgeTxStatus(
   this: SynapseSDK,
   destChainId: number,
   bridgeModuleName: string,
-  bridgeID: string
+  synapseTxId: string
 ): Promise<boolean> {
   return getRouterSet
     .call(this, bridgeModuleName)
-    .getBridgeTxStatus(destChainId, bridgeID)
+    .getBridgeTxStatus(destChainId, synapseTxId)
 }
 
 /**

--- a/packages/sdk-router/src/operations/bridge.ts
+++ b/packages/sdk-router/src/operations/bridge.ts
@@ -211,7 +211,17 @@ export async function getBridgeGas(
   return this.synapseRouterSet.getSynapseRouter(chainId).chainGasAmount()
 }
 
-function getRouterSet(this: SynapseSDK, bridgeModuleName: string): RouterSet {
+/**
+ * Extracts the RouterSet from the SynapseSDK based on the given bridge module name.
+ *
+ * @param bridgeModuleName - The name of the bridge module, SynapseBridge or SynapseCCTP.
+ * @returns The corresponding RouterSet.
+ * @throws Will throw an error if the bridge module is unknown.
+ */
+export function getRouterSet(
+  this: SynapseSDK,
+  bridgeModuleName: string
+): RouterSet {
   if (this.synapseRouterSet.bridgeModuleName === bridgeModuleName) {
     return this.synapseRouterSet
   }

--- a/packages/sdk-router/src/router/router.ts
+++ b/packages/sdk-router/src/router/router.ts
@@ -62,6 +62,25 @@ export abstract class Router {
   ): Promise<PopulatedTransaction>
 
   /**
+   * Returns the bridge transaction ID for a given transaction hash on the current chain.
+   * This is used to track the status of a bridge transaction originating from the current chain.
+   *
+   * @param txHash - The transaction hash of the bridge transaction.
+   * @returns A promise that resolves to the bridge transaction ID.
+   */
+  abstract getBridgeID(txHash: string): Promise<string>
+
+  /**
+   * Checks whether a bridge transaction has been completed on the current chain.
+   * This is used to track the status of a bridge transaction originating from another chain, having
+   * current chain as the destination chain.
+   *
+   * @param bridgeID - The unique bridge ID of the bridge transaction.
+   * @returns A promise that resolves to a boolean indicating whether the bridge transaction has been completed.
+   */
+  abstract getBridgeTxStatus(bridgeID: string): Promise<boolean>
+
+  /**
    * Fetches bridge tokens for a destination chain and output token.
    *
    * Checks the cache first, and fetches from the router if not cached. Filters invalid tokens and caches the result.

--- a/packages/sdk-router/src/router/router.ts
+++ b/packages/sdk-router/src/router/router.ts
@@ -62,23 +62,23 @@ export abstract class Router {
   ): Promise<PopulatedTransaction>
 
   /**
-   * Returns the bridge transaction ID for a given transaction hash on the current chain.
+   * Returns the Synapse transaction ID for a given transaction hash on the current chain.
    * This is used to track the status of a bridge transaction originating from the current chain.
    *
    * @param txHash - The transaction hash of the bridge transaction.
-   * @returns A promise that resolves to the bridge transaction ID.
+   * @returns A promise that resolves to the Synapse transaction ID.
    */
-  abstract getBridgeID(txHash: string): Promise<string>
+  abstract getSynapseTxId(txHash: string): Promise<string>
 
   /**
    * Checks whether a bridge transaction has been completed on the current chain.
    * This is used to track the status of a bridge transaction originating from another chain, having
    * current chain as the destination chain.
    *
-   * @param bridgeID - The unique bridge ID of the bridge transaction.
+   * @param synapseTxId - The unique Synapse txId of the bridge transaction.
    * @returns A promise that resolves to a boolean indicating whether the bridge transaction has been completed.
    */
-  abstract getBridgeTxStatus(bridgeID: string): Promise<boolean>
+  abstract getBridgeTxStatus(synapseTxId: string): Promise<boolean>
 
   /**
    * Fetches bridge tokens for a destination chain and output token.

--- a/packages/sdk-router/src/router/routerSet.ts
+++ b/packages/sdk-router/src/router/routerSet.ts
@@ -72,25 +72,28 @@ export abstract class RouterSet {
   abstract getEstimatedTime(chainId: number): number
 
   /**
-   * Returns the bridge transaction ID for a given transaction hash on a given chain.
+   * Returns the Synapse transaction ID for a given transaction hash on a given chain.
    * This is used to track the status of a bridge transaction.
    *
    * @param originChainId - The ID of the origin chain.
    * @param txHash - The transaction hash of the bridge transaction.
-   * @returns A promise that resolves to the bridge transaction ID.
+   * @returns A promise that resolves to the Synapse transaction ID.
    */
-  abstract getBridgeID(originChainId: number, txHash: string): Promise<string>
+  abstract getSynapseTxId(
+    originChainId: number,
+    txHash: string
+  ): Promise<string>
 
   /**
    * Checks whether a bridge transaction has been completed on the destination chain.
    *
    * @param destChainId - The ID of the destination chain.
-   * @param bridgeID - The unique bridge ID of the bridge transaction.
+   * @param synapseTxId - The unique Synapse txId of the bridge transaction.
    * @returns A promise that resolves to a boolean indicating whether the bridge transaction has been completed.
    */
   abstract getBridgeTxStatus(
     destChainId: number,
-    bridgeID: string
+    synapseTxId: string
   ): Promise<boolean>
 
   /**

--- a/packages/sdk-router/src/router/routerSet.ts
+++ b/packages/sdk-router/src/router/routerSet.ts
@@ -72,6 +72,28 @@ export abstract class RouterSet {
   abstract getEstimatedTime(chainId: number): number
 
   /**
+   * Returns the bridge transaction ID for a given transaction hash on a given chain.
+   * This is used to track the status of a bridge transaction.
+   *
+   * @param originChainId - The ID of the origin chain.
+   * @param txHash - The transaction hash of the bridge transaction.
+   * @returns A promise that resolves to the bridge transaction ID.
+   */
+  abstract getBridgeID(originChainId: number, txHash: string): Promise<string>
+
+  /**
+   * Checks whether a bridge transaction has been completed on the destination chain.
+   *
+   * @param destChainId - The ID of the destination chain.
+   * @param bridgeID - The unique bridge ID of the bridge transaction.
+   * @returns A promise that resolves to a boolean indicating whether the bridge transaction has been completed.
+   */
+  abstract getBridgeTxStatus(
+    destChainId: number,
+    bridgeID: string
+  ): Promise<boolean>
+
+  /**
    * Returns the existing Router instance for the given address on the given chain.
    * If the router address is not valid, it will return undefined.
    *

--- a/packages/sdk-router/src/router/synapseCCTPRouter.ts
+++ b/packages/sdk-router/src/router/synapseCCTPRouter.ts
@@ -114,4 +114,18 @@ export class SynapseCCTPRouter extends Router {
       narrowToCCTPRouterQuery(destQuery)
     )
   }
+
+  /**
+   * @inheritdoc Router.getBridgeID
+   */
+  public async getBridgeID(txHash: string): Promise<string> {
+    return txHash
+  }
+
+  /**
+   * @inheritdoc Router.getBridgeTxStatus
+   */
+  public async getBridgeTxStatus(bridgeID: string): Promise<boolean> {
+    return bridgeID.length % 2 === 0
+  }
 }

--- a/packages/sdk-router/src/router/synapseCCTPRouter.ts
+++ b/packages/sdk-router/src/router/synapseCCTPRouter.ts
@@ -131,6 +131,9 @@ export class SynapseCCTPRouter extends Router {
     )
     // Iterate through logs to find CircleRequestSent event emitted by SynapseCCTP in the provided tx
     const txReceipt = await this.provider.getTransactionReceipt(txHash)
+    if (!txReceipt) {
+      throw new Error('Failed to get transaction receipt')
+    }
     const cctpLog = txReceipt.logs.find((log) => {
       return (
         log.address === cctpContract.address &&

--- a/packages/sdk-router/src/router/synapseCCTPRouter.ts
+++ b/packages/sdk-router/src/router/synapseCCTPRouter.ts
@@ -122,9 +122,9 @@ export class SynapseCCTPRouter extends Router {
   }
 
   /**
-   * @inheritdoc Router.getBridgeID
+   * @inheritdoc Router.getSynapseTxId
    */
-  public async getBridgeID(txHash: string): Promise<string> {
+  public async getSynapseTxId(txHash: string): Promise<string> {
     const cctpContract = await this.getCctpContract()
     const cctpLog = await getMatchingTxLog(
       this.provider,
@@ -140,9 +140,9 @@ export class SynapseCCTPRouter extends Router {
   /**
    * @inheritdoc Router.getBridgeTxStatus
    */
-  public async getBridgeTxStatus(bridgeID: string): Promise<boolean> {
+  public async getBridgeTxStatus(synapseTxId: string): Promise<boolean> {
     const cctpContract = await this.getCctpContract()
-    return cctpContract.isRequestFulfilled(bridgeID)
+    return cctpContract.isRequestFulfilled(synapseTxId)
   }
 
   private async getCctpContract(): Promise<Contract> {

--- a/packages/sdk-router/src/router/synapseCCTPRouterSet.ts
+++ b/packages/sdk-router/src/router/synapseCCTPRouterSet.ts
@@ -29,6 +29,26 @@ export class SynapseCCTPRouterSet extends RouterSet {
   }
 
   /**
+   * @inheritdoc RouterSet.getBridgeID
+   */
+  public async getBridgeID(
+    originChainId: number,
+    txHash: string
+  ): Promise<string> {
+    return this.getSynapseCCTPRouter(originChainId).getBridgeID(txHash)
+  }
+
+  /**
+   * @inheritdoc RouterSet.getBridgeTxStatus
+   */
+  public async getBridgeTxStatus(
+    destChainId: number,
+    bridgeID: string
+  ): Promise<boolean> {
+    return this.getSynapseCCTPRouter(destChainId).getBridgeTxStatus(bridgeID)
+  }
+
+  /**
    * Returns the existing SynapseCCTPRouter instance for the given chain.
    *
    * @throws Will throw an error if SynapseCCTPRouter is not deployed on the given chain.

--- a/packages/sdk-router/src/router/synapseCCTPRouterSet.ts
+++ b/packages/sdk-router/src/router/synapseCCTPRouterSet.ts
@@ -29,13 +29,13 @@ export class SynapseCCTPRouterSet extends RouterSet {
   }
 
   /**
-   * @inheritdoc RouterSet.getBridgeID
+   * @inheritdoc RouterSet.getSynapseTxId
    */
-  public async getBridgeID(
+  public async getSynapseTxId(
     originChainId: number,
     txHash: string
   ): Promise<string> {
-    return this.getSynapseCCTPRouter(originChainId).getBridgeID(txHash)
+    return this.getSynapseCCTPRouter(originChainId).getSynapseTxId(txHash)
   }
 
   /**
@@ -43,9 +43,9 @@ export class SynapseCCTPRouterSet extends RouterSet {
    */
   public async getBridgeTxStatus(
     destChainId: number,
-    bridgeID: string
+    synapseTxId: string
   ): Promise<boolean> {
-    return this.getSynapseCCTPRouter(destChainId).getBridgeTxStatus(bridgeID)
+    return this.getSynapseCCTPRouter(destChainId).getBridgeTxStatus(synapseTxId)
   }
 
   /**

--- a/packages/sdk-router/src/router/synapseRouter.ts
+++ b/packages/sdk-router/src/router/synapseRouter.ts
@@ -150,9 +150,9 @@ export class SynapseRouter extends Router {
   }
 
   /**
-   * @inheritdoc Router.getBridgeID
+   * @inheritdoc Router.getSynapseTxId
    */
-  public async getBridgeID(txHash: string): Promise<string> {
+  public async getSynapseTxId(txHash: string): Promise<string> {
     // Check that the transaction hash refers to an origin transaction
     const bridgeContract = await this.getBridgeContract()
     await getMatchingTxLog(
@@ -161,16 +161,16 @@ export class SynapseRouter extends Router {
       bridgeContract,
       this.originEvents
     )
-    // Once we know the transaction is an origin transaction, we can calculate the bridge ID
+    // Once we know the transaction is an origin transaction, we can calculate the Synapse txId
     return solidityKeccak256(['string'], [txHash])
   }
 
   /**
    * @inheritdoc Router.getBridgeTxStatus
    */
-  public async getBridgeTxStatus(bridgeID: string): Promise<boolean> {
+  public async getBridgeTxStatus(synapseTxId: string): Promise<boolean> {
     const bridgeContract = await this.getBridgeContract()
-    return bridgeContract.kappaExists(bridgeID)
+    return bridgeContract.kappaExists(synapseTxId)
   }
 
   // ═════════════════════════════════════════ SYNAPSE ROUTER (V1) ONLY ══════════════════════════════════════════════

--- a/packages/sdk-router/src/router/synapseRouter.ts
+++ b/packages/sdk-router/src/router/synapseRouter.ts
@@ -25,6 +25,7 @@ import {
   reduceToFeeConfig,
   reduceToPoolToken,
 } from './types'
+import { getMatchingTxLog } from '../utils/logs'
 
 /**
  * Wraps [tokens, lpToken] returned by the SynapseRouter contract into a PoolInfo object.
@@ -59,6 +60,16 @@ export class SynapseRouter extends Router {
 
   private readonly routerContract: SynapseRouterContract
   private bridgeContractCache: Contract | undefined
+
+  // All possible events emitted by the SynapseBridge contract in the origin transaction (in alphabetical order)
+  private readonly originEvents = [
+    'TokenDeposit',
+    'TokenDepositAndSwap',
+    'TokenRedeem',
+    'TokenRedeemAndRemove',
+    'TokenRedeemAndSwap',
+    'TokenRedeemV2',
+  ]
 
   constructor(chainId: number, provider: Provider, address: string) {
     // Parent constructor throws if chainId or provider are undefined
@@ -142,6 +153,15 @@ export class SynapseRouter extends Router {
    * @inheritdoc Router.getBridgeID
    */
   public async getBridgeID(txHash: string): Promise<string> {
+    // Check that the transaction hash refers to an origin transaction
+    const bridgeContract = await this.getBridgeContract()
+    await getMatchingTxLog(
+      this.provider,
+      txHash,
+      bridgeContract,
+      this.originEvents
+    )
+    // Once we know the transaction is an origin transaction, we can calculate the bridge ID
     return solidityKeccak256(['string'], [txHash])
   }
 

--- a/packages/sdk-router/src/router/synapseRouter.ts
+++ b/packages/sdk-router/src/router/synapseRouter.ts
@@ -3,6 +3,7 @@ import invariant from 'tiny-invariant'
 import { Contract, PopulatedTransaction } from '@ethersproject/contracts'
 import { Interface } from '@ethersproject/abi'
 import { BigNumber } from '@ethersproject/bignumber'
+import { solidityKeccak256 } from 'ethers/lib/utils'
 
 import routerAbi from '../abi/SynapseRouter.json'
 import {
@@ -141,14 +142,15 @@ export class SynapseRouter extends Router {
    * @inheritdoc Router.getBridgeID
    */
   public async getBridgeID(txHash: string): Promise<string> {
-    return txHash
+    return solidityKeccak256(['string'], [txHash])
   }
 
   /**
    * @inheritdoc Router.getBridgeTxStatus
    */
   public async getBridgeTxStatus(bridgeID: string): Promise<boolean> {
-    return bridgeID.length % 2 === 0
+    const bridgeContract = await this.getBridgeContract()
+    return bridgeContract.kappaExists(bridgeID)
   }
 
   // ═════════════════════════════════════════ SYNAPSE ROUTER (V1) ONLY ══════════════════════════════════════════════

--- a/packages/sdk-router/src/router/synapseRouter.ts
+++ b/packages/sdk-router/src/router/synapseRouter.ts
@@ -137,6 +137,20 @@ export class SynapseRouter extends Router {
     )
   }
 
+  /**
+   * @inheritdoc Router.getBridgeID
+   */
+  public async getBridgeID(txHash: string): Promise<string> {
+    return txHash
+  }
+
+  /**
+   * @inheritdoc Router.getBridgeTxStatus
+   */
+  public async getBridgeTxStatus(bridgeID: string): Promise<boolean> {
+    return bridgeID.length % 2 === 0
+  }
+
   // ═════════════════════════════════════════ SYNAPSE ROUTER (V1) ONLY ══════════════════════════════════════════════
 
   private async getBridgeContract(): Promise<Contract> {

--- a/packages/sdk-router/src/router/synapseRouterSet.ts
+++ b/packages/sdk-router/src/router/synapseRouterSet.ts
@@ -37,13 +37,13 @@ export class SynapseRouterSet extends RouterSet {
   }
 
   /**
-   * @inheritdoc RouterSet.getBridgeID
+   * @inheritdoc RouterSet.getSynapseTxId
    */
-  public async getBridgeID(
+  public async getSynapseTxId(
     originChainId: number,
     txHash: string
   ): Promise<string> {
-    return this.getSynapseRouter(originChainId).getBridgeID(txHash)
+    return this.getSynapseRouter(originChainId).getSynapseTxId(txHash)
   }
 
   /**
@@ -51,9 +51,9 @@ export class SynapseRouterSet extends RouterSet {
    */
   public async getBridgeTxStatus(
     destChainId: number,
-    bridgeID: string
+    synapseTxId: string
   ): Promise<boolean> {
-    return this.getSynapseRouter(destChainId).getBridgeTxStatus(bridgeID)
+    return this.getSynapseRouter(destChainId).getBridgeTxStatus(synapseTxId)
   }
 
   /**

--- a/packages/sdk-router/src/router/synapseRouterSet.ts
+++ b/packages/sdk-router/src/router/synapseRouterSet.ts
@@ -37,6 +37,26 @@ export class SynapseRouterSet extends RouterSet {
   }
 
   /**
+   * @inheritdoc RouterSet.getBridgeID
+   */
+  public async getBridgeID(
+    originChainId: number,
+    txHash: string
+  ): Promise<string> {
+    return this.getSynapseRouter(originChainId).getBridgeID(txHash)
+  }
+
+  /**
+   * @inheritdoc RouterSet.getBridgeTxStatus
+   */
+  public async getBridgeTxStatus(
+    destChainId: number,
+    bridgeID: string
+  ): Promise<boolean> {
+    return this.getSynapseRouter(destChainId).getBridgeTxStatus(bridgeID)
+  }
+
+  /**
    * Returns the existing SynapseRouter instance for the given chain.
    *
    * @throws Will throw an error if SynapseRouter is not deployed on the given chain.

--- a/packages/sdk-router/src/sdk.test.ts
+++ b/packages/sdk-router/src/sdk.test.ts
@@ -29,6 +29,7 @@ import {
   SupportedChainId,
 } from './constants'
 import { BridgeQuote, FeeConfig, RouterQuery, SwapQuote } from './router'
+import * as operations from './operations'
 
 const expectCorrectFeeConfig = (feeConfig: FeeConfig) => {
   expect(feeConfig).toBeDefined()
@@ -1290,6 +1291,30 @@ describe('SynapseSDK', () => {
       expect(result.routerAddress).toEqual(
         ROUTER_ADDRESS_MAP[SupportedChainId.ARBITRUM]
       )
+    })
+  })
+
+  describe('Internal functions', () => {
+    const synapse = new SynapseSDK(
+      [SupportedChainId.ARBITRUM, SupportedChainId.ETH],
+      [arbProvider, ethProvider]
+    )
+    describe('getRouterSet', () => {
+      it('Returns correct set for SynapseBridge', () => {
+        const routerSet = operations.getRouterSet.call(synapse, 'SynapseBridge')
+        expect(routerSet).toEqual(synapse.synapseRouterSet)
+      })
+
+      it('Returns correct set for SynapseCCTP', () => {
+        const routerSet = operations.getRouterSet.call(synapse, 'SynapseCCTP')
+        expect(routerSet).toEqual(synapse.synapseCCTPRouterSet)
+      })
+
+      it('Throws when bridge module name is invalid', () => {
+        expect(() =>
+          operations.getRouterSet.call(synapse, 'SynapseSynapse')
+        ).toThrow('Unknown bridge module')
+      })
     })
   })
 })

--- a/packages/sdk-router/src/sdk.test.ts
+++ b/packages/sdk-router/src/sdk.test.ts
@@ -784,6 +784,18 @@ describe('SynapseSDK', () => {
             )
           ).rejects.toThrow('CircleRequestSent log not found')
         })
+
+        it('Throws when given a destination tx', async () => {
+          // Destination tx hash for ARB -> ETH
+          // Has CircleRequestFulfilled log, which should be ignored
+          await expect(
+            synapse.getBridgeID(
+              SupportedChainId.ETH,
+              'SynapseCCTP',
+              '0xefb946d2acf8343ac5526de66de498e0d5f70ae73c81b833181616ee058a22d7'
+            )
+          ).rejects.toThrow('CircleRequestSent log not found')
+        })
       })
 
       it('Throws when bridge module name is invalid', async () => {

--- a/packages/sdk-router/src/sdk.test.ts
+++ b/packages/sdk-router/src/sdk.test.ts
@@ -775,6 +775,17 @@ describe('SynapseSDK', () => {
           expect(bridgeID).toEqual(cctpArbToEthTx.bridgeID)
         })
 
+        it('Throws when given a txHash that does not exist', async () => {
+          // Use txHash for another chain
+          await expect(
+            synapse.getBridgeID(
+              SupportedChainId.ETH,
+              'SynapseCCTP',
+              bridgeArbToEthTx.txHash
+            )
+          ).rejects.toThrow('Failed to get transaction receipt')
+        })
+
         it('Throws when origin tx does not refer to SynapseCCTP', async () => {
           await expect(
             synapse.getBridgeID(

--- a/packages/sdk-router/src/sdk.test.ts
+++ b/packages/sdk-router/src/sdk.test.ts
@@ -704,7 +704,7 @@ describe('SynapseSDK', () => {
     const bridgeEthToArbTx = {
       txHash:
         '0xe3f0f0c1d139c48730492c900f9978449d70c0939c654d5abbfd6b191f9c7b3d',
-      bridgeID:
+      synapseTxId:
         '0x2f223fb1509f04f777b5c9dd2287931b6e63d994a6a697db7a08cfbe784b5e90',
     }
 
@@ -713,7 +713,7 @@ describe('SynapseSDK', () => {
     const bridgeArbToEthTx = {
       txHash:
         '0xe226c7e38e4b83072aa9d947e533be32c8bb38120bbdd8f490c5c6a5894e62c9',
-      bridgeID:
+      synapseTxId:
         '0xf7b8085d96b1ea3f6bf7a07ad93d1861b8fcd551ef56665d6a22c9fb7633a097',
     }
 
@@ -722,7 +722,7 @@ describe('SynapseSDK', () => {
     const cctpEthToArbTx = {
       txHash:
         '0x1a25b0dfde1e2cc43f1dc659ba60f2b8e7ff8177555773fea0c4fba2d6e9c393',
-      bridgeID:
+      synapseTxId:
         '0x492b923b5a0ace2715a8d0a80fb93c094bf6d35b142a010bdc3761b8613439fc',
     }
 
@@ -731,38 +731,38 @@ describe('SynapseSDK', () => {
     const cctpArbToEthTx = {
       txHash:
         '0x2a6d04ba5a48331454f00d136b3666869d03f004395fea25d97d42715c119096',
-      bridgeID:
+      synapseTxId:
         '0xed98b02f712c940d3b37a1aa9005a5986ecefa5cdbb4505118a22ae65d4903af',
     }
 
-    describe('getBridgeID', () => {
+    describe('getSynapseTxId', () => {
       describe('SynapseBridge', () => {
         const ethSynBridge = '0x2796317b0fF8538F253012862c06787Adfb8cEb6'
         const events =
           'TokenDeposit, TokenDepositAndSwap, TokenRedeem, TokenRedeemAndRemove, TokenRedeemAndSwap, TokenRedeemV2'
 
         it('ETH -> ARB', async () => {
-          const bridgeID = await synapse.getBridgeID(
+          const synapseTxId = await synapse.getSynapseTxId(
             SupportedChainId.ETH,
             'SynapseBridge',
             bridgeEthToArbTx.txHash
           )
-          expect(bridgeID).toEqual(bridgeEthToArbTx.bridgeID)
+          expect(synapseTxId).toEqual(bridgeEthToArbTx.synapseTxId)
         })
 
         it('ARB -> ETH', async () => {
-          const bridgeID = await synapse.getBridgeID(
+          const synapseTxId = await synapse.getSynapseTxId(
             SupportedChainId.ARBITRUM,
             'SynapseBridge',
             bridgeArbToEthTx.txHash
           )
-          expect(bridgeID).toEqual(bridgeArbToEthTx.bridgeID)
+          expect(synapseTxId).toEqual(bridgeArbToEthTx.synapseTxId)
         })
 
         it('Throws when given a txHash that does not exist', async () => {
           // Use txHash for another chain
           await expect(
-            synapse.getBridgeID(
+            synapse.getSynapseTxId(
               SupportedChainId.ETH,
               'SynapseBridge',
               bridgeArbToEthTx.txHash
@@ -775,7 +775,7 @@ describe('SynapseSDK', () => {
             `Contract ${ethSynBridge} in transaction ${cctpEthToArbTx.txHash}` +
             ` did not emit any of the expected events: ${events}`
           await expect(
-            synapse.getBridgeID(
+            synapse.getSynapseTxId(
               SupportedChainId.ETH,
               'SynapseBridge',
               cctpEthToArbTx.txHash
@@ -791,7 +791,11 @@ describe('SynapseSDK', () => {
             `Contract ${ethSynBridge} in transaction ${txHash}` +
             ` did not emit any of the expected events: ${events}`
           await expect(
-            synapse.getBridgeID(SupportedChainId.ETH, 'SynapseBridge', txHash)
+            synapse.getSynapseTxId(
+              SupportedChainId.ETH,
+              'SynapseBridge',
+              txHash
+            )
           ).rejects.toThrow(errorMsg)
         })
       })
@@ -801,27 +805,27 @@ describe('SynapseSDK', () => {
         const events = 'CircleRequestSent'
 
         it('ETH -> ARB', async () => {
-          const bridgeID = await synapse.getBridgeID(
+          const synapseTxId = await synapse.getSynapseTxId(
             SupportedChainId.ETH,
             'SynapseCCTP',
             cctpEthToArbTx.txHash
           )
-          expect(bridgeID).toEqual(cctpEthToArbTx.bridgeID)
+          expect(synapseTxId).toEqual(cctpEthToArbTx.synapseTxId)
         })
 
         it('ARB -> ETH', async () => {
-          const bridgeID = await synapse.getBridgeID(
+          const synapseTxId = await synapse.getSynapseTxId(
             SupportedChainId.ARBITRUM,
             'SynapseCCTP',
             cctpArbToEthTx.txHash
           )
-          expect(bridgeID).toEqual(cctpArbToEthTx.bridgeID)
+          expect(synapseTxId).toEqual(cctpArbToEthTx.synapseTxId)
         })
 
         it('Throws when given a txHash that does not exist', async () => {
           // Use txHash for another chain
           await expect(
-            synapse.getBridgeID(
+            synapse.getSynapseTxId(
               SupportedChainId.ETH,
               'SynapseCCTP',
               cctpArbToEthTx.txHash
@@ -834,7 +838,7 @@ describe('SynapseSDK', () => {
             `Contract ${ethSynCCTP} in transaction ${bridgeEthToArbTx.txHash}` +
             ` did not emit any of the expected events: ${events}`
           await expect(
-            synapse.getBridgeID(
+            synapse.getSynapseTxId(
               SupportedChainId.ETH,
               'SynapseCCTP',
               bridgeEthToArbTx.txHash
@@ -850,14 +854,14 @@ describe('SynapseSDK', () => {
             `Contract ${ethSynCCTP} in transaction ${txHash}` +
             ` did not emit any of the expected events: ${events}`
           await expect(
-            synapse.getBridgeID(SupportedChainId.ETH, 'SynapseCCTP', txHash)
+            synapse.getSynapseTxId(SupportedChainId.ETH, 'SynapseCCTP', txHash)
           ).rejects.toThrow(errorMsg)
         })
       })
 
       it('Throws when bridge module name is invalid', async () => {
         await expect(
-          synapse.getBridgeID(
+          synapse.getSynapseTxId(
             SupportedChainId.ETH,
             'SynapseSynapse',
             bridgeEthToArbTx.txHash
@@ -872,7 +876,7 @@ describe('SynapseSDK', () => {
           const txStatus = await synapse.getBridgeTxStatus(
             SupportedChainId.ARBITRUM,
             'SynapseBridge',
-            bridgeEthToArbTx.bridgeID
+            bridgeEthToArbTx.synapseTxId
           )
           expect(txStatus).toBe(true)
         })
@@ -881,13 +885,13 @@ describe('SynapseSDK', () => {
           const txStatus = await synapse.getBridgeTxStatus(
             SupportedChainId.ETH,
             'SynapseBridge',
-            bridgeArbToEthTx.bridgeID
+            bridgeArbToEthTx.synapseTxId
           )
           expect(txStatus).toBe(true)
         })
 
-        it('Returns false when unknown bridgeID', async () => {
-          // Using txHash instead of bridgeID
+        it('Returns false when unknown synapseTxId', async () => {
+          // Using txHash instead of synapseTxId
           const txStatus = await synapse.getBridgeTxStatus(
             SupportedChainId.ETH,
             'SynapseBridge',
@@ -901,7 +905,7 @@ describe('SynapseSDK', () => {
           const txStatus = await synapse.getBridgeTxStatus(
             SupportedChainId.ETH,
             'SynapseBridge',
-            bridgeEthToArbTx.bridgeID
+            bridgeEthToArbTx.synapseTxId
           )
           expect(txStatus).toBe(false)
         })
@@ -912,7 +916,7 @@ describe('SynapseSDK', () => {
           const txStatus = await synapse.getBridgeTxStatus(
             SupportedChainId.ARBITRUM,
             'SynapseCCTP',
-            cctpEthToArbTx.bridgeID
+            cctpEthToArbTx.synapseTxId
           )
           expect(txStatus).toBe(true)
         })
@@ -921,13 +925,13 @@ describe('SynapseSDK', () => {
           const txStatus = await synapse.getBridgeTxStatus(
             SupportedChainId.ETH,
             'SynapseCCTP',
-            cctpArbToEthTx.bridgeID
+            cctpArbToEthTx.synapseTxId
           )
           expect(txStatus).toBe(true)
         })
 
-        it('Returns false when unknown bridgeID', async () => {
-          // Using txHash instead of bridgeID
+        it('Returns false when unknown synapseTxId', async () => {
+          // Using txHash instead of synapseTxId
           const txStatus = await synapse.getBridgeTxStatus(
             SupportedChainId.ETH,
             'SynapseCCTP',
@@ -941,7 +945,7 @@ describe('SynapseSDK', () => {
           const txStatus = await synapse.getBridgeTxStatus(
             SupportedChainId.ETH,
             'SynapseCCTP',
-            cctpEthToArbTx.bridgeID
+            cctpEthToArbTx.synapseTxId
           )
           expect(txStatus).toBe(false)
         })

--- a/packages/sdk-router/src/sdk.ts
+++ b/packages/sdk-router/src/sdk.ts
@@ -48,7 +48,7 @@ class SynapseSDK {
   public bridgeQuote = operations.bridgeQuote
   public getBridgeModuleName = operations.getBridgeModuleName
   public getEstimatedTime = operations.getEstimatedTime
-  public getBridgeID = operations.getBridgeID
+  public getSynapseTxId = operations.getSynapseTxId
   public getBridgeTxStatus = operations.getBridgeTxStatus
 
   public getBridgeGas = operations.getBridgeGas

--- a/packages/sdk-router/src/sdk.ts
+++ b/packages/sdk-router/src/sdk.ts
@@ -48,6 +48,8 @@ class SynapseSDK {
   public bridgeQuote = operations.bridgeQuote
   public getBridgeModuleName = operations.getBridgeModuleName
   public getEstimatedTime = operations.getEstimatedTime
+  public getBridgeID = operations.getBridgeID
+  public getBridgeTxStatus = operations.getBridgeTxStatus
 
   public getBridgeGas = operations.getBridgeGas
 

--- a/packages/sdk-router/src/utils/logs.ts
+++ b/packages/sdk-router/src/utils/logs.ts
@@ -1,0 +1,52 @@
+import { Log, Provider } from '@ethersproject/abstract-provider'
+import { Contract } from '@ethersproject/contracts'
+import { Interface } from '@ethersproject/abi'
+
+/**
+ * Extracts the first log from a transaction receipt that matches
+ * the provided contract and any of the provided event names.
+ *
+ * @param provider - Ethers provider for the network
+ * @param txHash - Transaction hash
+ * @param contract - Contract that should have emitted the event
+ * @param eventNames - Names of the events that could have been emitted
+ * @returns The first log that matches the contract and any of the event names
+ * @throws If the transaction receipt cannot be retrieved, or if no matching log is found
+ */
+export const getMatchingTxLog = async (
+  provider: Provider,
+  txHash: string,
+  contract: Contract,
+  eventNames: string[]
+): Promise<Log> => {
+  const txReceipt = await provider.getTransactionReceipt(txHash)
+  if (!txReceipt) {
+    throw new Error('Failed to get transaction receipt')
+  }
+  const topics = getEventTopics(contract.interface, eventNames)
+  // Find the log with the correct contract address and topic matching any of the provided topics
+  const matchingLog = txReceipt.logs.find((log) => {
+    return log.address === contract.address && topics.includes(log.topics[0])
+  })
+  if (!matchingLog) {
+    // Throw an error and include the event names in the message
+    throw new Error(
+      `Contract ${
+        contract.address
+      } in transaction ${txHash} did not emit any of the expected events: ${eventNames.join(
+        ', '
+      )}`
+    )
+  }
+  return matchingLog
+}
+
+const getEventTopics = (
+  contractInterface: Interface,
+  eventNames: string[]
+): string[] => {
+  // Filter events that match the provided event names and map them to their topics
+  return Object.values(contractInterface.events)
+    .filter((event) => eventNames.includes(event.name))
+    .map((event) => contractInterface.getEventTopic(event))
+}


### PR DESCRIPTION
**Description**
Added two functions to track the Synapse transactions:
- `getBridgeID(originChainId, bridgeModuleName, txHash)` returns `bridgeID`, which can be used to track the transaction status.
  - If the provided transaction is not an "origin transaction" for the corresponding "bridge module" (SynapseBridge / SynapseCCTP), this will throw an explicit error: 7f92da2
 - `getBridgeTxStatus(destChainId, bridgeModuleName, bridgeID)` returns the status of the transaction on the destination chain.
   - This will always return `false` for unrelated `bridgeID` 

**Additional context**
Add any other context about the problem you're solving.

**Metadata**
- Fixes #[Link to Issue]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Added bridge transaction ID retrieval and transaction completion status check functions.

- **Enhancements**
	- Improved estimation of bridge operation times for enhanced user experience.

- **Tests**
	- Added tests to ensure reliability of new bridge transaction features.

- **Documentation**
	- Updated public API documentation to include new bridge transaction tracking functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->