### PR TITLE
Gas rebates

### DIFF
--- a/packages/contracts-rfq/contracts/interfaces/IFastBridge.sol
+++ b/packages/contracts-rfq/contracts/interfaces/IFastBridge.sol
@@ -11,7 +11,9 @@ interface IFastBridge {
         address destToken;
         uint256 originAmount; // amount in on origin bridge less originFeeAmount
         uint256 destAmount;
-        uint256 originFeeAmount;
+        uint256 originFeeAmount; // protocol fee taken on origin claim
+        uint256 originGasRebate; // gas rebate deposited by user for relayer
+        uint256 destGasRebate; // gas rebate sent to user by relayer
         uint256 deadline;
         uint256 nonce;
     }
@@ -24,11 +26,15 @@ interface IFastBridge {
     // ============ Events ============
 
     event BridgeRequested(bytes32 transactionId, address sender, bytes request);
-    event BridgeRelayed(bytes32 transactionId, address relayer, address to, address token, uint256 amount);
+    event BridgeRelayed(
+        bytes32 transactionId, address relayer, address to, address token, uint256 amount, uint256 rebate
+    );
     event BridgeProofProvided(bytes32 transactionId, address relayer, bytes32 transactionHash);
     event BridgeProofDisputed(bytes32 transactionId, address relayer);
-    event BridgeDepositClaimed(bytes32 transactionId, address relayer, address to, address token, uint256 amount);
-    event BridgeDepositRefunded(bytes32 transactionId, address to, address token, uint256 amount);
+    event BridgeDepositClaimed(
+        bytes32 transactionId, address relayer, address to, address token, uint256 amount, uint256 rebate
+    );
+    event BridgeDepositRefunded(bytes32 transactionId, address to, address token, uint256 amount, uint256 rebate);
 
     // ============ Methods ============
 
@@ -39,6 +45,8 @@ interface IFastBridge {
         address destToken;
         uint256 originAmount; // should include protocol fee (if any)
         uint256 destAmount; // should include relayer fee
+        uint256 originGasRebate; // user provides on origin chain for relayer
+        uint256 destGasRebate; // relayer provides on dest chain for user
         uint256 deadline;
     }
 
@@ -74,7 +82,7 @@ interface IFastBridge {
     /// @notice Decodes bridge request into a bridge transaction
     /// @param request The bridge request to decode
     function getBridgeTransaction(bytes memory request) external pure returns (BridgeTransaction memory);
-    
+
     /// @notice Checks if the dispute period has passed so bridge deposit can be claimed
     /// @param transactionId The transaction id associated with the encoded bridge transaction to check
     /// @param relayer The address of the relayer attempting to claim

--- a/packages/contracts-rfq/contracts/libs/UniversalToken.sol
+++ b/packages/contracts-rfq/contracts/libs/UniversalToken.sol
@@ -19,7 +19,7 @@ library UniversalTokenLib {
         if (token == ETH_ADDRESS) {
             /// @dev Note: this can potentially lead to executing code in `to`.
             // solhint-disable-next-line avoid-low-level-calls
-            (bool success, ) = to.call{value: value}("");
+            (bool success,) = to.call{value: value}("");
             require(success, "ETH transfer failed");
         } else {
             IERC20(token).safeTransfer(to, value);

--- a/packages/contracts-rfq/test/FastBridge.t.sol
+++ b/packages/contracts-rfq/test/FastBridge.t.sol
@@ -42,11 +42,10 @@ contract FastBridgeTest is Test {
         ethUSDC.mint(dstUser, 100 * 10 ** 6);
     }
 
-    function _getBridgeRequestAndId(
-        uint256 chainId,
-        uint256 currentNonce,
-        uint256 protocolFeeRate
-    ) internal returns (bytes memory request, bytes32 transactionId) {
+    function _getBridgeRequestAndId(uint256 chainId, uint256 currentNonce, uint256 protocolFeeRate)
+        internal
+        returns (bytes memory request, bytes32 transactionId)
+    {
         // Define input variables for the bridge transaction
         address to = user;
         address oldRelayer = relayer;
@@ -74,6 +73,8 @@ contract FastBridgeTest is Test {
                 originAmount: originAmount,
                 destAmount: destAmount,
                 originFeeAmount: originFeeAmount,
+                originGasRebate: 0,
+                destGasRebate: 0,
                 deadline: deadline,
                 nonce: currentNonce
             })
@@ -81,11 +82,10 @@ contract FastBridgeTest is Test {
         transactionId = keccak256(request);
     }
 
-    function _getBridgeRequestAndIdWithETH(
-        uint256 chainId,
-        uint256 currentNonce,
-        uint256 protocolFeeRate
-    ) internal returns (bytes memory request, bytes32 transactionId) {
+    function _getBridgeRequestAndIdWithETH(uint256 chainId, uint256 currentNonce, uint256 protocolFeeRate)
+        internal
+        returns (bytes memory request, bytes32 transactionId)
+    {
         // Define input variables for the bridge transaction
         address to = user;
         address oldRelayer = relayer;
@@ -113,6 +113,8 @@ contract FastBridgeTest is Test {
                 originAmount: originAmount,
                 destAmount: destAmount,
                 originFeeAmount: originFeeAmount,
+                originGasRebate: 0,
+                destGasRebate: 0,
                 deadline: deadline,
                 nonce: currentNonce
             })
@@ -209,7 +211,7 @@ contract FastBridgeTest is Test {
         assertEq(fastBridge.protocolFeeRate(), 0);
 
         vm.startPrank(governor);
-        uint256 protocolFeeRate = 0.0010e6;
+        uint256 protocolFeeRate = 0.001e6;
         fastBridge.setProtocolFeeRate(protocolFeeRate);
         assertEq(fastBridge.protocolFeeRate(), protocolFeeRate);
         vm.stopPrank();
@@ -217,7 +219,7 @@ contract FastBridgeTest is Test {
 
     function test_onlyGovernorCanSetProtocolFeeRate() public {
         setUpRoles();
-        uint256 protocolFeeRate = 0.0010e6;
+        uint256 protocolFeeRate = 0.001e6;
         vm.expectRevert();
         fastBridge.setProtocolFeeRate(protocolFeeRate);
     }
@@ -255,6 +257,8 @@ contract FastBridgeTest is Test {
             destToken: address(ethUSDC),
             originAmount: 11 * 10 ** 6,
             destAmount: 10.97e6,
+            originGasRebate: 0,
+            destGasRebate: 0,
             deadline: block.timestamp + 3600
         });
         fastBridge.bridge(params);
@@ -291,6 +295,8 @@ contract FastBridgeTest is Test {
             destToken: UniversalTokenLib.ETH_ADDRESS,
             originAmount: 11 * 10 ** 18,
             destAmount: 10.97e18,
+            originGasRebate: 0,
+            destGasRebate: 0,
             deadline: block.timestamp + 3600
         });
         fastBridge.bridge{value: params.originAmount}(params);
@@ -311,7 +317,7 @@ contract FastBridgeTest is Test {
 
         // set protocol fee with governor to 10 bps
         vm.startPrank(governor);
-        uint256 protocolFeeRate = 0.0010e6;
+        uint256 protocolFeeRate = 0.001e6;
         fastBridge.setProtocolFeeRate(protocolFeeRate);
         assertEq(fastBridge.protocolFeeRate(), protocolFeeRate);
         vm.stopPrank();
@@ -323,11 +329,8 @@ contract FastBridgeTest is Test {
 
         // get expected bridge request and tx id
         uint256 currentNonce = fastBridge.nonce();
-        (bytes memory request, bytes32 transactionId) = _getBridgeRequestAndId(
-            block.chainid,
-            currentNonce,
-            protocolFeeRate
-        );
+        (bytes memory request, bytes32 transactionId) =
+            _getBridgeRequestAndId(block.chainid, currentNonce, protocolFeeRate);
 
         vm.expectEmit();
         emit BridgeRequested(transactionId, user, request);
@@ -340,6 +343,8 @@ contract FastBridgeTest is Test {
             destToken: address(ethUSDC),
             originAmount: 11 * 10 ** 6,
             destAmount: 10.97e6,
+            originGasRebate: 0,
+            destGasRebate: 0,
             deadline: block.timestamp + 3600
         });
         fastBridge.bridge(params);
@@ -361,7 +366,7 @@ contract FastBridgeTest is Test {
 
         // set protocol fee with governor to 10 bps
         vm.startPrank(governor);
-        uint256 protocolFeeRate = 0.0010e6;
+        uint256 protocolFeeRate = 0.001e6;
         fastBridge.setProtocolFeeRate(protocolFeeRate);
         assertEq(fastBridge.protocolFeeRate(), protocolFeeRate);
         vm.stopPrank();
@@ -376,11 +381,8 @@ contract FastBridgeTest is Test {
 
         // get expected bridge request and tx id
         uint256 currentNonce = fastBridge.nonce();
-        (bytes memory request, bytes32 transactionId) = _getBridgeRequestAndIdWithETH(
-            block.chainid,
-            currentNonce,
-            protocolFeeRate
-        );
+        (bytes memory request, bytes32 transactionId) =
+            _getBridgeRequestAndIdWithETH(block.chainid, currentNonce, protocolFeeRate);
 
         vm.expectEmit();
         emit BridgeRequested(transactionId, user, request);
@@ -393,6 +395,8 @@ contract FastBridgeTest is Test {
             destToken: UniversalTokenLib.ETH_ADDRESS,
             originAmount: 11 * 10 ** 18,
             destAmount: 10.97e18,
+            originGasRebate: 0,
+            destGasRebate: 0,
             deadline: block.timestamp + 3600
         });
         fastBridge.bridge{value: params.originAmount}(params);
@@ -422,6 +426,8 @@ contract FastBridgeTest is Test {
             destToken: address(ethUSDC),
             originAmount: 11 * 10 ** 6,
             destAmount: 10.97e6,
+            originGasRebate: 0,
+            destGasRebate: 0,
             deadline: block.timestamp + 3600
         });
         vm.expectRevert(abi.encodeWithSelector(ChainIncorrect.selector));
@@ -445,6 +451,8 @@ contract FastBridgeTest is Test {
             destToken: address(ethUSDC),
             originAmount: 0,
             destAmount: 10.97e6,
+            originGasRebate: 0,
+            destGasRebate: 0,
             deadline: block.timestamp + 3600
         });
         vm.expectRevert(abi.encodeWithSelector(AmountIncorrect.selector));
@@ -468,6 +476,8 @@ contract FastBridgeTest is Test {
             destToken: address(ethUSDC),
             originAmount: 11 * 10 ** 6,
             destAmount: 0,
+            originGasRebate: 0,
+            destGasRebate: 0,
             deadline: block.timestamp + 3600
         });
         vm.expectRevert(abi.encodeWithSelector(AmountIncorrect.selector));
@@ -491,6 +501,8 @@ contract FastBridgeTest is Test {
             destToken: address(ethUSDC),
             originAmount: 11 * 10 ** 6,
             destAmount: 10.97e6,
+            originGasRebate: 0,
+            destGasRebate: 0,
             deadline: block.timestamp + 3600
         });
         vm.expectRevert(abi.encodeWithSelector(ZeroAddress.selector));
@@ -514,6 +526,8 @@ contract FastBridgeTest is Test {
             destToken: address(0),
             originAmount: 11 * 10 ** 6,
             destAmount: 10.97e6,
+            originGasRebate: 0,
+            destGasRebate: 0,
             deadline: block.timestamp + 3600
         });
         vm.expectRevert(abi.encodeWithSelector(ZeroAddress.selector));
@@ -537,6 +551,8 @@ contract FastBridgeTest is Test {
             destToken: address(ethUSDC),
             originAmount: 11 * 10 ** 6,
             destAmount: 10.97e6,
+            originGasRebate: 0,
+            destGasRebate: 0,
             deadline: block.timestamp + 1800 - 1
         });
         vm.expectRevert(abi.encodeWithSelector(DeadlineTooShort.selector));
@@ -546,7 +562,9 @@ contract FastBridgeTest is Test {
         vm.stopPrank();
     }
 
-    event BridgeRelayed(bytes32 transactionId, address oldRelayer, address to, address token, uint256 amount);
+    event BridgeRelayed(
+        bytes32 transactionId, address oldRelayer, address to, address token, uint256 amount, uint256 rebate
+    );
 
     // This test checks the successful relaying of a destination bridge
     function test_successfulRelayDestination() public {
@@ -568,7 +586,7 @@ contract FastBridgeTest is Test {
         assertEq(ethUSDC.balanceOf(user), 100 * 10 ** 6);
         // Expect the BridgeRelayed event to be emitted
         vm.expectEmit();
-        emit BridgeRelayed(transactionId, relayer, user, address(ethUSDC), 10.97e6);
+        emit BridgeRelayed(transactionId, relayer, user, address(ethUSDC), 10.97e6, 0);
         // Relay the destination bridge
         vm.chainId(1); // set to dest chain
         fastBridge.relay(request);
@@ -818,7 +836,9 @@ contract FastBridgeTest is Test {
         vm.stopPrank();
     }
 
-    event BridgeDepositClaimed(bytes32 transactionId, address oldRelayer, address to, address token, uint256 amount);
+    event BridgeDepositClaimed(
+        bytes32 transactionId, address oldRelayer, address to, address token, uint256 amount, uint256 rebate
+    );
 
     function test_successfulClaimOriginTokens() public {
         setUpRoles();
@@ -833,7 +853,7 @@ contract FastBridgeTest is Test {
         vm.warp(block.timestamp + 31 minutes);
 
         vm.expectEmit();
-        emit BridgeDepositClaimed(transactionId, relayer, relayer, address(arbUSDC), 11 * 10 ** 6);
+        emit BridgeDepositClaimed(transactionId, relayer, relayer, address(arbUSDC), 11 * 10 ** 6, 0);
 
         uint256 preClaimBalanceRelayer = arbUSDC.balanceOf(relayer);
         uint256 preClaimBalanceBridge = arbUSDC.balanceOf(address(fastBridge));
@@ -899,7 +919,7 @@ contract FastBridgeTest is Test {
         uint256 amountClaimed = 11 * 10 ** 6 - amountToProtocol;
 
         vm.expectEmit();
-        emit BridgeDepositClaimed(transactionId, relayer, relayer, address(arbUSDC), amountClaimed);
+        emit BridgeDepositClaimed(transactionId, relayer, relayer, address(arbUSDC), amountClaimed, 0);
 
         uint256 preClaimBalanceRelayer = arbUSDC.balanceOf(relayer);
         uint256 preClaimBalanceBridge = arbUSDC.balanceOf(address(fastBridge));
@@ -931,11 +951,7 @@ contract FastBridgeTest is Test {
 
         // get bridge request and tx id
         uint256 protocolFeeRate = fastBridge.protocolFeeRate();
-        (bytes memory request, bytes32 transactionId) = _getBridgeRequestAndIdWithETH(
-            block.chainid,
-            0,
-            protocolFeeRate
-        );
+        (bytes memory request, bytes32 transactionId) = _getBridgeRequestAndIdWithETH(block.chainid, 0, protocolFeeRate);
 
         vm.startPrank(relayer);
         fastBridge.prove(request, bytes32("0x04"));
@@ -1154,7 +1170,7 @@ contract FastBridgeTest is Test {
         fastBridge.dispute(transactionId);
     }
 
-    event BridgeDepositRefunded(bytes32 transactionId, address to, address token, uint256 amount);
+    event BridgeDepositRefunded(bytes32 transactionId, address to, address token, uint256 amount, uint256 rebate);
 
     function test_successfulRefund() public {
         setUpRoles();
@@ -1168,7 +1184,7 @@ contract FastBridgeTest is Test {
         vm.warp(block.timestamp + 61 minutes);
 
         vm.expectEmit();
-        emit BridgeDepositRefunded(transactionId, user, address(arbUSDC), 11 * 10 ** 6);
+        emit BridgeDepositRefunded(transactionId, user, address(arbUSDC), 11 * 10 ** 6, 0);
 
         uint256 preRefundBalanceUser = arbUSDC.balanceOf(user);
         uint256 preRefundBalanceBridge = arbUSDC.balanceOf(address(fastBridge));
@@ -1229,7 +1245,7 @@ contract FastBridgeTest is Test {
         vm.warp(block.timestamp + 61 minutes);
 
         vm.expectEmit();
-        emit BridgeDepositRefunded(transactionId, user, address(arbUSDC), 11 * 10 ** 6);
+        emit BridgeDepositRefunded(transactionId, user, address(arbUSDC), 11 * 10 ** 6, 0);
 
         uint256 preRefundBalanceUser = arbUSDC.balanceOf(user);
         uint256 preRefundBalanceBridge = arbUSDC.balanceOf(address(fastBridge));
@@ -1256,11 +1272,7 @@ contract FastBridgeTest is Test {
 
         // get bridge request and tx id
         uint256 protocolFeeRate = fastBridge.protocolFeeRate();
-        (bytes memory request, bytes32 transactionId) = _getBridgeRequestAndIdWithETH(
-            block.chainid,
-            0,
-            protocolFeeRate
-        );
+        (bytes memory request, bytes32 transactionId) = _getBridgeRequestAndIdWithETH(block.chainid, 0, protocolFeeRate);
 
         vm.startPrank(user);
 

--- a/packages/contracts-rfq/test/FastBridgeMock.sol
+++ b/packages/contracts-rfq/test/FastBridgeMock.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.20;
 
 import {Admin} from "../contracts/Admin.sol";
 import {IFastBridge} from "../contracts/interfaces/IFastBridge.sol";
-import { FastBridge } from "../contracts/FastBridge.sol";
+import {FastBridge} from "../contracts/FastBridge.sol";
 
 contract FastBridgeMock is IFastBridge, Admin {
     // @dev the block the contract was deployed at
@@ -26,7 +26,7 @@ contract FastBridgeMock is IFastBridge, Admin {
     // or underliyng enum changes.
     //
     // TODO: a foundry test should be added to ensure this is always in sync.
-    function getEnumKeyByValue (FastBridge.BridgeStatus keyValue) public pure returns (string memory) {
+    function getEnumKeyByValue(FastBridge.BridgeStatus keyValue) public pure returns (string memory) {
         if (FastBridge.BridgeStatus.NULL == keyValue) return "NULL";
         if (FastBridge.BridgeStatus.REQUESTED == keyValue) return "REQUESTED";
         if (FastBridge.BridgeStatus.RELAYER_PROVED == keyValue) return "RELAYER_PROVED";
@@ -50,6 +50,8 @@ contract FastBridgeMock is IFastBridge, Admin {
                 originAmount: params.originAmount, // includes relayer fee
                 destAmount: params.destAmount,
                 originFeeAmount: originFeeAmount,
+                originGasRebate: params.originGasRebate,
+                destGasRebate: params.destGasRebate,
                 deadline: params.deadline,
                 nonce: nonce++ // increment nonce on every bridge
             })
@@ -58,15 +60,22 @@ contract FastBridgeMock is IFastBridge, Admin {
         emit BridgeRequested(transactionId, msg.sender, request);
     }
 
-    function mockBridgeRequestRaw(bytes32  transactionId, address sender, bytes memory request) external  {
+    function mockBridgeRequestRaw(bytes32 transactionId, address sender, bytes memory request) external {
         emit BridgeRequested(transactionId, sender, request);
     }
 
-    function mockBridgeRelayer(bytes32 transactionId, address relayer, address to, address token, uint256 amount) external  {
-        emit BridgeRelayed(transactionId, relayer, to, token, amount);
+    function mockBridgeRelayer(
+        bytes32 transactionId,
+        address relayer,
+        address to,
+        address token,
+        uint256 amount,
+        uint256 rebate
+    ) external {
+        emit BridgeRelayed(transactionId, relayer, to, token, amount, rebate);
     }
 
-    function bridge(BridgeParams memory params) external payable{
+    function bridge(BridgeParams memory params) external payable {
         revert("not implemented");
     }
 
@@ -77,7 +86,7 @@ contract FastBridgeMock is IFastBridge, Admin {
     function prove(bytes memory request, bytes32 destTxHash) external {
         revert("not implemented");
     }
-    
+
     function canClaim(bytes32 transactionid, address relayer) external view returns (bool) {
         revert("not implemented");
     }

--- a/packages/contracts-rfq/test/UniversalTokenLib.t.sol
+++ b/packages/contracts-rfq/test/UniversalTokenLib.t.sol
@@ -60,7 +60,7 @@ contract UniversalTokenLibraryTest is Test {
         assertEq(address(libHarness).balance, amount);
         // Simply sending ETH to the harness should still revert (no receive/fallback)
         deal(address(this), amount);
-        (bool success, ) = address(libHarness).call{value: amount}("");
+        (bool success,) = address(libHarness).call{value: amount}("");
         assertEq(success, false);
     }
 


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**
Origin and destination gas rebates for RFQ. Separate quantities from `originAmount, destAmount` so shouldn't influence quote prices, as long as rebates are "reasonable" given native gas token conversions.

`bridgeTransaction.originGasRebate` is claimed by relayer and `bridgeTransaction.destGasRebate` is sent by relayer to `destRecipient` on call to `relay` on dest chain.

**Additional context**
Add any other context about the problem you're solving.

**Metadata**
- Fixes #[Link to Issue]
