### PR TITLE
SDK: fix native value

### DIFF
--- a/packages/sdk-router/src/constants/testValues.ts
+++ b/packages/sdk-router/src/constants/testValues.ts
@@ -10,6 +10,8 @@ export const getTestProviderUrl = (chainId: number): string => {
   return `${sdkRpcUrl}${chainId}`
 }
 
+export const NATIVE_ADDRESS = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'
+
 // Token addresses on Ethereum mainnet
 export const ETH_DAI = '0x6B175474E89094C44Da98b954EedeAC495271d0F'
 export const ETH_NUSD = '0x1B84765dE8B7566e4cEAF4D0fD3c5aF52D3DdE4F'

--- a/packages/sdk-router/src/router/synapseCCTPRouter.ts
+++ b/packages/sdk-router/src/router/synapseCCTPRouter.ts
@@ -9,6 +9,7 @@ import { SynapseCCTPRouter as SynapseCCTPRouterContract } from '../typechain/Syn
 import { Router } from './router'
 import { Query, narrowToCCTPRouterQuery, reduceToQuery } from './query'
 import cctpAbi from '../abi/SynapseCCTP.json'
+import { adjustValueIfNative } from '../utils/handleNativeToken'
 import { getMatchingTxLog } from '../utils/logs'
 import { BigintIsh } from '../constants'
 import {
@@ -111,13 +112,20 @@ export class SynapseCCTPRouter extends Router {
     originQuery: Query,
     destQuery: Query
   ): Promise<PopulatedTransaction> {
-    return this.routerContract.populateTransaction.bridge(
-      to,
-      chainId,
+    const populatedTransaction =
+      await this.routerContract.populateTransaction.bridge(
+        to,
+        chainId,
+        token,
+        amount,
+        narrowToCCTPRouterQuery(originQuery),
+        narrowToCCTPRouterQuery(destQuery)
+      )
+    // Adjust the tx.value if the token is native
+    return adjustValueIfNative(
+      populatedTransaction,
       token,
-      amount,
-      narrowToCCTPRouterQuery(originQuery),
-      narrowToCCTPRouterQuery(destQuery)
+      BigNumber.from(amount)
     )
   }
 

--- a/packages/sdk-router/src/router/synapseRouter.ts
+++ b/packages/sdk-router/src/router/synapseRouter.ts
@@ -25,6 +25,7 @@ import {
   reduceToFeeConfig,
   reduceToPoolToken,
 } from './types'
+import { adjustValueIfNative } from '../utils/handleNativeToken'
 import { getMatchingTxLog } from '../utils/logs'
 
 /**
@@ -139,13 +140,20 @@ export class SynapseRouter extends Router {
     originQuery: Query,
     destQuery: Query
   ): Promise<PopulatedTransaction> {
-    return this.routerContract.populateTransaction.bridge(
-      to,
-      chainId,
+    const populatedTransaction =
+      await this.routerContract.populateTransaction.bridge(
+        to,
+        chainId,
+        token,
+        amount,
+        narrowToRouterQuery(originQuery),
+        narrowToRouterQuery(destQuery)
+      )
+    // Adjust the tx.value if the initial token is native
+    return adjustValueIfNative(
+      populatedTransaction,
       token,
-      amount,
-      narrowToRouterQuery(originQuery),
-      narrowToRouterQuery(destQuery)
+      BigNumber.from(amount)
     )
   }
 
@@ -250,11 +258,18 @@ export class SynapseRouter extends Router {
     amount: BigintIsh,
     query: Query
   ): Promise<PopulatedTransaction> {
-    return this.routerContract.populateTransaction.swap(
-      to,
+    const populatedTransaction =
+      await this.routerContract.populateTransaction.swap(
+        to,
+        token,
+        amount,
+        narrowToRouterQuery(query)
+      )
+    // Adjust the tx.value if the initial token is native
+    return adjustValueIfNative(
+      populatedTransaction,
       token,
-      amount,
-      narrowToRouterQuery(query)
+      BigNumber.from(amount)
     )
   }
 }

--- a/packages/sdk-router/src/sdk.test.ts
+++ b/packages/sdk-router/src/sdk.test.ts
@@ -355,6 +355,41 @@ describe('SynapseSDK', () => {
         })
       })
     })
+
+    describe('ETH Native -> ARB Native', () => {
+      const amount = BigNumber.from(10).pow(18)
+      const resultPromise: Promise<BridgeQuote> = synapse.bridgeQuote(
+        SupportedChainId.ETH,
+        SupportedChainId.ARBITRUM,
+        NATIVE_ADDRESS,
+        NATIVE_ADDRESS,
+        amount
+      )
+
+      createBridgeQuoteTests(
+        synapse,
+        SupportedChainId.ETH,
+        SupportedChainId.ARBITRUM,
+        NATIVE_ADDRESS,
+        amount,
+        resultPromise
+      )
+
+      it('Fetches a Synapse bridge quote', async () => {
+        resultPromise.then((result) => {
+          expect(result.routerAddress).toEqual(
+            ROUTER_ADDRESS_MAP[SupportedChainId.ETH]
+          )
+          // SynapseRouterQuery has swapAdapter property
+          expect(result.originQuery.swapAdapter).toBeDefined()
+          // Estimated time must match the SynapseBridge median time
+          expect(result.estimatedTime).toEqual(
+            MEDIAN_TIME_BRIDGE[SupportedChainId.ETH]
+          )
+          expect(result.bridgeModuleName).toEqual('SynapseBridge')
+        })
+      })
+    })
   })
 
   describe('Bridging: AVAX -> BSC', () => {
@@ -506,6 +541,41 @@ describe('SynapseSDK', () => {
             MEDIAN_TIME_CCTP[SupportedChainId.ARBITRUM]
           )
           expect(result.bridgeModuleName).toEqual('SynapseCCTP')
+        })
+      })
+    })
+
+    describe('ARB Native -> ETH Native', () => {
+      const amount = BigNumber.from(10).pow(18)
+      const resultPromise: Promise<BridgeQuote> = synapse.bridgeQuote(
+        SupportedChainId.ARBITRUM,
+        SupportedChainId.ETH,
+        NATIVE_ADDRESS,
+        NATIVE_ADDRESS,
+        amount
+      )
+
+      createBridgeQuoteTests(
+        synapse,
+        SupportedChainId.ETH,
+        SupportedChainId.ARBITRUM,
+        NATIVE_ADDRESS,
+        amount,
+        resultPromise
+      )
+
+      it('Fetches a Synapse bridge quote', async () => {
+        resultPromise.then((result) => {
+          expect(result.routerAddress).toEqual(
+            ROUTER_ADDRESS_MAP[SupportedChainId.ARBITRUM]
+          )
+          // SynapseRouterQuery has swapAdapter property
+          expect(result.originQuery.swapAdapter).toBeDefined()
+          // Estimated time must match the SynapseBridge median time
+          expect(result.estimatedTime).toEqual(
+            MEDIAN_TIME_BRIDGE[SupportedChainId.ARBITRUM]
+          )
+          expect(result.bridgeModuleName).toEqual('SynapseBridge')
         })
       })
     })

--- a/packages/sdk-router/src/sdk.test.ts
+++ b/packages/sdk-router/src/sdk.test.ts
@@ -54,7 +54,6 @@ const expectCorrectPopulatedTransaction = (
   expectedValue: BigNumber = Zero
 ) => {
   expect(populatedTransaction).toBeDefined()
-  console.log(populatedTransaction)
   expect(populatedTransaction.data?.length).toBeGreaterThan(0)
   expect(populatedTransaction.to?.length).toBeGreaterThan(0)
   expect(populatedTransaction.value).toEqual(expectedValue)

--- a/packages/sdk-router/src/sdk.test.ts
+++ b/packages/sdk-router/src/sdk.test.ts
@@ -24,6 +24,7 @@ import {
   ETH_USDT,
   MEDIAN_TIME_BRIDGE,
   MEDIAN_TIME_CCTP,
+  NATIVE_ADDRESS,
   ROUTER_ADDRESS_MAP,
   getTestProviderUrl,
   SupportedChainId,
@@ -49,11 +50,14 @@ const expectCorrectBridgeQuote = (bridgeQuote: BridgeQuote) => {
 }
 
 const expectCorrectPopulatedTransaction = (
-  populatedTransaction: PopulatedTransaction
+  populatedTransaction: PopulatedTransaction,
+  expectedValue: BigNumber = Zero
 ) => {
   expect(populatedTransaction).toBeDefined()
+  console.log(populatedTransaction)
   expect(populatedTransaction.data?.length).toBeGreaterThan(0)
   expect(populatedTransaction.to?.length).toBeGreaterThan(0)
+  expect(populatedTransaction.value).toEqual(expectedValue)
 }
 
 const createBridgeQuoteTests = (
@@ -74,18 +78,18 @@ const createBridgeQuoteTests = (
   })
 
   it('Could be used for bridging', async () => {
-    synapse
-      .bridge(
-        '0x0000000000000000000000000000000000001337',
-        result.routerAddress,
-        originChainId,
-        destChainId,
-        token,
-        amount,
-        result.originQuery,
-        result.destQuery
-      )
-      .then(expectCorrectPopulatedTransaction)
+    const expectedValue = token === NATIVE_ADDRESS ? amount : Zero
+    const data = await synapse.bridge(
+      '0x0000000000000000000000000000000000001337',
+      result.routerAddress,
+      originChainId,
+      destChainId,
+      token,
+      amount,
+      result.originQuery,
+      result.destQuery
+    )
+    expectCorrectPopulatedTransaction(data, expectedValue)
   })
 }
 
@@ -109,15 +113,15 @@ const createSwapQuoteTests = (
   })
 
   it('Could be used for swapping', async () => {
-    synapse
-      .swap(
-        chainId,
-        '0x0000000000000000000000000000000000001337',
-        token,
-        amount,
-        result.query
-      )
-      .then(expectCorrectPopulatedTransaction)
+    const expectedValue = token === NATIVE_ADDRESS ? amount : Zero
+    const data = await synapse.swap(
+      chainId,
+      '0x0000000000000000000000000000000000001337',
+      token,
+      amount,
+      result.query
+    )
+    expectCorrectPopulatedTransaction(data, expectedValue)
   })
 }
 

--- a/packages/sdk-router/src/utils/handleNativeToken.ts
+++ b/packages/sdk-router/src/utils/handleNativeToken.ts
@@ -1,4 +1,6 @@
-import { AddressZero } from '@ethersproject/constants'
+import { AddressZero, Zero } from '@ethersproject/constants'
+import { BigNumber } from '@ethersproject/bignumber'
+import { PopulatedTransaction } from '@ethersproject/contracts'
 
 export const ETH_NATIVE_TOKEN_ADDRESS =
   '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'
@@ -7,4 +9,27 @@ export const handleNativeToken = (tokenAddr: string) => {
   return tokenAddr === '' || tokenAddr === AddressZero
     ? ETH_NATIVE_TOKEN_ADDRESS
     : tokenAddr
+}
+
+export const isNativeToken = (tokenAddr: string): boolean => {
+  return tokenAddr.toLowerCase() === ETH_NATIVE_TOKEN_ADDRESS.toLowerCase()
+}
+
+/**
+ * Sets the tx.value to the amount if the token is native, otherwise sets it to 0.
+ *
+ * @param tx - The transaction to adjust.
+ * @param tokenAddr - The address of the token to check for being native.
+ * @param amountNative - The amount to set if the token is native.
+ * @param amountOther - The amount to set if the token is not native (optional, defaults to 0).
+ * @returns The adjusted populated transaction.
+ */
+export const adjustValueIfNative = (
+  tx: PopulatedTransaction,
+  tokenAddr: string,
+  amountNative: BigNumber,
+  amountOther: BigNumber = Zero
+): PopulatedTransaction => {
+  tx.value = isNativeToken(tokenAddr) ? amountNative : amountOther
+  return tx
 }


### PR DESCRIPTION
**Description**
Fixed both `synapseSDK.bridge()` and `synapseSDK.swap()` to include the correct `value` property, based on the token user is willing to spend:
- The value is set to the token amount, if native gas token is selected.
- Otherwise, the value is set to zero.

This guarantees that using the returned payload+value combination will result in a successful transaction without any value manipulation on the SDK consumer side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced bridge and swap methods to support transactions involving native tokens.

- **Bug Fixes**
  - Improved transaction value adjustments for native token operations to ensure accuracy.

- **Tests**
  - Expanded test suite with new cases for bridging and swapping native tokens, including value verification.

- **Documentation**
  - No visible changes to end-user documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->