### PR TITLE
Fix failing test (not enough pool liquidity)

### DIFF
--- a/packages/sdk-router/src/sdk.test.ts
+++ b/packages/sdk-router/src/sdk.test.ts
@@ -237,15 +237,15 @@ describe('SynapseSDK', () => {
       )
     })
 
-    describe('ETH USDC -> ARB USDC.e (excludeCCTP flag omitted)', () => {
-      // Try to find ETH USDC -> ARB USDC.e quote for 1M USDC,
+    describe('ETH USDC -> ARB USDT (excludeCCTP flag omitted)', () => {
+      // Try to find ETH USDC -> ARB USDT quote for 1M USDC,
       // which by default is routed through USDC
       const amount = BigNumber.from(10).pow(12)
       const resultPromise: Promise<BridgeQuote> = synapse.bridgeQuote(
         SupportedChainId.ETH,
         SupportedChainId.ARBITRUM,
         ETH_USDC,
-        ARB_USDC_E,
+        ARB_USDT,
         amount
       )
 
@@ -274,15 +274,15 @@ describe('SynapseSDK', () => {
       })
     })
 
-    describe('ETH USDC -> ARB USDC.e (excludeCCTP flag off)', () => {
-      // Try to find ETH USDC -> ARB USDC.e quote for 1M USDC,
+    describe('ETH USDC -> ARB USDT (excludeCCTP flag off)', () => {
+      // Try to find ETH USDC -> ARB USDT quote for 1M USDC,
       // which by default is routed through USDC
       const amount = BigNumber.from(10).pow(12)
       const resultPromise: Promise<BridgeQuote> = synapse.bridgeQuote(
         SupportedChainId.ETH,
         SupportedChainId.ARBITRUM,
         ETH_USDC,
-        ARB_USDC_E,
+        ARB_USDT,
         amount,
         undefined,
         false
@@ -313,15 +313,15 @@ describe('SynapseSDK', () => {
       })
     })
 
-    describe('ETH USDC -> ARB USDC.e (excludeCCTP flag on)', () => {
-      // Try to find ETH USDC -> ARB USDC.e quote for 1M USDC,
+    describe('ETH USDC -> ARB USDT (excludeCCTP flag on)', () => {
+      // Try to find ETH USDC -> ARB USDT quote for 1M USDC,
       // which by default is routed through USDC
       const amount = BigNumber.from(10).pow(12)
       const resultPromise: Promise<BridgeQuote> = synapse.bridgeQuote(
         SupportedChainId.ETH,
         SupportedChainId.ARBITRUM,
         ETH_USDC,
-        ARB_USDC_E,
+        ARB_USDT,
         amount,
         undefined,
         true


### PR DESCRIPTION
**Description**
Some of the fork tests were failing due to not enough external liquidity for USDC.e/USDC on Arbitrum. This PR fixes that.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated descriptions and target currency in test cases from "USDC.e" to "USDT" for improved accuracy and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->