### PR TITLE
remove tunnel from readme

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -26,7 +26,6 @@ root
 ├── <a href="./server">server</a>: Provides a context-safe server that can be used to start/stop a server.
 ├── <a href="./testsuite">testsuite</a>: Provides a wrapper around testify/suite.
 ├── <a href="./threaditer">threaditer</a>: Provides a thread-safe generic iterator for a slice.
-├── <a href="./tunnel">tunnel</a>: Reverse tunneling service for debugging services in ci.
 </pre>
 
 


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**

cut tunnel links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the core documentation to reflect the removal of the reverse tunneling service for debugging in continuous integration (CI) environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->