### PR TITLE
SDK: all quotes, Query modifications

### DIFF
--- a/packages/sdk-router/src/module/query.test.ts
+++ b/packages/sdk-router/src/module/query.test.ts
@@ -193,6 +193,17 @@ describe('#query', () => {
           rawParams: '5',
         })
       })
+
+      it('does not modify the original query', () => {
+        applySlippage(query, 50, 10000)
+        expect(query).toEqual({
+          swapAdapter: '1',
+          tokenOut: '2',
+          minAmountOut: BigNumber.from(10).pow(18).mul(1_000_000),
+          deadline: BigNumber.from(4),
+          rawParams: '5',
+        })
+      })
     })
 
     describe('CCTPRouterQuery', () => {
@@ -261,6 +272,17 @@ describe('#query', () => {
           rawParams: '5',
         })
       })
+
+      it('does not modify the original query', () => {
+        applySlippage(query, 50, 10000)
+        expect(query).toEqual({
+          routerAdapter: '1',
+          tokenOut: '2',
+          minAmountOut: BigNumber.from(10).pow(6).mul(1_000_000),
+          deadline: BigNumber.from(4),
+          rawParams: '5',
+        })
+      })
     })
 
     describe('errors', () => {
@@ -324,6 +346,17 @@ describe('#query', () => {
       const newQuery = applySlippage(query, 50, 10000)
       const newQueryInBips = applySlippageInBips(query, 50)
       expect(newQuery).toEqual(newQueryInBips)
+    })
+
+    it('does not modify the original query', () => {
+      applySlippageInBips(query, 50)
+      expect(query).toEqual({
+        swapAdapter: '1',
+        tokenOut: '2',
+        minAmountOut: BigNumber.from(10).pow(18).mul(1_000_000),
+        deadline: BigNumber.from(4),
+        rawParams: '5',
+      })
     })
 
     it('throws if basis points are negative', () => {

--- a/packages/sdk-router/src/module/query.test.ts
+++ b/packages/sdk-router/src/module/query.test.ts
@@ -8,6 +8,7 @@ import {
   narrowToRouterQuery,
   narrowToCCTPRouterQuery,
   modifyDeadline,
+  applySlippage,
 } from './query'
 
 describe('#query', () => {
@@ -120,6 +121,164 @@ describe('#query', () => {
           deadline: BigNumber.from(9),
           rawParams: '10',
         })
+      })
+    })
+  })
+
+  describe('applySlippage', () => {
+    describe('RouterQuery', () => {
+      // 1M in 18 decimals
+      const query: RouterQuery = {
+        swapAdapter: '1',
+        tokenOut: '2',
+        minAmountOut: BigNumber.from(10).pow(18).mul(1_000_000),
+        deadline: BigNumber.from(4),
+        rawParams: '5',
+      }
+
+      it('applies 0% slippage', () => {
+        const newQuery = applySlippage(query, 0, 10000)
+        expect(newQuery).toEqual({
+          swapAdapter: '1',
+          tokenOut: '2',
+          minAmountOut: BigNumber.from(10).pow(18).mul(1_000_000),
+          deadline: BigNumber.from(4),
+          rawParams: '5',
+        })
+      })
+
+      it('applies 0.5% slippage', () => {
+        // 50 bips
+        const newQuery = applySlippage(query, 50, 10000)
+        expect(newQuery).toEqual({
+          swapAdapter: '1',
+          tokenOut: '2',
+          minAmountOut: BigNumber.from(10).pow(18).mul(995_000),
+          deadline: BigNumber.from(4),
+          rawParams: '5',
+        })
+      })
+
+      it('applies 10% slippage', () => {
+        const newQuery = applySlippage(query, 10, 100)
+        expect(newQuery).toEqual({
+          swapAdapter: '1',
+          tokenOut: '2',
+          minAmountOut: BigNumber.from(10).pow(18).mul(900_000),
+          deadline: BigNumber.from(4),
+          rawParams: '5',
+        })
+      })
+
+      it('applies 100% slippage', () => {
+        const newQuery = applySlippage(query, 1, 1)
+        expect(newQuery).toEqual({
+          swapAdapter: '1',
+          tokenOut: '2',
+          minAmountOut: BigNumber.from(0),
+          deadline: BigNumber.from(4),
+          rawParams: '5',
+        })
+      })
+
+      it('rounds down', () => {
+        query.minAmountOut = query.minAmountOut.add(1)
+        const newQuery = applySlippage(query, 50, 10000)
+        expect(newQuery).toEqual({
+          swapAdapter: '1',
+          tokenOut: '2',
+          minAmountOut: BigNumber.from(10).pow(18).mul(995_000).add(1),
+          deadline: BigNumber.from(4),
+          rawParams: '5',
+        })
+      })
+    })
+
+    describe('CCTPRouterQuery', () => {
+      // 1M in 6 decimals
+      const query: CCTPRouterQuery = {
+        routerAdapter: '1',
+        tokenOut: '2',
+        minAmountOut: BigNumber.from(10).pow(6).mul(1_000_000),
+        deadline: BigNumber.from(4),
+        rawParams: '5',
+      }
+
+      it('applies 0% slippage', () => {
+        const newQuery = applySlippage(query, 0, 10000)
+        expect(newQuery).toEqual({
+          routerAdapter: '1',
+          tokenOut: '2',
+          minAmountOut: BigNumber.from(10).pow(6).mul(1_000_000),
+          deadline: BigNumber.from(4),
+          rawParams: '5',
+        })
+      })
+
+      it('applies 0.5% slippage', () => {
+        // 50 bips
+        const newQuery = applySlippage(query, 50, 10000)
+        expect(newQuery).toEqual({
+          routerAdapter: '1',
+          tokenOut: '2',
+          minAmountOut: BigNumber.from(10).pow(6).mul(995_000),
+          deadline: BigNumber.from(4),
+          rawParams: '5',
+        })
+      })
+
+      it('applies 10% slippage', () => {
+        const newQuery = applySlippage(query, 10, 100)
+        expect(newQuery).toEqual({
+          routerAdapter: '1',
+          tokenOut: '2',
+          minAmountOut: BigNumber.from(10).pow(6).mul(900_000),
+          deadline: BigNumber.from(4),
+          rawParams: '5',
+        })
+      })
+
+      it('applies 100% slippage', () => {
+        const newQuery = applySlippage(query, 1, 1)
+        expect(newQuery).toEqual({
+          routerAdapter: '1',
+          tokenOut: '2',
+          minAmountOut: BigNumber.from(0),
+          deadline: BigNumber.from(4),
+          rawParams: '5',
+        })
+      })
+
+      it('rounds down', () => {
+        query.minAmountOut = query.minAmountOut.add(1)
+        const newQuery = applySlippage(query, 50, 10000)
+        expect(newQuery).toEqual({
+          routerAdapter: '1',
+          tokenOut: '2',
+          minAmountOut: BigNumber.from(10).pow(6).mul(995_000).add(1),
+          deadline: BigNumber.from(4),
+          rawParams: '5',
+        })
+      })
+    })
+
+    describe('errors', () => {
+      it('throws if slippage denominator is zero', () => {
+        expect(() => applySlippage(routerQuery, 1, 0)).toThrow(
+          'Slippage denominator cannot be zero'
+        )
+      })
+
+      it('throws if slippage numerator is negative', () => {
+        expect(() => applySlippage(routerQuery, -1, 1)).toThrow(
+          'Slippage numerator cannot be negative'
+        )
+      })
+
+      it('throws if slippage numerator is greater than denominator', () => {
+        expect(() => applySlippage(routerQuery, 2, 1)).toThrow(
+          'Slippage cannot be greater than 1'
+        )
       })
     })
   })

--- a/packages/sdk-router/src/module/query.test.ts
+++ b/packages/sdk-router/src/module/query.test.ts
@@ -9,6 +9,7 @@ import {
   narrowToCCTPRouterQuery,
   modifyDeadline,
   applySlippage,
+  applySlippageInBips,
 } from './query'
 
 describe('#query', () => {
@@ -280,6 +281,61 @@ describe('#query', () => {
           'Slippage cannot be greater than 1'
         )
       })
+    })
+  })
+
+  describe('applySlippageInBips parity', () => {
+    // 1M in 18 decimals
+    const query: RouterQuery = {
+      swapAdapter: '1',
+      tokenOut: '2',
+      minAmountOut: BigNumber.from(10).pow(18).mul(1_000_000),
+      deadline: BigNumber.from(4),
+      rawParams: '5',
+    }
+
+    it('applies 0% slippage', () => {
+      const newQuery = applySlippage(query, 0, 10000)
+      const newQueryInBips = applySlippageInBips(query, 0)
+      expect(newQuery).toEqual(newQueryInBips)
+    })
+
+    it('applies 0.5% slippage', () => {
+      // 50 bips
+      const newQuery = applySlippage(query, 50, 10000)
+      const newQueryInBips = applySlippageInBips(query, 50)
+      expect(newQuery).toEqual(newQueryInBips)
+    })
+
+    it('applies 10% slippage', () => {
+      const newQuery = applySlippage(query, 10, 100)
+      const newQueryInBips = applySlippageInBips(query, 1000)
+      expect(newQuery).toEqual(newQueryInBips)
+    })
+
+    it('applies 100% slippage', () => {
+      const newQuery = applySlippage(query, 1, 1)
+      const newQueryInBips = applySlippageInBips(query, 10000)
+      expect(newQuery).toEqual(newQueryInBips)
+    })
+
+    it('rounds down', () => {
+      query.minAmountOut = query.minAmountOut.add(1)
+      const newQuery = applySlippage(query, 50, 10000)
+      const newQueryInBips = applySlippageInBips(query, 50)
+      expect(newQuery).toEqual(newQueryInBips)
+    })
+
+    it('throws if basis points are negative', () => {
+      expect(() => applySlippageInBips(routerQuery, -1)).toThrow(
+        'Slippage numerator cannot be negative'
+      )
+    })
+
+    it('throws if basis points are greater than 10000', () => {
+      expect(() => applySlippageInBips(routerQuery, 10001)).toThrow(
+        'Slippage cannot be greater than 1'
+      )
     })
   })
 })

--- a/packages/sdk-router/src/module/query.test.ts
+++ b/packages/sdk-router/src/module/query.test.ts
@@ -7,6 +7,7 @@ import {
   reduceToQuery,
   narrowToRouterQuery,
   narrowToCCTPRouterQuery,
+  modifyDeadline,
 } from './query'
 
 describe('#query', () => {
@@ -70,6 +71,56 @@ describe('#query', () => {
       expect(() => narrowToCCTPRouterQuery(query)).toThrow(
         'routerAdapter is undefined'
       )
+    })
+  })
+
+  describe('modifyDeadline', () => {
+    describe('RouterQuery', () => {
+      it('modifies the deadline', () => {
+        const query = modifyDeadline(routerQuery, BigNumber.from(42))
+        expect(query).toEqual({
+          swapAdapter: '1',
+          tokenOut: '2',
+          minAmountOut: BigNumber.from(3),
+          deadline: BigNumber.from(42),
+          rawParams: '5',
+        })
+      })
+
+      it('does not modify the original query', () => {
+        modifyDeadline(routerQuery, BigNumber.from(42))
+        expect(routerQuery).toEqual({
+          swapAdapter: '1',
+          tokenOut: '2',
+          minAmountOut: BigNumber.from(3),
+          deadline: BigNumber.from(4),
+          rawParams: '5',
+        })
+      })
+    })
+
+    describe('CCTPRouterQuery', () => {
+      it('modifies the deadline', () => {
+        const query = modifyDeadline(cctpRouterQuery, BigNumber.from(42))
+        expect(query).toEqual({
+          routerAdapter: '6',
+          tokenOut: '7',
+          minAmountOut: BigNumber.from(8),
+          deadline: BigNumber.from(42),
+          rawParams: '10',
+        })
+      })
+
+      it('does not modify the original query', () => {
+        modifyDeadline(cctpRouterQuery, BigNumber.from(42))
+        expect(cctpRouterQuery).toEqual({
+          routerAdapter: '6',
+          tokenOut: '7',
+          minAmountOut: BigNumber.from(8),
+          deadline: BigNumber.from(9),
+          rawParams: '10',
+        })
+      })
     })
   })
 })

--- a/packages/sdk-router/src/module/query.test.ts
+++ b/packages/sdk-router/src/module/query.test.ts
@@ -183,8 +183,11 @@ describe('#query', () => {
       })
 
       it('rounds down', () => {
-        query.minAmountOut = query.minAmountOut.add(1)
-        const newQuery = applySlippage(query, 50, 10000)
+        const queryPlusOne = {
+          ...query,
+          minAmountOut: query.minAmountOut.add(1),
+        }
+        const newQuery = applySlippage(queryPlusOne, 50, 10000)
         expect(newQuery).toEqual({
           swapAdapter: '1',
           tokenOut: '2',
@@ -262,8 +265,11 @@ describe('#query', () => {
       })
 
       it('rounds down', () => {
-        query.minAmountOut = query.minAmountOut.add(1)
-        const newQuery = applySlippage(query, 50, 10000)
+        const queryPlusOne = {
+          ...query,
+          minAmountOut: query.minAmountOut.add(1),
+        }
+        const newQuery = applySlippage(queryPlusOne, 50, 10000)
         expect(newQuery).toEqual({
           routerAdapter: '1',
           tokenOut: '2',
@@ -342,9 +348,12 @@ describe('#query', () => {
     })
 
     it('rounds down', () => {
-      query.minAmountOut = query.minAmountOut.add(1)
-      const newQuery = applySlippage(query, 50, 10000)
-      const newQueryInBips = applySlippageInBips(query, 50)
+      const queryPlusOne = {
+        ...query,
+        minAmountOut: query.minAmountOut.add(1),
+      }
+      const newQuery = applySlippage(queryPlusOne, 50, 10000)
+      const newQueryInBips = applySlippageInBips(queryPlusOne, 50)
       expect(newQuery).toEqual(newQueryInBips)
     })
 

--- a/packages/sdk-router/src/module/query.ts
+++ b/packages/sdk-router/src/module/query.ts
@@ -101,3 +101,18 @@ export const hasComplexBridgeAction = (destQuery: Query): boolean => {
     destQuery.tokenOut !== ETH_NATIVE_TOKEN_ADDRESS
   )
 }
+
+/**
+ * Modifies the deadline of the query and returns the modified query.
+ * Note: the original query is preserved unchanged.
+ *
+ * @param query - The query to modify.
+ * @param deadline - The new deadline.
+ * @returns The modified query with the new deadline.
+ */
+export const modifyDeadline = (query: Query, deadline: BigNumber): Query => {
+  return {
+    ...query,
+    deadline,
+  }
+}

--- a/packages/sdk-router/src/module/query.ts
+++ b/packages/sdk-router/src/module/query.ts
@@ -116,3 +116,33 @@ export const modifyDeadline = (query: Query, deadline: BigNumber): Query => {
     deadline,
   }
 }
+
+/**
+ * Applies the slippage to the query's minAmountOut (rounded down), and returns the modified query
+ * with the reduced minAmountOut.
+ * Note: the original query is preserved unchanged.
+ *
+ * @param query - The query to modify.
+ * @param slipNumerator - The numerator of the slippage.
+ * @param slipDenominator - The denominator of the slippage.
+ * @returns The modified query with the reduced minAmountOut.
+ */
+export const applySlippage = (
+  query: Query,
+  slipNumerator: number,
+  slipDenominator: number
+): Query => {
+  invariant(slipDenominator > 0, 'Slippage denominator cannot be zero')
+  invariant(slipNumerator >= 0, 'Slippage numerator cannot be negative')
+  invariant(
+    slipNumerator <= slipDenominator,
+    'Slippage cannot be greater than 1'
+  )
+  const slippageAmount = query.minAmountOut
+    .mul(slipNumerator)
+    .div(slipDenominator)
+  return {
+    ...query,
+    minAmountOut: query.minAmountOut.sub(slippageAmount),
+  }
+}

--- a/packages/sdk-router/src/module/query.ts
+++ b/packages/sdk-router/src/module/query.ts
@@ -126,6 +126,7 @@ export const modifyDeadline = (query: Query, deadline: BigNumber): Query => {
  * @param slipNumerator - The numerator of the slippage.
  * @param slipDenominator - The denominator of the slippage.
  * @returns The modified query with the reduced minAmountOut.
+ * @throws If the slippage fraction is invalid (<0, >1, or NaN)
  */
 export const applySlippage = (
   query: Query,
@@ -145,4 +146,22 @@ export const applySlippage = (
     ...query,
     minAmountOut: query.minAmountOut.sub(slippageAmount),
   }
+}
+
+/**
+ * Applies the slippage (in basis points) to the query's minAmountOut (rounded down), and returns the modified query
+ * with the reduced minAmountOut.
+ * Note: the original query is preserved unchanged.
+ * Note: the slippage is applied as a fraction of 10000, e.g. 100 bips = 1%.
+ *
+ * @param query - The query to modify.
+ * @param slipBasisPoints - The slippage in basis points.
+ * @returns The modified query with the reduced minAmountOut.
+ * @throws If the basis points are invalid (<0, >10000)
+ */
+export const applySlippageInBips = (
+  query: Query,
+  slipBasisPoints: number
+): Query => {
+  return applySlippage(query, slipBasisPoints, 10000)
 }

--- a/packages/sdk-router/src/module/types.ts
+++ b/packages/sdk-router/src/module/types.ts
@@ -76,14 +76,3 @@ export type BridgeRoute = {
   bridgeToken: BridgeToken
   bridgeModuleName: string
 }
-
-/**
- * Finds the best route: the one with the maximum amount out in the destination query.
- */
-export const findBestRoute = (bridgeRoutes: BridgeRoute[]): BridgeRoute => {
-  return bridgeRoutes.reduce((best, current) => {
-    return current.destQuery.minAmountOut.gt(best.destQuery.minAmountOut)
-      ? current
-      : best
-  })
-}

--- a/packages/sdk-router/src/operations/bridge.ts
+++ b/packages/sdk-router/src/operations/bridge.ts
@@ -145,7 +145,7 @@ export async function allBridgeQuotes(
   )
   tokenOut = handleNativeToken(tokenOut)
   tokenIn = handleNativeToken(tokenIn)
-  const allQuotes = await Promise.all(
+  const allQuotes: BridgeQuote[][] = await Promise.all(
     this.allRouterSets.map(async (routerSet) => {
       const routes = await routerSet.getBridgeRoutes(
         originChainId,
@@ -162,7 +162,10 @@ export async function allBridgeQuotes(
       )
     })
   )
-  return allQuotes.flat()
+  // Flatten the result and sort by maxAmountOut in descending order
+  return allQuotes
+    .flat()
+    .sort((a, b) => (a.maxAmountOut.gt(b.maxAmountOut) ? -1 : 1))
 }
 
 /**

--- a/packages/sdk-router/src/sdk.test.ts
+++ b/packages/sdk-router/src/sdk.test.ts
@@ -648,6 +648,55 @@ describe('SynapseSDK', () => {
     })
   })
 
+  describe('allBridgeQuotes', () => {
+    const synapse = new SynapseSDK(
+      [SupportedChainId.ETH, SupportedChainId.ARBITRUM],
+      [ethProvider, arbProvider]
+    )
+
+    it('Fetches SynapseBridge and SynapseCCTP quotes for USDC', async () => {
+      const allQuotes = await synapse.allBridgeQuotes(
+        SupportedChainId.ETH,
+        SupportedChainId.ARBITRUM,
+        ETH_USDC,
+        ARB_USDT,
+        BigNumber.from(10).pow(9)
+      )
+      expect(allQuotes.length).toEqual(2)
+      expectCorrectBridgeQuote(allQuotes[0])
+      expectCorrectBridgeQuote(allQuotes[1])
+      // First quote should have better quote
+      expect(allQuotes[0].maxAmountOut.gte(allQuotes[1].maxAmountOut)).toBe(
+        true
+      )
+      // One should be SynapseBridge and the other SynapseCCTP
+      expect(allQuotes[0].bridgeModuleName).not.toEqual(
+        allQuotes[1].bridgeModuleName
+      )
+      expect(
+        allQuotes[0].bridgeModuleName === 'SynapseBridge' ||
+          allQuotes[1].bridgeModuleName === 'SynapseBridge'
+      ).toBe(true)
+      expect(
+        allQuotes[0].bridgeModuleName === 'SynapseCCTP' ||
+          allQuotes[1].bridgeModuleName === 'SynapseCCTP'
+      ).toBe(true)
+    })
+
+    it('Fetches only SynapseBridge quotes for ETH', async () => {
+      const allQuotes = await synapse.allBridgeQuotes(
+        SupportedChainId.ETH,
+        SupportedChainId.ARBITRUM,
+        NATIVE_ADDRESS,
+        NATIVE_ADDRESS,
+        BigNumber.from(10).pow(18)
+      )
+      expect(allQuotes.length).toEqual(1)
+      expectCorrectBridgeQuote(allQuotes[0])
+      expect(allQuotes[0].bridgeModuleName).toEqual('SynapseBridge')
+    })
+  })
+
   describe('Errors', () => {
     const synapse = new SynapseSDK(
       [SupportedChainId.ETH, SupportedChainId.BSC],

--- a/packages/sdk-router/src/sdk.ts
+++ b/packages/sdk-router/src/sdk.ts
@@ -2,6 +2,7 @@ import { Provider } from '@ethersproject/abstract-provider'
 import invariant from 'tiny-invariant'
 
 import {
+  RouterSet,
   SynapseRouterSet,
   SynapseCCTPRouterSet,
   ChainProvider,
@@ -12,6 +13,7 @@ import { ETH_NATIVE_TOKEN_ADDRESS } from './utils/handleNativeToken'
 import { Query, modifyDeadline } from './module'
 
 class SynapseSDK {
+  public allRouterSets: RouterSet[]
   public synapseRouterSet: SynapseRouterSet
   public synapseCCTPRouterSet: SynapseCCTPRouterSet
   public providers: { [chainId: number]: Provider }
@@ -41,11 +43,13 @@ class SynapseSDK {
     // Initialize SynapseRouterSet and SynapseCCTPRouterSet
     this.synapseRouterSet = new SynapseRouterSet(chainProviders)
     this.synapseCCTPRouterSet = new SynapseCCTPRouterSet(chainProviders)
+    this.allRouterSets = [this.synapseRouterSet, this.synapseCCTPRouterSet]
   }
 
   // Define Bridge operations
   public bridge = operations.bridge
   public bridgeQuote = operations.bridgeQuote
+  public allBridgeQuotes = operations.allBridgeQuotes
   public getBridgeModuleName = operations.getBridgeModuleName
   public getEstimatedTime = operations.getEstimatedTime
   public getSynapseTxId = operations.getSynapseTxId

--- a/packages/sdk-router/src/sdk.ts
+++ b/packages/sdk-router/src/sdk.ts
@@ -10,7 +10,12 @@ import {
 } from './router'
 import * as operations from './operations'
 import { ETH_NATIVE_TOKEN_ADDRESS } from './utils/handleNativeToken'
-import { Query, modifyDeadline } from './module'
+import {
+  Query,
+  applySlippage,
+  applySlippageInBips,
+  modifyDeadline,
+} from './module'
 
 class SynapseSDK {
   public allRouterSets: RouterSet[]
@@ -71,6 +76,8 @@ class SynapseSDK {
   public swapQuote = operations.swapQuote
 
   // Define Query operations
+  public applySlippage = applySlippage
+  public applySlippageInBips = applySlippageInBips
   public modifyDeadline = modifyDeadline
 }
 

--- a/packages/sdk-router/src/sdk.ts
+++ b/packages/sdk-router/src/sdk.ts
@@ -9,7 +9,7 @@ import {
 } from './router'
 import * as operations from './operations'
 import { ETH_NATIVE_TOKEN_ADDRESS } from './utils/handleNativeToken'
-import { Query } from './module'
+import { Query, modifyDeadline } from './module'
 
 class SynapseSDK {
   public synapseRouterSet: SynapseRouterSet
@@ -65,6 +65,9 @@ class SynapseSDK {
   // Define Swap operations
   public swap = operations.swap
   public swapQuote = operations.swapQuote
+
+  // Define Query operations
+  public modifyDeadline = modifyDeadline
 }
 
 export { SynapseSDK, ETH_NATIVE_TOKEN_ADDRESS, Query, PoolToken }


### PR DESCRIPTION
**Description**
This PR aims to expand the bridge-related functionality:
- Adds `allBridgeQuotes()` function that returns **all** quotes for bridging using **all** available bridge modules. 
  - `bridgeModuleName` is included into each `BridgeQuote` object, allowing the consumer to do filtering on their side, if required.
  - The list of "bridge quotes" is sorted by the expected amount out on destination chain in descending order.
  > Optional `deadline` parameter allows to set a default deadline for all returned bridge quotes.
- Adds generic functions for modifying the `Query` object, which is required for every bridge or swap interaction:
  - `modifyDeadline` to set the query's deadline. 
  - `applySlippage` and `applySlippageInBips` to apply the slippage to the query's "amount out"
  > Both functions do **NOT** modify the input Query and instead return a new object. This allows consumer to fetch the bridge quote once and then additionally modify it as per user settings (which could as well be not static).

**Additional context**
#1695 will be rebased once this is merged into master.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new slippage and deadline modification functions for enhanced quote calculations.
  - Added functionality to retrieve and filter quotes from multiple bridge modules.

- **Enhancements**
  - Implemented new test suite for validating multi-bridge quote retrieval.

- **Refactor**
  - Removed the `findBestRoute` function to streamline the SDK's exposed functionality.

- **Bug Fixes**
  - Adjusted quote functions to ensure accurate and reliable financial data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->