### PR TITLE
SDK: further generalize modules

### DIFF
--- a/packages/sdk-router/src/module/synapseModuleSet.ts
+++ b/packages/sdk-router/src/module/synapseModuleSet.ts
@@ -4,7 +4,11 @@ import invariant from 'tiny-invariant'
 import { BigintIsh } from '../constants'
 import { BridgeQuote, BridgeRoute, FeeConfig } from './types'
 import { SynapseModule } from './synapseModule'
-import { ONE_WEEK, TEN_MINUTES, calculateDeadline } from '../utils/deadlines'
+import {
+  ONE_WEEK,
+  TEN_MINUTES,
+  applyOptionalDeadline,
+} from '../utils/deadlines'
 
 export abstract class SynapseModuleSet {
   abstract readonly bridgeModuleName: string
@@ -140,9 +144,9 @@ export abstract class SynapseModuleSet {
     )
     const { originQuery, destQuery } = bridgeRoute
     // Set origin deadline to 10 mins if not provided
-    originQuery.deadline = deadline ?? calculateDeadline(TEN_MINUTES)
+    originQuery.deadline = applyOptionalDeadline(deadline, TEN_MINUTES)
     // Destination deadline is always 1 week
-    destQuery.deadline = calculateDeadline(ONE_WEEK)
+    destQuery.deadline = applyOptionalDeadline(undefined, ONE_WEEK)
     const { feeAmount, feeConfig } = await this.getFeeData(bridgeRoute)
     return {
       feeAmount,

--- a/packages/sdk-router/src/operations/bridge.ts
+++ b/packages/sdk-router/src/operations/bridge.ts
@@ -207,13 +207,13 @@ export function getBridgeModuleName(
   this: SynapseSDK,
   eventName: string
 ): string {
-  if (this.synapseRouterSet.allEvents.includes(eventName)) {
-    return this.synapseRouterSet.bridgeModuleName
+  const moduleSet = this.allModuleSets.find((set) =>
+    set.allEvents.includes(eventName)
+  )
+  if (!moduleSet) {
+    throw new Error('Unknown event')
   }
-  if (this.synapseCCTPRouterSet.allEvents.includes(eventName)) {
-    return this.synapseCCTPRouterSet.bridgeModuleName
-  }
-  throw new Error('Unknown event')
+  return moduleSet.bridgeModuleName
 }
 
 /**
@@ -261,11 +261,11 @@ export function getModuleSet(
   this: SynapseSDK,
   bridgeModuleName: string
 ): SynapseModuleSet {
-  if (this.synapseRouterSet.bridgeModuleName === bridgeModuleName) {
-    return this.synapseRouterSet
+  const moduleSet = this.allModuleSets.find(
+    (set) => set.bridgeModuleName === bridgeModuleName
+  )
+  if (!moduleSet) {
+    throw new Error('Unknown bridge module')
   }
-  if (this.synapseCCTPRouterSet.bridgeModuleName === bridgeModuleName) {
-    return this.synapseCCTPRouterSet
-  }
-  throw new Error('Unknown bridge module')
+  return moduleSet
 }

--- a/packages/sdk-router/src/operations/bridge.ts
+++ b/packages/sdk-router/src/operations/bridge.ts
@@ -40,20 +40,14 @@ export async function bridge(
     'Origin chainId cannot be equal to destination chainId'
   )
   token = handleNativeToken(token)
-  // Get Router instance for given chain and address
-  const router =
-    this.synapseRouterSet.getModuleWithAddress(
-      originChainId,
-      originRouterAddress
-    ) ??
-    this.synapseCCTPRouterSet.getModuleWithAddress(
-      originChainId,
-      originRouterAddress
-    )
-  // Throw if Router is not found
-  invariant(router, 'Invalid router address')
-  // Ask the Router to populate the bridge transaction
-  return router.bridge(to, destChainId, token, amount, originQuery, destQuery)
+  // Find the module that is using the given router address
+  const module = this.allModuleSets
+    .map((set) => set.getModuleWithAddress(originChainId, originRouterAddress))
+    .find(Boolean)
+  if (!module) {
+    throw new Error('Invalid router address')
+  }
+  return module.bridge(to, destChainId, token, amount, originQuery, destQuery)
 }
 
 /**

--- a/packages/sdk-router/src/operations/swap.ts
+++ b/packages/sdk-router/src/operations/swap.ts
@@ -5,7 +5,7 @@ import { BigintIsh } from '../constants'
 import { Query, SwapQuote } from '../module'
 import { handleNativeToken } from '../utils/handleNativeToken'
 import { SynapseSDK } from '../sdk'
-import { getOriginDeadline } from '../utils/deadlines'
+import { TEN_MINUTES, applyOptionalDeadline } from '../utils/deadlines'
 
 /**
  * Performs a swap through a Synapse Router.
@@ -61,6 +61,6 @@ export async function swapQuote(
   if (query.minAmountOut.isZero()) {
     throw Error('No queries found for this route')
   }
-  query.deadline = getOriginDeadline(deadline)
+  query.deadline = applyOptionalDeadline(deadline, TEN_MINUTES)
   return { routerAddress, maxAmountOut, query }
 }

--- a/packages/sdk-router/src/router/routerSet.ts
+++ b/packages/sdk-router/src/router/routerSet.ts
@@ -12,6 +12,7 @@ import {
   SynapseModuleSet,
 } from '../module'
 import { hasComplexBridgeAction } from '../module/query'
+import { ONE_WEEK, TEN_MINUTES } from '../utils/deadlines'
 
 export type ChainProvider = {
   chainId: number
@@ -158,5 +159,19 @@ export abstract class RouterSet extends SynapseModuleSet {
       bridgeRoute.originQuery.minAmountOut,
       hasComplexBridgeAction(bridgeRoute.destQuery)
     )
+  }
+
+  /**
+   * @inheritdoc SynapseModuleSet.getDefaultPeriods
+   */
+  getDefaultPeriods(): {
+    originPeriod: number
+    destPeriod: number
+  } {
+    // Use the same default periods for SynapseBridge and SynapseCCTP modules
+    return {
+      originPeriod: TEN_MINUTES,
+      destPeriod: ONE_WEEK,
+    }
   }
 }

--- a/packages/sdk-router/src/sdk.test.ts
+++ b/packages/sdk-router/src/sdk.test.ts
@@ -1411,20 +1411,20 @@ describe('SynapseSDK', () => {
       [SupportedChainId.ARBITRUM, SupportedChainId.ETH],
       [arbProvider, ethProvider]
     )
-    describe('getRouterSet', () => {
+    describe('getModuleSet', () => {
       it('Returns correct set for SynapseBridge', () => {
-        const routerSet = operations.getRouterSet.call(synapse, 'SynapseBridge')
+        const routerSet = operations.getModuleSet.call(synapse, 'SynapseBridge')
         expect(routerSet).toEqual(synapse.synapseRouterSet)
       })
 
       it('Returns correct set for SynapseCCTP', () => {
-        const routerSet = operations.getRouterSet.call(synapse, 'SynapseCCTP')
+        const routerSet = operations.getModuleSet.call(synapse, 'SynapseCCTP')
         expect(routerSet).toEqual(synapse.synapseCCTPRouterSet)
       })
 
       it('Throws when bridge module name is invalid', () => {
         expect(() =>
-          operations.getRouterSet.call(synapse, 'SynapseSynapse')
+          operations.getModuleSet.call(synapse, 'SynapseSynapse')
         ).toThrow('Unknown bridge module')
       })
     })

--- a/packages/sdk-router/src/sdk.ts
+++ b/packages/sdk-router/src/sdk.ts
@@ -2,7 +2,6 @@ import { Provider } from '@ethersproject/abstract-provider'
 import invariant from 'tiny-invariant'
 
 import {
-  RouterSet,
   SynapseRouterSet,
   SynapseCCTPRouterSet,
   ChainProvider,
@@ -11,6 +10,7 @@ import {
 import * as operations from './operations'
 import { ETH_NATIVE_TOKEN_ADDRESS } from './utils/handleNativeToken'
 import {
+  SynapseModuleSet,
   Query,
   applySlippage,
   applySlippageInBips,
@@ -18,7 +18,7 @@ import {
 } from './module'
 
 class SynapseSDK {
-  public allRouterSets: RouterSet[]
+  public allModuleSets: SynapseModuleSet[]
   public synapseRouterSet: SynapseRouterSet
   public synapseCCTPRouterSet: SynapseCCTPRouterSet
   public providers: { [chainId: number]: Provider }
@@ -48,7 +48,7 @@ class SynapseSDK {
     // Initialize SynapseRouterSet and SynapseCCTPRouterSet
     this.synapseRouterSet = new SynapseRouterSet(chainProviders)
     this.synapseCCTPRouterSet = new SynapseCCTPRouterSet(chainProviders)
-    this.allRouterSets = [this.synapseRouterSet, this.synapseCCTPRouterSet]
+    this.allModuleSets = [this.synapseRouterSet, this.synapseCCTPRouterSet]
   }
 
   // Define Bridge operations

--- a/packages/sdk-router/src/utils/deadlines.test.ts
+++ b/packages/sdk-router/src/utils/deadlines.test.ts
@@ -1,45 +1,30 @@
 import { BigNumber } from '@ethersproject/bignumber'
 
-import {
-  calculateDeadline,
-  getDestinationDeadline,
-  getOriginDeadline,
-} from './deadlines'
+import { applyOptionalDeadline, calculateDeadline } from './deadlines'
 
 describe('deadlines', () => {
   // Something good happened on this day
   Date.now = jest.fn(() => Date.parse('2021-08-29'))
 
-  it('calculates correct deadlines', () => {
-    const seconds = 1337
-    const deadline = calculateDeadline(seconds)
-    const now = Math.floor(Date.now() / 1000)
-    expect(deadline.toNumber()).toBe(now + seconds)
-  })
-
-  describe('getOriginDeadline', () => {
-    it('returns the deadline if it is defined', () => {
-      const deadline = BigNumber.from(1337)
-      expect(getOriginDeadline(deadline)).toBe(deadline)
-    })
-
-    it('Uses 10 minutes if deadline is undefined', () => {
-      const deadline = getOriginDeadline()
+  describe('calculateDeadline', () => {
+    it('calculates correct deadlines', () => {
+      const seconds = 1337
+      const deadline = calculateDeadline(seconds)
       const now = Math.floor(Date.now() / 1000)
-      expect(deadline.toNumber()).toBe(now + 10 * 60)
+      expect(deadline.toNumber()).toBe(now + seconds)
     })
   })
 
-  describe('getDestinationDeadline', () => {
+  describe('applyOptionalDeadline', () => {
     it('returns the deadline if it is defined', () => {
       const deadline = BigNumber.from(1337)
-      expect(getDestinationDeadline(deadline)).toBe(deadline)
+      expect(applyOptionalDeadline(deadline, 1234)).toBe(deadline)
     })
 
-    it('Uses 1 week if deadline is undefined', () => {
-      const deadline = getDestinationDeadline()
+    it('applies the default period if the deadline is undefined', () => {
+      const deadline = applyOptionalDeadline(undefined, 1234)
       const now = Math.floor(Date.now() / 1000)
-      expect(deadline.toNumber()).toBe(now + 7 * 24 * 60 * 60)
+      expect(deadline.toNumber()).toBe(now + 1234)
     })
   })
 })

--- a/packages/sdk-router/src/utils/deadlines.ts
+++ b/packages/sdk-router/src/utils/deadlines.ts
@@ -8,10 +8,9 @@ export const calculateDeadline = (seconds: number) => {
   return BigNumber.from(Math.floor(Date.now() / 1000) + seconds)
 }
 
-export const getOriginDeadline = (deadline?: BigNumber) => {
-  return deadline ?? calculateDeadline(TEN_MINUTES)
-}
-
-export const getDestinationDeadline = (deadline?: BigNumber) => {
-  return deadline ?? calculateDeadline(ONE_WEEK)
+export const applyOptionalDeadline = (
+  deadline: BigNumber | undefined,
+  defaultPeriod: number
+): BigNumber => {
+  return deadline ?? calculateDeadline(defaultPeriod)
 }


### PR DESCRIPTION
# Description
Continues the work started in #1691. The bridge logic is further generalized to ease the addition of the alternative bridge modules.

# Additional context
- #1695 will be rebased once this is merged into master.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Transitioned from using specific `RouterSet` instances to a more generic `SynapseModuleSet` for handling bridge operations in the SDK, enhancing the flexibility and modularity of the system.

- **Tests**
	- Updated SDK test suite to reflect the renaming and logic changes in the core SDK functionality.

- **Documentation**
	- Adjusted documentation to align with the new `SynapseModuleSet` terminology and usage within the SDK.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->