### PR TITLE
Add `BaseGasPrice` to submitter

### DIFF
--- a/ethergo/submitter/config/config.go
+++ b/ethergo/submitter/config/config.go
@@ -31,6 +31,8 @@ type ChainConfig struct {
 	DoNotBatch bool `yaml:"skip_batching"`
 	// MaxGasPrice is the maximum gas price to use for transactions
 	MaxGasPrice *big.Int `yaml:"max_gas_price"`
+	// BaseGasPrice is the gas price that will be used if 0 is returned from the gas price oracle
+	BaseGasPrice *big.Int `yaml:"base_gas_price"`
 	// BumpIntervalSeconds is the number of seconds to wait before bumping a transaction
 	BumpIntervalSeconds int `yaml:"bump_interval_seconds"`
 	// GasBumpPercentages is the percentage to bump the gas price by
@@ -63,6 +65,9 @@ const (
 
 // DefaultMaxPrice is the default max price of a tx.
 var DefaultMaxPrice = big.NewInt(500 * params.GWei)
+
+// DefaultBaseGasPrice is the default max price of a tx.
+var DefaultBaseGasPrice = big.NewInt(1 * params.GWei)
 
 // note: there's probably a way to clean these getters up with generics, the real problem comes with the fact that
 // that this would require the caller to override the entire struct, which is not ideal..
@@ -100,6 +105,21 @@ func (c *Config) GetMaxGasPrice(chainID int) (maxPrice *big.Int) {
 
 	if maxPrice == nil || maxPrice == big.NewInt(0) {
 		maxPrice = DefaultMaxPrice
+	}
+	return
+}
+
+// GetBaseGasPrice returns the maximum gas price to use for transactions.
+func (c *Config) GetBaseGasPrice(chainID int) (basePrice *big.Int) {
+	basePrice = c.BaseGasPrice
+
+	chainConfig, ok := c.Chains[chainID]
+	if ok && chainConfig.BaseGasPrice != nil {
+		basePrice = chainConfig.BaseGasPrice
+	}
+
+	if basePrice == nil || basePrice == big.NewInt(0) {
+		basePrice = DefaultBaseGasPrice
 	}
 	return
 }
@@ -194,6 +214,11 @@ func (c *Config) SupportsEIP1559(chainID int) bool {
 // SetGlobalMaxGasPrice is a helper function that sets the global gas price.
 func (c *Config) SetGlobalMaxGasPrice(maxPrice *big.Int) {
 	c.MaxGasPrice = maxPrice
+}
+
+// SetBaseGasPrice is a helper function that sets the base gas price.
+func (c *Config) SetBaseGasPrice(basePrice *big.Int) {
+	c.BaseGasPrice = basePrice
 }
 
 // SetGlobalEIP1559Support is a helper function that sets the global EIP1559 support.

--- a/ethergo/submitter/config/iconfig_generated.go
+++ b/ethergo/submitter/config/iconfig_generated.go
@@ -15,6 +15,8 @@ type IConfig interface {
 	GetBatch(chainID int) bool
 	// GetMaxGasPrice returns the maximum gas price to use for transactions.
 	GetMaxGasPrice(chainID int) (maxPrice *big.Int)
+	// GetBaseGasPrice returns the gas price to be used instead of zero.
+	GetBaseGasPrice(chainID int) (basePrice *big.Int)
 	// GetBumpInterval returns the number of seconds to wait before bumping a transaction
 	// TODO: test this method.
 	GetBumpInterval(chainID int) time.Duration

--- a/ethergo/submitter/submitter.go
+++ b/ethergo/submitter/submitter.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/puzpuzpuz/xsync/v2"
 	"math"
 	"math/big"
 	"reflect"
 	"runtime"
 	"sync"
 	"time"
+
+	"github.com/puzpuzpuz/xsync/v2"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -372,6 +373,7 @@ func (t *txSubmitterImpl) setGasPrice(ctx context.Context, client client.EVM,
 			return fmt.Errorf("could not get gas price: %w", err)
 		}
 	}
+	t.applyBaseGasPrice(transactor, chainID)
 
 	//nolint: nestif
 	if prevTx != nil {
@@ -394,6 +396,22 @@ func (t *txSubmitterImpl) setGasPrice(ctx context.Context, client client.EVM,
 		gas.BumpGasFees(transactor, t.config.GetGasBumpPercentage(chainID), gasBlock.BaseFee, maxPrice)
 	}
 	return nil
+}
+
+// applyBaseGasPrice applies the base gas price to the transactor if a gas price value is zero.
+func (t *txSubmitterImpl) applyBaseGasPrice(transactor *bind.TransactOpts, chainID int) {
+	if t.config.SupportsEIP1559(chainID) {
+		if transactor.GasFeeCap == nil || transactor.GasFeeCap.Cmp(big.NewInt(0)) == 0 {
+			transactor.GasFeeCap = t.config.GetBaseGasPrice(chainID)
+		}
+		if transactor.GasTipCap == nil || transactor.GasTipCap.Cmp(big.NewInt(0)) == 0 {
+			transactor.GasTipCap = t.config.GetBaseGasPrice(chainID)
+		}
+	} else {
+		if transactor.GasPrice == nil || transactor.GasPrice.Cmp(big.NewInt(0)) == 0 {
+			transactor.GasPrice = t.config.GetBaseGasPrice(chainID)
+		}
+	}
 }
 
 // getGasBlock gets the gas block for the given chain.

--- a/ethergo/submitter/submitter_test.go
+++ b/ethergo/submitter/submitter_test.go
@@ -91,8 +91,8 @@ func (s *SubmitterSuite) TestSetGasPrice() {
 
 	s.Equal(baseGasPrice, transactor.GasTipCap, testsuite.BigIntComparer())
 
-	// 5. Test with bump (TODO)
-	// 6. Test with bump and max (TODO)
+	// 6. Test with bump (TODO)
+	// 7. Test with bump and max (TODO)
 }
 
 func (s *SubmitterSuite) TestGetGasBlock() {


### PR DESCRIPTION
**Description**
Adds `BaseGasPrice` to the transaction submitter, which should be used in the case that the gas price oracle returns zero. If the value is not set, we default to 1 gwei.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option for setting the base gas price in transactions.

- **Enhancements**
	- Improved gas price handling for compatibility with EIP-1559.

- **Tests**
	- Added test cases to ensure correct gas pricing under various scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->