### PR TITLE
Add contract addresses to quoter API response

### DIFF
--- a/services/rfq/api/client/client.go
+++ b/services/rfq/api/client/client.go
@@ -175,14 +175,15 @@ func (c *unauthenticatedClient) GetQuoteByRelayerAddress(relayerAddr string) ([]
 
 // APIQuotePutRequest is the struct for the quote API.
 type APIQuotePutRequest struct {
-	OriginChainID     string `json:"origin_chain_id"`
-	OriginTokenAddr   string `json:"origin_token_addr"`
-	DestChainID       string `json:"dest_chain_id"`
-	DestTokenAddr     string `json:"dest_token_addr"`
-	DestAmount        string `json:"dest_amount"`
-	MaxOriginAmount   string `json:"max_origin_amount"`
-	FixedFee          string `json:"fixed_fee"`
-	FastBridgeAddress string `json:"fast_bridge_address"`
+	OriginChainID           string `json:"origin_chain_id"`
+	OriginTokenAddr         string `json:"origin_token_addr"`
+	DestChainID             string `json:"dest_chain_id"`
+	DestTokenAddr           string `json:"dest_token_addr"`
+	DestAmount              string `json:"dest_amount"`
+	MaxOriginAmount         string `json:"max_origin_amount"`
+	FixedFee                string `json:"fixed_fee"`
+	OriginFastBridgeAddress string `json:"origin_fast_bridge_address"`
+	DestFastBridgeAddress   string `json:"dest_fast_bridge_address"`
 }
 
 // APIQuoteSpecificGetRequest is the struct for the quote API.

--- a/services/rfq/api/client/client.go
+++ b/services/rfq/api/client/client.go
@@ -175,13 +175,14 @@ func (c *unauthenticatedClient) GetQuoteByRelayerAddress(relayerAddr string) ([]
 
 // APIQuotePutRequest is the struct for the quote API.
 type APIQuotePutRequest struct {
-	OriginChainID   string `json:"origin_chain_id"`
-	OriginTokenAddr string `json:"origin_token_addr"`
-	DestChainID     string `json:"dest_chain_id"`
-	DestTokenAddr   string `json:"dest_token_addr"`
-	DestAmount      string `json:"dest_amount"`
-	MaxOriginAmount string `json:"max_origin_amount"`
-	FixedFee        string `json:"fixed_fee"`
+	OriginChainID     string `json:"origin_chain_id"`
+	OriginTokenAddr   string `json:"origin_token_addr"`
+	DestChainID       string `json:"dest_chain_id"`
+	DestTokenAddr     string `json:"dest_token_addr"`
+	DestAmount        string `json:"dest_amount"`
+	MaxOriginAmount   string `json:"max_origin_amount"`
+	FixedFee          string `json:"fixed_fee"`
+	FastBridgeAddress string `json:"fast_bridge_address"`
 }
 
 // APIQuoteSpecificGetRequest is the struct for the quote API.

--- a/services/rfq/relayer/quoter/quoter.go
+++ b/services/rfq/relayer/quoter/quoter.go
@@ -155,9 +155,9 @@ func (m *Manager) prepareAndSubmitQuotes(ctx context.Context, inv map[int]map[co
 // We can do this by looking at the quotableTokens map, and finding the key that matches the destination chain token.
 // Generates quotes for a given chain ID, address, and balance.
 func (m *Manager) GenerateQuotes(ctx context.Context, chainID int, address common.Address, balance *big.Int) ([]rfqAPIClient.APIQuotePutRequest, error) {
-	chainCfg, ok := m.config.Chains[chainID]
+	destChainCfg, ok := m.config.Chains[chainID]
 	if !ok {
-		return nil, fmt.Errorf("error getting chain config for chain ID %d", chainID)
+		return nil, fmt.Errorf("error getting chain config for destination chain ID %d", chainID)
 	}
 	destTokenID := fmt.Sprintf("%d-%s", chainID, address.Hex())
 	var quotes []rfqAPIClient.APIQuotePutRequest
@@ -178,15 +178,20 @@ func (m *Manager) GenerateQuotes(ctx context.Context, chainID int, address commo
 				if err != nil {
 					return nil, fmt.Errorf("error getting total fee: %w", err)
 				}
+				originChainCfg, ok := m.config.Chains[origin]
+				if !ok {
+					return nil, fmt.Errorf("error getting chain config for origin chain ID %d", origin)
+				}
 				quote := rfqAPIClient.APIQuotePutRequest{
-					OriginChainID:     originStr,
-					OriginTokenAddr:   strings.Split(keyTokenID, "-")[1],
-					DestChainID:       fmt.Sprint(chainID),
-					DestTokenAddr:     address.Hex(),
-					DestAmount:        balance.String(),
-					MaxOriginAmount:   balance.String(),
-					FixedFee:          fee.String(),
-					FastBridgeAddress: chainCfg.Bridge,
+					OriginChainID:           originStr,
+					OriginTokenAddr:         strings.Split(keyTokenID, "-")[1],
+					DestChainID:             fmt.Sprint(chainID),
+					DestTokenAddr:           address.Hex(),
+					DestAmount:              balance.String(),
+					MaxOriginAmount:         balance.String(),
+					FixedFee:                fee.String(),
+					OriginFastBridgeAddress: originChainCfg.Bridge,
+					DestFastBridgeAddress:   destChainCfg.Bridge,
 				}
 				quotes = append(quotes, quote)
 			}


### PR DESCRIPTION
**Description**
Gets the appropriate `OriginFastBridgeAddress` and `DestFastBridgeAddress` from the relayer config and includes them in the quoter API response.