### PR TITLE
add custom evm-version to abigen

### DIFF
--- a/tools/abigen/internal/export_test.go
+++ b/tools/abigen/internal/export_test.go
@@ -11,8 +11,8 @@ func CreateRunFile(version string) (runFile *os.File, err error) {
 }
 
 // CompileSolidity exports compileSolidity for testingw.
-func CompileSolidity(version string, filePath string, optimizeRuns int) (map[string]*compiler.Contract, error) {
-	return compileSolidity(version, filePath, optimizeRuns)
+func CompileSolidity(version string, filePath string, optimizeRuns int, evmVersion *string) (map[string]*compiler.Contract, error) {
+	return compileSolidity(version, filePath, optimizeRuns, evmVersion)
 }
 
 // FilePathsAreEqual exports filePathsAreEqual for testing.


### PR DESCRIPTION
This was a feature that was needed for #1650 since our version of embedded geth is too old to support push0 (see #1767). It also allows us to target any evm for abigen by passing the param to the solc compiler.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new command-line flags to customize the ABI generation process.
  - Added functionality to specify the Ethereum Virtual Machine (EVM) version for Solidity compilation.

- **Improvements**
  - Solidity files are now created in a specified directory, enhancing the organization of generated files.

- **Testing Enhancements**
  - Expanded test coverage to include scenarios with explicit EVM version specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->