### PR TITLE
Add `FixedFeeMultiplier` to rfq fee pricer

### DIFF
--- a/services/rfq/relayer/pricer/fee_pricer.go
+++ b/services/rfq/relayer/pricer/fee_pricer.go
@@ -118,8 +118,10 @@ func (f *feePricer) getFee(ctx context.Context, gasChain, denomChain uint32, gas
 	feeUSDC := new(big.Float).Mul(feeUSD, new(big.Float).SetFloat64(denomTokenPrice))
 	// Note that this rounds towards zero- we may need to apply rounding here if
 	// we want to be conservative and lean towards overestimating fees.
-	feeUSDCDecimals, _ := new(big.Float).Mul(feeUSDC, new(big.Float).SetInt(denomDecimalsFactor)).Int(nil)
-	return feeUSDCDecimals, nil
+	feeUSDCDecimals := new(big.Float).Mul(feeUSDC, new(big.Float).SetInt(denomDecimalsFactor))
+	// Apply the fixed fee multiplier.
+	feeUSDCDecimalsScaled, _ := new(big.Float).Mul(feeUSDCDecimals, new(big.Float).SetFloat64(f.config.GetFixedFeeMultiplier())).Int(nil)
+	return feeUSDCDecimalsScaled, nil
 }
 
 // getGasPrice returns the gas price for a given chainID in native units.

--- a/services/rfq/relayer/relconfig/config.go
+++ b/services/rfq/relayer/relconfig/config.go
@@ -71,6 +71,8 @@ type FeePricerConfig struct {
 	OriginGasEstimate int `yaml:"origin_gas_estimate"`
 	// DestinationGasEstimate is the gas required to execute relay transaction on destination chain.
 	DestinationGasEstimate int `yaml:"destination_gas_estimate"`
+	// FixedFeeMultiplier is the multiplier for the fixed fee.
+	FixedFeeMultiplier float64 `yaml:"fixed_fee_multiplier"`
 	// GasPriceCacheTTLSeconds is the TTL for the gas price cache.
 	GasPriceCacheTTLSeconds int `yaml:"gas_price_cache_ttl"`
 	// TokenPriceCacheTTLSeconds is the TTL for the token price cache.
@@ -191,6 +193,16 @@ func (c Config) GetTokenName(chain uint32, addr string) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("no tokenName found for chain %d and address %s", chain, addr)
+}
+
+const defaultFixedFeeMultiplier = 1
+
+// GetFixedFeeMultiplier returns the fixed fee multiplier.
+func (c Config) GetFixedFeeMultiplier() float64 {
+	if c.FeePricer.FixedFeeMultiplier <= 0 {
+		return defaultFixedFeeMultiplier
+	}
+	return c.FeePricer.FixedFeeMultiplier
 }
 
 var _ IConfig = &Config{}

--- a/services/rfq/relayer/relconfig/iconfig_generated.go
+++ b/services/rfq/relayer/relconfig/iconfig_generated.go
@@ -32,4 +32,6 @@ type IConfig interface {
 	GetTokens(chainID uint32) (map[string]TokenConfig, error)
 	// GetTokenName returns the token name for the given chain and address.
 	GetTokenName(chain uint32, addr string) (string, error)
+	// GetFixedFeeMultiplier returns the fixed fee multiplier.
+	GetFixedFeeMultiplier() float64
 }


### PR DESCRIPTION
**Description**
Adds a `FixedFeeMultiplier` param that defaults to 1 if unset. This scales each returned fee by the given multiplier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a fixed fee multiplier to the fee calculation process for enhanced pricing accuracy.
- **Tests**
	- Added tests to ensure accurate fee calculations with the new fixed fee multiplier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->