### PR TITLE
Prevent extraneous bridge quote fetches

### DIFF
--- a/packages/synapse-interface/pages/state-managed-bridge/index.tsx
+++ b/packages/synapse-interface/pages/state-managed-bridge/index.tsx
@@ -87,13 +87,8 @@ const StateManagedBridge = () => {
     fromToken,
     toToken,
     bridgeQuote,
-    fromValue,
     debouncedFromValue,
     destinationAddress,
-    fromChainIds,
-    toChainIds,
-    fromTokens,
-    toTokens,
   }: BridgeState = useBridgeState()
   const {
     showSettingsSlideOver,

--- a/packages/synapse-interface/pages/state-managed-bridge/index.tsx
+++ b/packages/synapse-interface/pages/state-managed-bridge/index.tsx
@@ -81,9 +81,6 @@ const StateManagedBridge = () => {
   const router = useRouter()
   const { query, pathname } = router
 
-  const { balancesAndAllowances: portfolioBalances, status: portfolioStatus } =
-    useFetchPortfolioBalances()
-
   const {
     fromChainId,
     toChainId,

--- a/packages/synapse-interface/pages/state-managed-bridge/index.tsx
+++ b/packages/synapse-interface/pages/state-managed-bridge/index.tsx
@@ -135,15 +135,7 @@ const StateManagedBridge = () => {
       dispatch(setBridgeQuote(EMPTY_BRIDGE_QUOTE_ZERO))
       dispatch(setIsLoading(false))
     }
-  }, [
-    fromChainId,
-    toChainId,
-    fromToken,
-    toToken,
-    debouncedFromValue,
-    address,
-    portfolioBalances,
-  ])
+  }, [fromChainId, toChainId, fromToken, toToken, debouncedFromValue])
 
   // don't like this, rewrite: could be custom hook
   useEffect(() => {
@@ -240,16 +232,14 @@ const StateManagedBridge = () => {
       }
 
       // TODO: do this properly (RFQ needs no slippage, others do)
-      const originMinWithSlippage = bridgeModuleName === "SynapseRFQ" ? (originQuery?.minAmountOut ?? 0n) : subtractSlippage(
-        originQuery?.minAmountOut ?? 0n,
-        'ONE_TENTH',
-        null
-      )
-      const destMinWithSlippage = bridgeModuleName === "SynapseRFQ" ? (destQuery?.minAmountOut ?? 0n) : subtractSlippage(
-        destQuery?.minAmountOut ?? 0n,
-        'ONE_TENTH',
-        null
-      )
+      const originMinWithSlippage =
+        bridgeModuleName === 'SynapseRFQ'
+          ? originQuery?.minAmountOut ?? 0n
+          : subtractSlippage(originQuery?.minAmountOut ?? 0n, 'ONE_TENTH', null)
+      const destMinWithSlippage =
+        bridgeModuleName === 'SynapseRFQ'
+          ? destQuery?.minAmountOut ?? 0n
+          : subtractSlippage(destQuery?.minAmountOut ?? 0n, 'ONE_TENTH', null)
 
       let newOriginQuery = { ...originQuery }
       newOriginQuery.minAmountOut = originMinWithSlippage


### PR DESCRIPTION
Remove unused deps in useEffect to trigger bridge quote

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced stability and performance of the state-managed bridge interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
c2faa8a56deb45a0a0fc4e60c86e4fbe4f33f741: [synapse-interface preview link ](https://sanguine-synapse-interface-cart8swqo-synapsecns.vercel.app)
8562b9554335bad3bdbaf62015fbd671b03f2bde: [synapse-interface preview link ](https://sanguine-synapse-interface-g6oai27vm-synapsecns.vercel.app)
59365b21651fb380cc776c8d694478b60f7db24f: [synapse-interface preview link ](https://sanguine-synapse-interface-r7x0gzewa-synapsecns.vercel.app)