### PR TITLE
 [rfq] fix codecov/flake

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -60,6 +60,7 @@ flags:
   rfq:
     paths:
       - services/rfq/
+    carryforward: true
   explorer:
     paths:
       - services/explorer/

--- a/services/rfq/README.md
+++ b/services/rfq/README.md
@@ -2,4 +2,3 @@
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/synapsecns/sanguine/services/rfq.svg)](https://pkg.go.dev/github.com/synapsecns/sanguine/services/rfq)
 [![Go Report Card](https://goreportcard.com/badge/github.com/synapsecns/sanguine/services/rfq)](https://goreportcard.com/report/github.com/synapsecns/sanguine/services/rfq)
-

--- a/services/rfq/e2e/rfq_test.go
+++ b/services/rfq/e2e/rfq_test.go
@@ -137,7 +137,7 @@ func (i *IntegrationSuite) TestUSDCtoUSDC() {
 		SendChainGas: true,
 		DestToken:    destUSDC.Address(),
 		OriginAmount: realWantAmount,
-		DestAmount:   new(big.Int).Sub(realWantAmount, big.NewInt(1)),
+		DestAmount:   new(big.Int).Sub(realWantAmount, big.NewInt(1000)),
 		Deadline:     new(big.Int).SetInt64(time.Now().Add(time.Hour * 24).Unix()),
 	})
 	i.NoError(err)


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**

Fixes rfq codecov & flakes

Tacking CI Flake nere:

- It's not new to this pr, as I've observed in #1795 #1796 #1782 and as far back as #1776 (#1650 was working)
- Initially [investigated](https://github.com/synapsecns/sanguine/commit/8eb23293270e62e1be9456a3c6f041b7dac2dfc1) anvil docker tag break, but no update in 19 days
- In debugger would appear 
<img width="1065" alt="image" src="https://github.com/synapsecns/sanguine/assets/83933037/3f1d688b-6561-481f-b2dd-9b2acd4e3d79">
-  this case in e2e is never hit, which would explain everything. Querying the db, it appears the final case is 4:
<img width="613" alt="image" src="https://github.com/synapsecns/sanguine/assets/83933037/2ca63686-5b98-459b-8657-2e7f3d03ca16">

If we query this, we see this is [WillNotProcess](https://pkg.go.dev/github.com/synapsens/sanguine/services/rfq@v0.0.6/relayer/reldb)

Everything else in the nearly 1.7gb of logs generated over an hour are context cancellation errors, so we can narrow the issue down to this 1 line:

<img width="1124" alt="image" src="https://github.com/synapsecns/sanguine/assets/83933037/aa135ce5-c0bc-413e-a02b-61a4c7b0ed6d">

And should be able to add breakpoints to find the exact issue:

<img width="1191" alt="image" src="https://github.com/synapsecns/sanguine/assets/83933037/92ebd783-8d26-4a60-8e7d-ee823358f8ad">

Since we hit none, we can tell it's isProfitable:

<img width="1226" alt="image" src="https://github.com/synapsecns/sanguine/assets/83933037/d1021b35-b452-4a40-8522-595141984760">

and since cost (500000045) > dest amount out (500000000) this will fail.

For now, we can just subtract a bigger number:



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated codecov configuration to carry forward flags for improved coverage tracking.
  - Updated Anvil backend Docker image tag from "latest" to "nightly-02292f2d2caa547968bd039c06dc53d98b72bf39".
  - Removed Go documentation and report card badge links from RFQ service README.
  - Modified logic in the `TestUSDCtoUSDC` function for improved test case behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->