### PR TITLE
`refund` to originSender only

### DIFF
--- a/packages/contracts-rfq/contracts/FastBridge.sol
+++ b/packages/contracts-rfq/contracts/FastBridge.sol
@@ -236,17 +236,17 @@ contract FastBridge is IFastBridge, Admin {
     }
 
     /// @inheritdoc IFastBridge
-    function refund(bytes memory request, address to) external {
+    function refund(bytes memory request) external {
         bytes32 transactionId = keccak256(request);
         BridgeTransaction memory transaction = getBridgeTransaction(request);
-        if (transaction.originSender != msg.sender) revert SenderIncorrect();
         if (block.timestamp <= transaction.deadline) revert DeadlineNotExceeded();
 
         // set status to refunded if still in requested state
         if (bridgeStatuses[transactionId] != BridgeStatus.REQUESTED) revert StatusIncorrect();
         bridgeStatuses[transactionId] = BridgeStatus.REFUNDED;
 
-        // transfer origin collateral back to original sender's specified recipient
+        // transfer origin collateral back to original sender
+        address to = transaction.originSender;
         address token = transaction.originToken;
         uint256 amount = transaction.originAmount + transaction.originFeeAmount;
         token.universalTransfer(to, amount);

--- a/packages/contracts-rfq/contracts/interfaces/IFastBridge.sol
+++ b/packages/contracts-rfq/contracts/interfaces/IFastBridge.sol
@@ -91,8 +91,7 @@ interface IFastBridge {
 
     /// @notice Refunds an outstanding bridge transaction in case optimistic bridging failed
     /// @param request The encoded bridge transaction to refund
-    /// @param to The recipient address of the funds
-    function refund(bytes memory request, address to) external;
+    function refund(bytes memory request) external;
 
     // ============ Views ============
 

--- a/packages/contracts-rfq/test/FastBridge.t.sol
+++ b/packages/contracts-rfq/test/FastBridge.t.sol
@@ -1664,7 +1664,7 @@ contract FastBridgeTest is Test {
         uint256 preRefundBalanceUser = arbUSDC.balanceOf(user);
         uint256 preRefundBalanceBridge = arbUSDC.balanceOf(address(fastBridge));
 
-        fastBridge.refund(request, user);
+        fastBridge.refund(request);
 
         // check balance changes
         uint256 postRefundBalanceUser = arbUSDC.balanceOf(user);
@@ -1694,7 +1694,7 @@ contract FastBridgeTest is Test {
         uint256 preRefundBalanceUser = user.balance;
         uint256 preRefundBalanceBridge = address(fastBridge).balance;
 
-        fastBridge.refund(request, user);
+        fastBridge.refund(request);
 
         // check balance changes
         uint256 postRefundBalanceUser = user.balance;
@@ -1725,7 +1725,7 @@ contract FastBridgeTest is Test {
         uint256 preRefundBalanceUser = arbUSDC.balanceOf(user);
         uint256 preRefundBalanceBridge = arbUSDC.balanceOf(address(fastBridge));
 
-        fastBridge.refund(request, user);
+        fastBridge.refund(request);
 
         // check balance changes
         uint256 postRefundBalanceUser = arbUSDC.balanceOf(user);
@@ -1756,7 +1756,7 @@ contract FastBridgeTest is Test {
         uint256 preRefundBalanceUser = user.balance;
         uint256 preRefundBalanceBridge = address(fastBridge).balance;
 
-        fastBridge.refund(request, user);
+        fastBridge.refund(request);
 
         // check balance changes
         uint256 postRefundBalanceUser = user.balance;
@@ -1786,7 +1786,7 @@ contract FastBridgeTest is Test {
         uint256 preRefundBalanceUser = arbUSDC.balanceOf(user);
         uint256 preRefundBalanceBridge = arbUSDC.balanceOf(address(fastBridge));
 
-        fastBridge.refund(request, user);
+        fastBridge.refund(request);
 
         // check balance changes
         uint256 postRefundBalanceUser = arbUSDC.balanceOf(user);
@@ -1802,6 +1802,34 @@ contract FastBridgeTest is Test {
         vm.stopPrank();
     }
 
+    function test_successfulRefundNotSender() public {
+        setUpRoles();
+        test_successfulBridge();
+
+        // get bridge request and tx id
+        (bytes memory request, bytes32 transactionId) = _getBridgeRequestAndId(block.chainid, 0, 0);
+
+        vm.warp(block.timestamp + 61 minutes);
+
+        vm.expectEmit();
+        emit BridgeDepositRefunded(transactionId, user, address(arbUSDC), 11 * 10 ** 6);
+
+        uint256 preRefundBalanceUser = arbUSDC.balanceOf(user);
+        uint256 preRefundBalanceBridge = arbUSDC.balanceOf(address(fastBridge));
+
+        fastBridge.refund(request);
+
+        // check balance changes
+        uint256 postRefundBalanceUser = arbUSDC.balanceOf(user);
+        uint256 postRefundBalanceBridge = arbUSDC.balanceOf(address(fastBridge));
+
+        assertEq(postRefundBalanceUser - preRefundBalanceUser, 11 * 10 ** 6);
+        assertEq(preRefundBalanceBridge - postRefundBalanceBridge, 11 * 10 ** 6);
+
+        // check bridge status updated
+        assertEq(uint256(fastBridge.bridgeStatuses(transactionId)), uint256(FastBridge.BridgeStatus.REFUNDED));
+    }
+
     function test_failedRefundNotEnoughTime() public {
         setUpRoles();
         test_successfulBridge();
@@ -1814,23 +1842,7 @@ contract FastBridgeTest is Test {
         vm.warp(block.timestamp + 59 minutes);
 
         vm.expectRevert(abi.encodeWithSelector(DeadlineNotExceeded.selector));
-        fastBridge.refund(request, user);
-
-        // We stop a prank to contain within test
-        vm.stopPrank();
-    }
-
-    function test_failedRefundNotUser() public {
-        setUpRoles();
-        test_successfulBridge();
-
-        // get bridge request and tx id
-        (bytes memory request, bytes32 transactionId) = _getBridgeRequestAndId(block.chainid, 0, 0);
-
-        vm.warp(block.timestamp + 61 minutes);
-
-        vm.expectRevert(abi.encodeWithSelector(SenderIncorrect.selector));
-        fastBridge.refund(request, user);
+        fastBridge.refund(request);
 
         // We stop a prank to contain within test
         vm.stopPrank();
@@ -1847,7 +1859,7 @@ contract FastBridgeTest is Test {
         vm.warp(block.timestamp + 61 minutes);
 
         vm.expectRevert(abi.encodeWithSelector(StatusIncorrect.selector));
-        fastBridge.refund(request, user);
+        fastBridge.refund(request);
 
         // We stop a prank to contain within test
         vm.stopPrank();

--- a/packages/contracts-rfq/test/FastBridgeMock.sol
+++ b/packages/contracts-rfq/test/FastBridgeMock.sol
@@ -124,7 +124,7 @@ contract FastBridgeMock is IFastBridge, Admin {
         revert("not implemented");
     }
 
-    function refund(bytes memory request, address to) external {
+    function refund(bytes memory request) external {
         revert("not implemented");
     }
 }


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**
Removes `address to` param from `FastBridge.sol::refund`

**Additional context**
Add any other context about the problem you're solving.

**Metadata**
- Fixes #[Link to Issue]
