### PR TITLE
Fix: submitter always uses `getGasEstimate()` when bumping

### DIFF
--- a/ethergo/submitter/chain_queue.go
+++ b/ethergo/submitter/chain_queue.go
@@ -157,13 +157,9 @@ func (c *chainQueue) bumpTX(parentCtx context.Context, ogTx db.TX) {
 			metrics.EndSpanWithErr(span, err)
 		}()
 
-		newGasEstimate := tx.Gas()
-
-		if c.config.GetDynamicGasEstimate(c.chainIDInt()) {
-			newGasEstimate, err = c.getGasEstimate(ctx, c.client, c.chainIDInt(), tx)
-			if err != nil {
-				return fmt.Errorf("could not get gas estimate: %w", err)
-			}
+		newGasEstimate, err := c.getGasEstimate(ctx, c.client, c.chainIDInt(), tx)
+		if err != nil {
+			return fmt.Errorf("could not get gas estimate: %w", err)
 		}
 
 		transactor, err := c.signer.GetTransactor(ctx, c.chainID)

--- a/ethergo/submitter/submitter.go
+++ b/ethergo/submitter/submitter.go
@@ -453,7 +453,7 @@ func (t *txSubmitterImpl) getGasBlock(ctx context.Context, chainClient client.EV
 }
 
 // getGasEstimate gets the gas estimate for the given transaction.
-// TODO: handle l2s w/ custom gas pricing through contracts
+// TODO: handle l2s w/ custom gas pricing through contracts.
 func (t *txSubmitterImpl) getGasEstimate(ctx context.Context, chainClient client.EVM, chainID int, tx *types.Transaction) (gasEstimate uint64, err error) {
 	if !t.config.GetDynamicGasEstimate(chainID) {
 		return t.config.GetGasEstimate(chainID), nil

--- a/ethergo/submitter/submitter.go
+++ b/ethergo/submitter/submitter.go
@@ -453,7 +453,7 @@ func (t *txSubmitterImpl) getGasBlock(ctx context.Context, chainClient client.EV
 }
 
 // getGasEstimate gets the gas estimate for the given transaction.
-// TODO: handle l2s w/ custom gas pricing through contracts.
+// TODO: handle l2s w/ custom gas pricing through contracts
 func (t *txSubmitterImpl) getGasEstimate(ctx context.Context, chainClient client.EVM, chainID int, tx *types.Transaction) (gasEstimate uint64, err error) {
 	if !t.config.GetDynamicGasEstimate(chainID) {
 		return t.config.GetGasEstimate(chainID), nil

--- a/ethergo/submitter/submitter.go
+++ b/ethergo/submitter/submitter.go
@@ -469,19 +469,17 @@ func (t *txSubmitterImpl) getGasEstimate(ctx context.Context, chainClient client
 		metrics.EndSpanWithErr(span, err)
 	}()
 
-	// if it needs a dynamic gas estimate, we'll get it.
-	if t.config.GetDynamicGasEstimate(chainID) {
-		call, err := util.TxToCall(tx)
-		if err != nil {
-			return 0, fmt.Errorf("could not convert tx to call: %w", err)
-		}
+	// since we checked for dynamic gas estimate above, we can fetch the gas estimate here
+	call, err := util.TxToCall(tx)
+	if err != nil {
+		return 0, fmt.Errorf("could not convert tx to call: %w", err)
+	}
 
-		gasEstimate, err = chainClient.EstimateGas(ctx, *call)
-		if err != nil {
-			span.AddEvent("could not estimate gas", trace.WithAttributes(attribute.String("error", err.Error())))
-			// fallback to default
-			return t.config.GetGasEstimate(chainID), nil
-		}
+	gasEstimate, err = chainClient.EstimateGas(ctx, *call)
+	if err != nil {
+		span.AddEvent("could not estimate gas", trace.WithAttributes(attribute.String("error", err.Error())))
+		// fallback to default
+		return t.config.GetGasEstimate(chainID), nil
 	}
 
 	return gasEstimate, nil


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**
A clear and concise description of the features you're adding in this pull request.

**Additional context**
Add any other context about the problem you're solving.

**Metadata**
- Fixes #[Link to Issue]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the reliability of gas estimate retrieval for transactions.
	- Enhanced error handling for scenarios where gas estimate cannot be determined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->