### PR TITLE
FE: Fix slippage calculation for tokens with different decimals

### DIFF
--- a/packages/synapse-interface/pages/state-managed-bridge/index.tsx
+++ b/packages/synapse-interface/pages/state-managed-bridge/index.tsx
@@ -189,15 +189,17 @@ const StateManagedBridge = () => {
 
       const toValueBigInt = BigInt(maxAmountOut.toString()) ?? 0n
 
-      const originTokenDecimals = fromToken?.decimals[fromChainId]
+      // Bridge Lifecycle: originToken -> bridgeToken -> destToken
+      // debouncedFromValue is in originToken decimals
+      // originQuery.minAmountOut and feeAmount is in bridgeToken decimals
+      // Adjust feeAmount to be in originToken decimals
       const adjustedFeeAmount =
-        BigInt(feeAmount) <
-        stringToBigInt(
-          `${debouncedFromValue}`,
-          fromToken?.decimals[fromChainId]
-        )
-          ? BigInt(feeAmount)
-          : BigInt(feeAmount) / powBigInt(10n, BigInt(18 - originTokenDecimals))
+        (BigInt(feeAmount) *
+          stringToBigInt(
+            `${debouncedFromValue}`,
+            fromToken?.decimals[fromChainId]
+          )) /
+        BigInt(originQuery.minAmountOut)
 
       const isUnsupported = AcceptedChainId[fromChainId] ? false : true
 

--- a/packages/synapse-interface/utils/actions/fetchBridgeQuotes.tsx
+++ b/packages/synapse-interface/utils/actions/fetchBridgeQuotes.tsx
@@ -54,11 +54,12 @@ export async function fetchBridgeQuote(
       )
 
       const toValueBigInt: bigint = BigInt(maxAmountOut.toString()) ?? 0n
-      const originTokenDecimals: number = originToken.decimals[originChainId]
-      const adjustedFeeAmount: bigint =
-        BigInt(feeAmount) < amount
-          ? BigInt(feeAmount)
-          : BigInt(feeAmount) / powBigInt(10n, BigInt(18 - originTokenDecimals))
+      // Bridge Lifecycle: originToken -> bridgeToken -> destToken
+      // amount is in originToken decimals
+      // originQuery.minAmountOut and feeAmount is in bridgeToken decimals
+      // Adjust feeAmount to be in originToken decimals
+      const adjustedFeeAmount =
+        (BigInt(feeAmount) * BigInt(amount)) / BigInt(originQuery.minAmountOut)
 
       // TODO: do this properly (RFQ needs no slippage, others do)
       const originMinWithSlippage = bridgeModuleName === "SynapseRFQ" ? (originQuery?.minAmountOut ?? 0n) : subtractSlippage(


### PR DESCRIPTION
**Description**
Slippage was calculated incorrectly, when origin token had more decimals than the bridged token.

Example: DAI (OP) -> USDC / FRAX (ETH). In both cases the underlying bridged token is `USDC`, and slippage is shown incorrectly on the prod FE.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the accuracy of fee calculations in the bridge transfer feature.
	- Enhanced the bridge lifecycle representation for a better user understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
ee0caea41696b8000a55a7d8d8a9c5f630906f34: [synapse-interface preview link ](https://sanguine-synapse-interface-iqr9d5b2r-synapsecns.vercel.app)