### PR TITLE
Remove duplicate portfolio fetch in Portfolio, trigger in UserProvider

### DIFF
--- a/packages/synapse-interface/components/Portfolio/Portfolio.tsx
+++ b/packages/synapse-interface/components/Portfolio/Portfolio.tsx
@@ -131,13 +131,10 @@ export const Portfolio = () => {
   }, [address])
 
   useEffect(() => {
-    ;(async () => {
-      if (address && chain?.id) {
-        await dispatch(setFromChainId(chain.id))
-        await dispatch(fetchAndStorePortfolioBalances(address))
-      }
-    })()
-  }, [chain, address])
+    if (address && chain?.id) {
+      dispatch(setFromChainId(chain.id))
+    }
+  }, [chain])
 
   const [mounted, setMounted] = useState<boolean>(false)
   useEffect(() => setMounted(true), [])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the portfolio balance fetching process to be more efficient when an address and chain ID are present.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->
c0994a2c1cc4047358bfa45c72c2ca33ac77d3a0: [synapse-interface preview link ](https://sanguine-synapse-interface-5so6rnxsk-synapsecns.vercel.app)