### PR TITLE
do not run go tests if target is fe-release

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,6 +3,9 @@ name: Go Workflows
 # note, because of generate tests using path filters here is too complicated
 on:
   pull_request:
+    branches-ignore:
+        - 'gh-pages'
+        - 'fe-release'
   push:
     branches-ignore:
       - 'gh-pages'


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**

See description

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow settings to exclude `gh-pages` and `fe-release` branches from triggering actions on pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->