### PR TITLE
Op mainnet to llamarpc

### DIFF
--- a/packages/synapse-interface/constants/chains/master.tsx
+++ b/packages/synapse-interface/constants/chains/master.tsx
@@ -155,7 +155,7 @@ export const OPTIMISM: Chain = {
   codeName: 'optimism',
   blockTime: 2000,
   rpcUrls: {
-    primary: 'https://mainnet.optimism.io',
+    primary: 'https://optimism.llamarpc.com',
     fallback: 'https://1rpc.io/op',
   },
   nativeCurrency: { name: 'Ethereum', symbol: 'ETH', decimals: 18 },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the RPC URL for Optimism network to enhance connection reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
9de5ee977bdc559a7e43801e6d917c3d14d2967c: [synapse-interface preview link ](https://sanguine-synapse-interface-p5a5n3n0u-synapsecns.vercel.app)