### PR TITLE
Add quote sizing logic to RFQ

### DIFF
--- a/services/rfq/relayer/pricer/fee_pricer.go
+++ b/services/rfq/relayer/pricer/fee_pricer.go
@@ -77,7 +77,7 @@ func (f *feePricer) GetOriginFee(ctx context.Context, origin, destination uint32
 	return f.getFee(ctx, origin, destination, f.config.GetFeePricer().OriginGasEstimate, denomToken, useMultiplier)
 }
 
-func (f *feePricer) GetDestinationFee(ctx context.Context, origin, destination uint32, denomToken string, useMultiplier bool) (*big.Int, error) {
+func (f *feePricer) GetDestinationFee(ctx context.Context, _, destination uint32, denomToken string, useMultiplier bool) (*big.Int, error) {
 	return f.getFee(ctx, destination, destination, f.config.GetFeePricer().DestinationGasEstimate, denomToken, useMultiplier)
 }
 

--- a/services/rfq/relayer/quoter/export_test.go
+++ b/services/rfq/relayer/quoter/export_test.go
@@ -2,12 +2,22 @@ package quoter
 
 import (
 	"context"
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/synapsecns/sanguine/services/rfq/api/model"
-	"math/big"
+	"github.com/synapsecns/sanguine/services/rfq/relayer/relconfig"
 )
 
 func (m *Manager) GenerateQuotes(ctx context.Context, chainID int, address common.Address, balance *big.Int) ([]model.PutQuoteRequest, error) {
 	// nolint: errcheck
 	return m.generateQuotes(ctx, chainID, address, balance)
+}
+
+func (m *Manager) GetQuoteAmount(chainID int, address common.Address, balance *big.Int) *big.Int {
+	return m.getQuoteAmount(chainID, address, balance)
+}
+
+func (m *Manager) SetConfig(cfg relconfig.Config) {
+	m.config = cfg
 }

--- a/services/rfq/relayer/quoter/export_test.go
+++ b/services/rfq/relayer/quoter/export_test.go
@@ -14,8 +14,8 @@ func (m *Manager) GenerateQuotes(ctx context.Context, chainID int, address commo
 	return m.generateQuotes(ctx, chainID, address, balance)
 }
 
-func (m *Manager) GetQuoteAmount(chainID int, address common.Address, balance *big.Int) *big.Int {
-	return m.getQuoteAmount(chainID, address, balance)
+func (m *Manager) GetQuoteAmount(ctx context.Context, chainID int, address common.Address, balance *big.Int) *big.Int {
+	return m.getQuoteAmount(ctx, chainID, address, balance)
 }
 
 func (m *Manager) SetConfig(cfg relconfig.Config) {

--- a/services/rfq/relayer/quoter/quoter.go
+++ b/services/rfq/relayer/quoter/quoter.go
@@ -243,7 +243,7 @@ func (m *Manager) generateQuotes(ctx context.Context, chainID int, address commo
 }
 
 func (m *Manager) getQuoteAmount(chainID int, address common.Address, balance *big.Int) *big.Int {
-	// Apply the QuotePct
+	// Apply the quotePct
 	balanceFlt := new(big.Float).SetInt(balance)
 	quoteAmount, _ := new(big.Float).Mul(balanceFlt, new(big.Float).SetFloat64(m.config.GetQuotePct()/100)).Int(nil)
 

--- a/services/rfq/relayer/quoter/quoter.go
+++ b/services/rfq/relayer/quoter/quoter.go
@@ -245,7 +245,7 @@ func (m *Manager) generateQuotes(ctx context.Context, chainID int, address commo
 func (m *Manager) getQuoteAmount(chainID int, address common.Address, balance *big.Int) *big.Int {
 	// Apply the QuotePct
 	balanceFlt := new(big.Float).SetInt(balance)
-	quoteAmount, _ := new(big.Float).Mul(balanceFlt, new(big.Float).SetFloat64(m.config.GetQuotePct())).Int(nil)
+	quoteAmount, _ := new(big.Float).Mul(balanceFlt, new(big.Float).SetFloat64(m.config.GetQuotePct()/100)).Int(nil)
 
 	// Clip the quoteAmount by the minQuoteAmount
 	minQuoteAmount := m.config.GetMinQuoteAmount(chainID, address)

--- a/services/rfq/relayer/quoter/quoter_test.go
+++ b/services/rfq/relayer/quoter/quoter_test.go
@@ -73,3 +73,46 @@ func (s *QuoterSuite) TestShouldProcess() {
 	}
 	s.False(s.manager.ShouldProcess(s.GetTestContext(), quote))
 }
+
+func (s *QuoterSuite) TestGetQuoteAmount() {
+	chainID := int(s.origin)
+	address := common.HexToAddress("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")
+	balance := big.NewInt(1000_000_000) // 1000 USDC
+
+	setQuoteParams := func(quotePct float64, minQuoteAmount string) {
+		s.config.QuotePct = quotePct
+		tokenCfg := s.config.Chains[chainID].Tokens["USDC"]
+		tokenCfg.MinQuoteAmount = minQuoteAmount
+		s.config.Chains[chainID].Tokens["USDC"] = tokenCfg
+		s.manager.SetConfig(s.config)
+	}
+
+	// Set default quote params; should return the balance.
+	quoteAmount := s.manager.GetQuoteAmount(chainID, address, balance)
+	expectedAmount := balance
+	s.Equal(expectedAmount, quoteAmount)
+
+	// Set QuotePct to 50 with MinQuoteAmount of 0; should be 50% of balance.
+	setQuoteParams(50, "0")
+	quoteAmount = s.manager.GetQuoteAmount(chainID, address, balance)
+	expectedAmount = big.NewInt(500_000_000)
+	s.Equal(expectedAmount, quoteAmount)
+
+	// Set QuotePct to 50 with MinQuoteAmount of 500; should be 50% of balance.
+	setQuoteParams(50, "500")
+	quoteAmount = s.manager.GetQuoteAmount(chainID, address, balance)
+	expectedAmount = big.NewInt(500_000_000)
+	s.Equal(expectedAmount, quoteAmount)
+
+	// Set QuotePct to 25 with MinQuoteAmount of 500; should be 50% of balance.
+	setQuoteParams(25, "500")
+	quoteAmount = s.manager.GetQuoteAmount(chainID, address, balance)
+	expectedAmount = big.NewInt(500_000_000)
+	s.Equal(expectedAmount, quoteAmount)
+
+	// Set QuotePct to 25 with MinQuoteAmount of 1500; should be total balance.
+	setQuoteParams(25, "1500")
+	quoteAmount = s.manager.GetQuoteAmount(chainID, address, balance)
+	expectedAmount = big.NewInt(1000_000_000)
+	s.Equal(expectedAmount, quoteAmount)
+}

--- a/services/rfq/relayer/quoter/quoter_test.go
+++ b/services/rfq/relayer/quoter/quoter_test.go
@@ -88,31 +88,31 @@ func (s *QuoterSuite) TestGetQuoteAmount() {
 	}
 
 	// Set default quote params; should return the balance.
-	quoteAmount := s.manager.GetQuoteAmount(chainID, address, balance)
+	quoteAmount := s.manager.GetQuoteAmount(s.GetTestContext(), chainID, address, balance)
 	expectedAmount := balance
 	s.Equal(expectedAmount, quoteAmount)
 
 	// Set QuotePct to 50 with MinQuoteAmount of 0; should be 50% of balance.
 	setQuoteParams(50, "0")
-	quoteAmount = s.manager.GetQuoteAmount(chainID, address, balance)
+	quoteAmount = s.manager.GetQuoteAmount(s.GetTestContext(), chainID, address, balance)
 	expectedAmount = big.NewInt(500_000_000)
 	s.Equal(expectedAmount, quoteAmount)
 
 	// Set QuotePct to 50 with MinQuoteAmount of 500; should be 50% of balance.
 	setQuoteParams(50, "500")
-	quoteAmount = s.manager.GetQuoteAmount(chainID, address, balance)
+	quoteAmount = s.manager.GetQuoteAmount(s.GetTestContext(), chainID, address, balance)
 	expectedAmount = big.NewInt(500_000_000)
 	s.Equal(expectedAmount, quoteAmount)
 
 	// Set QuotePct to 25 with MinQuoteAmount of 500; should be 50% of balance.
 	setQuoteParams(25, "500")
-	quoteAmount = s.manager.GetQuoteAmount(chainID, address, balance)
+	quoteAmount = s.manager.GetQuoteAmount(s.GetTestContext(), chainID, address, balance)
 	expectedAmount = big.NewInt(500_000_000)
 	s.Equal(expectedAmount, quoteAmount)
 
 	// Set QuotePct to 25 with MinQuoteAmount of 1500; should be total balance.
 	setQuoteParams(25, "1500")
-	quoteAmount = s.manager.GetQuoteAmount(chainID, address, balance)
+	quoteAmount = s.manager.GetQuoteAmount(s.GetTestContext(), chainID, address, balance)
 	expectedAmount = big.NewInt(1000_000_000)
 	s.Equal(expectedAmount, quoteAmount)
 }

--- a/services/rfq/relayer/relconfig/config.go
+++ b/services/rfq/relayer/relconfig/config.go
@@ -230,8 +230,15 @@ func (c Config) GetMinQuoteAmount(chainID int, addr common.Address) *big.Int {
 	if !ok {
 		return big.NewInt(defaultMinQuoteAmount)
 	}
-	tokenCfg, ok := chainCfg.Tokens[strings.ToLower(addr.String())]
-	if !ok {
+
+	var tokenCfg *TokenConfig
+	for _, cfg := range chainCfg.Tokens {
+		if strings.ToLower(cfg.Address) == strings.ToLower(addr.String()) {
+			tokenCfg = &cfg
+			break
+		}
+	}
+	if tokenCfg == nil {
 		return big.NewInt(defaultMinQuoteAmount)
 	}
 	quoteAmountFlt, ok := new(big.Float).SetString(tokenCfg.MinQuoteAmount)

--- a/services/rfq/relayer/relconfig/config.go
+++ b/services/rfq/relayer/relconfig/config.go
@@ -233,8 +233,9 @@ func (c Config) GetMinQuoteAmount(chainID int, addr common.Address) *big.Int {
 
 	var tokenCfg *TokenConfig
 	for _, cfg := range chainCfg.Tokens {
-		if strings.ToLower(cfg.Address) == strings.ToLower(addr.String()) {
-			tokenCfg = &cfg
+		if strings.EqualFold(cfg.Address, addr.String()) {
+			cfgCopy := cfg
+			tokenCfg = &cfgCopy
 			break
 		}
 	}

--- a/services/rfq/relayer/relconfig/config.go
+++ b/services/rfq/relayer/relconfig/config.go
@@ -3,9 +3,11 @@ package relconfig
 
 import (
 	"fmt"
+	"math/big"
 	"os"
 	"strings"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/jftuga/ellipsis"
 	"github.com/synapsecns/sanguine/ethergo/signer/config"
 	submitterConfig "github.com/synapsecns/sanguine/ethergo/submitter/config"
@@ -35,6 +37,8 @@ type Config struct {
 	SubmitterConfig submitterConfig.Config `yaml:"submitter_config"`
 	// FeePricer is the fee pricer config.
 	FeePricer FeePricerConfig `yaml:"fee_pricer"`
+	// QuotePct is the percent of balance to quote.
+	QuotePct float64 `yaml:"quote_pct"`
 }
 
 // ChainConfig represents the configuration for a chain.
@@ -57,6 +61,8 @@ type TokenConfig struct {
 	Decimals uint8 `yaml:"decimals"`
 	// For now, specify the USD price of the token in the config.
 	PriceUSD float64 `yaml:"price_usd"`
+	// MinQuoteAmount is the minimum amount to quote for this token in human-readable units.
+	MinQuoteAmount string `yaml:"min_quote_amount"`
 }
 
 // DatabaseConfig represents the configuration for the database.
@@ -203,6 +209,43 @@ func (c Config) GetFixedFeeMultiplier() float64 {
 		return defaultFixedFeeMultiplier
 	}
 	return c.FeePricer.FixedFeeMultiplier
+}
+
+const defaultQuotePct = 100.
+
+// GetQuotePct returns the quote percentage.
+func (c Config) GetQuotePct() float64 {
+	if c.QuotePct <= 0 {
+		return defaultQuotePct
+	}
+	return c.QuotePct
+}
+
+const defaultMinQuoteAmount = 0
+
+// GetMinQuoteAmount returns the quote amount for the given chain and address.
+// Note that this getter returns the value in native token decimals.
+func (c Config) GetMinQuoteAmount(chainID int, addr common.Address) *big.Int {
+	chainCfg, ok := c.Chains[chainID]
+	if !ok {
+		return big.NewInt(defaultMinQuoteAmount)
+	}
+	tokenCfg, ok := chainCfg.Tokens[strings.ToLower(addr.String())]
+	if !ok {
+		return big.NewInt(defaultMinQuoteAmount)
+	}
+	quoteAmountFlt, ok := new(big.Float).SetString(tokenCfg.MinQuoteAmount)
+	if !ok {
+		return big.NewInt(defaultMinQuoteAmount)
+	}
+	if quoteAmountFlt.Cmp(big.NewFloat(0)) <= 0 {
+		return big.NewInt(defaultMinQuoteAmount)
+	}
+
+	// Scale the minQuoteAmount by the token decimals.
+	denomDecimalsFactor := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(tokenCfg.Decimals)), nil)
+	quoteAmountScaled, _ := new(big.Float).Mul(quoteAmountFlt, new(big.Float).SetInt(denomDecimalsFactor)).Int(nil)
+	return quoteAmountScaled
 }
 
 var _ IConfig = &Config{}

--- a/services/rfq/relayer/relconfig/iconfig_generated.go
+++ b/services/rfq/relayer/relconfig/iconfig_generated.go
@@ -3,6 +3,9 @@
 package relconfig
 
 import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/synapsecns/sanguine/ethergo/signer/config"
 )
 
@@ -34,4 +37,9 @@ type IConfig interface {
 	GetTokenName(chain uint32, addr string) (string, error)
 	// GetFixedFeeMultiplier returns the fixed fee multiplier.
 	GetFixedFeeMultiplier() float64
+	// GetQuotePct returns the quote percentage.
+	GetQuotePct() float64
+	// GetMinQuoteAmount returns the quote amount for the given chain and address.
+	// Note that this getter returns the value in native token decimals.
+	GetMinQuoteAmount(chainID int, addr common.Address) *big.Int
 }


### PR DESCRIPTION
**Description**
Adds two new params: `QuotePct` and `MinQuoteAmount`.

The application follows this formula:

```
quote_amount = min(balance, max(quote_pct * balance, min_quote_amount))
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced quote generation logic to include new quote amount calculations.
  - Introduced minimum quote amount and quote percentage configurations.

- **Bug Fixes**
  - Fixed the ordering of import statements for improved maintainability.

- **Tests**
  - Added tests for the new quote amount calculation method.

- **Documentation**
  - Updated configuration documentation to reflect new quote-related settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->