### PR TITLE
Configurable deadline buffer for RFQ relayer

### DIFF
--- a/services/rfq/relayer/relconfig/config.go
+++ b/services/rfq/relayer/relconfig/config.go
@@ -42,8 +42,8 @@ type Config struct {
 	FeePricer FeePricerConfig `yaml:"fee_pricer"`
 	// QuotePct is the percent of balance to quote.
 	QuotePct float64 `yaml:"quote_pct"`
-	// DeadlineSeconds is the deadline for relaying a transaction.
-	DeadlineSeconds int `yaml:"deadline_seconds"`
+	// DeadlineBufferSeconds is the deadline buffer for relaying a transaction.
+	DeadlineBufferSeconds int `yaml:"deadline_buffer_seconds"`
 }
 
 // ChainConfig represents the configuration for a chain.
@@ -328,13 +328,10 @@ func (c Config) GetMinQuoteAmount(chainID int, addr common.Address) *big.Int {
 	return quoteAmountScaled
 }
 
-// GetDeadline returns the deadline for relaying a transaction.
-func (c Config) GetDeadline() *time.Duration {
-	if c.DeadlineSeconds <= 0 {
-		return nil
-	}
-	duration := time.Duration(c.DeadlineSeconds) * time.Second
-	return &duration
+// GetDeadlineBuffer returns the deadline buffer for relaying a transaction.
+func (c Config) GetDeadlineBuffer() time.Duration {
+	duration := time.Duration(c.DeadlineBufferSeconds) * time.Second
+	return duration
 }
 
 var _ IConfig = &Config{}

--- a/services/rfq/relayer/relconfig/config.go
+++ b/services/rfq/relayer/relconfig/config.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/jftuga/ellipsis"
@@ -41,6 +42,8 @@ type Config struct {
 	FeePricer FeePricerConfig `yaml:"fee_pricer"`
 	// QuotePct is the percent of balance to quote.
 	QuotePct float64 `yaml:"quote_pct"`
+	// DeadlineSeconds is the deadline for relaying a transaction.
+	DeadlineSeconds int `yaml:"deadline_seconds"`
 }
 
 // ChainConfig represents the configuration for a chain.
@@ -323,6 +326,15 @@ func (c Config) GetMinQuoteAmount(chainID int, addr common.Address) *big.Int {
 	denomDecimalsFactor := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(tokenCfg.Decimals)), nil)
 	quoteAmountScaled, _ := new(big.Float).Mul(quoteAmountFlt, new(big.Float).SetInt(denomDecimalsFactor)).Int(nil)
 	return quoteAmountScaled
+}
+
+// GetDeadline returns the deadline for relaying a transaction.
+func (c Config) GetDeadline() *time.Duration {
+	if c.DeadlineSeconds <= 0 {
+		return nil
+	}
+	duration := time.Duration(c.DeadlineSeconds) * time.Second
+	return &duration
 }
 
 var _ IConfig = &Config{}

--- a/services/rfq/relayer/relconfig/iconfig_generated.go
+++ b/services/rfq/relayer/relconfig/iconfig_generated.go
@@ -49,6 +49,6 @@ type IConfig interface {
 	// GetMinQuoteAmount returns the quote amount for the given chain and address.
 	// Note that this getter returns the value in native token decimals.
 	GetMinQuoteAmount(chainID int, addr common.Address) *big.Int
-	// GetDeadline returns the deadline for relaying a transaction.
-	GetDeadline() *time.Duration
+	// GetDeadlineBuffer returns the deadline buffer for relaying a transaction.
+	GetDeadlineBuffer() time.Duration
 }

--- a/services/rfq/relayer/relconfig/iconfig_generated.go
+++ b/services/rfq/relayer/relconfig/iconfig_generated.go
@@ -4,6 +4,7 @@ package relconfig
 
 import (
 	"math/big"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/synapsecns/sanguine/ethergo/signer/config"
@@ -48,4 +49,6 @@ type IConfig interface {
 	// GetMinQuoteAmount returns the quote amount for the given chain and address.
 	// Note that this getter returns the value in native token decimals.
 	GetMinQuoteAmount(chainID int, addr common.Address) *big.Int
+	// GetDeadline returns the deadline for relaying a transaction.
+	GetDeadline() *time.Duration
 }

--- a/services/rfq/relayer/relconfig/iconfig_generated.go
+++ b/services/rfq/relayer/relconfig/iconfig_generated.go
@@ -50,5 +50,5 @@ type IConfig interface {
 	// Note that this getter returns the value in native token decimals.
 	GetMinQuoteAmount(chainID int, addr common.Address) *big.Int
 	// GetDeadlineBuffer returns the deadline buffer for relaying a transaction.
-	GetDeadlineBuffer() time.Duration
+	GetDeadlineBuffer(chainID int) time.Duration
 }

--- a/services/rfq/relayer/service/statushandler.go
+++ b/services/rfq/relayer/service/statushandler.go
@@ -84,12 +84,10 @@ func (r *Relayer) requestToHandler(ctx context.Context, req reldb.QuoteRequest) 
 	return qr, nil
 }
 
-// TODO: this is where you need ot check the deadline.
 func (r *Relayer) deadlineMiddleware(next func(ctx context.Context, span trace.Span, req reldb.QuoteRequest) error) func(ctx context.Context, span trace.Span, req reldb.QuoteRequest) error {
 	return func(ctx context.Context, span trace.Span, req reldb.QuoteRequest) error {
-		// 10 minute barrier to prove the transaction
-		// TODO: make barrier configurable
-		almostNow := time.Now().Add(-10 * time.Minute)
+		// apply deadline buffer
+		almostNow := time.Now().Add(-r.cfg.GetDeadlineBuffer())
 
 		// if deadline < now, we don't even have to bother calling the underlying function
 		if req.Transaction.Deadline.Cmp(big.NewInt(almostNow.Unix())) < 0 {

--- a/services/rfq/relayer/service/statushandler.go
+++ b/services/rfq/relayer/service/statushandler.go
@@ -87,7 +87,7 @@ func (r *Relayer) requestToHandler(ctx context.Context, req reldb.QuoteRequest) 
 func (r *Relayer) deadlineMiddleware(next func(ctx context.Context, span trace.Span, req reldb.QuoteRequest) error) func(ctx context.Context, span trace.Span, req reldb.QuoteRequest) error {
 	return func(ctx context.Context, span trace.Span, req reldb.QuoteRequest) error {
 		// apply deadline buffer
-		almostNow := time.Now().Add(-r.cfg.GetDeadlineBuffer())
+		almostNow := time.Now().Add(-r.cfg.GetDeadlineBuffer(int(req.Transaction.DestChainId)))
 
 		// if deadline < now, we don't even have to bother calling the underlying function
 		if req.Transaction.Deadline.Cmp(big.NewInt(almostNow.Unix())) < 0 {


### PR DESCRIPTION
**Description**
Adds `deadline_buffer_seconds`, specifiable on a per-chain basis or globally via `base_deadline_buffer_seconds`. This is applied in the `deadlineMiddleware()`.

**Metadata**
- Fixes #1832


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Implemented configurable deadline buffers for transaction relaying to enhance flexibility and performance.
- **Refactor**
  - Updated transaction deadline calculation to use new configurable settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->