### PR TITLE
Check all quotes for rfq before default quote query

### DIFF
--- a/packages/synapse-interface/pages/state-managed-bridge/index.tsx
+++ b/packages/synapse-interface/pages/state-managed-bridge/index.tsx
@@ -154,14 +154,6 @@ const StateManagedBridge = () => {
     try {
       dispatch(setIsLoading(true))
 
-      const defaultQuote = await synapseSDK.bridgeQuote(
-        fromChainId,
-        toChainId,
-        fromToken.addresses[fromChainId],
-        toToken.addresses[toChainId],
-        stringToBigInt(debouncedFromValue, fromToken?.decimals[fromChainId])
-      )
-
       const allQuotes = await synapseSDK.allBridgeQuotes(
         fromChainId,
         toChainId,
@@ -174,6 +166,20 @@ const StateManagedBridge = () => {
         (quote) => quote.bridgeModuleName === 'SynapseRFQ'
       )
 
+      let quote
+
+      if (rfqQuote) {
+        quote = rfqQuote
+      } else {
+        quote = await synapseSDK.bridgeQuote(
+          fromChainId,
+          toChainId,
+          fromToken.addresses[fromChainId],
+          toToken.addresses[toChainId],
+          stringToBigInt(debouncedFromValue, fromToken?.decimals[fromChainId])
+        )
+      }
+
       const {
         feeAmount,
         routerAddress,
@@ -182,7 +188,7 @@ const StateManagedBridge = () => {
         destQuery,
         estimatedTime,
         bridgeModuleName,
-      } = rfqQuote ? rfqQuote : defaultQuote
+      } = quote
 
       // console.log(`[getAndSetQuote] fromChainId`, fromChainId)
       // console.log(`[getAndSetQuote] toChainId`, toChainId)

--- a/packages/synapse-interface/pages/state-managed-bridge/index.tsx
+++ b/packages/synapse-interface/pages/state-managed-bridge/index.tsx
@@ -162,6 +162,11 @@ const StateManagedBridge = () => {
         stringToBigInt(debouncedFromValue, fromToken?.decimals[fromChainId])
       )
 
+      if (allQuotes.length === 0) {
+        const msg = `No route found for bridging ${debouncedFromValue} ${fromToken?.symbol} on ${CHAINS_BY_ID[fromChainId]?.name} to ${toToken?.symbol} on ${CHAINS_BY_ID[toChainId]?.name}`
+        throw new Error(msg)
+      }
+
       const rfqQuote = allQuotes.find(
         (quote) => quote.bridgeModuleName === 'SynapseRFQ'
       )

--- a/packages/synapse-interface/pages/state-managed-bridge/index.tsx
+++ b/packages/synapse-interface/pages/state-managed-bridge/index.tsx
@@ -171,13 +171,8 @@ const StateManagedBridge = () => {
       if (rfqQuote) {
         quote = rfqQuote
       } else {
-        quote = await synapseSDK.bridgeQuote(
-          fromChainId,
-          toChainId,
-          fromToken.addresses[fromChainId],
-          toToken.addresses[toChainId],
-          stringToBigInt(debouncedFromValue, fromToken?.decimals[fromChainId])
-        )
+        /* allBridgeQuotes returns sorted quotes by maxAmountOut descending */
+        quote = allQuotes[0]
       }
 
       const {


### PR DESCRIPTION
* Check all quotes for rfq, otherwise use best quote

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced quote management in the bridge interface for improved reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
3c6abd8cb784f34ed935c41c2282c53b98728784: [synapse-interface preview link ](https://sanguine-synapse-interface-obr2kmpvh-synapsecns.vercel.app)
60d802411e8c5eb39c824f8baf728114008275e5: [synapse-interface preview link ](https://sanguine-synapse-interface-dq7y3kw8w-synapsecns.vercel.app)
2b38d7901c1ee0436914a85899144854a27592ad: [synapse-interface preview link ](https://sanguine-synapse-interface-qvzopezdk-synapsecns.vercel.app)
242fbcb946fb4613d2c1d82eda161f07d5d19bc9: [synapse-interface preview link ](https://sanguine-synapse-interface-i7l11i962-synapsecns.vercel.app)