### PR TITLE
Wrap `getErc20TokenAllowance` in try catch

### DIFF
--- a/packages/synapse-interface/actions/getErc20TokenAllowance.ts
+++ b/packages/synapse-interface/actions/getErc20TokenAllowance.ts
@@ -12,13 +12,18 @@ export const getErc20TokenAllowance = async ({
   tokenAddress: Address
   spender: Address
 }): Promise<bigint> => {
-  const allowance = await readContract({
-    chainId,
-    address: tokenAddress,
-    abi: erc20ABI,
-    functionName: 'allowance',
-    args: [address, spender],
-  })
+  try {
+    const allowance = await readContract({
+      chainId,
+      address: tokenAddress,
+      abi: erc20ABI,
+      functionName: 'allowance',
+      args: [address, spender],
+    })
 
-  return allowance
+    return allowance
+  } catch (error) {
+    console.log(error)
+    return 0n
+  }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in ERC20 token allowance retrieval, ensuring a fallback value is returned in case of an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
596e4af236686e9ed3a857099695817d03628557: [synapse-interface preview link ](https://sanguine-synapse-interface-nqcrmmqwv-synapsecns.vercel.app)