### PR TITLE
Use checksummed addresses in RFQ config

### DIFF
--- a/services/rfq/relayer/quoter/quoter_test.go
+++ b/services/rfq/relayer/quoter/quoter_test.go
@@ -19,7 +19,7 @@ func (s *QuoterSuite) TestGenerateQuotes() {
 	expectedQuotes := []model.PutQuoteRequest{
 		{
 			OriginChainID:   int(s.origin),
-			OriginTokenAddr: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+			OriginTokenAddr: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
 			DestChainID:     int(s.destination),
 			DestTokenAddr:   "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85",
 			DestAmount:      balance.String(),

--- a/services/rfq/relayer/relconfig/config.go
+++ b/services/rfq/relayer/relconfig/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/big"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -106,6 +107,30 @@ type ChainFeeParams struct {
 	L1FeeOriginGasEstimate int `yaml:"l1_fee_origin_gas_estimate"`
 	// L1FeeDestGasEstimate is the gas estimate for the L1 fee on destination.
 	L1FeeDestGasEstimate int `yaml:"l1_fee_dest_gas_estimate"`
+}
+
+// tokenID is used to represent a chain and token pairing.
+type tokenID struct {
+	chainID uint32
+	addr    common.Address
+}
+
+const tokenIDDelimiter = "-"
+
+// SanitizeTokenID takes a raw string, makes sure it is a valid token ID,
+// and returns the token ID as string with a checksummed address.
+func SanitizeTokenID(id string) (sanitized string, err error) {
+	split := strings.Split(id, tokenIDDelimiter)
+	if len(split) != 2 {
+		return sanitized, fmt.Errorf("invalid token ID: %s", id)
+	}
+	chainID, err := strconv.Atoi(split[0])
+	if err != nil {
+		return sanitized, fmt.Errorf("invalid chain ID: %s", split[0])
+	}
+	addr := common.HexToAddress(split[1])
+	sanitized = fmt.Sprintf("%d%s%s", chainID, tokenIDDelimiter, addr.Hex())
+	return sanitized, nil
 }
 
 // LoadConfig loads the config from the given path.
@@ -216,8 +241,7 @@ func (c Config) GetTokenName(chain uint32, addr string) (string, error) {
 		return "", fmt.Errorf("no chain config for chain %d", chain)
 	}
 	for tokenName, tokenConfig := range chainConfig.Tokens {
-		// TODO: probably a better way to do this.
-		if strings.ToLower(tokenConfig.Address) == strings.ToLower(addr) {
+		if common.HexToAddress(tokenConfig.Address).Hex() == common.HexToAddress(addr).Hex() {
 			return tokenName, nil
 		}
 	}
@@ -307,7 +331,7 @@ func (c Config) GetMinQuoteAmount(chainID int, addr common.Address) *big.Int {
 
 	var tokenCfg *TokenConfig
 	for _, cfg := range chainCfg.Tokens {
-		if strings.EqualFold(cfg.Address, addr.String()) {
+		if common.HexToAddress(cfg.Address).Hex() == addr.Hex() {
 			cfgCopy := cfg
 			tokenCfg = &cfgCopy
 			break

--- a/services/rfq/relayer/relconfig/config.go
+++ b/services/rfq/relayer/relconfig/config.go
@@ -109,12 +109,6 @@ type ChainFeeParams struct {
 	L1FeeDestGasEstimate int `yaml:"l1_fee_dest_gas_estimate"`
 }
 
-// tokenID is used to represent a chain and token pairing.
-type tokenID struct {
-	chainID uint32
-	addr    common.Address
-}
-
 const tokenIDDelimiter = "-"
 
 // SanitizeTokenID takes a raw string, makes sure it is a valid token ID,

--- a/services/rfq/relayer/reldb/db.go
+++ b/services/rfq/relayer/reldb/db.go
@@ -5,7 +5,6 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/synapsecns/sanguine/core/dbcommon"
@@ -74,14 +73,14 @@ type QuoteRequest struct {
 // for some reason, this is specified as [chainid]-[tokenaddr] in the config.
 // this represents the origin pair.
 func (q QuoteRequest) GetOriginIDPair() string {
-	return strings.ToLower(fmt.Sprintf("%d-%s", q.Transaction.OriginChainId, q.Transaction.OriginToken.String()))
+	return fmt.Sprintf("%d-%s", q.Transaction.OriginChainId, q.Transaction.OriginToken.Hex())
 }
 
 // GetDestIDPair gets the destination chain id and token address pair.
 // for some reason, this is specified as [chainid]-[tokenaddr] in the config.
 // this represents the destination pair.
 func (q QuoteRequest) GetDestIDPair() string {
-	return strings.ToLower(fmt.Sprintf("%d-%s", q.Transaction.DestChainId, q.Transaction.DestToken.String()))
+	return fmt.Sprintf("%d-%s", q.Transaction.DestChainId, q.Transaction.DestToken.Hex())
 }
 
 // QuoteRequestStatus is the status of a quote request in the db.


### PR DESCRIPTION
**Description**
Use checksummed addresses instead of forcing `strings.ToLower()` usage for address comparisons.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Implemented enhanced token ID sanitization for improved security and consistency.

- **Bug Fixes**
  - Corrected token ID comparison logic to ensure accurate processing of quote requests.

- **Refactor**
  - Optimized token-related operations for better performance and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->