### PR TITLE
Fe/track token transfers by sender

### DIFF
--- a/packages/synapse-interface/pages/index.tsx
+++ b/packages/synapse-interface/pages/index.tsx
@@ -5,56 +5,8 @@ import { LandingPageWrapper } from '@/components/layouts/LandingPageWrapper'
 import ReactGA from 'react-ga'
 import useSyncQueryParamsWithBridgeState from '@/utils/hooks/useSyncQueryParamsWithBridgeState'
 
-import { useState, useEffect } from 'react'
-import { useContractEvent, erc20ABI } from 'wagmi'
-
-import { createPublicClient, http, parseAbiItem, Address, Log } from 'viem'
-import { arbitrum } from 'viem/chains'
-
-export const publicClient = createPublicClient({
-  chain: arbitrum,
-  transport: http(),
-})
-
-const getErc20TokenTransferLogs = async (
-  tokenAddress: Address,
-  fromAddress: Address,
-  toAddress: Address,
-  startBlock: bigint
-) => {
-  const logs: Log[] = await publicClient.getLogs({
-    address: tokenAddress,
-    event: {
-      type: 'event',
-      name: 'Transfer',
-      inputs: [
-        { type: 'address', indexed: true, name: 'from' },
-        { type: 'address', indexed: true, name: 'to' },
-        { type: 'uint256', indexed: false, name: 'value' },
-      ],
-    },
-    args: {
-      from: fromAddress,
-      to: toAddress,
-    },
-    fromBlock: startBlock,
-  })
-
-  return logs
-}
-
-const transformTransferLogsToData = (logs: any[]) => {
-  return logs.map((log) => {
-    return {
-      tokenAddress: log.address,
-      fromAddress: log?.args?.from,
-      toAddress: log?.args?.to,
-      transferValue: log?.args?.value,
-      blockNumber: log.blockNumber,
-      transactionHash: log.transactionHash,
-    }
-  })
-}
+import { useEffect } from 'react'
+import { getErc20TokenTransfers } from '@/utils/actions/getErc20TokenTransfers'
 
 // TODO: someone should add this to the .env, disable if blank, etc.
 // this is being added as a hotfix to assess user load on the synapse explorer api
@@ -67,16 +19,14 @@ const Home = () => {
 
   useEffect(() => {
     ;(async () => {
-      const logs = await getErc20TokenTransferLogs(
+      const data = await getErc20TokenTransfers(
         '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
         '0xF080B794AbF6BB905F2330d25DF545914e6027F8',
         '0x81EF4608B796265F1e3695cE00FdCfC8aA5933Dd',
         173545720n
       )
 
-      const parsedLogs = transformTransferLogsToData(logs)
-
-      console.log('parsedLogs:', parsedLogs)
+      console.log('data:', data)
     })()
   }, [])
 

--- a/packages/synapse-interface/pages/index.tsx
+++ b/packages/synapse-interface/pages/index.tsx
@@ -7,6 +7,7 @@ import useSyncQueryParamsWithBridgeState from '@/utils/hooks/useSyncQueryParamsW
 
 import { useEffect } from 'react'
 import { getErc20TokenTransfers } from '@/utils/actions/getErc20TokenTransfers'
+import { arbitrum } from 'viem/chains'
 
 // TODO: someone should add this to the .env, disable if blank, etc.
 // this is being added as a hotfix to assess user load on the synapse explorer api
@@ -23,7 +24,8 @@ const Home = () => {
         '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
         '0xF080B794AbF6BB905F2330d25DF545914e6027F8',
         '0x81EF4608B796265F1e3695cE00FdCfC8aA5933Dd',
-        173545720n
+        173545720n,
+        arbitrum
       )
 
       console.log('data:', data)

--- a/packages/synapse-interface/pages/index.tsx
+++ b/packages/synapse-interface/pages/index.tsx
@@ -16,9 +16,14 @@ export const publicClient = createPublicClient({
   transport: http(),
 })
 
-const getErc20TokenTransferLogs = async () => {
+const getErc20TokenTransferLogs = async (
+  tokenAddress: Address,
+  fromAddress: Address,
+  toAddress: Address,
+  startBlock: bigint
+) => {
   const logs = await publicClient.getLogs({
-    address: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+    address: tokenAddress,
     event: {
       type: 'event', // Added 'type' property
       name: 'Transfer',
@@ -29,10 +34,10 @@ const getErc20TokenTransferLogs = async () => {
       ],
     },
     args: {
-      from: '0xF080B794AbF6BB905F2330d25DF545914e6027F8',
-      to: '0x81EF4608B796265F1e3695cE00FdCfC8aA5933Dd',
+      from: fromAddress,
+      to: toAddress,
     },
-    fromBlock: 173545730n,
+    fromBlock: startBlock,
   })
 
   console.log('logs: ', logs)
@@ -49,7 +54,12 @@ const Home = () => {
 
   useEffect(() => {
     ;(async () => {
-      await getErc20TokenTransferLogs()
+      await getErc20TokenTransferLogs(
+        '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+        '0xF080B794AbF6BB905F2330d25DF545914e6027F8',
+        '0x81EF4608B796265F1e3695cE00FdCfC8aA5933Dd',
+        173545720n
+      )
     })()
   }, [])
 

--- a/packages/synapse-interface/pages/index.tsx
+++ b/packages/synapse-interface/pages/index.tsx
@@ -20,15 +20,14 @@ const Home = () => {
 
   useEffect(() => {
     ;(async () => {
-      const data = await getErc20TokenTransfers(
+      const transfers = await getErc20TokenTransfers(
         '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
         '0xF080B794AbF6BB905F2330d25DF545914e6027F8',
         '0x81EF4608B796265F1e3695cE00FdCfC8aA5933Dd',
         arbitrum,
         173545720n
       )
-
-      console.log('data:', data)
+      console.log('transfers:', transfers)
     })()
   }, [])
 

--- a/packages/synapse-interface/pages/index.tsx
+++ b/packages/synapse-interface/pages/index.tsx
@@ -5,6 +5,39 @@ import { LandingPageWrapper } from '@/components/layouts/LandingPageWrapper'
 import ReactGA from 'react-ga'
 import useSyncQueryParamsWithBridgeState from '@/utils/hooks/useSyncQueryParamsWithBridgeState'
 
+import { useState, useEffect } from 'react'
+import { useContractEvent, erc20ABI } from 'wagmi'
+
+import { createPublicClient, http, parseAbiItem, Address } from 'viem'
+import { arbitrum } from 'viem/chains'
+
+export const publicClient = createPublicClient({
+  chain: arbitrum,
+  transport: http(),
+})
+
+const getErc20TokenTransferLogs = async () => {
+  const logs = await publicClient.getLogs({
+    address: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+    event: {
+      type: 'event', // Added 'type' property
+      name: 'Transfer',
+      inputs: [
+        { type: 'address', indexed: true, name: 'from' },
+        { type: 'address', indexed: true, name: 'to' },
+        { type: 'uint256', indexed: false, name: 'value' },
+      ],
+    },
+    args: {
+      from: '0xF080B794AbF6BB905F2330d25DF545914e6027F8',
+      to: '0x81EF4608B796265F1e3695cE00FdCfC8aA5933Dd',
+    },
+    fromBlock: 173545730n,
+  })
+
+  console.log('logs: ', logs)
+}
+
 // TODO: someone should add this to the .env, disable if blank, etc.
 // this is being added as a hotfix to assess user load on the synapse explorer api
 // I'd recommend moving this to a sushi-style analytics provider wrapper.
@@ -13,6 +46,12 @@ ReactGA.initialize(TRACKING_ID)
 
 const Home = () => {
   useSyncQueryParamsWithBridgeState()
+
+  useEffect(() => {
+    ;(async () => {
+      await getErc20TokenTransferLogs()
+    })()
+  }, [])
 
   return (
     <LandingPageWrapper>

--- a/packages/synapse-interface/pages/index.tsx
+++ b/packages/synapse-interface/pages/index.tsx
@@ -24,8 +24,8 @@ const Home = () => {
         '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
         '0xF080B794AbF6BB905F2330d25DF545914e6027F8',
         '0x81EF4608B796265F1e3695cE00FdCfC8aA5933Dd',
-        173545720n,
-        arbitrum
+        arbitrum,
+        173545720n
       )
 
       console.log('data:', data)

--- a/packages/synapse-interface/utils/actions/getErc20TokenTransferLogs.ts
+++ b/packages/synapse-interface/utils/actions/getErc20TokenTransferLogs.ts
@@ -1,0 +1,76 @@
+import { createPublicClient, http, Address, Log } from 'viem'
+import { arbitrum } from 'viem/chains'
+
+export const publicClient = createPublicClient({
+  chain: arbitrum,
+  transport: http(),
+})
+
+export const getErc20TokenTransferData = async (
+  tokenAddress: Address,
+  fromAddress: Address,
+  toAddress: Address,
+  startBlock: bigint
+) => {
+  if (!tokenAddress || !fromAddress || !toAddress) {
+    console.error('Missing required address')
+    return null
+  }
+  if (!startBlock && typeof startBlock !== 'bigint') {
+    console.error('Invalid start block')
+    return null
+  }
+
+  const logs = await getErc20TokenTransferLogs(
+    tokenAddress,
+    fromAddress,
+    toAddress,
+    startBlock
+  )
+  const data = transformTransferLogsToData(logs)
+
+  return {
+    logs,
+    data,
+  }
+}
+
+const getErc20TokenTransferLogs = async (
+  tokenAddress: Address,
+  fromAddress: Address,
+  toAddress: Address,
+  startBlock: bigint
+) => {
+  const logs: Log[] = await publicClient.getLogs({
+    address: tokenAddress,
+    event: {
+      type: 'event',
+      name: 'Transfer',
+      inputs: [
+        { type: 'address', indexed: true, name: 'from' },
+        { type: 'address', indexed: true, name: 'to' },
+        { type: 'uint256', indexed: false, name: 'value' },
+      ],
+    },
+    args: {
+      from: fromAddress,
+      to: toAddress,
+    },
+    fromBlock: startBlock,
+  })
+
+  return logs
+}
+
+const transformTransferLogsToData = (logs: any[]) => {
+  return logs.map((log) => {
+    return {
+      tokenAddress: log.address,
+      fromAddress: log?.args?.from,
+      toAddress: log?.args?.to,
+      transferValue: log?.args?.value,
+      blockNumber: log.blockNumber,
+      transactionHash: log.transactionHash,
+    }
+  })
+}

--- a/packages/synapse-interface/utils/actions/getErc20TokenTransfers.ts
+++ b/packages/synapse-interface/utils/actions/getErc20TokenTransfers.ts
@@ -6,7 +6,7 @@ export const publicClient = createPublicClient({
   transport: http(),
 })
 
-export const getErc20TokenTransferData = async (
+export const getErc20TokenTransfers = async (
   tokenAddress: Address,
   fromAddress: Address,
   toAddress: Address,

--- a/packages/synapse-interface/utils/actions/getErc20TokenTransfers.ts
+++ b/packages/synapse-interface/utils/actions/getErc20TokenTransfers.ts
@@ -1,23 +1,22 @@
-import { createPublicClient, http, Address, Log } from 'viem'
-import { arbitrum } from 'viem/chains'
-
-export const publicClient = createPublicClient({
-  chain: arbitrum,
-  transport: http(),
-})
+import { createPublicClient, http, Address, Log, Chain } from 'viem'
 
 export const getErc20TokenTransfers = async (
   tokenAddress: Address,
   fromAddress: Address,
   toAddress: Address,
-  startBlock: bigint
+  startBlock: bigint,
+  chain: Chain
 ) => {
   if (!tokenAddress || !fromAddress || !toAddress) {
-    console.error('Missing required address')
+    console.error('Invalid address')
     return null
   }
   if (!startBlock && typeof startBlock !== 'bigint') {
     console.error('Invalid start block')
+    return null
+  }
+  if (!chain) {
+    console.error('Invalid Viem Chain')
     return null
   }
 
@@ -25,7 +24,8 @@ export const getErc20TokenTransfers = async (
     tokenAddress,
     fromAddress,
     toAddress,
-    startBlock
+    startBlock,
+    chain
   )
   const data = transformTransferLogsToData(logs)
 
@@ -39,8 +39,16 @@ const getErc20TokenTransferLogs = async (
   tokenAddress: Address,
   fromAddress: Address,
   toAddress: Address,
-  startBlock: bigint
+  startBlock: bigint,
+  chain: Chain
 ) => {
+  // const publicClient = getPublicClient(wagmiConfig[chainId])
+
+  const publicClient = createPublicClient({
+    chain,
+    transport: http(),
+  })
+
   const logs: Log[] = await publicClient.getLogs({
     address: tokenAddress,
     event: {

--- a/packages/synapse-interface/utils/actions/getErc20TokenTransfers.ts
+++ b/packages/synapse-interface/utils/actions/getErc20TokenTransfers.ts
@@ -1,11 +1,23 @@
 import { createPublicClient, http, Address, Log, Chain } from 'viem'
 
+/**
+ * Wrapper function around getErc20TokenTransferLogs() and transformTransferLogsToData()
+ *
+ * @param tokenAddress token to query transfer logs
+ * @param fromAddress transfer from address
+ * @param toAddress transfer to address
+ * @param startBlock block to start query logs
+ * @param toBlock block to stop query logs
+ * @param chain viem Chain where token resides
+ * @returns Will return raw logs and parsed logs
+ */
 export const getErc20TokenTransfers = async (
   tokenAddress: Address,
   fromAddress: Address,
   toAddress: Address,
+  chain: Chain,
   startBlock: bigint,
-  chain: Chain
+  toBlock?: bigint
 ) => {
   if (!tokenAddress || !fromAddress || !toAddress) {
     console.error('Invalid address')
@@ -24,8 +36,9 @@ export const getErc20TokenTransfers = async (
     tokenAddress,
     fromAddress,
     toAddress,
+    chain,
     startBlock,
-    chain
+    toBlock
   )
   const data = transformTransferLogsToData(logs)
 
@@ -39,11 +52,11 @@ const getErc20TokenTransferLogs = async (
   tokenAddress: Address,
   fromAddress: Address,
   toAddress: Address,
+  chain: Chain,
   startBlock: bigint,
-  chain: Chain
+  toBlock?: bigint
 ) => {
-  // const publicClient = getPublicClient(wagmiConfig[chainId])
-
+  /** Create public client to access logs while connected to any chain */
   const publicClient = createPublicClient({
     chain,
     transport: http(),
@@ -65,6 +78,7 @@ const getErc20TokenTransferLogs = async (
       to: toAddress,
     },
     fromBlock: startBlock,
+    toBlock: toBlock ?? null,
   })
 
   return logs


### PR DESCRIPTION
Create util function `getErc20TokenTransfers()` to query Erc20 Transfer (Event) logs using the following params:

```
/**
 * Wrapper function around getErc20TokenTransferLogs() and transformTransferLogsToData()
 *
 * @param tokenAddress token to query transfer logs
 * @param fromAddress transfer from address
 * @param toAddress transfer to address
 * @param startBlock block to start query logs
 * @param toBlock block to stop query logs
 * @param chain viem Chain where token resides
 * @returns Will return raw logs and parsed logs
 */
```

Utilizing a contained viem `publicClient` instance to ensure we can query logs in app while Browser Wallet is connected to any other chain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced functionality to fetch and display ERC20 token transfer information within the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
89ae24062026fc95755ecff022c34227be793601: [synapse-interface preview link ](https://sanguine-synapse-interface-4komfajo1-synapsecns.vercel.app)