### PR TITLE
Add `QuoteOffsetBps` to RFQ quoter

### DIFF
--- a/services/rfq/relayer/quoter/export_test.go
+++ b/services/rfq/relayer/quoter/export_test.go
@@ -18,6 +18,10 @@ func (m *Manager) GetQuoteAmount(ctx context.Context, chainID int, address commo
 	return m.getQuoteAmount(ctx, chainID, address, balance)
 }
 
+func (m *Manager) GetDestAmount(quoteAmount *big.Int) *big.Int {
+	return m.getDestAmount(quoteAmount)
+}
+
 func (m *Manager) SetConfig(cfg relconfig.Config) {
 	m.config = cfg
 }

--- a/services/rfq/relayer/quoter/export_test.go
+++ b/services/rfq/relayer/quoter/export_test.go
@@ -18,8 +18,8 @@ func (m *Manager) GetQuoteAmount(ctx context.Context, chainID int, address commo
 	return m.getQuoteAmount(ctx, chainID, address, balance)
 }
 
-func (m *Manager) GetDestAmount(quoteAmount *big.Int) *big.Int {
-	return m.getDestAmount(quoteAmount)
+func (m *Manager) GetDestAmount(ctx context.Context, quoteAmount *big.Int) *big.Int {
+	return m.getDestAmount(ctx, quoteAmount)
 }
 
 func (m *Manager) SetConfig(cfg relconfig.Config) {

--- a/services/rfq/relayer/quoter/quoter.go
+++ b/services/rfq/relayer/quoter/quoter.go
@@ -266,7 +266,7 @@ func (m *Manager) generateQuotes(ctx context.Context, chainID int, address commo
 					OriginTokenAddr:         strings.Split(keyTokenID, "-")[1],
 					DestChainID:             chainID,
 					DestTokenAddr:           address.Hex(),
-					DestAmount:              m.getDestAmount(quoteAmount).String(),
+					DestAmount:              m.getDestAmount(ctx, quoteAmount).String(),
 					MaxOriginAmount:         quoteAmount.String(),
 					FixedFee:                fee.String(),
 					OriginFastBridgeAddress: originChainCfg.Bridge,
@@ -317,11 +317,25 @@ func (m *Manager) getQuoteAmount(parentCtx context.Context, chainID int, address
 	return quoteAmount
 }
 
-func (m *Manager) getDestAmount(quoteAmount *big.Int) *big.Int {
+func (m *Manager) getDestAmount(parentCtx context.Context, quoteAmount *big.Int) *big.Int {
+	_, span := m.metricsHandler.Tracer().Start(parentCtx, "getDestAmount", trace.WithAttributes(
+		attribute.String("quote_amount", quoteAmount.String()),
+	))
+	defer func() {
+		metrics.EndSpan(span)
+	}()
+
 	quoteOffsetBps := m.config.GetQuoteOffsetBps()
 	quoteOffsetFraction := new(big.Float).Quo(new(big.Float).SetInt64(int64(quoteOffsetBps)), new(big.Float).SetInt64(10000))
 	quoteOffsetFactor := new(big.Float).Sub(new(big.Float).SetInt64(1), quoteOffsetFraction)
 	destAmount, _ := new(big.Float).Mul(new(big.Float).SetInt(quoteAmount), quoteOffsetFactor).Int(nil)
+
+	span.SetAttributes(
+		attribute.Int("quote_offset_bps", quoteOffsetBps),
+		attribute.String("quote_offset_fraction", quoteOffsetFraction.String()),
+		attribute.String("quote_offset_factor", quoteOffsetFactor.String()),
+		attribute.String("dest_amount", destAmount.String()),
+	)
 	return destAmount
 }
 

--- a/services/rfq/relayer/quoter/quoter.go
+++ b/services/rfq/relayer/quoter/quoter.go
@@ -319,8 +319,9 @@ func (m *Manager) getQuoteAmount(parentCtx context.Context, chainID int, address
 
 func (m *Manager) getDestAmount(quoteAmount *big.Int) *big.Int {
 	quoteOffsetBps := m.config.GetQuoteOffsetBps()
-	quoteOffsetFactor := 1 - (float64(quoteOffsetBps) / 10000)
-	destAmount, _ := new(big.Float).Mul(new(big.Float).SetInt(quoteAmount), new(big.Float).SetFloat64(quoteOffsetFactor)).Int(nil)
+	quoteOffsetFraction := new(big.Float).Quo(new(big.Float).SetInt64(int64(quoteOffsetBps)), new(big.Float).SetInt64(10000))
+	quoteOffsetFactor := new(big.Float).Sub(new(big.Float).SetInt64(1), quoteOffsetFraction)
+	destAmount, _ := new(big.Float).Mul(new(big.Float).SetInt(quoteAmount), quoteOffsetFactor).Int(nil)
 	return destAmount
 }
 

--- a/services/rfq/relayer/quoter/quoter_test.go
+++ b/services/rfq/relayer/quoter/quoter_test.go
@@ -116,3 +116,35 @@ func (s *QuoterSuite) TestGetQuoteAmount() {
 	expectedAmount = big.NewInt(1000_000_000)
 	s.Equal(expectedAmount, quoteAmount)
 }
+
+func (s *QuoterSuite) TestGetDestAmount() {
+	balance := big.NewInt(1000_000_000) // 1000 USDC
+
+	setQuoteParams := func(quoteOffsetBps int) {
+		s.config.QuoteOffsetBps = quoteOffsetBps
+		s.manager.SetConfig(s.config)
+	}
+
+	// Set default quote params; should return the balance.
+	destAmount := s.manager.GetDestAmount(balance)
+	expectedAmount := balance
+	s.Equal(expectedAmount, destAmount)
+
+	// Set QuoteOffsetBps to 100, should return 99% of balance.
+	setQuoteParams(100)
+	destAmount = s.manager.GetDestAmount(balance)
+	expectedAmount = big.NewInt(990_000_000)
+	s.Equal(expectedAmount, destAmount)
+
+	// Set QuoteOffsetBps to 500, should return 95% of balance.
+	setQuoteParams(500)
+	destAmount = s.manager.GetDestAmount(balance)
+	expectedAmount = big.NewInt(950_000_000)
+	s.Equal(expectedAmount, destAmount)
+
+	// Set QuoteOffsetBps to -100, should default to balance.
+	setQuoteParams(-100)
+	destAmount = s.manager.GetDestAmount(balance)
+	expectedAmount = balance
+	s.Equal(expectedAmount, expectedAmount)
+}

--- a/services/rfq/relayer/quoter/quoter_test.go
+++ b/services/rfq/relayer/quoter/quoter_test.go
@@ -126,25 +126,25 @@ func (s *QuoterSuite) TestGetDestAmount() {
 	}
 
 	// Set default quote params; should return the balance.
-	destAmount := s.manager.GetDestAmount(balance)
+	destAmount := s.manager.GetDestAmount(s.GetTestContext(), balance)
 	expectedAmount := balance
 	s.Equal(expectedAmount, destAmount)
 
 	// Set QuoteOffsetBps to 100, should return 99% of balance.
 	setQuoteParams(100)
-	destAmount = s.manager.GetDestAmount(balance)
+	destAmount = s.manager.GetDestAmount(s.GetTestContext(), balance)
 	expectedAmount = big.NewInt(990_000_000)
 	s.Equal(expectedAmount, destAmount)
 
 	// Set QuoteOffsetBps to 500, should return 95% of balance.
 	setQuoteParams(500)
-	destAmount = s.manager.GetDestAmount(balance)
+	destAmount = s.manager.GetDestAmount(s.GetTestContext(), balance)
 	expectedAmount = big.NewInt(950_000_000)
 	s.Equal(expectedAmount, destAmount)
 
 	// Set QuoteOffsetBps to -100, should default to balance.
 	setQuoteParams(-100)
-	destAmount = s.manager.GetDestAmount(balance)
+	destAmount = s.manager.GetDestAmount(s.GetTestContext(), balance)
 	expectedAmount = balance
 	s.Equal(expectedAmount, expectedAmount)
 }

--- a/services/rfq/relayer/relconfig/config.go
+++ b/services/rfq/relayer/relconfig/config.go
@@ -301,7 +301,7 @@ func (c Config) GetQuotePct() float64 {
 
 const defaultQuoteOffsetBps = 0
 
-// GetQuoteOffsetBps returns the quote offset bps.
+// GetQuoteOffsetBps returns the quote offset in basis points.
 func (c Config) GetQuoteOffsetBps() int {
 	if c.QuoteOffsetBps <= 0 {
 		return defaultQuoteOffsetBps

--- a/services/rfq/relayer/relconfig/config.go
+++ b/services/rfq/relayer/relconfig/config.go
@@ -42,6 +42,8 @@ type Config struct {
 	FeePricer FeePricerConfig `yaml:"fee_pricer"`
 	// QuotePct is the percent of balance to quote.
 	QuotePct float64 `yaml:"quote_pct"`
+	// QuoteOffsetBps is the number of basis points to deduct from the dest amount.
+	QuoteOffsetBps int `yaml:"quote_offset_bps"`
 	// ScreenerAPIUrl is the TRM API key.
 	ScreenerAPIUrl string `yaml:"screener_api_url"`
 	// BaseDeadlineBufferSeconds is the deadline buffer for relaying a transaction.
@@ -295,6 +297,16 @@ func (c Config) GetQuotePct() float64 {
 		return defaultQuotePct
 	}
 	return c.QuotePct
+}
+
+const defaultQuoteOffsetBps = 0
+
+// GetQuoteOffsetBps returns the quote offset bps.
+func (c Config) GetQuoteOffsetBps() int {
+	if c.QuoteOffsetBps <= 0 {
+		return defaultQuoteOffsetBps
+	}
+	return c.QuoteOffsetBps
 }
 
 const defaultMinQuoteAmount = 0


### PR DESCRIPTION
**Description**
Add a `QuoteOffsetBps` parameter that allows adjustment of the quote `DestAmount` by configured basis points.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced quote generation accuracy by introducing a new method to calculate destination amounts based on quote offsets.
- **Tests**
	- Added tests to ensure the reliability of the new destination amount calculation method.
- **Refactor**
	- Expanded configuration options to include quote offset parameters, allowing for more flexible quote adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->