### PR TITLE
Increase STIP rebate precision

### DIFF
--- a/services/stiprelayer/relayer/relayer.go
+++ b/services/stiprelayer/relayer/relayer.go
@@ -439,12 +439,9 @@ func (s *STIPRelayer) CalculateTransferAmount(transaction *db.STIPTransactions) 
 		return nil, fmt.Errorf("token configuration not found for token %s", transaction.Token)
 	}
 
-	rebateInBPS := tokenConfig.Rebate
-
-	// Convert amountUSD to big.Float for precision during calculations
+	// Convert values to big.Float for precision during calculations
 	amountUSD := new(big.Float).SetFloat64(transaction.AmountUSD)
-
-	rebateBPS := new(big.Float).SetFloat64(float64(rebateInBPS))
+	rebateBPS := new(big.Float).SetFloat64(tokenConfig.RebateBps)
 
 	// Calculate rebate in USD (amountUSD * rebateBPS / 10000)
 	// Divide rebateBPS by 10000 to get the actual rebate rate

--- a/services/stiprelayer/stipapi/server.go
+++ b/services/stiprelayer/stipapi/server.go
@@ -139,7 +139,7 @@ func ConvertFeesAndRebatesToJSON(feesAndRebates stipconfig.FeesAndRebates) map[i
 
 			for token, feeRebate := range tokenFeeRebate {
 				// Convert each FeeRebate into a map with "fee" and "rebate" as keys
-				moduleMap[token] = map[string]int{"fee": feeRebate.Fee, "rebate": feeRebate.Rebate}
+				moduleMap[token] = map[string]float64{"fee": feeRebate.Fee, "rebate": feeRebate.RebateBps}
 			}
 		}
 	}

--- a/services/stiprelayer/stipconfig/config.go
+++ b/services/stiprelayer/stipconfig/config.go
@@ -21,8 +21,8 @@ type DatabaseConfig struct {
 
 // FeeRebate represents the fee and rebate values.
 type FeeRebate struct {
-	Fee    int `yaml:"fee"`    // Fee is the cost that will be charged.
-	Rebate int `yaml:"rebate"` // Rebate is the amount that will be returned.
+	Fee       int     `yaml:"fee"`        // Fee is the cost that will be charged.
+	RebateBps float64 `yaml:"rebate_bps"` // RebateBps is the amount that will be returned, in units of basis points.
 }
 
 // TokenFeeRebate is a map where the key is a string representing a token,

--- a/services/stiprelayer/stipconfig/config.go
+++ b/services/stiprelayer/stipconfig/config.go
@@ -21,7 +21,7 @@ type DatabaseConfig struct {
 
 // FeeRebate represents the fee and rebate values.
 type FeeRebate struct {
-	Fee       int     `yaml:"fee"`        // Fee is the cost that will be charged.
+	Fee       float64 `yaml:"fee"`        // Fee is the cost that will be charged.
 	RebateBps float64 `yaml:"rebate_bps"` // RebateBps is the amount that will be returned, in units of basis points.
 }
 


### PR DESCRIPTION
**Description**
Allow `RebateBps` to be `float64` instead of `int` for increased precision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the rebate calculation logic in the transfer amount calculation to directly use the new basis points field from the token configuration, enhancing the precision of rebate calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->