### PR TITLE
Add ARB cap per address in STIP relayer

### DIFF
--- a/services/stiprelayer/db/sql/base/store.go
+++ b/services/stiprelayer/db/sql/base/store.go
@@ -42,7 +42,7 @@ func (s *Store) GetTotalArbRebated(ctx context.Context, address string) (*big.In
 		if !ok {
 			return nil, fmt.Errorf("failed to convert arb amount rebated to number")
 		}
-		totalRebated = totalRebated.Add(totalRebated, rebatedAmount)
+		totalRebated.Add(totalRebated, rebatedAmount)
 	}
 	return totalRebated, nil
 }

--- a/services/stiprelayer/db/stip_db.go
+++ b/services/stiprelayer/db/stip_db.go
@@ -3,6 +3,7 @@ package db
 
 import (
 	"context"
+	"math/big"
 	"time"
 
 	submitterDB "github.com/synapsecns/sanguine/ethergo/submitter/db"
@@ -30,6 +31,7 @@ type STIPTransactions struct {
 // STIPDBReader is the interface for reading from the database.
 type STIPDBReader interface {
 	GetSTIPTransactionsNotRebated(ctx context.Context) ([]*STIPTransactions, error)
+	GetTotalArbRebated(ctx context.Context, address string) (*big.Int, error)
 }
 
 // STIPDBWriter is the interface for writing to the database.

--- a/services/stiprelayer/relayer/relayer.go
+++ b/services/stiprelayer/relayer/relayer.go
@@ -439,12 +439,9 @@ func (s *STIPRelayer) CalculateTransferAmount(transaction *db.STIPTransactions) 
 		return nil, fmt.Errorf("token configuration not found for token %s", transaction.Token)
 	}
 
-	rebateInBPS := tokenConfig.Rebate
-
-	// Convert amountUSD to big.Float for precision during calculations
+	// Convert values to big.Float for precision during calculations
 	amountUSD := new(big.Float).SetFloat64(transaction.AmountUSD)
-
-	rebateBPS := new(big.Float).SetFloat64(float64(rebateInBPS))
+	rebateBPS := new(big.Float).SetFloat64(tokenConfig.RebateBps)
 
 	// Calculate rebate in USD (amountUSD * rebateBPS / 10000)
 	// Divide rebateBPS by 10000 to get the actual rebate rate

--- a/services/stiprelayer/relayer/relayer.go
+++ b/services/stiprelayer/relayer/relayer.go
@@ -483,14 +483,13 @@ func (s *STIPRelayer) applyRebateCap(ctx context.Context, transaction *db.STIPTr
 	if err != nil {
 		return nil, fmt.Errorf("could not get total ARB rebated: %w", err)
 	}
-	cap := new(big.Int).Mul(big.NewInt(s.cfg.GetArbCapPerAddress()), big.NewInt(1e18)) // Convert to wei
-	remainingAmount := new(big.Int).Sub(cap, totalArbRebated)
+	rebateCap := new(big.Int).Mul(big.NewInt(s.cfg.GetArbCapPerAddress()), big.NewInt(1e18)) // Convert to wei
+	remainingAmount := new(big.Int).Sub(rebateCap, totalArbRebated)
 
 	if remainingAmount.Cmp(big.NewInt(0)) <= 0 {
-		return nil, fmt.Errorf("address has reached the ARB rebate cap: %s", cap.String())
+		return nil, fmt.Errorf("address has reached the ARB rebate cap: %s", rebateCap.String())
 	} else if amount.Cmp(remainingAmount) >= 0 {
 		return remainingAmount, nil
-	} else {
-		return amount, nil
 	}
+	return amount, nil
 }

--- a/services/stiprelayer/relayer/relayer.go
+++ b/services/stiprelayer/relayer/relayer.go
@@ -371,7 +371,7 @@ func (s *STIPRelayer) SubmitAndRebateTransaction(ctx context.Context, transactio
 	// Calculate the transfer amount based on transaction details
 	// This function encapsulates the logic for determining the transfer amount
 	// You can define it elsewhere and call it here
-	transferAmount, err := s.CalculateTransferAmount(transaction)
+	transferAmount, err := s.CalculateTransferAmount(ctx, transaction)
 	if err != nil {
 		err := s.db.UpdateSTIPTransactionDoNotProcess(ctx, transaction.Hash)
 		if err != nil {
@@ -418,7 +418,7 @@ func (s *STIPRelayer) SubmitAndRebateTransaction(ctx context.Context, transactio
 }
 
 // CalculateTransferAmount determines the amount to transfer based on the transaction.
-func (s *STIPRelayer) CalculateTransferAmount(transaction *db.STIPTransactions) (*big.Int, error) {
+func (s *STIPRelayer) CalculateTransferAmount(ctx context.Context, transaction *db.STIPTransactions) (*big.Int, error) {
 	var toChainID int
 	switch transaction.Direction {
 	case "ARB":
@@ -468,5 +468,29 @@ func (s *STIPRelayer) CalculateTransferAmount(transaction *db.STIPTransactions) 
 	// transferAmount := new(big.Int)
 	// transferAmountFloat.Int(transferAmount) // Round to the nearest integer
 
+	// Finally, apply the rebate cap
+	var err error
+	transferAmount, err = s.applyRebateCap(ctx, transaction, transferAmount)
+	if err != nil {
+		return nil, fmt.Errorf("could not apply rebate cap: %w", err)
+	}
+
 	return transferAmount, nil
+}
+
+func (s *STIPRelayer) applyRebateCap(ctx context.Context, transaction *db.STIPTransactions, amount *big.Int) (*big.Int, error) {
+	totalArbRebated, err := s.db.GetTotalArbRebated(ctx, transaction.Address)
+	if err != nil {
+		return nil, fmt.Errorf("could not get total ARB rebated: %w", err)
+	}
+	cap := new(big.Int).Mul(big.NewInt(s.cfg.ArbCapPerAddress), big.NewInt(1e18)) // Convert to wei
+	remainingAmount := new(big.Int).Sub(cap, totalArbRebated)
+
+	if remainingAmount.Cmp(big.NewInt(0)) <= 0 {
+		return nil, fmt.Errorf("address has reached the ARB rebate cap: %s", cap.String())
+	} else if amount.Cmp(remainingAmount) >= 0 {
+		return remainingAmount, nil
+	} else {
+		return amount, nil
+	}
 }

--- a/services/stiprelayer/relayer/relayer.go
+++ b/services/stiprelayer/relayer/relayer.go
@@ -483,7 +483,7 @@ func (s *STIPRelayer) applyRebateCap(ctx context.Context, transaction *db.STIPTr
 	if err != nil {
 		return nil, fmt.Errorf("could not get total ARB rebated: %w", err)
 	}
-	cap := new(big.Int).Mul(big.NewInt(s.cfg.ArbCapPerAddress), big.NewInt(1e18)) // Convert to wei
+	cap := new(big.Int).Mul(big.NewInt(s.cfg.GetArbCapPerAddress()), big.NewInt(1e18)) // Convert to wei
 	remainingAmount := new(big.Int).Sub(cap, totalArbRebated)
 
 	if remainingAmount.Cmp(big.NewInt(0)) <= 0 {

--- a/services/stiprelayer/stipapi/server.go
+++ b/services/stiprelayer/stipapi/server.go
@@ -139,7 +139,7 @@ func ConvertFeesAndRebatesToJSON(feesAndRebates stipconfig.FeesAndRebates) map[i
 
 			for token, feeRebate := range tokenFeeRebate {
 				// Convert each FeeRebate into a map with "fee" and "rebate" as keys
-				moduleMap[token] = map[string]int{"fee": feeRebate.Fee, "rebate": feeRebate.Rebate}
+				moduleMap[token] = map[string]float64{"fee": feeRebate.Fee, "rebate": feeRebate.RebateBps}
 			}
 		}
 	}

--- a/services/stiprelayer/stipconfig/config.go
+++ b/services/stiprelayer/stipconfig/config.go
@@ -55,6 +55,16 @@ type Config struct {
 	ArbCapPerAddress int64                  `yaml:"arb_cap_per_address"`
 }
 
+const defaultArbCapPerAddress = 2000
+
+// GetArbCapPerAddress returns the configured arb cap per address, in human-readable units.
+func (c Config) GetArbCapPerAddress() int64 {
+	if c.ArbCapPerAddress == 0 {
+		return defaultArbCapPerAddress
+	}
+	return c.ArbCapPerAddress
+}
+
 // LoadConfig loads the config from the given path.
 func LoadConfig(path string) (config Config, err error) {
 	input, err := os.ReadFile(filepath.Clean(path))

--- a/services/stiprelayer/stipconfig/config.go
+++ b/services/stiprelayer/stipconfig/config.go
@@ -41,17 +41,18 @@ type FeesAndRebates map[int]ModuleFeeRebate
 type Config struct {
 	Signer config.SignerConfig `yaml:"signer"`
 	// Submitter is the submitter config.
-	SubmitterConfig submitterConfig.Config `yaml:"submitter_config"`
-	ArbAddress      string                 `yaml:"arb_address"`
-	ArbChainID      uint64                 `yaml:"arb_chain_id"`
-	StartDate       time.Time              `yaml:"start_date"`
-	Database        DatabaseConfig         `yaml:"database"`
-	OmniRPCURL      string                 `yaml:"omnirpc_url"`
-	FeesAndRebates  FeesAndRebates         `yaml:"fees_and_rebates"`
-	DuneInterval    time.Duration          `yaml:"dune_interval"`
-	RebateInterval  time.Duration          `yaml:"rebate_interval"`
-	StipAPIPort     string                 `yaml:"stip_api_port"`
-	ARBMaxTransfer  int64                  `yaml:"ARB_max_transfer"`
+	SubmitterConfig  submitterConfig.Config `yaml:"submitter_config"`
+	ArbAddress       string                 `yaml:"arb_address"`
+	ArbChainID       uint64                 `yaml:"arb_chain_id"`
+	StartDate        time.Time              `yaml:"start_date"`
+	Database         DatabaseConfig         `yaml:"database"`
+	OmniRPCURL       string                 `yaml:"omnirpc_url"`
+	FeesAndRebates   FeesAndRebates         `yaml:"fees_and_rebates"`
+	DuneInterval     time.Duration          `yaml:"dune_interval"`
+	RebateInterval   time.Duration          `yaml:"rebate_interval"`
+	StipAPIPort      string                 `yaml:"stip_api_port"`
+	ARBMaxTransfer   int64                  `yaml:"ARB_max_transfer"`
+	ArbCapPerAddress int64                  `yaml:"arb_cap_per_address"`
 }
 
 // LoadConfig loads the config from the given path.

--- a/services/stiprelayer/stipconfig/config.go
+++ b/services/stiprelayer/stipconfig/config.go
@@ -21,8 +21,8 @@ type DatabaseConfig struct {
 
 // FeeRebate represents the fee and rebate values.
 type FeeRebate struct {
-	Fee    int `yaml:"fee"`    // Fee is the cost that will be charged.
-	Rebate int `yaml:"rebate"` // Rebate is the amount that will be returned.
+	Fee       int     `yaml:"fee"`        // Fee is the cost that will be charged.
+	RebateBps float64 `yaml:"rebate_bps"` // RebateBps is the amount that will be returned, in units of basis points.
 }
 
 // TokenFeeRebate is a map where the key is a string representing a token,

--- a/services/stiprelayer/stipconfig/config.go
+++ b/services/stiprelayer/stipconfig/config.go
@@ -21,7 +21,7 @@ type DatabaseConfig struct {
 
 // FeeRebate represents the fee and rebate values.
 type FeeRebate struct {
-	Fee       int     `yaml:"fee"`        // Fee is the cost that will be charged.
+	Fee       float64 `yaml:"fee"`        // Fee is the cost that will be charged.
 	RebateBps float64 `yaml:"rebate_bps"` // RebateBps is the amount that will be returned, in units of basis points.
 }
 


### PR DESCRIPTION
**Description**
Adds a cap of ARB per address in the STIP relayer. This is done by querying all STIP transactions for a given address and summing the `arb_amount_rebated` field.

Note that the default cap is set to 2000 ARB, but config value will override.