### PR TITLE
Explorer UI fix

### DIFF
--- a/packages/explorer-ui/pages/tx/[kappa].tsx
+++ b/packages/explorer-ui/pages/tx/[kappa].tsx
@@ -1,4 +1,4 @@
-import { ApolloClient, HttpLink, InMemoryCache, from } from '@apollo/client'
+import { ApolloClient, HttpLink, InMemoryCache } from '@apollo/client'
 import { TRANSACTIONS_PATH, ACCOUNTS_PATH } from '@urls'
 import { ChainInfo } from '@components/misc/ChainInfo'
 import { Error } from '@components/Error'

--- a/packages/explorer-ui/pages/tx/[kappa].tsx
+++ b/packages/explorer-ui/pages/tx/[kappa].tsx
@@ -1,4 +1,4 @@
-import { ApolloClient, HttpLink, InMemoryCache } from '@apollo/client'
+import { ApolloClient, HttpLink, InMemoryCache, from } from '@apollo/client'
 import { TRANSACTIONS_PATH, ACCOUNTS_PATH } from '@urls'
 import { ChainInfo } from '@components/misc/ChainInfo'
 import { Error } from '@components/Error'
@@ -154,18 +154,24 @@ export default function BridgeTransaction({ queryResult }) {
 
                 <div className="flex gap-x-[1.8rem] py-1">
                   <p className="text-white text-opacity-60">TX Hash</p>
-                  <a
-                    target="_blank"
-                    rel="noreferrer"
-                    className="text-white break-all text-sm underline"
-                    href={
-                      CHAINS_BY_ID[fromInfo.chainId]?.explorerUrl +
-                      '/tx/' +
-                      fromInfo.hash
-                    }
-                  >
-                    {fromInfo.hash}
-                  </a>
+                  {fromInfo ? (
+                    <a
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-white break-all text-sm underline"
+                      href={
+                        CHAINS_BY_ID[fromInfo.chainID]?.explorerUrl +
+                        '/tx/' +
+                        fromInfo.hash
+                      }
+                    >
+                      {fromInfo.hash}
+                    </a>
+                  ) : (
+                    <p className="text-white break-all text-sm ">
+                      {pendingContent}
+                    </p>
+                  )}
                 </div>
                 <div className="flex gap-x-[1.7rem] py-1">
                   <p className="text-white text-opacity-60">Contract</p>


### PR DESCRIPTION
Fixes the routing on the /tx page for the explorer. 

Bug: 
On: [https://explorer.synapseprotocol.com/tx/6a786a392cf63d87a1775133583f9fb3ece2c60730fcff55d64fddcea20b750e?chainIdFrom=42161&chainIdTo=1088] , when we click the origin TX Hash it routes us to the default explorer.synapseprotocol.com/tx with an undefined full path. The added check to confirm the receipt of the fromInfo ensures that the link is to the correct blockchain explorer. 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced transaction details page to conditionally display transaction hash information based on available data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
2e6325613178668f2fe4e0055ed46a0e7a089c97: [explorer-ui preview link ](https://sanguine-o09ofan24-synapsecns.vercel.app)
a61fbd08d2ce6c03bad9f8719518b9c7ed37a767: [explorer-ui preview link ](https://sanguine-1t8u5tpn9-synapsecns.vercel.app)