### PR TITLE
RFQ quoter retries unprofitable quotes

### DIFF
--- a/services/rfq/relayer/quoter/quoter_test.go
+++ b/services/rfq/relayer/quoter/quoter_test.go
@@ -100,34 +100,10 @@ func (s *QuoterSuite) TestGenerateQuotesForNativeToken() {
 }
 
 func (s *QuoterSuite) TestShouldProcess() {
-	// Set fee to breakeven; i.e. destAmount = originAmount - fee.
+	// Set different numbers of decimals for origin / dest tokens; should never process this.
 	balance := big.NewInt(1000_000_000) // 1000 USDC
 	fee := big.NewInt(100_050_000)      // 100.05 USDC
 	quote := reldb.QuoteRequest{
-		BlockNumber:         1,
-		OriginTokenDecimals: 6,
-		DestTokenDecimals:   6,
-		Transaction: fastbridge.IFastBridgeBridgeTransaction{
-			OriginChainId: s.origin,
-			DestChainId:   s.destination,
-			OriginToken:   common.HexToAddress("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"),
-			DestToken:     common.HexToAddress("0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85"),
-			OriginAmount:  balance,
-			DestAmount:    new(big.Int).Sub(balance, fee),
-		},
-	}
-	s.True(s.manager.ShouldProcess(s.GetTestContext(), quote))
-
-	// Set fee to greater than breakeven; i.e. destAmount > originAmount - fee.
-	quote.Transaction.DestAmount = new(big.Int).Sub(balance, new(big.Int).Mul(fee, big.NewInt(2)))
-	s.True(s.manager.ShouldProcess(s.GetTestContext(), quote))
-
-	// Set fee to less than breakeven; i.e. destAmount < originAmount - fee.
-	quote.Transaction.DestAmount = balance
-	s.False(s.manager.ShouldProcess(s.GetTestContext(), quote))
-
-	// Set different numbers of decimals for origin / dest tokens; should never process this.
-	quote = reldb.QuoteRequest{
 		BlockNumber:         1,
 		OriginTokenDecimals: 6,
 		DestTokenDecimals:   18,
@@ -145,6 +121,34 @@ func (s *QuoterSuite) TestShouldProcess() {
 	// Toggle insufficient gas; should not process.
 	s.setGasSufficiency(false)
 	s.False(s.manager.ShouldProcess(s.GetTestContext(), quote))
+}
+
+func (s *QuoterSuite) TestIsProfitable() {
+	// Set fee to breakeven; i.e. destAmount = originAmount - fee.
+	balance := big.NewInt(1000_000_000) // 1000 USDC
+	fee := big.NewInt(100_050_000)      // 100.05 USDC
+	quote := reldb.QuoteRequest{
+		BlockNumber:         1,
+		OriginTokenDecimals: 6,
+		DestTokenDecimals:   6,
+		Transaction: fastbridge.IFastBridgeBridgeTransaction{
+			OriginChainId: s.origin,
+			DestChainId:   s.destination,
+			OriginToken:   common.HexToAddress("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"),
+			DestToken:     common.HexToAddress("0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85"),
+			OriginAmount:  balance,
+			DestAmount:    new(big.Int).Sub(balance, fee),
+		},
+	}
+	s.True(s.manager.IsProfitable(s.GetTestContext(), quote))
+
+	// Set fee to greater than breakeven; i.e. destAmount > originAmount - fee.
+	quote.Transaction.DestAmount = new(big.Int).Sub(balance, new(big.Int).Mul(fee, big.NewInt(2)))
+	s.True(s.manager.IsProfitable(s.GetTestContext(), quote))
+
+	// Set fee to less than breakeven; i.e. destAmount < originAmount - fee.
+	quote.Transaction.DestAmount = balance
+	s.False(s.manager.IsProfitable(s.GetTestContext(), quote))
 }
 
 func (s *QuoterSuite) TestGetQuoteAmount() {

--- a/services/rfq/relayer/relconfig/config.go
+++ b/services/rfq/relayer/relconfig/config.go
@@ -43,8 +43,8 @@ type Config struct {
 	FeePricer FeePricerConfig `yaml:"fee_pricer"`
 	// ScreenerAPIUrl is the TRM API key.
 	ScreenerAPIUrl string `yaml:"screener_api_url"`
-	// BaseDeadlineBufferSeconds is the deadline buffer for relaying a transaction.
-	BaseDeadlineBufferSeconds int `yaml:"base_deadline_buffer_seconds"`
+	// DBSelectorIntervalSeconds is the interval for the db selector.
+	DBSelectorIntervalSeconds int `yaml:"db_selector_interval_seconds"`
 }
 
 // ChainConfig represents the configuration for a chain.

--- a/services/rfq/relayer/relconfig/getters.go
+++ b/services/rfq/relayer/relconfig/getters.go
@@ -440,3 +440,14 @@ func (c Config) GetMinQuoteAmount(chainID int, addr common.Address) *big.Int {
 	quoteAmountScaled, _ := new(big.Float).Mul(quoteAmountFlt, new(big.Float).SetInt(denomDecimalsFactor)).Int(nil)
 	return quoteAmountScaled
 }
+
+const defaultDBSelectorIntervalSeconds = 1
+
+// GetDBSelectorInterval returns the interval for the DB selector.
+func (c Config) GetDBSelectorInterval() time.Duration {
+	interval := c.DBSelectorIntervalSeconds
+	if interval <= 0 {
+		return defaultDBSelectorIntervalSeconds
+	}
+	return time.Duration(interval) * time.Second
+}

--- a/services/rfq/relayer/service/handlers.go
+++ b/services/rfq/relayer/service/handlers.go
@@ -93,7 +93,7 @@ func (r *Relayer) handleBridgeRequestedLog(parentCtx context.Context, req *fastb
 //
 // This is the second step in the bridge process. It is emitted when the relayer sees the request.
 // We check if we have enough inventory to process the request and mark it as committed pending.
-func (q *QuoteRequestHandler) handleSeen(ctx context.Context, _ trace.Span, request reldb.QuoteRequest) (err error) {
+func (q *QuoteRequestHandler) handleSeen(ctx context.Context, span trace.Span, request reldb.QuoteRequest) (err error) {
 	shouldProcess, err := q.Quoter.ShouldProcess(ctx, request)
 	if err != nil {
 		// will retry later
@@ -107,6 +107,18 @@ func (q *QuoteRequestHandler) handleSeen(ctx context.Context, _ trace.Span, requ
 		// shouldn't process from here on out
 		return nil
 	}
+
+	// check if the quote is profitable
+	isProfitable, err := q.Quoter.IsProfitable(ctx, request)
+	if err != nil {
+		// will retry later
+		return fmt.Errorf("could not determine if profitable: %w", err)
+	}
+	if !isProfitable {
+		span.AddEvent("quote is not profitable")
+		return nil
+	}
+
 	// get destination committable balancs
 	committableBalance, err := q.Inventory.GetCommittableBalance(ctx, int(q.Dest.ChainID), request.Transaction.DestToken)
 	if err != nil {

--- a/services/rfq/relayer/service/handlers.go
+++ b/services/rfq/relayer/service/handlers.go
@@ -115,6 +115,7 @@ func (q *QuoteRequestHandler) handleSeen(ctx context.Context, span trace.Span, r
 		return fmt.Errorf("could not determine if profitable: %w", err)
 	}
 	if !isProfitable {
+		// will retry later since profitability is dependent on dynamic gas prices
 		span.AddEvent("quote is not profitable")
 		return nil
 	}

--- a/services/rfq/relayer/service/relayer.go
+++ b/services/rfq/relayer/service/relayer.go
@@ -203,15 +203,13 @@ func (r *Relayer) Start(ctx context.Context) error {
 	return nil
 }
 
-// TODO: make this configurable.
-const dbSelectorInterval = 1
-
 func (r *Relayer) runDBSelector(ctx context.Context) error {
+	interval := r.cfg.GetDBSelectorInterval()
 	for {
 		select {
 		case <-ctx.Done():
 			return fmt.Errorf("could not run db selector: %w", ctx.Err())
-		case <-time.After(dbSelectorInterval * time.Second):
+		case <-time.After(interval):
 			// TODO: add context w/ timeout
 			// TODO: add trigger
 			// TODO: should not fail on error


### PR DESCRIPTION
**Description**
Exports the `IsProfitable` check outside of `ShouldProcess` and into the `Quoter` interface. If a quote is not profitable, we simply return early and let the db loop retry the `handleSeen()` handler so that the quote may eventually be processed if gas prices change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved quote processing by adding a method to determine quote profitability, enhancing decision-making.
- **Refactor**
	- Refactored quote processing logic to utilize the new profitability evaluation method for improved efficiency.
- **Tests**
	- Enhanced test coverage by adding checks for token decimals, gas sufficiency, and quote profitability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->