### PR TITLE
Stip relayer min ARB transfer

### DIFF
--- a/services/stiprelayer/relayer/relayer.go
+++ b/services/stiprelayer/relayer/relayer.go
@@ -464,6 +464,13 @@ func (s *STIPRelayer) CalculateTransferAmount(ctx context.Context, transaction *
 	if transferAmount.Cmp(limit) > 0 {
 		return nil, fmt.Errorf("transfer amount exceeds the limit of %d ARB", s.cfg.ARBMaxTransfer)
 	}
+	// Check if transferAmount is lower than configured min ARB (MinAmount * 10^18 wei)
+	minAmountFloat := new(big.Float).SetFloat64(s.cfg.ARBMinTransfer)
+	minAmountFloatWei := new(big.Float).Mul(minAmountFloat, big.NewFloat(1e18))
+	minAmount, _ := minAmountFloatWei.Int(nil) // Truncate fractional part
+	if transferAmount.Cmp(minAmount) < 0 {
+		return nil, fmt.Errorf("transfer amount is lower than the minimum of %f ARB", s.cfg.ARBMinTransfer)
+	}
 	// If you need to round to the nearest integer instead of truncating, use the following:
 	// transferAmount := new(big.Int)
 	// transferAmountFloat.Int(transferAmount) // Round to the nearest integer

--- a/services/stiprelayer/stipconfig/config.go
+++ b/services/stiprelayer/stipconfig/config.go
@@ -53,6 +53,7 @@ type Config struct {
 	StipAPIPort      string                 `yaml:"stip_api_port"`
 	ARBMaxTransfer   int64                  `yaml:"ARB_max_transfer"`
 	ArbCapPerAddress int64                  `yaml:"arb_cap_per_address"`
+	ARBMinTransfer   float64                `yaml:"ARB_min_transfer"`
 }
 
 const defaultArbCapPerAddress = 2000


### PR DESCRIPTION
**Description**
Implements a lower bound for ARB transfers in `stip-relayer`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced security by ensuring transfer amounts meet a minimum threshold before processing.
- **Refactor**
	- Introduced a configuration setting for specifying the minimum transfer amount.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->