### PR TITLE
Use unified dune query for all STIP transaction types

### DIFF
--- a/services/stiprelayer/relayer/dune.go
+++ b/services/stiprelayer/relayer/dune.go
@@ -21,11 +21,11 @@ const dunePerformance = "large"
 
 type duneQueryBody struct {
 	QueryParameters stipQueryParams `json:"query_parameters"`
+	Performance     string          `json:"performance"`
 }
 
 type stipQueryParams struct {
-	Performance string `json:"performance"`
-	LastHours   int    `json:"last_hours"`
+	LastHours int `json:"last_hours"`
 }
 
 // ExecuteDuneQuery executes a predefined query on the Dune API and returns the http response.
@@ -39,9 +39,9 @@ func (s *STIPRelayer) ExecuteDuneQuery(parentCtx context.Context) (executionID s
 	s.handler.ConfigureHTTPClient(client)
 	params := duneQueryBody{
 		QueryParameters: stipQueryParams{
-			Performance: dunePerformance,
-			LastHours:   s.cfg.GetDuneLookbackHours(),
+			LastHours: s.cfg.GetDuneLookbackHours(),
 		},
+		Performance: dunePerformance,
 	}
 	reqBody, err := json.Marshal(params)
 	if err != nil {

--- a/services/stiprelayer/relayer/dune.go
+++ b/services/stiprelayer/relayer/dune.go
@@ -17,7 +17,6 @@ import (
 // DuneAPIKey is the API key for Dune, fetched from the environment variables.
 var DuneAPIKey = os.Getenv("DUNE_API_KEY")
 
-const stipQueryID = 3403369
 const dunePerformance = "large"
 
 type duneQueryParams struct {
@@ -42,7 +41,7 @@ func (s *STIPRelayer) ExecuteDuneQuery(parentCtx context.Context) (executionID s
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal request body: %w", err)
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("https://api.dune.com/api/v1/query/%d/execute", stipQueryID), bytes.NewBuffer(reqBody))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("https://api.dune.com/api/v1/query/%d/execute", s.cfg.StipQueryID), bytes.NewBuffer(reqBody))
 	if err != nil {
 		return "", fmt.Errorf("failed to create request: %w", err)
 	}

--- a/services/stiprelayer/relayer/dune.go
+++ b/services/stiprelayer/relayer/dune.go
@@ -21,15 +21,14 @@ const stipQueryID = 3403369
 
 // ExecuteDuneQuery executes a predefined query on the Dune API and returns the http response.
 func (s *STIPRelayer) ExecuteDuneQuery(parentCtx context.Context) (executionID string, err error) {
-	ctx, span := s.handler.Tracer().Start(parentCtx, "ExecuteDuneQuery", trace.WithAttributes(attribute.String("queryType", queryType)))
+	ctx, span := s.handler.Tracer().Start(parentCtx, "ExecuteDuneQuery")
 	defer func() {
 		metrics.EndSpanWithErr(span, err)
 	}()
 
 	client := &http.Client{}
-	var queryID string
 	s.handler.ConfigureHTTPClient(client)
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("https://api.dune.com/api/v1/query/%d/execute", queryID), bytes.NewBufferString(`{"performance": "large"}`))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("https://api.dune.com/api/v1/query/%d/execute", stipQueryID), bytes.NewBufferString(`{"performance": "large"}`))
 	if err != nil {
 		return "", fmt.Errorf("failed to create request: %w", err)
 	}

--- a/services/stiprelayer/relayer/dune.go
+++ b/services/stiprelayer/relayer/dune.go
@@ -84,6 +84,7 @@ func (s *STIPRelayer) ExecuteDuneQuery(parentCtx context.Context) (executionID s
 	if !ok {
 		return "", fmt.Errorf("no execution_id found in response")
 	}
+	span.SetAttributes(attribute.String("execution_id", executionID))
 
 	return executionID, nil
 }

--- a/services/stiprelayer/relayer/dune.go
+++ b/services/stiprelayer/relayer/dune.go
@@ -18,6 +18,7 @@ import (
 var DuneAPIKey = os.Getenv("DUNE_API_KEY")
 
 const stipQueryID = 3403369
+const dunePerformance = "large"
 
 type duneQueryParams struct {
 	Performance string `json:"performance"`
@@ -34,8 +35,8 @@ func (s *STIPRelayer) ExecuteDuneQuery(parentCtx context.Context) (executionID s
 	client := &http.Client{}
 	s.handler.ConfigureHTTPClient(client)
 	params := duneQueryParams{
-		Performance: "large",
-		LastHours:   24,
+		Performance: dunePerformance,
+		LastHours:   s.cfg.GetDuneLookbackHours(),
 	}
 	reqBody, err := json.Marshal(params)
 	if err != nil {

--- a/services/stiprelayer/relayer/dune.go
+++ b/services/stiprelayer/relayer/dune.go
@@ -19,7 +19,11 @@ var DuneAPIKey = os.Getenv("DUNE_API_KEY")
 
 const dunePerformance = "large"
 
-type duneQueryParams struct {
+type duneQueryBody struct {
+	QueryParameters stipQueryParams `json:"query_parameters"`
+}
+
+type stipQueryParams struct {
 	Performance string `json:"performance"`
 	LastHours   int    `json:"last_hours"`
 }
@@ -33,9 +37,11 @@ func (s *STIPRelayer) ExecuteDuneQuery(parentCtx context.Context) (executionID s
 
 	client := &http.Client{}
 	s.handler.ConfigureHTTPClient(client)
-	params := duneQueryParams{
-		Performance: dunePerformance,
-		LastHours:   s.cfg.GetDuneLookbackHours(),
+	params := duneQueryBody{
+		QueryParameters: stipQueryParams{
+			Performance: dunePerformance,
+			LastHours:   s.cfg.GetDuneLookbackHours(),
+		},
 	}
 	reqBody, err := json.Marshal(params)
 	if err != nil {

--- a/services/stiprelayer/stipconfig/config.go
+++ b/services/stiprelayer/stipconfig/config.go
@@ -55,6 +55,7 @@ type Config struct {
 	ArbCapPerAddress  int64                  `yaml:"arb_cap_per_address"`
 	ARBMinTransfer    float64                `yaml:"ARB_min_transfer"`
 	DuneLookbackHours int                    `yaml:"dune_lookback_hours"`
+	StipQueryID       int                    `yaml:"stip_query_id"`
 }
 
 const defaultArbCapPerAddress = 2000

--- a/services/stiprelayer/stipconfig/config.go
+++ b/services/stiprelayer/stipconfig/config.go
@@ -41,19 +41,20 @@ type FeesAndRebates map[int]ModuleFeeRebate
 type Config struct {
 	Signer config.SignerConfig `yaml:"signer"`
 	// Submitter is the submitter config.
-	SubmitterConfig  submitterConfig.Config `yaml:"submitter_config"`
-	ArbAddress       string                 `yaml:"arb_address"`
-	ArbChainID       uint64                 `yaml:"arb_chain_id"`
-	StartDate        time.Time              `yaml:"start_date"`
-	Database         DatabaseConfig         `yaml:"database"`
-	OmniRPCURL       string                 `yaml:"omnirpc_url"`
-	FeesAndRebates   FeesAndRebates         `yaml:"fees_and_rebates"`
-	DuneInterval     time.Duration          `yaml:"dune_interval"`
-	RebateInterval   time.Duration          `yaml:"rebate_interval"`
-	StipAPIPort      string                 `yaml:"stip_api_port"`
-	ARBMaxTransfer   int64                  `yaml:"ARB_max_transfer"`
-	ArbCapPerAddress int64                  `yaml:"arb_cap_per_address"`
-	ARBMinTransfer   float64                `yaml:"ARB_min_transfer"`
+	SubmitterConfig   submitterConfig.Config `yaml:"submitter_config"`
+	ArbAddress        string                 `yaml:"arb_address"`
+	ArbChainID        uint64                 `yaml:"arb_chain_id"`
+	StartDate         time.Time              `yaml:"start_date"`
+	Database          DatabaseConfig         `yaml:"database"`
+	OmniRPCURL        string                 `yaml:"omnirpc_url"`
+	FeesAndRebates    FeesAndRebates         `yaml:"fees_and_rebates"`
+	DuneInterval      time.Duration          `yaml:"dune_interval"`
+	RebateInterval    time.Duration          `yaml:"rebate_interval"`
+	StipAPIPort       string                 `yaml:"stip_api_port"`
+	ARBMaxTransfer    int64                  `yaml:"ARB_max_transfer"`
+	ArbCapPerAddress  int64                  `yaml:"arb_cap_per_address"`
+	ARBMinTransfer    float64                `yaml:"ARB_min_transfer"`
+	DuneLookbackHours int                    `yaml:"dune_lookback_hours"`
 }
 
 const defaultArbCapPerAddress = 2000
@@ -64,6 +65,16 @@ func (c Config) GetArbCapPerAddress() int64 {
 		return defaultArbCapPerAddress
 	}
 	return c.ArbCapPerAddress
+}
+
+const defaultDuneLookbackHours = 24
+
+// GetDuneLookbackHours returns the configured dune lookback hours.
+func (c Config) GetDuneLookbackHours() int {
+	if c.DuneLookbackHours == 0 {
+		return defaultDuneLookbackHours
+	}
+	return c.DuneLookbackHours
 }
 
 // LoadConfig loads the config from the given path.


### PR DESCRIPTION
**Description**
Conserves dune credits by doing a single query for CCTP, SynapseBridge, and RFQ transactions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved the performance of data queries by optimizing the query execution process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->