### PR TITLE
Global db nonces in `InterchainDB`

### DIFF
--- a/packages/contracts-communication/contracts/InterchainClientV1.sol
+++ b/packages/contracts-communication/contracts/InterchainClientV1.sol
@@ -52,7 +52,7 @@ contract InterchainClientV1 is Ownable, IInterchainClientV1 {
         uint64 nonce,
         bytes options,
         bytes32 indexed transactionId,
-        uint256 dbWriterNonce
+        uint256 dbNonce
     );
 
     // @notice Emitted when an interchain transaction is executed.
@@ -66,7 +66,7 @@ contract InterchainClientV1 is Ownable, IInterchainClientV1 {
         uint64 nonce,
         bytes options,
         bytes32 indexed transactionId,
-        uint256 dbWriterNonce
+        uint256 dbNonce
     );
 
     /**
@@ -81,7 +81,7 @@ contract InterchainClientV1 is Ownable, IInterchainClientV1 {
         uint64 nonce;
         bytes options;
         bytes32 transactionId;
-        uint256 dbWriterNonce;
+        uint256 dbNonce;
     }
 
     function _generateTransactionId(
@@ -123,7 +123,7 @@ contract InterchainClientV1 is Ownable, IInterchainClientV1 {
             nonce: clientNonce,
             options: options,
             transactionId: 0,
-            dbWriterNonce: 0
+            dbNonce: 0
         });
 
         bytes32 transactionId = _generateTransactionId(
@@ -131,10 +131,10 @@ contract InterchainClientV1 is Ownable, IInterchainClientV1 {
         );
         icTx.transactionId = transactionId;
 
-        uint256 dbWriterNonce = IInterchainDB(interchainDB).writeEntryWithVerification{value: totalModuleFees}(
+        uint256 dbNonce = IInterchainDB(interchainDB).writeEntryWithVerification{value: totalModuleFees}(
             icTx.dstChainId, icTx.transactionId, srcModules
         );
-        icTx.dbWriterNonce = dbWriterNonce;
+        icTx.dbNonce = dbNonce;
 
         emit InterchainTransactionSent(
             icTx.srcSender,
@@ -145,7 +145,7 @@ contract InterchainClientV1 is Ownable, IInterchainClientV1 {
             icTx.nonce,
             icTx.options,
             icTx.transactionId,
-            icTx.dbWriterNonce
+            icTx.dbNonce
         );
         // Increment nonce for next message
         clientNonce++;
@@ -177,8 +177,8 @@ contract InterchainClientV1 is Ownable, IInterchainClientV1 {
         // Construct expected entry based on icTransaction data
         InterchainEntry memory icEntry = InterchainEntry({
             srcChainId: icTx.srcChainId,
+            dbNonce: icTx.dbNonce,
             srcWriter: linkedClients[icTx.srcChainId],
-            writerNonce: icTx.dbWriterNonce,
             dataHash: icTx.transactionId
         });
 
@@ -265,7 +265,7 @@ contract InterchainClientV1 is Ownable, IInterchainClientV1 {
             icTx.nonce,
             icTx.options,
             icTx.transactionId,
-            icTx.dbWriterNonce
+            icTx.dbNonce
         );
     }
 }

--- a/packages/contracts-communication/contracts/events/InterchainDBEvents.sol
+++ b/packages/contracts-communication/contracts/events/InterchainDBEvents.sol
@@ -3,12 +3,10 @@ pragma solidity ^0.8.0;
 
 abstract contract InterchainDBEvents {
     // TODO: figure out indexing
-    event InterchainEntryWritten(uint256 srcChainId, bytes32 srcWriter, uint256 writerNonce, bytes32 dataHash);
+    event InterchainEntryWritten(uint256 srcChainId, uint256 dbNonce, bytes32 srcWriter, bytes32 dataHash);
     event InterchainEntryVerified(
         address module, uint256 srcChainId, bytes32 srcWriter, uint256 writerNonce, bytes32 dataHash
     );
 
-    event InterchainVerificationRequested(
-        uint256 destChainId, bytes32 srcWriter, uint256 writerNonce, address[] srcModules
-    );
+    event InterchainVerificationRequested(uint256 destChainId, uint256 dbNonce, address[] srcModules);
 }

--- a/packages/contracts-communication/contracts/events/InterchainDBEvents.sol
+++ b/packages/contracts-communication/contracts/events/InterchainDBEvents.sol
@@ -5,7 +5,7 @@ abstract contract InterchainDBEvents {
     // TODO: figure out indexing
     event InterchainEntryWritten(uint256 srcChainId, uint256 dbNonce, bytes32 srcWriter, bytes32 dataHash);
     event InterchainEntryVerified(
-        address module, uint256 srcChainId, bytes32 srcWriter, uint256 writerNonce, bytes32 dataHash
+        address module, uint256 srcChainId, uint256 dbNonce, bytes32 srcWriter, bytes32 dataHash
     );
 
     event InterchainVerificationRequested(uint256 destChainId, uint256 dbNonce, address[] srcModules);

--- a/packages/contracts-communication/contracts/interfaces/IInterchainDB.sol
+++ b/packages/contracts-communication/contracts/interfaces/IInterchainDB.sol
@@ -14,13 +14,13 @@ interface IInterchainDB {
 
     /// @notice Struct representing an entry from the remote Interchain DataBase verified by the Interchain Module
     /// @param verifiedAt   The block timestamp at which the entry was verified by the module
-    /// @param dataHash     The hash of the data written on the source chain
+    /// @param entryValue   The value of the entry: writer + dataHash hashed together
     struct RemoteEntry {
         uint256 verifiedAt;
-        bytes32 dataHash;
+        bytes32 entryValue;
     }
 
-    error InterchainDB__ConflictingEntries(bytes32 existingDataHash, InterchainEntry newEntry);
+    error InterchainDB__ConflictingEntries(bytes32 existingEntryValue, InterchainEntry newEntry);
     error InterchainDB__EntryDoesNotExist(uint256 dbNonce);
     error InterchainDB__IncorrectFeeAmount(uint256 actualFee, uint256 expectedFee);
     error InterchainDB__NoModulesSpecified();

--- a/packages/contracts-communication/contracts/interfaces/IInterchainDB.sol
+++ b/packages/contracts-communication/contracts/interfaces/IInterchainDB.sol
@@ -4,6 +4,14 @@ pragma solidity ^0.8.0;
 import {InterchainEntry} from "../libs/InterchainEntry.sol";
 
 interface IInterchainDB {
+    /// @notice Struct representing an entry from the local Interchain DataBase.
+    /// @param writer       The address of the writer on the local chain
+    /// @param dataHash     The hash of the data written on the local chain
+    struct LocalEntry {
+        address writer;
+        bytes32 dataHash;
+    }
+
     /// @notice Struct representing an entry from the remote Interchain DataBase verified by the Interchain Module
     /// @param verifiedAt   The block timestamp at which the entry was verified by the module
     /// @param dataHash     The hash of the data written on the source chain
@@ -13,7 +21,7 @@ interface IInterchainDB {
     }
 
     error InterchainDB__ConflictingEntries(bytes32 existingDataHash, InterchainEntry newEntry);
-    error InterchainDB__EntryDoesNotExist(address writer, uint256 writerNonce);
+    error InterchainDB__EntryDoesNotExist(uint256 dbNonce);
     error InterchainDB__IncorrectFeeAmount(uint256 actualFee, uint256 expectedFee);
     error InterchainDB__NoModulesSpecified();
     error InterchainDB__SameChainId();
@@ -22,8 +30,8 @@ interface IInterchainDB {
     /// Note: there are no guarantees that this entry will be available for reading on any of the remote chains.
     /// Use `verifyEntry` to ensure that the entry is available for reading on the destination chain.
     /// @param dataHash     The hash of the data to be written to the Interchain DataBase as a new entry
-    /// @return writerNonce The writer-specific nonce of the written entry
-    function writeEntry(bytes32 dataHash) external returns (uint256 writerNonce);
+    /// @return dbNonce     The database nonce of the written entry on this chain
+    function writeEntry(bytes32 dataHash) external returns (uint256 dbNonce);
 
     /// @notice Request the given Interchain Modules to verify the already written entry on the destination chain.
     /// Note: every module has a separate fee paid in the native gas token of the source chain,
@@ -31,28 +39,21 @@ interface IInterchainDB {
     /// Note: this method is permissionless, and anyone can request verification for any entry.
     /// @dev Will revert if the entry with the given nonce does not exist.
     /// @param destChainId   The chain id of the destination chain
-    /// @param writer        The address of the writer on the source chain
-    /// @param writerNonce   The nonce of the writer on the source chain
+    /// @param dbNonce       The database nonce of the written entry on this chain
     /// @param srcModules    The source chain addresses of the Interchain Modules to use for verification
-    function requestVerification(
-        uint256 destChainId,
-        address writer,
-        uint256 writerNonce,
-        address[] memory srcModules
-    )
-        external
-        payable;
+    function requestVerification(uint256 destChainId, uint256 dbNonce, address[] memory srcModules) external payable;
 
     /// @notice Write data to the Interchain DataBase,
     /// and request the given Interchain Modules to verify it on the destination chain.
     /// Note: every module has a separate fee paid in the native gas token of the source chain,
     /// and `msg.value` must be equal to the sum of all fees.
-    /// Note: additional verification for the same entry could be later done using `requestVerification`.
+    /// Note: additional verification for the same entry could be later done using `requestVerification`
+    /// by providing the returned `dbNonce`.
     /// @dev Will revert if the empty array of modules is provided.
     /// @param destChainId  The chain id of the destination chain
     /// @param dataHash     The hash of the data to be written to the Interchain DataBase as a new entry
     /// @param srcModules   The source chain addresses of the Interchain Modules to use for verification
-    /// @return writerNonce The writer-specific nonce of the written entry
+    /// @return dbNonce     The database nonce of the written entry on this chain
     function writeEntryWithVerification(
         uint256 destChainId,
         bytes32 dataHash,
@@ -60,7 +61,7 @@ interface IInterchainDB {
     )
         external
         payable
-        returns (uint256 writerNonce);
+        returns (uint256 dbNonce);
 
     /// @notice Allows the Interchain Module to verify the entry coming from a remote source chain.
     /// @param entry        The Interchain Entry to confirm
@@ -75,13 +76,11 @@ interface IInterchainDB {
 
     /// @notice Get the Interchain Entry by the writer and the writer nonce.
     /// @dev Will revert if the entry with the given nonce does not exist.
-    /// @param writer       The address of the writer on this chain
-    /// @param writerNonce  The nonce of the writer's entry on this chain
-    function getEntry(address writer, uint256 writerNonce) external view returns (InterchainEntry memory);
+    /// @param dbNonce      The database nonce of the written entry on this chain
+    function getEntry(uint256 dbNonce) external view returns (InterchainEntry memory);
 
-    /// @notice Get the nonce of the writer on this chain.
-    /// @param writer       The address of the writer on this chain
-    function getWriterNonce(address writer) external view returns (uint256);
+    /// @notice Get the nonce of the database.
+    function getDBNonce() external view returns (uint256);
 
     /// @notice Read the data written on specific source chain by a specific writer,
     /// and verify it on the destination chain using the provided Interchain Module.

--- a/packages/contracts-communication/contracts/libs/InterchainEntry.sol
+++ b/packages/contracts-communication/contracts/libs/InterchainEntry.sol
@@ -3,27 +3,30 @@ pragma solidity ^0.8.0;
 
 import {TypeCasts} from "./TypeCasts.sol";
 
-/// @notice Struct representing an entry in the Interchain DataBase
+/// @notice Struct representing an entry in the Interchain DataBase.
+/// Entry has a globally unique identifier (key) and a value.
+/// - key: srcChainId + dbNonce
+/// - value: srcWriter + dataHash
 /// @param srcChainId   The chain id of the source chain
+/// @param dbNonce      The database nonce of the entry on the source chain
 /// @param srcWriter    The address of the writer on the source chain
-/// @param writerNonce  The nonce of the writer on the source chain
 /// @param dataHash     The hash of the data written on the source chain
 struct InterchainEntry {
     uint256 srcChainId;
+    uint256 dbNonce;
     bytes32 srcWriter;
-    uint256 writerNonce;
     bytes32 dataHash;
 }
 
 library InterchainEntryLib {
     /// @notice Constructs an InterchainEntry struct to be written on the local chain
+    /// @param dbNonce      The database nonce of the entry on the source chain
     /// @param srcWriter    The address of the writer on the local chain
-    /// @param writerNonce  The nonce of the writer on the local chain
     /// @param dataHash     The hash of the data written on the local chain
     /// @return entry       The constructed InterchainEntry struct
     function constructLocalEntry(
+        uint256 dbNonce,
         address srcWriter,
-        uint256 writerNonce,
         bytes32 dataHash
     )
         internal
@@ -32,14 +35,19 @@ library InterchainEntryLib {
     {
         return InterchainEntry({
             srcChainId: block.chainid,
+            dbNonce: dbNonce,
             srcWriter: TypeCasts.addressToBytes32(srcWriter),
-            writerNonce: writerNonce,
             dataHash: dataHash
         });
     }
 
     /// @notice Returns the globally unique identifier of the entry
-    function entryId(InterchainEntry memory entry) internal pure returns (bytes32) {
-        return keccak256(abi.encode(entry.srcChainId, entry.srcWriter, entry.writerNonce));
+    function entryKey(InterchainEntry memory entry) internal pure returns (bytes32) {
+        return keccak256(abi.encode(entry.srcChainId, entry.dbNonce));
+    }
+
+    /// @notice Returns the value of the entry: writer + dataHash hashed together
+    function entryValue(InterchainEntry memory entry) internal pure returns (bytes32) {
+        return keccak256(abi.encode(entry.srcWriter, entry.dataHash));
     }
 }

--- a/packages/contracts-communication/contracts/libs/InterchainEntry.sol
+++ b/packages/contracts-communication/contracts/libs/InterchainEntry.sol
@@ -21,12 +21,12 @@ struct InterchainEntry {
 library InterchainEntryLib {
     /// @notice Constructs an InterchainEntry struct to be written on the local chain
     /// @param dbNonce      The database nonce of the entry on the source chain
-    /// @param srcWriter    The address of the writer on the local chain
+    /// @param writer       The address of the writer on the local chain
     /// @param dataHash     The hash of the data written on the local chain
     /// @return entry       The constructed InterchainEntry struct
     function constructLocalEntry(
         uint256 dbNonce,
-        address srcWriter,
+        address writer,
         bytes32 dataHash
     )
         internal
@@ -36,7 +36,7 @@ library InterchainEntryLib {
         return InterchainEntry({
             srcChainId: block.chainid,
             dbNonce: dbNonce,
-            srcWriter: TypeCasts.addressToBytes32(srcWriter),
+            srcWriter: TypeCasts.addressToBytes32(writer),
             dataHash: dataHash
         });
     }

--- a/packages/contracts-communication/test/InterchainClientV1Test.t.sol
+++ b/packages/contracts-communication/test/InterchainClientV1Test.t.sol
@@ -126,7 +126,7 @@ contract InterchainClientV1Test is Test {
             keccak256(abi.encode(srcSender, SRC_CHAIN_ID, dstReceiver, DST_CHAIN_ID, message, nonce, options));
 
         InterchainEntry memory entry =
-            InterchainEntry({srcChainId: SRC_CHAIN_ID, srcWriter: srcSender, writerNonce: 0, dataHash: transactionID});
+            InterchainEntry({srcChainId: SRC_CHAIN_ID, srcWriter: srcSender, dbNonce: 0, dataHash: transactionID});
 
         icModule.mockVerifyEntry(address(icDB), entry);
 
@@ -139,7 +139,7 @@ contract InterchainClientV1Test is Test {
             nonce: nonce,
             options: options,
             transactionId: transactionID,
-            dbWriterNonce: 0
+            dbNonce: 0
         });
         // Skip ahead of optimistic period
         vm.warp(icApp.getOptimisticTimePeriod() + 1 minutes);

--- a/packages/contracts-communication/test/InterchainDB.Dst.t.sol
+++ b/packages/contracts-communication/test/InterchainDB.Dst.t.sol
@@ -1,7 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.20;
 
-import {InterchainDB, InterchainEntry, IInterchainDB, InterchainDBEvents} from "../contracts/InterchainDB.sol";
+import {
+    InterchainDB,
+    InterchainEntry,
+    InterchainEntryLib,
+    IInterchainDB,
+    InterchainDBEvents
+} from "../contracts/InterchainDB.sol";
 
 import {InterchainModuleMock, IInterchainModule} from "./mocks/InterchainModuleMock.sol";
 
@@ -32,20 +38,20 @@ contract InterchainDBDestinationTest is Test, InterchainDBEvents {
         // Format is writer: {chainId: nonce}
         // Verify some entries with module A
         // writerF: {0: 0}, {0: 10}, {1: 10}
-        verifyEntry(moduleA, getMockEntry(SRC_CHAIN_ID_0, writerF, 0));
-        verifyEntry(moduleA, getMockEntry(SRC_CHAIN_ID_0, writerF, 10));
-        verifyEntry(moduleA, getMockEntry(SRC_CHAIN_ID_1, writerF, 10));
-        // writerS: {1: 0}, {1: 10}
-        verifyEntry(moduleA, getMockEntry(SRC_CHAIN_ID_1, writerS, 0));
-        verifyEntry(moduleA, getMockEntry(SRC_CHAIN_ID_1, writerS, 10));
+        verifyEntry(moduleA, getMockEntry(SRC_CHAIN_ID_0, 0, writerF));
+        verifyEntry(moduleA, getMockEntry(SRC_CHAIN_ID_0, 10, writerF));
+        verifyEntry(moduleA, getMockEntry(SRC_CHAIN_ID_1, 10, writerF));
+        // writerS: {1: 1}, {1: 11}
+        verifyEntry(moduleA, getMockEntry(SRC_CHAIN_ID_1, 1, writerS));
+        verifyEntry(moduleA, getMockEntry(SRC_CHAIN_ID_1, 11, writerS));
         // Verify some entries with module B
         // writerF: {1: 0}, {1: 10}
-        verifyEntry(moduleB, getMockEntry(SRC_CHAIN_ID_1, writerF, 0));
-        verifyEntry(moduleB, getMockEntry(SRC_CHAIN_ID_1, writerF, 10));
-        // writerS: {0: 0}, {0: 10}, {1: 0}
-        verifyEntry(moduleB, getMockEntry(SRC_CHAIN_ID_0, writerS, 0));
-        verifyEntry(moduleB, getMockEntry(SRC_CHAIN_ID_0, writerS, 10));
-        verifyEntry(moduleB, getMockEntry(SRC_CHAIN_ID_1, writerS, 0));
+        verifyEntry(moduleB, getMockEntry(SRC_CHAIN_ID_1, 0, writerF));
+        verifyEntry(moduleB, getMockEntry(SRC_CHAIN_ID_1, 10, writerF));
+        // writerS: {0: 1}, {0: 11}, {1: 1}
+        verifyEntry(moduleB, getMockEntry(SRC_CHAIN_ID_0, 1, writerS));
+        verifyEntry(moduleB, getMockEntry(SRC_CHAIN_ID_0, 11, writerS));
+        verifyEntry(moduleB, getMockEntry(SRC_CHAIN_ID_1, 1, writerS));
     }
 
     function verifyEntry(InterchainModuleMock module, InterchainEntry memory entry) internal {
@@ -54,43 +60,50 @@ contract InterchainDBDestinationTest is Test, InterchainDBEvents {
         module.mockVerifyEntry(address(icDB), entry);
     }
 
-    function introduceConflicts() public {
-        // Have module A verify a different entry for writerS {0:10} (already verified by module B)
-        verifyEntry(moduleA, getFakeEntry(SRC_CHAIN_ID_0, writerS, 10));
+    function introduceConflictsSameWriter() public {
+        // Have module A verify a different entry for writerS {0:11} (already verified by module B)
+        verifyEntry(moduleA, getFakeEntry(SRC_CHAIN_ID_0, 11, writerS));
         // Have module B verify a different entry for writerF {0:10} (already verified by module A)
-        verifyEntry(moduleB, getFakeEntry(SRC_CHAIN_ID_0, writerF, 10));
+        verifyEntry(moduleB, getFakeEntry(SRC_CHAIN_ID_0, 10, writerF));
+    }
+
+    function introduceConflictsDiffWriter() public {
+        // Have module A verify an entry for writerF {0: 11} (already verified by module B with writerS)
+        verifyEntry(moduleA, getFakeEntry(SRC_CHAIN_ID_0, 11, writerF));
+        // Have module B verify an entry for writerS {0: 10} (already verified by module A with writerF)
+        verifyEntry(moduleB, getFakeEntry(SRC_CHAIN_ID_0, 10, writerS));
     }
 
     function introduceEmptyEntries() public {
         // Have module A verify an empty entry for entries that module B has not verified
         // writerF {0:20}
-        verifyEntry(moduleA, getEmptyEntry(SRC_CHAIN_ID_0, writerF, 20));
+        verifyEntry(moduleA, getEmptyEntry(SRC_CHAIN_ID_0, 20, writerF));
         // writerS {1:5}
-        verifyEntry(moduleA, getEmptyEntry(SRC_CHAIN_ID_1, writerS, 5));
+        verifyEntry(moduleA, getEmptyEntry(SRC_CHAIN_ID_1, 5, writerS));
         // Have module A verify an empty entry for entries that module B has verified
         // writerF {1:0}
-        verifyEntry(moduleA, getEmptyEntry(SRC_CHAIN_ID_1, writerF, 0));
-        // writerS {0:0}
-        verifyEntry(moduleA, getEmptyEntry(SRC_CHAIN_ID_0, writerS, 0));
+        verifyEntry(moduleA, getEmptyEntry(SRC_CHAIN_ID_1, 0, writerF));
+        // writerS {0:1}
+        verifyEntry(moduleA, getEmptyEntry(SRC_CHAIN_ID_0, 1, writerS));
         // Have module B verify an empty entry for entries that module A has not verified
-        // writerF {0:5}
-        verifyEntry(moduleB, getEmptyEntry(SRC_CHAIN_ID_0, writerF, 5));
-        // writerS {1:20}
-        verifyEntry(moduleB, getEmptyEntry(SRC_CHAIN_ID_1, writerS, 20));
+        // writerF {0:30}
+        verifyEntry(moduleB, getEmptyEntry(SRC_CHAIN_ID_0, 30, writerF));
+        // writerS {1:21}
+        verifyEntry(moduleB, getEmptyEntry(SRC_CHAIN_ID_1, 21, writerS));
         // Have module B verify an empty entry for entries that module A has verified
         // writerF {0: 10}
-        verifyEntry(moduleB, getEmptyEntry(SRC_CHAIN_ID_0, writerF, 10));
-        // writerS {1: 10}
-        verifyEntry(moduleB, getEmptyEntry(SRC_CHAIN_ID_1, writerS, 10));
+        verifyEntry(moduleB, getEmptyEntry(SRC_CHAIN_ID_0, 10, writerF));
+        // writerS {1: 11}
+        verifyEntry(moduleB, getEmptyEntry(SRC_CHAIN_ID_1, 11, writerS));
     }
 
     function introduceEqualEmptyEntries() public {
         // writerF {0: 20}
-        verifyEntry(moduleA, getEmptyEntry(SRC_CHAIN_ID_0, writerF, 20));
-        verifyEntry(moduleB, getEmptyEntry(SRC_CHAIN_ID_0, writerF, 20));
+        verifyEntry(moduleA, getEmptyEntry(SRC_CHAIN_ID_0, 20, writerF));
+        verifyEntry(moduleB, getEmptyEntry(SRC_CHAIN_ID_0, 20, writerF));
         // writerS {1: 5}
-        verifyEntry(moduleB, getEmptyEntry(SRC_CHAIN_ID_1, writerS, 5));
-        verifyEntry(moduleA, getEmptyEntry(SRC_CHAIN_ID_1, writerS, 5));
+        verifyEntry(moduleB, getEmptyEntry(SRC_CHAIN_ID_1, 5, writerS));
+        verifyEntry(moduleA, getEmptyEntry(SRC_CHAIN_ID_1, 5, writerS));
     }
 
     // ══════════════════════════════════════════════ DATA GENERATION ══════════════════════════════════════════════════
@@ -101,8 +114,8 @@ contract InterchainDBDestinationTest is Test, InterchainDBEvents {
 
     function getMockEntry(
         uint256 srcChainId,
-        address writer,
-        uint256 nonce
+        uint256 dbNonce,
+        address writer
     )
         internal
         pure
@@ -110,9 +123,9 @@ contract InterchainDBDestinationTest is Test, InterchainDBEvents {
     {
         return InterchainEntry({
             srcChainId: srcChainId,
+            dbNonce: dbNonce,
             srcWriter: addressToBytes32(writer),
-            writerNonce: nonce,
-            dataHash: getMockDataHash(writer, nonce)
+            dataHash: getMockDataHash(writer, dbNonce)
         });
     }
 
@@ -122,8 +135,8 @@ contract InterchainDBDestinationTest is Test, InterchainDBEvents {
 
     function getFakeEntry(
         uint256 srcChainId,
-        address writer,
-        uint256 nonce
+        uint256 dbNonce,
+        address writer
     )
         internal
         pure
@@ -131,16 +144,16 @@ contract InterchainDBDestinationTest is Test, InterchainDBEvents {
     {
         return InterchainEntry({
             srcChainId: srcChainId,
+            dbNonce: dbNonce,
             srcWriter: addressToBytes32(writer),
-            writerNonce: nonce,
-            dataHash: getFakeDataHash(writer, nonce)
+            dataHash: getFakeDataHash(writer, dbNonce)
         });
     }
 
     function getEmptyEntry(
         uint256 srcChainId,
-        address writer,
-        uint256 nonce
+        uint256 dbNonce,
+        address writer
     )
         internal
         pure
@@ -148,8 +161,8 @@ contract InterchainDBDestinationTest is Test, InterchainDBEvents {
     {
         return InterchainEntry({
             srcChainId: srcChainId,
+            dbNonce: dbNonce,
             srcWriter: addressToBytes32(writer),
-            writerNonce: nonce,
             dataHash: 0
         });
     }
@@ -167,14 +180,14 @@ contract InterchainDBDestinationTest is Test, InterchainDBEvents {
     )
         internal
     {
+        assertGt(timestampToCheck, 0);
         assertEq(timestampToCheck, verifiedAt[module][keccak256(abi.encode(entry))]);
     }
 
     function expectConflictingEntries(InterchainEntry memory existingEntry, InterchainEntry memory newEntry) internal {
+        bytes32 entryValue = InterchainEntryLib.entryValue(existingEntry);
         vm.expectRevert(
-            abi.encodeWithSelector(
-                IInterchainDB.InterchainDB__ConflictingEntries.selector, existingEntry.dataHash, newEntry
-            )
+            abi.encodeWithSelector(IInterchainDB.InterchainDB__ConflictingEntries.selector, entryValue, newEntry)
         );
     }
 
@@ -186,48 +199,44 @@ contract InterchainDBDestinationTest is Test, InterchainDBEvents {
 
     function test_verifyEntry_new_emitsEvent() public {
         skip(1 days);
-        InterchainEntry memory entry = getMockEntry(SRC_CHAIN_ID_0, writerF, 20);
+        InterchainEntry memory entry = getMockEntry(SRC_CHAIN_ID_0, 20, writerF);
         vm.expectEmit(address(icDB));
-        emit InterchainEntryVerified(
-            address(moduleA), entry.srcChainId, entry.srcWriter, entry.writerNonce, entry.dataHash
-        );
+        emit InterchainEntryVerified(address(moduleA), entry.srcChainId, entry.dbNonce, entry.srcWriter, entry.dataHash);
         verifyEntry(moduleA, entry);
     }
 
     function test_verifyEntry_new_savesVerificationTime() public {
-        InterchainEntry memory entry = getMockEntry(SRC_CHAIN_ID_0, writerF, 20);
+        InterchainEntry memory entry = getMockEntry(SRC_CHAIN_ID_0, 20, writerF);
         verifyEntry(moduleA, entry);
         assertEq(icDB.readEntry(address(moduleA), entry), block.timestamp);
     }
 
     function test_verifyEntry_existing_diffModule_emitsEvent() public {
-        // writerS {0:0} was already verified by module B
-        InterchainEntry memory entry = getMockEntry(SRC_CHAIN_ID_0, writerS, 0);
+        // writerS {0:1} was already verified by module B
+        InterchainEntry memory entry = getMockEntry(SRC_CHAIN_ID_0, 1, writerS);
         vm.expectEmit(address(icDB));
-        emit InterchainEntryVerified(
-            address(moduleA), entry.srcChainId, entry.srcWriter, entry.writerNonce, entry.dataHash
-        );
+        emit InterchainEntryVerified(address(moduleA), entry.srcChainId, entry.dbNonce, entry.srcWriter, entry.dataHash);
         verifyEntry(moduleA, entry);
     }
 
     function test_verifyEntry_existing_diffModule_doesNotUpdateExistingVerificationTime() public {
-        // writerS {0:0} was already verified by module B
-        InterchainEntry memory entry = getMockEntry(SRC_CHAIN_ID_0, writerS, 0);
+        // writerS {0:1} was already verified by module B
+        InterchainEntry memory entry = getMockEntry(SRC_CHAIN_ID_0, 1, writerS);
         uint256 moduleBVerifiedAt = verifiedAt[address(moduleB)][keccak256(abi.encode(entry))];
         verifyEntry(moduleA, entry);
         assertEq(icDB.readEntry(address(moduleB), entry), moduleBVerifiedAt);
     }
 
     function test_verifyEntry_existing_diffModule_savesVerificationTime() public {
-        // writerS {0:0} was already verified by module B
-        InterchainEntry memory entry = getMockEntry(SRC_CHAIN_ID_0, writerS, 0);
+        // writerS {0:1} was already verified by module B
+        InterchainEntry memory entry = getMockEntry(SRC_CHAIN_ID_0, 1, writerS);
         verifyEntry(moduleA, entry);
         assertEq(icDB.readEntry(address(moduleA), entry), block.timestamp);
     }
 
     function test_verifyEntry_existing_sameModule_doesNotEmitEvent() public {
         // writerF {0:0} was already verified by module A
-        InterchainEntry memory entry = getMockEntry(SRC_CHAIN_ID_0, writerF, 0);
+        InterchainEntry memory entry = getMockEntry(SRC_CHAIN_ID_0, 0, writerF);
         vm.recordLogs();
         verifyEntry(moduleA, entry);
         assertEq(vm.getRecordedLogs().length, 0);
@@ -235,51 +244,56 @@ contract InterchainDBDestinationTest is Test, InterchainDBEvents {
 
     function test_verifyEntry_existing_sameModule_doesNotUpdateExistingVerificationTime() public {
         // writerF {0:0} was already verified by module A
-        InterchainEntry memory entry = getMockEntry(SRC_CHAIN_ID_0, writerF, 0);
+        InterchainEntry memory entry = getMockEntry(SRC_CHAIN_ID_0, 0, writerF);
         uint256 moduleAVerifiedAt = verifiedAt[address(moduleA)][keccak256(abi.encode(entry))];
         verifyEntry(moduleA, entry);
         assertEq(icDB.readEntry(address(moduleA), entry), moduleAVerifiedAt);
     }
 
     function test_verifyEntry_conflict_diffModule_emitsEvent() public {
-        // writerS {0:0} was already verified by module B
-        InterchainEntry memory entry = getFakeEntry(SRC_CHAIN_ID_0, writerS, 0);
+        // writerS {0:1} was already verified by module B
+        InterchainEntry memory entry = getFakeEntry(SRC_CHAIN_ID_0, 1, writerS);
         vm.expectEmit(address(icDB));
-        emit InterchainEntryVerified(
-            address(moduleA), entry.srcChainId, entry.srcWriter, entry.writerNonce, entry.dataHash
-        );
+        emit InterchainEntryVerified(address(moduleA), entry.srcChainId, entry.dbNonce, entry.srcWriter, entry.dataHash);
         verifyEntry(moduleA, entry);
     }
 
     function test_verifyEntry_conflict_diffModule_doesNotUpdateExistingVerificationTime() public {
-        // writerS {0:0} was already verified by module B
-        InterchainEntry memory entry = getFakeEntry(SRC_CHAIN_ID_0, writerS, 0);
-        InterchainEntry memory realEntry = getMockEntry(SRC_CHAIN_ID_0, writerS, 0);
-        uint256 moduleBVerifiedAt = verifiedAt[address(moduleB)][keccak256(abi.encode(realEntry))];
+        // writerS {0:1} was already verified by module B
+        InterchainEntry memory entry = getFakeEntry(SRC_CHAIN_ID_0, 1, writerS);
+        InterchainEntry memory realEntry = getMockEntry(SRC_CHAIN_ID_0, 1, writerS);
         verifyEntry(moduleA, entry);
-        assertEq(icDB.readEntry(address(moduleB), realEntry), moduleBVerifiedAt);
+        assertCorrectVerificationTime(realEntry, address(moduleB), icDB.readEntry(address(moduleB), realEntry));
     }
 
     function test_verifyEntry_conflict_diffModule_savesVerificationTime() public {
-        // writerS {0:0} was already verified by module B
-        InterchainEntry memory entry = getFakeEntry(SRC_CHAIN_ID_0, writerS, 0);
+        // writerS {0:1} was already verified by module B
+        InterchainEntry memory entry = getFakeEntry(SRC_CHAIN_ID_0, 1, writerS);
         verifyEntry(moduleA, entry);
         assertEq(icDB.readEntry(address(moduleA), entry), block.timestamp);
     }
 
     // ════════════════════════════════════ TESTS: VERIFYING ENTRIES (REVERTS) ═════════════════════════════════════════
 
-    function test_verifyEntry_revert_conflict_sameModule() public {
+    function test_verifyEntry_revert_conflict_sameModule_sameWriter() public {
         // writerF {0:0} was already verified by module A
-        InterchainEntry memory existingEntry = getMockEntry(SRC_CHAIN_ID_0, writerF, 0);
-        InterchainEntry memory conflictingEntry = getFakeEntry(SRC_CHAIN_ID_0, writerF, 0);
+        InterchainEntry memory existingEntry = getMockEntry(SRC_CHAIN_ID_0, 0, writerF);
+        InterchainEntry memory conflictingEntry = getFakeEntry(SRC_CHAIN_ID_0, 0, writerF);
+        expectConflictingEntries(existingEntry, conflictingEntry);
+        verifyEntry(moduleA, conflictingEntry);
+    }
+
+    function test_verifyEntry_revert_conflict_sameModule_diffWriter() public {
+        // writerF {0:0} was already verified by module A
+        InterchainEntry memory existingEntry = getMockEntry(SRC_CHAIN_ID_0, 0, writerF);
+        InterchainEntry memory conflictingEntry = getFakeEntry(SRC_CHAIN_ID_0, 0, writerS);
         expectConflictingEntries(existingEntry, conflictingEntry);
         verifyEntry(moduleA, conflictingEntry);
     }
 
     function test_verifyEntry_revert_sameChainId() public {
         // Try to verify entry coming from the same chain
-        InterchainEntry memory entry = getMockEntry(DST_CHAIN_ID, writerF, 0);
+        InterchainEntry memory entry = getMockEntry(DST_CHAIN_ID, 0, writerF);
         expectSameChainId();
         verifyEntry(moduleA, entry);
     }
@@ -288,34 +302,46 @@ contract InterchainDBDestinationTest is Test, InterchainDBEvents {
 
     function test_readEntry_existingA_existingB() public {
         // writerF {1: 10} was verified by module A and module B
-        InterchainEntry memory entryF = getMockEntry(SRC_CHAIN_ID_1, writerF, 10);
+        InterchainEntry memory entryF = getMockEntry(SRC_CHAIN_ID_1, 10, writerF);
         assertCorrectVerificationTime(entryF, address(moduleA), icDB.readEntry(address(moduleA), entryF));
         assertCorrectVerificationTime(entryF, address(moduleB), icDB.readEntry(address(moduleB), entryF));
-        // writerS {1: 0} was verified by module A and module B
-        InterchainEntry memory entryS = getMockEntry(SRC_CHAIN_ID_1, writerS, 0);
+        // writerS {1: 1} was verified by module A and module B
+        InterchainEntry memory entryS = getMockEntry(SRC_CHAIN_ID_1, 1, writerS);
         assertCorrectVerificationTime(entryS, address(moduleA), icDB.readEntry(address(moduleA), entryS));
         assertCorrectVerificationTime(entryS, address(moduleB), icDB.readEntry(address(moduleB), entryS));
     }
 
     function test_readEntry_existingA_unknownB() public {
         // writerF {0: 0} was verified by module A, but not by module B
-        InterchainEntry memory entryF = getMockEntry(SRC_CHAIN_ID_0, writerF, 10);
+        InterchainEntry memory entryF = getMockEntry(SRC_CHAIN_ID_0, 0, writerF);
         assertCorrectVerificationTime(entryF, address(moduleA), icDB.readEntry(address(moduleA), entryF));
         assertEq(icDB.readEntry(address(moduleB), entryF), 0);
-        // writerS {1: 10} was verified by module A, but not by module B
-        InterchainEntry memory entryS = getMockEntry(SRC_CHAIN_ID_1, writerS, 10);
+        // writerS {1: 11} was verified by module A, but not by module B
+        InterchainEntry memory entryS = getMockEntry(SRC_CHAIN_ID_1, 11, writerS);
         assertCorrectVerificationTime(entryS, address(moduleA), icDB.readEntry(address(moduleA), entryS));
         assertEq(icDB.readEntry(address(moduleB), entryS), 0);
     }
 
-    function test_readEntry_existingA_differentB() public {
-        introduceConflicts();
+    function test_readEntry_existingA_differentB_sameWriter() public {
+        introduceConflictsSameWriter();
         // writerF {0: 10} was verified by module A, but a "fake" entry was verified by module B
-        InterchainEntry memory entryF = getMockEntry(SRC_CHAIN_ID_0, writerF, 10);
+        InterchainEntry memory entryF = getMockEntry(SRC_CHAIN_ID_0, 10, writerF);
         assertCorrectVerificationTime(entryF, address(moduleA), icDB.readEntry(address(moduleA), entryF));
         assertEq(icDB.readEntry(address(moduleB), entryF), 0);
-        // writerS {0: 10} was verified by module B, but a "fake" entry was verified by module A
-        InterchainEntry memory fakeEntryS = getFakeEntry(SRC_CHAIN_ID_0, writerS, 10);
+        // writerS {0: 11} was verified by module B, but a "fake" entry was verified by module A
+        InterchainEntry memory fakeEntryS = getFakeEntry(SRC_CHAIN_ID_0, 11, writerS);
+        assertCorrectVerificationTime(fakeEntryS, address(moduleA), icDB.readEntry(address(moduleA), fakeEntryS));
+        assertEq(icDB.readEntry(address(moduleB), fakeEntryS), 0);
+    }
+
+    function test_readEntry_existingA_differentB_diffWriter() public {
+        introduceConflictsDiffWriter();
+        // writerF {0: 10} was verified by module A, but a "fake" entry was verified by module B
+        InterchainEntry memory entryF = getMockEntry(SRC_CHAIN_ID_0, 10, writerF);
+        assertCorrectVerificationTime(entryF, address(moduleA), icDB.readEntry(address(moduleA), entryF));
+        assertEq(icDB.readEntry(address(moduleB), entryF), 0);
+        // writerS {0: 11} was verified by module B, but a "fake" entry was verified by module A
+        InterchainEntry memory fakeEntryS = getFakeEntry(SRC_CHAIN_ID_0, 11, writerF);
         assertCorrectVerificationTime(fakeEntryS, address(moduleA), icDB.readEntry(address(moduleA), fakeEntryS));
         assertEq(icDB.readEntry(address(moduleB), fakeEntryS), 0);
     }
@@ -323,33 +349,33 @@ contract InterchainDBDestinationTest is Test, InterchainDBEvents {
     function test_readEntry_existingA_emptyB() public {
         introduceEmptyEntries();
         // writerF {0: 10} was verified by module A, but an "empty" entry was verified by module B
-        InterchainEntry memory entryF = getMockEntry(SRC_CHAIN_ID_0, writerF, 10);
+        InterchainEntry memory entryF = getMockEntry(SRC_CHAIN_ID_0, 10, writerF);
         assertCorrectVerificationTime(entryF, address(moduleA), icDB.readEntry(address(moduleA), entryF));
         assertEq(icDB.readEntry(address(moduleB), entryF), 0);
-        // writerS {1: 10} was verified by module A, but an "empty" entry was verified by module B
-        InterchainEntry memory entryS = getMockEntry(SRC_CHAIN_ID_1, writerS, 10);
+        // writerS {1: 11} was verified by module A, but an "empty" entry was verified by module B
+        InterchainEntry memory entryS = getMockEntry(SRC_CHAIN_ID_1, 11, writerS);
         assertCorrectVerificationTime(entryS, address(moduleA), icDB.readEntry(address(moduleA), entryS));
         assertEq(icDB.readEntry(address(moduleB), entryS), 0);
     }
 
     function test_readEntry_unknownA_existingB() public {
         // writerF {1: 0} was verified by module B, but not by module A
-        InterchainEntry memory entryF = getMockEntry(SRC_CHAIN_ID_1, writerF, 0);
+        InterchainEntry memory entryF = getMockEntry(SRC_CHAIN_ID_1, 0, writerF);
         assertEq(icDB.readEntry(address(moduleA), entryF), 0);
         assertCorrectVerificationTime(entryF, address(moduleB), icDB.readEntry(address(moduleB), entryF));
-        // writerS {0: 0} was verified by module B, but not by module A
-        InterchainEntry memory entryS = getMockEntry(SRC_CHAIN_ID_0, writerS, 0);
+        // writerS {0: 1} was verified by module B, but not by module A
+        InterchainEntry memory entryS = getMockEntry(SRC_CHAIN_ID_0, 1, writerS);
         assertEq(icDB.readEntry(address(moduleA), entryS), 0);
         assertCorrectVerificationTime(entryS, address(moduleB), icDB.readEntry(address(moduleB), entryS));
     }
 
     function test_readEntry_unknownA_unknownB() public {
         // writerF {0: 20} was not verified by any module
-        InterchainEntry memory entryF = getMockEntry(SRC_CHAIN_ID_0, writerF, 20);
+        InterchainEntry memory entryF = getMockEntry(SRC_CHAIN_ID_0, 20, writerF);
         assertEq(icDB.readEntry(address(moduleA), entryF), 0);
         assertEq(icDB.readEntry(address(moduleB), entryF), 0);
         // writerS {1: 5} was not verified by any module
-        InterchainEntry memory entryS = getMockEntry(SRC_CHAIN_ID_1, writerS, 5);
+        InterchainEntry memory entryS = getMockEntry(SRC_CHAIN_ID_1, 5, writerS);
         assertEq(icDB.readEntry(address(moduleA), entryS), 0);
         assertEq(icDB.readEntry(address(moduleB), entryS), 0);
     }
@@ -357,38 +383,52 @@ contract InterchainDBDestinationTest is Test, InterchainDBEvents {
     function test_readEntry_unknownA_differentB() public {
         // writerF {1: 0} was verified by module B, but not by module A
         // Check the fake entry that neither module verified
-        InterchainEntry memory fakeEntryF = getFakeEntry(SRC_CHAIN_ID_1, writerF, 0);
+        InterchainEntry memory fakeEntryF = getFakeEntry(SRC_CHAIN_ID_1, 0, writerF);
         assertEq(icDB.readEntry(address(moduleA), fakeEntryF), 0);
         assertEq(icDB.readEntry(address(moduleB), fakeEntryF), 0);
-        // writerS {0: 10} was verified by module B, but not by module A
+        // writerS {0: 11} was verified by module B, but not by module A
         // Check the fake entry that neither module verified
-        InterchainEntry memory fakeEntryS = getFakeEntry(SRC_CHAIN_ID_0, writerS, 10);
+        InterchainEntry memory fakeEntryS = getFakeEntry(SRC_CHAIN_ID_0, 11, writerS);
         assertEq(icDB.readEntry(address(moduleA), fakeEntryS), 0);
         assertEq(icDB.readEntry(address(moduleB), fakeEntryS), 0);
     }
 
     function test_readEntry_unknownA_emptyB() public {
         introduceEmptyEntries();
-        // writerF {0: 5} was not verified by module A, but an "empty" entry was verified by module B
-        InterchainEntry memory emptyEntryF = getEmptyEntry(SRC_CHAIN_ID_0, writerF, 5);
+        // writerF {0: 30} was not verified by module A, but an "empty" entry was verified by module B
+        InterchainEntry memory emptyEntryF = getEmptyEntry(SRC_CHAIN_ID_0, 30, writerF);
         assertEq(icDB.readEntry(address(moduleA), emptyEntryF), 0);
         assertCorrectVerificationTime(emptyEntryF, address(moduleB), icDB.readEntry(address(moduleB), emptyEntryF));
-        // writerS {1: 20} was not verified by module A, but an "empty" entry was verified by module B
-        InterchainEntry memory emptyEntryS = getEmptyEntry(SRC_CHAIN_ID_1, writerS, 20);
+        // writerS {1: 21} was not verified by module A, but an "empty" entry was verified by module B
+        InterchainEntry memory emptyEntryS = getEmptyEntry(SRC_CHAIN_ID_1, 21, writerS);
         assertEq(icDB.readEntry(address(moduleA), emptyEntryS), 0);
         assertCorrectVerificationTime(emptyEntryS, address(moduleB), icDB.readEntry(address(moduleB), emptyEntryS));
     }
 
-    function test_readEntry_differentA_existingB() public {
-        introduceConflicts();
+    function test_readEntry_differentA_existingB_sameWriter() public {
+        introduceConflictsSameWriter();
         // writerF {0: 10} was verified by module A, but a "fake" entry was verified by module B
         // Check the fake entry that A never verified
-        InterchainEntry memory fakeEntryF = getFakeEntry(SRC_CHAIN_ID_0, writerF, 10);
+        InterchainEntry memory fakeEntryF = getFakeEntry(SRC_CHAIN_ID_0, 10, writerF);
         assertEq(icDB.readEntry(address(moduleA), fakeEntryF), 0);
         assertCorrectVerificationTime(fakeEntryF, address(moduleB), icDB.readEntry(address(moduleB), fakeEntryF));
-        // writerS {0: 10} was verified by module B, but a "fake" entry was verified by module A
+        // writerS {0: 11} was verified by module B, but a "fake" entry was verified by module A
         // Check the real entry that A never verified
-        InterchainEntry memory entryS = getMockEntry(SRC_CHAIN_ID_0, writerS, 10);
+        InterchainEntry memory entryS = getMockEntry(SRC_CHAIN_ID_0, 11, writerS);
+        assertEq(icDB.readEntry(address(moduleA), entryS), 0);
+        assertCorrectVerificationTime(entryS, address(moduleB), icDB.readEntry(address(moduleB), entryS));
+    }
+
+    function test_readEntry_differentA_existingB_diffWriter() public {
+        introduceConflictsDiffWriter();
+        // writerF {0: 10} was verified by module A, but a "fake" entry was verified by module B (with writerS)
+        // Check the fake entry that A never verified
+        InterchainEntry memory fakeEntryF = getFakeEntry(SRC_CHAIN_ID_0, 10, writerS);
+        assertEq(icDB.readEntry(address(moduleA), fakeEntryF), 0);
+        assertCorrectVerificationTime(fakeEntryF, address(moduleB), icDB.readEntry(address(moduleB), fakeEntryF));
+        // writerS {0: 11} was verified by module B, but a "fake" entry was verified by module A (with writerF)
+        // Check the real entry that A never verified
+        InterchainEntry memory entryS = getMockEntry(SRC_CHAIN_ID_0, 11, writerS);
         assertEq(icDB.readEntry(address(moduleA), entryS), 0);
         assertCorrectVerificationTime(entryS, address(moduleB), icDB.readEntry(address(moduleB), entryS));
     }
@@ -396,12 +436,12 @@ contract InterchainDBDestinationTest is Test, InterchainDBEvents {
     function test_readEntry_differentA_unknownB() public {
         // writerF {0: 10} was verified by module A, but not by module B
         // Check the fake entry that neither module verified
-        InterchainEntry memory fakeEntryF = getFakeEntry(SRC_CHAIN_ID_0, writerF, 10);
+        InterchainEntry memory fakeEntryF = getFakeEntry(SRC_CHAIN_ID_0, 10, writerF);
         assertEq(icDB.readEntry(address(moduleA), fakeEntryF), 0);
         assertEq(icDB.readEntry(address(moduleB), fakeEntryF), 0);
-        // writerS {1: 10} was verified by module A, but not by module B
+        // writerS {1: 11} was verified by module A, but not by module B
         // Check the fake entry that neither module verified
-        InterchainEntry memory fakeEntryS = getFakeEntry(SRC_CHAIN_ID_1, writerS, 10);
+        InterchainEntry memory fakeEntryS = getFakeEntry(SRC_CHAIN_ID_1, 11, writerS);
         assertEq(icDB.readEntry(address(moduleA), fakeEntryS), 0);
         assertEq(icDB.readEntry(address(moduleB), fakeEntryS), 0);
     }
@@ -409,12 +449,12 @@ contract InterchainDBDestinationTest is Test, InterchainDBEvents {
     function test_readEntry_differentA_differentB() public {
         // writerF {1: 10} was verified by module A and module B
         // Check the fake entry that neither module verified
-        InterchainEntry memory fakeEntryF = getFakeEntry(SRC_CHAIN_ID_1, writerF, 10);
+        InterchainEntry memory fakeEntryF = getFakeEntry(SRC_CHAIN_ID_1, 10, writerF);
         assertEq(icDB.readEntry(address(moduleA), fakeEntryF), 0);
         assertEq(icDB.readEntry(address(moduleB), fakeEntryF), 0);
-        // writerS {1: 0} was verified by module A and module B
+        // writerS {1: 1} was verified by module A and module B
         // Check the fake entry that neither module verified
-        InterchainEntry memory fakeEntryS = getFakeEntry(SRC_CHAIN_ID_1, writerS, 0);
+        InterchainEntry memory fakeEntryS = getFakeEntry(SRC_CHAIN_ID_1, 1, writerS);
         assertEq(icDB.readEntry(address(moduleA), fakeEntryS), 0);
         assertEq(icDB.readEntry(address(moduleB), fakeEntryS), 0);
     }
@@ -422,11 +462,11 @@ contract InterchainDBDestinationTest is Test, InterchainDBEvents {
     function test_readEntry_differentA_emptyB() public {
         introduceEmptyEntries();
         // writerF {0: 10} was verified by module A, but an "empty" entry was verified by module B
-        InterchainEntry memory emptyEntryF = getEmptyEntry(SRC_CHAIN_ID_0, writerF, 10);
+        InterchainEntry memory emptyEntryF = getEmptyEntry(SRC_CHAIN_ID_0, 10, writerF);
         assertEq(icDB.readEntry(address(moduleA), emptyEntryF), 0);
         assertCorrectVerificationTime(emptyEntryF, address(moduleB), icDB.readEntry(address(moduleB), emptyEntryF));
-        // writerS {1: 10} was verified by module A, but an "empty" entry was verified by module B
-        InterchainEntry memory emptyEntryS = getEmptyEntry(SRC_CHAIN_ID_1, writerS, 10);
+        // writerS {1: 11} was verified by module A, but an "empty" entry was verified by module B
+        InterchainEntry memory emptyEntryS = getEmptyEntry(SRC_CHAIN_ID_1, 11, writerS);
         assertEq(icDB.readEntry(address(moduleA), emptyEntryS), 0);
         assertCorrectVerificationTime(emptyEntryS, address(moduleB), icDB.readEntry(address(moduleB), emptyEntryS));
     }
@@ -434,11 +474,11 @@ contract InterchainDBDestinationTest is Test, InterchainDBEvents {
     function test_readEntry_emptyA_existingB() public {
         introduceEmptyEntries();
         // writerF {1: 0} was verified by module B, but an "empty" entry was verified by module A
-        InterchainEntry memory entryF = getMockEntry(SRC_CHAIN_ID_1, writerF, 0);
+        InterchainEntry memory entryF = getMockEntry(SRC_CHAIN_ID_1, 0, writerF);
         assertEq(icDB.readEntry(address(moduleA), entryF), 0);
         assertCorrectVerificationTime(entryF, address(moduleB), icDB.readEntry(address(moduleB), entryF));
-        // writerS {0: 0} was verified by module B, but an "empty" entry was verified by module A
-        InterchainEntry memory entryS = getMockEntry(SRC_CHAIN_ID_0, writerS, 0);
+        // writerS {0: 1} was verified by module B, but an "empty" entry was verified by module A
+        InterchainEntry memory entryS = getMockEntry(SRC_CHAIN_ID_0, 1, writerS);
         assertEq(icDB.readEntry(address(moduleA), entryS), 0);
         assertCorrectVerificationTime(entryS, address(moduleB), icDB.readEntry(address(moduleB), entryS));
     }
@@ -446,11 +486,11 @@ contract InterchainDBDestinationTest is Test, InterchainDBEvents {
     function test_readEntry_emptyA_unknownB() public {
         introduceEmptyEntries();
         // writerF {0: 20} was verified as "empty" by module A, but not by module B
-        InterchainEntry memory emptyEntryF = getEmptyEntry(SRC_CHAIN_ID_0, writerF, 20);
+        InterchainEntry memory emptyEntryF = getEmptyEntry(SRC_CHAIN_ID_0, 20, writerF);
         assertCorrectVerificationTime(emptyEntryF, address(moduleA), icDB.readEntry(address(moduleA), emptyEntryF));
         assertEq(icDB.readEntry(address(moduleB), emptyEntryF), 0);
         // writerS {1: 5} was verified as "empty" by module A, but not by module B
-        InterchainEntry memory emptyEntryS = getEmptyEntry(SRC_CHAIN_ID_1, writerS, 5);
+        InterchainEntry memory emptyEntryS = getEmptyEntry(SRC_CHAIN_ID_1, 5, writerS);
         assertCorrectVerificationTime(emptyEntryS, address(moduleA), icDB.readEntry(address(moduleA), emptyEntryS));
         assertEq(icDB.readEntry(address(moduleB), emptyEntryS), 0);
     }
@@ -458,11 +498,11 @@ contract InterchainDBDestinationTest is Test, InterchainDBEvents {
     function test_readEntry_emptyA_differentB() public {
         introduceEmptyEntries();
         // writerF {1: 0} was verified by module B, but an "empty" entry was verified by module A
-        InterchainEntry memory emptyEntryF = getEmptyEntry(SRC_CHAIN_ID_1, writerF, 0);
+        InterchainEntry memory emptyEntryF = getEmptyEntry(SRC_CHAIN_ID_1, 0, writerF);
         assertCorrectVerificationTime(emptyEntryF, address(moduleA), icDB.readEntry(address(moduleA), emptyEntryF));
         assertEq(icDB.readEntry(address(moduleB), emptyEntryF), 0);
-        // writerS {0: 0} was verified by module B, but an "empty" entry was verified by module A
-        InterchainEntry memory emptyEntryS = getEmptyEntry(SRC_CHAIN_ID_0, writerS, 0);
+        // writerS {0: 1} was verified by module B, but an "empty" entry was verified by module A
+        InterchainEntry memory emptyEntryS = getEmptyEntry(SRC_CHAIN_ID_0, 1, writerS);
         assertCorrectVerificationTime(emptyEntryS, address(moduleA), icDB.readEntry(address(moduleA), emptyEntryS));
         assertEq(icDB.readEntry(address(moduleB), emptyEntryS), 0);
     }
@@ -470,11 +510,11 @@ contract InterchainDBDestinationTest is Test, InterchainDBEvents {
     function test_readEntry_emptyA_emptyB() public {
         introduceEqualEmptyEntries();
         // writerF {0: 20} was verified as "empty" by module A and module B
-        InterchainEntry memory emptyEntryF = getEmptyEntry(SRC_CHAIN_ID_0, writerF, 20);
+        InterchainEntry memory emptyEntryF = getEmptyEntry(SRC_CHAIN_ID_0, 20, writerF);
         assertCorrectVerificationTime(emptyEntryF, address(moduleA), icDB.readEntry(address(moduleA), emptyEntryF));
         assertCorrectVerificationTime(emptyEntryF, address(moduleB), icDB.readEntry(address(moduleB), emptyEntryF));
         // writerS {1: 5} was verified as "empty" by module A and module B
-        InterchainEntry memory emptyEntryS = getEmptyEntry(SRC_CHAIN_ID_1, writerS, 5);
+        InterchainEntry memory emptyEntryS = getEmptyEntry(SRC_CHAIN_ID_1, 5, writerS);
         assertCorrectVerificationTime(emptyEntryS, address(moduleA), icDB.readEntry(address(moduleA), emptyEntryS));
         assertCorrectVerificationTime(emptyEntryS, address(moduleB), icDB.readEntry(address(moduleB), emptyEntryS));
     }
@@ -482,7 +522,7 @@ contract InterchainDBDestinationTest is Test, InterchainDBEvents {
     // ═════════════════════════════════════ TESTS: READING ENTRIES (REVERTS) ══════════════════════════════════════════
 
     function test_readEntry_revert_sameChainId() public {
-        InterchainEntry memory entry = getMockEntry(DST_CHAIN_ID, writerF, 0);
+        InterchainEntry memory entry = getMockEntry(DST_CHAIN_ID, 0, writerF);
         expectSameChainId();
         icDB.readEntry(address(moduleA), entry);
     }

--- a/packages/contracts-communication/test/InterchainDB.Src.t.sol
+++ b/packages/contracts-communication/test/InterchainDB.Src.t.sol
@@ -13,8 +13,9 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
     uint256 public constant SRC_CHAIN_ID = 1337;
     uint256 public constant DST_CHAIN_ID = 7331;
 
-    uint256 public constant INITIAL_WRITER_F_NONCE = 1;
-    uint256 public constant INITIAL_WRITER_S_NONCE = 2;
+    uint256 public constant INITIAL_WRITER_F = 1;
+    uint256 public constant INITIAL_WRITER_S = 2;
+    uint256 public constant INITIAL_DB_NONCE = INITIAL_WRITER_F + INITIAL_WRITER_S;
 
     uint256 public constant MODULE_A_FEE = 100;
     uint256 public constant MODULE_B_FEE = 200;
@@ -22,6 +23,8 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
     InterchainDB public icDB;
     InterchainModuleMock public moduleA;
     InterchainModuleMock public moduleB;
+
+    InterchainEntry[] public initialEntries;
 
     address[] public oneModule;
     address[] public twoModules;
@@ -39,28 +42,39 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
         oneModule.push(address(moduleA));
         twoModules.push(address(moduleA));
         twoModules.push(address(moduleB));
-        setupWriterNonce(writerF, INITIAL_WRITER_F_NONCE);
-        setupWriterNonce(writerS, INITIAL_WRITER_S_NONCE);
+        initialWrites();
         mockModuleFee(moduleA, MODULE_A_FEE);
         mockModuleFee(moduleB, MODULE_B_FEE);
     }
 
-    function setupWriterNonce(address writer, uint256 nonce) internal {
-        for (uint256 i = 0; i < nonce; i++) {
-            writeEntry(writer, getMockDataHash(writer, i));
+    function initialWrites() internal {
+        for (uint256 i = 0; i < INITIAL_WRITER_F; ++i) {
+            InterchainEntry memory entry = getMockEntry(i, writerF);
+            writeEntry(writerF, entry.dataHash);
+            initialEntries.push(entry);
         }
+        for (uint256 i = 0; i < INITIAL_WRITER_S; ++i) {
+            InterchainEntry memory entry = getMockEntry(INITIAL_WRITER_F + i, writerS);
+            writeEntry(writerS, entry.dataHash);
+            initialEntries.push(entry);
+        }
+    }
+
+    function getInitialEntry(uint256 dbNonce) internal view returns (InterchainEntry memory) {
+        require(dbNonce < initialEntries.length, "dbNonce out of range");
+        return initialEntries[dbNonce];
     }
 
     function getMockDataHash(address writer, uint256 nonce) internal pure returns (bytes32) {
         return keccak256(abi.encode(writer, nonce));
     }
 
-    function getMockEntry(address writer, uint256 nonce) internal pure returns (InterchainEntry memory entry) {
+    function getMockEntry(uint256 dbNonce, address writer) internal pure returns (InterchainEntry memory entry) {
         return InterchainEntry({
             srcChainId: SRC_CHAIN_ID,
+            dbNonce: dbNonce,
             srcWriter: addressToBytes32(writer),
-            writerNonce: nonce,
-            dataHash: getMockDataHash(writer, nonce)
+            dataHash: getMockDataHash(writer, dbNonce)
         });
     }
 
@@ -79,23 +93,22 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
         vm.mockCall(address(module), callData, returnData);
     }
 
-    function writeEntry(address writer, bytes32 dataHash) internal returns (uint256 writerNonce) {
+    function writeEntry(address writer, bytes32 dataHash) internal returns (uint256 dbNonce) {
         vm.prank(writer);
-        writerNonce = icDB.writeEntry(dataHash);
+        dbNonce = icDB.writeEntry(dataHash);
     }
 
     function requestVerification(
         address caller,
         uint256 msgValue,
-        address writer,
-        uint256 writerNonce,
+        uint256 dbNonce,
         address[] memory modules
     )
         internal
     {
         deal(caller, msgValue);
         vm.prank(caller);
-        icDB.requestVerification{value: msgValue}(DST_CHAIN_ID, writer, writerNonce, modules);
+        icDB.requestVerification{value: msgValue}(DST_CHAIN_ID, dbNonce, modules);
     }
 
     function writeEntryWithVerification(
@@ -105,26 +118,24 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
         address[] memory modules
     )
         internal
-        returns (uint256 writerNonce)
+        returns (uint256 dbNonce)
     {
         deal(writer, msgValue);
         vm.prank(writer);
-        writerNonce = icDB.writeEntryWithVerification{value: msgValue}(DST_CHAIN_ID, dataHash, modules);
+        dbNonce = icDB.writeEntryWithVerification{value: msgValue}(DST_CHAIN_ID, dataHash, modules);
     }
 
     // ═══════════════════════════════════════════════ TEST HELPERS ════════════════════════════════════════════════════
 
     function assertEq(InterchainEntry memory entry, InterchainEntry memory expected) internal {
         assertEq(entry.srcChainId, expected.srcChainId, "!srcChainId");
+        assertEq(entry.dbNonce, expected.dbNonce, "!dbNonce");
         assertEq(entry.srcWriter, expected.srcWriter, "!srcWriter");
-        assertEq(entry.writerNonce, expected.writerNonce, "!writerNonce");
         assertEq(entry.dataHash, expected.dataHash, "!dataHash");
     }
 
-    function expectEntryDoesNotExist(address writer, uint256 writerNonce) internal {
-        vm.expectRevert(
-            abi.encodeWithSelector(IInterchainDB.InterchainDB__EntryDoesNotExist.selector, writer, writerNonce)
-        );
+    function expectEntryDoesNotExist(uint256 dbNonce) internal {
+        vm.expectRevert(abi.encodeWithSelector(IInterchainDB.InterchainDB__EntryDoesNotExist.selector, dbNonce));
     }
 
     function expectIncorrectFeeAmount(uint256 actualFee, uint256 expectedFee) internal {
@@ -143,391 +154,371 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
 
     // ═══════════════════════════════════════════════ TESTS: SET UP ═══════════════════════════════════════════════════
 
-    function test_setup_getWriterNonce() public {
-        assertEq(icDB.getWriterNonce(writerF), INITIAL_WRITER_F_NONCE);
-        assertEq(icDB.getWriterNonce(writerS), INITIAL_WRITER_S_NONCE);
+    function test_setup_getDBNonce() public {
+        assertEq(icDB.getDBNonce(), INITIAL_DB_NONCE);
     }
 
     function test_setup_getEntry() public {
-        for (uint256 i = 0; i < INITIAL_WRITER_F_NONCE; i++) {
-            assertEq(icDB.getEntry(writerF, i), getMockEntry(writerF, i));
-        }
-        for (uint256 i = 0; i < INITIAL_WRITER_S_NONCE; i++) {
-            assertEq(icDB.getEntry(writerS, i), getMockEntry(writerS, i));
+        for (uint256 i = 0; i < INITIAL_DB_NONCE; ++i) {
+            assertEq(icDB.getEntry(i), getInitialEntry(i));
         }
     }
 
     // ══════════════════════════════════════════ TESTS: WRITING AN ENTRY ══════════════════════════════════════════════
 
     function test_writeEntry_writerF_emitsEvent() public {
-        bytes32 dataHash = getMockDataHash(writerF, INITIAL_WRITER_F_NONCE);
+        bytes32 dataHash = getMockDataHash(writerF, INITIAL_DB_NONCE);
         vm.expectEmit(address(icDB));
-        emit InterchainEntryWritten(SRC_CHAIN_ID, addressToBytes32(writerF), INITIAL_WRITER_F_NONCE, dataHash);
+        emit InterchainEntryWritten(SRC_CHAIN_ID, INITIAL_DB_NONCE, addressToBytes32(writerF), dataHash);
         writeEntry(writerF, dataHash);
     }
 
-    function test_writeEntry_writerF_increasesWriterNonce() public {
-        bytes32 dataHash = getMockDataHash(writerF, INITIAL_WRITER_F_NONCE);
+    function test_writeEntry_writerF_increasesDBNonce() public {
+        bytes32 dataHash = getMockDataHash(writerF, INITIAL_DB_NONCE);
         writeEntry(writerF, dataHash);
-        assertEq(icDB.getWriterNonce(writerF), INITIAL_WRITER_F_NONCE + 1);
+        assertEq(icDB.getDBNonce(), INITIAL_DB_NONCE + 1);
     }
 
     function test_writeEntry_writerF_returnsCorrectNonce() public {
-        bytes32 dataHash = getMockDataHash(writerF, INITIAL_WRITER_F_NONCE);
+        bytes32 dataHash = getMockDataHash(writerF, INITIAL_DB_NONCE);
         uint256 nonce = writeEntry(writerF, dataHash);
-        assertEq(nonce, INITIAL_WRITER_F_NONCE);
+        assertEq(nonce, INITIAL_DB_NONCE);
     }
 
     function test_writeEntry_writerF_savesEntry() public {
-        bytes32 dataHash = getMockDataHash(writerF, INITIAL_WRITER_F_NONCE);
-        writeEntry(writerF, dataHash);
-        assertEq(icDB.getEntry(writerF, INITIAL_WRITER_F_NONCE), getMockEntry(writerF, INITIAL_WRITER_F_NONCE));
+        InterchainEntry memory entry = getMockEntry(INITIAL_DB_NONCE, writerF);
+        writeEntry(writerF, entry.dataHash);
+        assertEq(icDB.getEntry(INITIAL_DB_NONCE), entry);
     }
 
     function test_writeEntry_writerS_emitsEvent() public {
-        bytes32 dataHash = getMockDataHash(writerS, INITIAL_WRITER_S_NONCE);
+        bytes32 dataHash = getMockDataHash(writerS, INITIAL_DB_NONCE);
         vm.expectEmit(address(icDB));
-        emit InterchainEntryWritten(SRC_CHAIN_ID, addressToBytes32(writerS), INITIAL_WRITER_S_NONCE, dataHash);
+        emit InterchainEntryWritten(SRC_CHAIN_ID, INITIAL_DB_NONCE, addressToBytes32(writerS), dataHash);
         writeEntry(writerS, dataHash);
     }
 
-    function test_writeEntry_writerS_increasesWriterNonce() public {
-        bytes32 dataHash = getMockDataHash(writerS, INITIAL_WRITER_S_NONCE);
+    function test_writeEntry_writerS_increasesDBNonce() public {
+        bytes32 dataHash = getMockDataHash(writerS, INITIAL_DB_NONCE);
         writeEntry(writerS, dataHash);
-        assertEq(icDB.getWriterNonce(writerS), INITIAL_WRITER_S_NONCE + 1);
+        assertEq(icDB.getDBNonce(), INITIAL_DB_NONCE + 1);
     }
 
     function test_writeEntry_writerS_returnsCorrectNonce() public {
-        bytes32 dataHash = getMockDataHash(writerS, INITIAL_WRITER_S_NONCE);
+        bytes32 dataHash = getMockDataHash(writerS, INITIAL_DB_NONCE);
         uint256 nonce = writeEntry(writerS, dataHash);
-        assertEq(nonce, INITIAL_WRITER_S_NONCE);
+        assertEq(nonce, INITIAL_DB_NONCE);
     }
 
     function test_writeEntry_writerS_savesEntry() public {
-        bytes32 dataHash = getMockDataHash(writerS, INITIAL_WRITER_S_NONCE);
-        writeEntry(writerS, dataHash);
-        assertEq(icDB.getEntry(writerS, INITIAL_WRITER_S_NONCE), getMockEntry(writerS, INITIAL_WRITER_S_NONCE));
+        InterchainEntry memory entry = getMockEntry(INITIAL_DB_NONCE, writerS);
+        writeEntry(writerS, entry.dataHash);
+        assertEq(icDB.getEntry(INITIAL_DB_NONCE), entry);
     }
 
     // ═══════════════════════════════════════ TESTS: REQUESTING VALIDATION ════════════════════════════════════════════
 
     function test_requestVerification_writerF_oneModule_emitsEvent() public {
-        uint256 writerNonce = 0;
+        uint256 dbNonce = 0;
         vm.expectEmit(address(icDB));
-        emit InterchainVerificationRequested(DST_CHAIN_ID, addressToBytes32(writerF), writerNonce, oneModule);
-        requestVerification(requestCaller, MODULE_A_FEE, writerF, writerNonce, oneModule);
+        emit InterchainVerificationRequested(DST_CHAIN_ID, dbNonce, oneModule);
+        requestVerification(requestCaller, MODULE_A_FEE, dbNonce, oneModule);
     }
 
     function test_requestVerification_writerF_oneModule_callsModule() public {
-        uint256 writerNonce = 0;
-        InterchainEntry memory entry = getMockEntry(writerF, writerNonce);
+        uint256 dbNonce = 0;
+        InterchainEntry memory entry = getInitialEntry(dbNonce);
         // expectCall(address callee, uint256 msgValue, bytes calldata data)
         vm.expectCall(address(moduleA), MODULE_A_FEE, getModuleCalldata(entry));
-        requestVerification(requestCaller, MODULE_A_FEE, writerF, writerNonce, oneModule);
+        requestVerification(requestCaller, MODULE_A_FEE, dbNonce, oneModule);
     }
 
     function test_requestVerification_writerF_twoModules_emitsEvent() public {
-        uint256 writerNonce = 0;
+        uint256 dbNonce = 0;
         vm.expectEmit(address(icDB));
-        emit InterchainVerificationRequested(DST_CHAIN_ID, addressToBytes32(writerF), writerNonce, twoModules);
-        requestVerification(requestCaller, MODULE_A_FEE + MODULE_B_FEE, writerF, writerNonce, twoModules);
+        emit InterchainVerificationRequested(DST_CHAIN_ID, dbNonce, twoModules);
+        requestVerification(requestCaller, MODULE_A_FEE + MODULE_B_FEE, dbNonce, twoModules);
     }
 
     function test_requestVerification_writerF_twoModules_callsModules() public {
-        uint256 writerNonce = 0;
-        InterchainEntry memory entry = getMockEntry(writerF, writerNonce);
+        uint256 dbNonce = 0;
+        InterchainEntry memory entry = getInitialEntry(dbNonce);
         // expectCall(address callee, uint256 msgValue, bytes calldata data)
         vm.expectCall(address(moduleA), MODULE_A_FEE, getModuleCalldata(entry));
         vm.expectCall(address(moduleB), MODULE_B_FEE, getModuleCalldata(entry));
-        requestVerification(requestCaller, MODULE_A_FEE + MODULE_B_FEE, writerF, writerNonce, twoModules);
+        requestVerification(requestCaller, MODULE_A_FEE + MODULE_B_FEE, dbNonce, twoModules);
     }
 
     function test_requestVerification_writerS_oneModule_emitsEvent() public {
-        uint256 writerNonce = 1;
+        uint256 dbNonce = 2;
         vm.expectEmit(address(icDB));
-        emit InterchainVerificationRequested(DST_CHAIN_ID, addressToBytes32(writerS), writerNonce, oneModule);
-        requestVerification(requestCaller, MODULE_A_FEE, writerS, writerNonce, oneModule);
+        emit InterchainVerificationRequested(DST_CHAIN_ID, dbNonce, oneModule);
+        requestVerification(requestCaller, MODULE_A_FEE, dbNonce, oneModule);
     }
 
     function test_requestVerification_writerS_oneModule_callsModule() public {
-        uint256 writerNonce = 1;
-        InterchainEntry memory entry = getMockEntry(writerS, writerNonce);
+        uint256 dbNonce = 2;
+        InterchainEntry memory entry = getInitialEntry(dbNonce);
         // expectCall(address callee, uint256 msgValue, bytes calldata data)
         vm.expectCall(address(moduleA), MODULE_A_FEE, getModuleCalldata(entry));
-        requestVerification(requestCaller, MODULE_A_FEE, writerS, writerNonce, oneModule);
+        requestVerification(requestCaller, MODULE_A_FEE, dbNonce, oneModule);
     }
 
     function test_requestVerification_writerS_twoModules_emitsEvent() public {
-        uint256 writerNonce = 1;
+        uint256 dbNonce = 2;
         vm.expectEmit(address(icDB));
-        emit InterchainVerificationRequested(DST_CHAIN_ID, addressToBytes32(writerS), writerNonce, twoModules);
-        requestVerification(requestCaller, MODULE_A_FEE + MODULE_B_FEE, writerS, writerNonce, twoModules);
+        emit InterchainVerificationRequested(DST_CHAIN_ID, dbNonce, twoModules);
+        requestVerification(requestCaller, MODULE_A_FEE + MODULE_B_FEE, dbNonce, twoModules);
     }
 
     function test_requestVerification_writerS_twoModules_callsModules() public {
-        uint256 writerNonce = 1;
-        InterchainEntry memory entry = getMockEntry(writerS, writerNonce);
+        uint256 dbNonce = 2;
+        InterchainEntry memory entry = getInitialEntry(dbNonce);
         // expectCall(address callee, uint256 msgValue, bytes calldata data)
         vm.expectCall(address(moduleA), MODULE_A_FEE, getModuleCalldata(entry));
         vm.expectCall(address(moduleB), MODULE_B_FEE, getModuleCalldata(entry));
-        requestVerification(requestCaller, MODULE_A_FEE + MODULE_B_FEE, writerS, writerNonce, twoModules);
+        requestVerification(requestCaller, MODULE_A_FEE + MODULE_B_FEE, dbNonce, twoModules);
     }
 
     // ══════════════════════════════════ TESTS: REQUESTING VALIDATION (REVERTS) ═══════════════════════════════════════
 
     function test_requestVerification_revert_entryDoesNotExist_oneModule_nextNonce() public {
-        expectEntryDoesNotExist(writerF, INITIAL_WRITER_F_NONCE);
-        requestVerification(requestCaller, MODULE_A_FEE, writerF, INITIAL_WRITER_F_NONCE, oneModule);
-        expectEntryDoesNotExist(writerS, INITIAL_WRITER_S_NONCE);
-        requestVerification(requestCaller, MODULE_A_FEE, writerS, INITIAL_WRITER_S_NONCE, oneModule);
-        expectEntryDoesNotExist(notWriter, 0);
-        requestVerification(requestCaller, MODULE_A_FEE, notWriter, 0, oneModule);
+        expectEntryDoesNotExist(INITIAL_DB_NONCE);
+        requestVerification(requestCaller, MODULE_A_FEE, INITIAL_DB_NONCE, oneModule);
     }
 
     function test_requestVerification_revert_entryDoesNotExist_oneModule_hugeNonce() public {
-        expectEntryDoesNotExist(writerF, 2 ** 32);
-        requestVerification(requestCaller, MODULE_A_FEE, writerF, 2 ** 32, oneModule);
-        expectEntryDoesNotExist(writerS, 2 ** 64);
-        requestVerification(requestCaller, MODULE_A_FEE, writerS, 2 ** 64, oneModule);
-        expectEntryDoesNotExist(notWriter, type(uint256).max);
-        requestVerification(requestCaller, MODULE_A_FEE, notWriter, type(uint256).max, oneModule);
+        expectEntryDoesNotExist(2 ** 32);
+        requestVerification(requestCaller, MODULE_A_FEE, 2 ** 32, oneModule);
+        expectEntryDoesNotExist(2 ** 64);
+        requestVerification(requestCaller, MODULE_A_FEE, 2 ** 64, oneModule);
+        expectEntryDoesNotExist(type(uint256).max);
+        requestVerification(requestCaller, MODULE_A_FEE, type(uint256).max, oneModule);
     }
 
     function test_requestVerification_revert_entryDoesNotExist_twoModules_nextNonce() public {
-        expectEntryDoesNotExist(writerF, INITIAL_WRITER_F_NONCE);
-        requestVerification(requestCaller, MODULE_A_FEE + MODULE_B_FEE, writerF, INITIAL_WRITER_F_NONCE, twoModules);
-        expectEntryDoesNotExist(writerS, INITIAL_WRITER_S_NONCE);
-        requestVerification(requestCaller, MODULE_A_FEE + MODULE_B_FEE, writerS, INITIAL_WRITER_S_NONCE, twoModules);
-        expectEntryDoesNotExist(notWriter, 0);
-        requestVerification(requestCaller, MODULE_A_FEE + MODULE_B_FEE, notWriter, 0, twoModules);
+        expectEntryDoesNotExist(INITIAL_DB_NONCE);
+        requestVerification(requestCaller, MODULE_A_FEE + MODULE_B_FEE, INITIAL_DB_NONCE, twoModules);
     }
 
     function test_requestVerification_revert_entryDoesNotExist_twoModules_hugeNonce() public {
-        expectEntryDoesNotExist(writerF, 2 ** 32);
-        requestVerification(requestCaller, MODULE_A_FEE + MODULE_B_FEE, writerF, 2 ** 32, twoModules);
-        expectEntryDoesNotExist(writerS, 2 ** 64);
-        requestVerification(requestCaller, MODULE_A_FEE + MODULE_B_FEE, writerS, 2 ** 64, twoModules);
-        expectEntryDoesNotExist(notWriter, type(uint256).max);
-        requestVerification(requestCaller, MODULE_A_FEE + MODULE_B_FEE, notWriter, type(uint256).max, twoModules);
+        expectEntryDoesNotExist(2 ** 32);
+        requestVerification(requestCaller, MODULE_A_FEE + MODULE_B_FEE, 2 ** 32, twoModules);
+        expectEntryDoesNotExist(2 ** 64);
+        requestVerification(requestCaller, MODULE_A_FEE + MODULE_B_FEE, 2 ** 64, twoModules);
+        expectEntryDoesNotExist(type(uint256).max);
+        requestVerification(requestCaller, MODULE_A_FEE + MODULE_B_FEE, type(uint256).max, twoModules);
     }
 
     function test_requestVerification_revert_incorrectFeeAmount_oneModule_underpaid() public {
         uint256 incorrectFee = MODULE_A_FEE - 1;
         expectIncorrectFeeAmount(incorrectFee, MODULE_A_FEE);
-        requestVerification(requestCaller, incorrectFee, writerF, 0, oneModule);
+        requestVerification(requestCaller, incorrectFee, 0, oneModule);
     }
 
     function test_requestVerification_revert_incorrectFeeAmount_oneModule_overpaid() public {
         uint256 incorrectFee = MODULE_A_FEE + 1;
         expectIncorrectFeeAmount(incorrectFee, MODULE_A_FEE);
-        requestVerification(requestCaller, incorrectFee, writerF, 0, oneModule);
+        requestVerification(requestCaller, incorrectFee, 0, oneModule);
     }
 
     function test_requestVerification_revert_incorrectFeeAmount_twoModules_underpaid() public {
         uint256 incorrectFee = MODULE_A_FEE + MODULE_B_FEE - 1;
         expectIncorrectFeeAmount(incorrectFee, MODULE_A_FEE + MODULE_B_FEE);
-        requestVerification(requestCaller, incorrectFee, writerF, 0, twoModules);
+        requestVerification(requestCaller, incorrectFee, 0, twoModules);
     }
 
     function test_requestVerification_revert_incorrectFeeAmount_twoModules_overpaid() public {
         uint256 incorrectFee = MODULE_A_FEE + MODULE_B_FEE + 1;
         expectIncorrectFeeAmount(incorrectFee, MODULE_A_FEE + MODULE_B_FEE);
-        requestVerification(requestCaller, incorrectFee, writerF, 0, twoModules);
+        requestVerification(requestCaller, incorrectFee, 0, twoModules);
     }
 
     function test_requestVerification_revert_noModulesSpecified() public {
         expectNoModulesSpecified();
-        requestVerification(requestCaller, MODULE_A_FEE, writerF, 0, new address[](0));
+        requestVerification(requestCaller, MODULE_A_FEE, 0, new address[](0));
     }
 
     function test_requestVerification_revert_sameChainId() public {
         expectSameChainId();
         vm.prank(requestCaller);
-        icDB.requestVerification(SRC_CHAIN_ID, writerF, 0, oneModule);
+        icDB.requestVerification(SRC_CHAIN_ID, 0, oneModule);
     }
 
     // ═════════════════════════════════════ TESTS: WRITE + REQUEST VALIDATION ═════════════════════════════════════════
 
     function test_writeEntryWithVerification_writerF_oneModule_callsModule() public {
-        bytes32 dataHash = getMockDataHash(writerF, INITIAL_WRITER_F_NONCE);
-        InterchainEntry memory entry = getMockEntry(writerF, INITIAL_WRITER_F_NONCE);
+        InterchainEntry memory entry = getMockEntry(INITIAL_DB_NONCE, writerF);
         vm.expectCall(address(moduleA), MODULE_A_FEE, getModuleCalldata(entry));
-        writeEntryWithVerification(MODULE_A_FEE, writerF, dataHash, oneModule);
+        writeEntryWithVerification(MODULE_A_FEE, writerF, entry.dataHash, oneModule);
     }
 
     function test_writeEntryWithVerification_writerF_oneModule_emitsEvents() public {
-        bytes32 dataHash = getMockDataHash(writerF, INITIAL_WRITER_F_NONCE);
+        bytes32 dataHash = getMockDataHash(writerF, INITIAL_DB_NONCE);
         vm.expectEmit(address(icDB));
-        emit InterchainEntryWritten(SRC_CHAIN_ID, addressToBytes32(writerF), INITIAL_WRITER_F_NONCE, dataHash);
+        emit InterchainEntryWritten(SRC_CHAIN_ID, INITIAL_DB_NONCE, addressToBytes32(writerF), dataHash);
         vm.expectEmit(address(icDB));
-        emit InterchainVerificationRequested(DST_CHAIN_ID, addressToBytes32(writerF), INITIAL_WRITER_F_NONCE, oneModule);
+        emit InterchainVerificationRequested(DST_CHAIN_ID, INITIAL_DB_NONCE, oneModule);
         writeEntryWithVerification(MODULE_A_FEE, writerF, dataHash, oneModule);
     }
 
-    function test_writeEntryWithVerification_writerF_oneModule_increasesWriterNonce() public {
-        bytes32 dataHash = getMockDataHash(writerF, INITIAL_WRITER_F_NONCE);
+    function test_writeEntryWithVerification_writerF_oneModule_increasesDBNonce() public {
+        bytes32 dataHash = getMockDataHash(writerF, INITIAL_DB_NONCE);
         writeEntryWithVerification(MODULE_A_FEE, writerF, dataHash, oneModule);
-        assertEq(icDB.getWriterNonce(writerF), INITIAL_WRITER_F_NONCE + 1);
+        assertEq(icDB.getDBNonce(), INITIAL_DB_NONCE + 1);
     }
 
     function test_writeEntryWithVerification_writerF_oneModule_returnsCorrectNonce() public {
-        bytes32 dataHash = getMockDataHash(writerF, INITIAL_WRITER_F_NONCE);
+        bytes32 dataHash = getMockDataHash(writerF, INITIAL_DB_NONCE);
         uint256 nonce = writeEntryWithVerification(MODULE_A_FEE, writerF, dataHash, oneModule);
-        assertEq(nonce, INITIAL_WRITER_F_NONCE);
+        assertEq(nonce, INITIAL_DB_NONCE);
     }
 
     function test_writeEntryWithVerification_writerF_oneModule_savesEntry() public {
-        bytes32 dataHash = getMockDataHash(writerF, INITIAL_WRITER_F_NONCE);
-        writeEntryWithVerification(MODULE_A_FEE, writerF, dataHash, oneModule);
-        assertEq(icDB.getEntry(writerF, INITIAL_WRITER_F_NONCE), getMockEntry(writerF, INITIAL_WRITER_F_NONCE));
+        InterchainEntry memory entry = getMockEntry(INITIAL_DB_NONCE, writerF);
+        writeEntryWithVerification(MODULE_A_FEE, writerF, entry.dataHash, oneModule);
+        assertEq(icDB.getEntry(INITIAL_DB_NONCE), entry);
     }
 
     function test_writeEntryWithVerification_writerF_twoModules_callsModules() public {
-        bytes32 dataHash = getMockDataHash(writerF, INITIAL_WRITER_F_NONCE);
-        InterchainEntry memory entry = getMockEntry(writerF, INITIAL_WRITER_F_NONCE);
+        InterchainEntry memory entry = getMockEntry(INITIAL_DB_NONCE, writerF);
         vm.expectCall(address(moduleA), MODULE_A_FEE, getModuleCalldata(entry));
         vm.expectCall(address(moduleB), MODULE_B_FEE, getModuleCalldata(entry));
-        writeEntryWithVerification(MODULE_A_FEE + MODULE_B_FEE, writerF, dataHash, twoModules);
+        writeEntryWithVerification(MODULE_A_FEE + MODULE_B_FEE, writerF, entry.dataHash, twoModules);
     }
 
     function test_writeEntryWithVerification_writerF_twoModules_emitsEvents() public {
-        bytes32 dataHash = getMockDataHash(writerF, INITIAL_WRITER_F_NONCE);
+        bytes32 dataHash = getMockDataHash(writerF, INITIAL_DB_NONCE);
         vm.expectEmit(address(icDB));
-        emit InterchainEntryWritten(SRC_CHAIN_ID, addressToBytes32(writerF), INITIAL_WRITER_F_NONCE, dataHash);
+        emit InterchainEntryWritten(SRC_CHAIN_ID, INITIAL_DB_NONCE, addressToBytes32(writerF), dataHash);
         vm.expectEmit(address(icDB));
-        emit InterchainVerificationRequested(
-            DST_CHAIN_ID, addressToBytes32(writerF), INITIAL_WRITER_F_NONCE, twoModules
-        );
+        emit InterchainVerificationRequested(DST_CHAIN_ID, INITIAL_DB_NONCE, twoModules);
         writeEntryWithVerification(MODULE_A_FEE + MODULE_B_FEE, writerF, dataHash, twoModules);
     }
 
-    function test_writeEntryWithVerification_writerF_twoModules_increasesWriterNonce() public {
-        bytes32 dataHash = getMockDataHash(writerF, INITIAL_WRITER_F_NONCE);
+    function test_writeEntryWithVerification_writerF_twoModules_increasesDBNonce() public {
+        bytes32 dataHash = getMockDataHash(writerF, INITIAL_DB_NONCE);
         writeEntryWithVerification(MODULE_A_FEE + MODULE_B_FEE, writerF, dataHash, twoModules);
-        assertEq(icDB.getWriterNonce(writerF), INITIAL_WRITER_F_NONCE + 1);
+        assertEq(icDB.getDBNonce(), INITIAL_DB_NONCE + 1);
     }
 
     function test_writeEntryWithVerification_writerF_twoModules_returnsCorrectNonce() public {
-        bytes32 dataHash = getMockDataHash(writerF, INITIAL_WRITER_F_NONCE);
+        bytes32 dataHash = getMockDataHash(writerF, INITIAL_DB_NONCE);
         uint256 nonce = writeEntryWithVerification(MODULE_A_FEE + MODULE_B_FEE, writerF, dataHash, twoModules);
-        assertEq(nonce, INITIAL_WRITER_F_NONCE);
+        assertEq(nonce, INITIAL_DB_NONCE);
     }
 
     function test_writeEntryWithVerification_writerF_twoModules_savesEntry() public {
-        bytes32 dataHash = getMockDataHash(writerF, INITIAL_WRITER_F_NONCE);
-        writeEntryWithVerification(MODULE_A_FEE + MODULE_B_FEE, writerF, dataHash, twoModules);
-        assertEq(icDB.getEntry(writerF, INITIAL_WRITER_F_NONCE), getMockEntry(writerF, INITIAL_WRITER_F_NONCE));
+        InterchainEntry memory entry = getMockEntry(INITIAL_DB_NONCE, writerF);
+        writeEntryWithVerification(MODULE_A_FEE + MODULE_B_FEE, writerF, entry.dataHash, twoModules);
+        assertEq(icDB.getEntry(INITIAL_DB_NONCE), entry);
     }
 
     function test_writeEntryWithVerification_writerS_oneModule_callsModule() public {
-        bytes32 dataHash = getMockDataHash(writerS, INITIAL_WRITER_S_NONCE);
-        InterchainEntry memory entry = getMockEntry(writerS, INITIAL_WRITER_S_NONCE);
+        InterchainEntry memory entry = getMockEntry(INITIAL_DB_NONCE, writerS);
         vm.expectCall(address(moduleA), MODULE_A_FEE, getModuleCalldata(entry));
-        writeEntryWithVerification(MODULE_A_FEE, writerS, dataHash, oneModule);
+        writeEntryWithVerification(MODULE_A_FEE, writerS, entry.dataHash, oneModule);
     }
 
     function test_writeEntryWithVerification_writerS_oneModule_emitsEvents() public {
-        bytes32 dataHash = getMockDataHash(writerS, INITIAL_WRITER_S_NONCE);
+        bytes32 dataHash = getMockDataHash(writerS, INITIAL_DB_NONCE);
         vm.expectEmit(address(icDB));
-        emit InterchainEntryWritten(SRC_CHAIN_ID, addressToBytes32(writerS), INITIAL_WRITER_S_NONCE, dataHash);
+        emit InterchainEntryWritten(SRC_CHAIN_ID, INITIAL_DB_NONCE, addressToBytes32(writerS), dataHash);
         vm.expectEmit(address(icDB));
-        emit InterchainVerificationRequested(DST_CHAIN_ID, addressToBytes32(writerS), INITIAL_WRITER_S_NONCE, oneModule);
+        emit InterchainVerificationRequested(DST_CHAIN_ID, INITIAL_DB_NONCE, oneModule);
         writeEntryWithVerification(MODULE_A_FEE, writerS, dataHash, oneModule);
     }
 
-    function test_writeEntryWithVerification_writerS_oneModule_increasesWriterNonce() public {
-        bytes32 dataHash = getMockDataHash(writerS, INITIAL_WRITER_S_NONCE);
+    function test_writeEntryWithVerification_writerS_oneModule_increasesDBNonce() public {
+        bytes32 dataHash = getMockDataHash(writerS, INITIAL_DB_NONCE);
         writeEntryWithVerification(MODULE_A_FEE, writerS, dataHash, oneModule);
-        assertEq(icDB.getWriterNonce(writerS), INITIAL_WRITER_S_NONCE + 1);
+        assertEq(icDB.getDBNonce(), INITIAL_DB_NONCE + 1);
     }
 
     function test_writeEntryWithVerification_writerS_oneModule_returnsCorrectNonce() public {
-        bytes32 dataHash = getMockDataHash(writerS, INITIAL_WRITER_S_NONCE);
+        bytes32 dataHash = getMockDataHash(writerS, INITIAL_DB_NONCE);
         uint256 nonce = writeEntryWithVerification(MODULE_A_FEE, writerS, dataHash, oneModule);
-        assertEq(nonce, INITIAL_WRITER_S_NONCE);
+        assertEq(nonce, INITIAL_DB_NONCE);
     }
 
     function test_writeEntryWithVerification_writerS_oneModule_savesEntry() public {
-        bytes32 dataHash = getMockDataHash(writerS, INITIAL_WRITER_S_NONCE);
-        writeEntryWithVerification(MODULE_A_FEE, writerS, dataHash, oneModule);
-        assertEq(icDB.getEntry(writerS, INITIAL_WRITER_S_NONCE), getMockEntry(writerS, INITIAL_WRITER_S_NONCE));
+        InterchainEntry memory entry = getMockEntry(INITIAL_DB_NONCE, writerS);
+        writeEntryWithVerification(MODULE_A_FEE, writerS, entry.dataHash, oneModule);
+        assertEq(icDB.getEntry(INITIAL_DB_NONCE), entry);
     }
 
     function test_writeEntryWithVerification_writerS_twoModules_callsModules() public {
-        bytes32 dataHash = getMockDataHash(writerS, INITIAL_WRITER_S_NONCE);
-        InterchainEntry memory entry = getMockEntry(writerS, INITIAL_WRITER_S_NONCE);
+        InterchainEntry memory entry = getMockEntry(INITIAL_DB_NONCE, writerS);
         vm.expectCall(address(moduleA), MODULE_A_FEE, getModuleCalldata(entry));
         vm.expectCall(address(moduleB), MODULE_B_FEE, getModuleCalldata(entry));
-        writeEntryWithVerification(MODULE_A_FEE + MODULE_B_FEE, writerS, dataHash, twoModules);
+        writeEntryWithVerification(MODULE_A_FEE + MODULE_B_FEE, writerS, entry.dataHash, twoModules);
     }
 
     function test_writeEntryWithVerification_writerS_twoModules_emitsEvents() public {
-        bytes32 dataHash = getMockDataHash(writerS, INITIAL_WRITER_S_NONCE);
+        bytes32 dataHash = getMockDataHash(writerS, INITIAL_DB_NONCE);
         vm.expectEmit(address(icDB));
-        emit InterchainEntryWritten(SRC_CHAIN_ID, addressToBytes32(writerS), INITIAL_WRITER_S_NONCE, dataHash);
+        emit InterchainEntryWritten(SRC_CHAIN_ID, INITIAL_DB_NONCE, addressToBytes32(writerS), dataHash);
         vm.expectEmit(address(icDB));
-        emit InterchainVerificationRequested(
-            DST_CHAIN_ID, addressToBytes32(writerS), INITIAL_WRITER_S_NONCE, twoModules
-        );
+        emit InterchainVerificationRequested(DST_CHAIN_ID, INITIAL_DB_NONCE, twoModules);
         writeEntryWithVerification(MODULE_A_FEE + MODULE_B_FEE, writerS, dataHash, twoModules);
     }
 
-    function test_writeEntryWithVerification_writerS_twoModules_increasesWriterNonce() public {
-        bytes32 dataHash = getMockDataHash(writerS, INITIAL_WRITER_S_NONCE);
+    function test_writeEntryWithVerification_writerS_twoModules_increasesDBNonce() public {
+        bytes32 dataHash = getMockDataHash(writerS, INITIAL_DB_NONCE);
         writeEntryWithVerification(MODULE_A_FEE + MODULE_B_FEE, writerS, dataHash, twoModules);
-        assertEq(icDB.getWriterNonce(writerS), INITIAL_WRITER_S_NONCE + 1);
+        assertEq(icDB.getDBNonce(), INITIAL_DB_NONCE + 1);
     }
 
     function test_writeEntryWithVerification_writerS_twoModules_returnsCorrectNonce() public {
-        bytes32 dataHash = getMockDataHash(writerS, INITIAL_WRITER_S_NONCE);
+        bytes32 dataHash = getMockDataHash(writerS, INITIAL_DB_NONCE);
         uint256 nonce = writeEntryWithVerification(MODULE_A_FEE + MODULE_B_FEE, writerS, dataHash, twoModules);
-        assertEq(nonce, INITIAL_WRITER_S_NONCE);
+        assertEq(nonce, INITIAL_DB_NONCE);
     }
 
     function test_writeEntryWithVerification_writerS_twoModules_savesEntry() public {
-        bytes32 dataHash = getMockDataHash(writerS, INITIAL_WRITER_S_NONCE);
-        writeEntryWithVerification(MODULE_A_FEE + MODULE_B_FEE, writerS, dataHash, twoModules);
-        assertEq(icDB.getEntry(writerS, INITIAL_WRITER_S_NONCE), getMockEntry(writerS, INITIAL_WRITER_S_NONCE));
+        InterchainEntry memory entry = getMockEntry(INITIAL_DB_NONCE, writerS);
+        writeEntryWithVerification(MODULE_A_FEE + MODULE_B_FEE, writerS, entry.dataHash, twoModules);
+        assertEq(icDB.getEntry(INITIAL_DB_NONCE), entry);
     }
 
     // ════════════════════════════════ TESTS: WRITE + REQUEST VALIDATION (REVERTS) ════════════════════════════════════
 
     function test_writeEntryWithVerification_revert_incorrectFeeAmount_oneModule_underpaid() public {
-        bytes32 dataHash = getMockDataHash(writerF, INITIAL_WRITER_F_NONCE);
+        bytes32 dataHash = getMockDataHash(writerF, INITIAL_DB_NONCE);
         uint256 incorrectFee = MODULE_A_FEE - 1;
         expectIncorrectFeeAmount(incorrectFee, MODULE_A_FEE);
         writeEntryWithVerification(incorrectFee, writerF, dataHash, oneModule);
     }
 
     function test_writeEntryWithVerification_revert_incorrectFeeAmount_oneModule_overpaid() public {
-        bytes32 dataHash = getMockDataHash(writerF, INITIAL_WRITER_F_NONCE);
+        bytes32 dataHash = getMockDataHash(writerF, INITIAL_DB_NONCE);
         uint256 incorrectFee = MODULE_A_FEE + 1;
         expectIncorrectFeeAmount(incorrectFee, MODULE_A_FEE);
         writeEntryWithVerification(incorrectFee, writerF, dataHash, oneModule);
     }
 
     function test_writeEntryWithVerification_revert_incorrectFeeAmount_twoModules_underpaid() public {
-        bytes32 dataHash = getMockDataHash(writerF, INITIAL_WRITER_F_NONCE);
+        bytes32 dataHash = getMockDataHash(writerF, INITIAL_DB_NONCE);
         uint256 incorrectFee = MODULE_A_FEE + MODULE_B_FEE - 1;
         expectIncorrectFeeAmount(incorrectFee, MODULE_A_FEE + MODULE_B_FEE);
         writeEntryWithVerification(incorrectFee, writerF, dataHash, twoModules);
     }
 
     function test_writeEntryWithVerification_revert_incorrectFeeAmount_twoModules_overpaid() public {
-        bytes32 dataHash = getMockDataHash(writerF, INITIAL_WRITER_F_NONCE);
+        bytes32 dataHash = getMockDataHash(writerF, INITIAL_DB_NONCE);
         uint256 incorrectFee = MODULE_A_FEE + MODULE_B_FEE + 1;
         expectIncorrectFeeAmount(incorrectFee, MODULE_A_FEE + MODULE_B_FEE);
         writeEntryWithVerification(incorrectFee, writerF, dataHash, twoModules);
     }
 
     function test_writeEntryWithVerification_revert_noModulesSpecified() public {
-        bytes32 dataHash = getMockDataHash(writerF, INITIAL_WRITER_F_NONCE);
+        bytes32 dataHash = getMockDataHash(writerF, INITIAL_DB_NONCE);
         expectNoModulesSpecified();
         writeEntryWithVerification(0, writerF, dataHash, new address[](0));
     }
 
     function test_writeEntryWithVerification_revert_sameChainId() public {
-        bytes32 dataHash = getMockDataHash(writerF, INITIAL_WRITER_F_NONCE);
+        bytes32 dataHash = getMockDataHash(writerF, INITIAL_DB_NONCE);
         expectSameChainId();
         vm.prank(writerF);
         icDB.writeEntryWithVerification(SRC_CHAIN_ID, dataHash, oneModule);

--- a/packages/contracts-communication/test/harnesses/InterchainClientV1Harness.sol
+++ b/packages/contracts-communication/test/harnesses/InterchainClientV1Harness.sol
@@ -3,7 +3,8 @@
 pragma solidity 0.8.20;
 
 import {InterchainClientV1} from "../../contracts/InterchainClientV1.sol";
-import { InterchainEntry } from "../../contracts/libs/InterchainEntry.sol";
+import {InterchainEntry} from "../../contracts/libs/InterchainEntry.sol";
+
 contract InterchainClientV1Harness is InterchainClientV1 {
     constructor() InterchainClientV1() {}
 
@@ -64,5 +65,4 @@ contract InterchainClientV1Harness is InterchainClientV1 {
     {
         return _getFinalizedResponsesCount(approvedResponses, optimisticTimePeriod);
     }
-
 }

--- a/packages/contracts-communication/test/harnesses/InterchainEntryLibHarness.sol
+++ b/packages/contracts-communication/test/harnesses/InterchainEntryLibHarness.sol
@@ -5,18 +5,22 @@ import {InterchainEntry, InterchainEntryLib} from "../../contracts/libs/Intercha
 
 contract InterchainEntryLibHarness {
     function constructLocalEntry(
+        uint256 dbNonce,
         address srcWriter,
-        uint256 writerNonce,
         bytes32 dataHash
     )
         external
         view
         returns (InterchainEntry memory)
     {
-        return InterchainEntryLib.constructLocalEntry(srcWriter, writerNonce, dataHash);
+        return InterchainEntryLib.constructLocalEntry(dbNonce, srcWriter, dataHash);
     }
 
-    function entryId(InterchainEntry memory entry) external pure returns (bytes32) {
-        return InterchainEntryLib.entryId(entry);
+    function entryKey(InterchainEntry memory entry) external pure returns (bytes32) {
+        return InterchainEntryLib.entryKey(entry);
+    }
+
+    function entryValue(InterchainEntry memory entry) external pure returns (bytes32) {
+        return InterchainEntryLib.entryValue(entry);
     }
 }

--- a/packages/contracts-communication/test/libs/InterchainEntryLib.t.sol
+++ b/packages/contracts-communication/test/libs/InterchainEntryLib.t.sol
@@ -9,7 +9,7 @@ contract InterchainEntryLibTest is Test {
     InterchainEntryLibHarness public libHarness;
 
     InterchainEntry public mockEntry =
-        InterchainEntry({srcChainId: 1, srcWriter: bytes32(uint256(2)), writerNonce: 3, dataHash: bytes32(uint256(4))});
+        InterchainEntry({srcChainId: 1, dbNonce: 2, srcWriter: bytes32(uint256(3)), dataHash: bytes32(uint256(4))});
 
     function setUp() public {
         libHarness = new InterchainEntryLibHarness();
@@ -17,46 +17,49 @@ contract InterchainEntryLibTest is Test {
 
     function assertEq(InterchainEntry memory actual, InterchainEntry memory expected) public {
         assertEq(actual.srcChainId, expected.srcChainId, "!srcChainId");
+        assertEq(actual.dbNonce, expected.dbNonce, "!dbNonce");
         assertEq(actual.srcWriter, expected.srcWriter, "!srcWriter");
-        assertEq(actual.writerNonce, expected.writerNonce, "!writerNonce");
         assertEq(actual.dataHash, expected.dataHash, "!dataHash");
     }
 
     function test_constructLocalEntry() public {
         vm.chainId(1);
-        address srcWriter = address(2);
-        uint256 writerNonce = 3;
+        uint256 dbNonce = 2;
+        address srcWriter = address(3);
         bytes32 dataHash = bytes32(uint256(4));
-        InterchainEntry memory actual = libHarness.constructLocalEntry(srcWriter, writerNonce, dataHash);
+        InterchainEntry memory actual = libHarness.constructLocalEntry(dbNonce, srcWriter, dataHash);
         assertEq(actual, mockEntry);
     }
 
-    function test_constructLocalEntry(
-        uint64 chainId,
-        address srcWriter,
-        uint256 writerNonce,
-        bytes32 dataHash
-    )
-        public
-    {
+    function test_constructLocalEntry(uint64 chainId, uint256 dbNonce, address srcWriter, bytes32 dataHash) public {
         vm.chainId(chainId);
         InterchainEntry memory expected = InterchainEntry({
             srcChainId: chainId,
+            dbNonce: dbNonce,
             srcWriter: bytes32(uint256(uint160(srcWriter))),
-            writerNonce: writerNonce,
             dataHash: dataHash
         });
-        InterchainEntry memory actual = libHarness.constructLocalEntry(srcWriter, writerNonce, dataHash);
+        InterchainEntry memory actual = libHarness.constructLocalEntry(dbNonce, srcWriter, dataHash);
         assertEq(actual, expected);
     }
 
-    function test_entryId() public {
-        bytes32 expected = keccak256(abi.encode(1, 2, 3));
-        assertEq(libHarness.entryId(mockEntry), expected);
+    function test_entryKey() public {
+        bytes32 expected = keccak256(abi.encode(1, 2));
+        assertEq(libHarness.entryKey(mockEntry), expected);
     }
 
-    function test_entryId(InterchainEntry memory entry) public {
-        bytes32 expected = keccak256(abi.encode(entry.srcChainId, entry.srcWriter, entry.writerNonce));
-        assertEq(libHarness.entryId(entry), expected);
+    function test_entryKey(InterchainEntry memory entry) public {
+        bytes32 expected = keccak256(abi.encode(entry.srcChainId, entry.dbNonce));
+        assertEq(libHarness.entryKey(entry), expected);
+    }
+
+    function test_entryValue() public {
+        bytes32 expected = keccak256(abi.encode(3, 4));
+        assertEq(libHarness.entryValue(mockEntry), expected);
+    }
+
+    function test_entryValue(InterchainEntry memory entry) public {
+        bytes32 expected = keccak256(abi.encode(entry.srcWriter, entry.dataHash));
+        assertEq(libHarness.entryValue(entry), expected);
     }
 }

--- a/packages/contracts-communication/test/mocks/InterchainDBMock.sol
+++ b/packages/contracts-communication/test/mocks/InterchainDBMock.sol
@@ -6,15 +6,7 @@ import {IInterchainDB, InterchainEntry} from "../../contracts/interfaces/IInterc
 contract InterchainDBMock is IInterchainDB {
     function writeEntry(bytes32 dataHash) external returns (uint256 writerNonce) {}
 
-    function requestVerification(
-        uint256 destChainId,
-        address writer,
-        uint256 writerNonce,
-        address[] memory srcModules
-    )
-        external
-        payable
-    {}
+    function requestVerification(uint256 destChainId, uint256 dbNonce, address[] memory srcModules) external payable {}
 
     function writeEntryWithVerification(
         uint256 destChainId,
@@ -30,9 +22,9 @@ contract InterchainDBMock is IInterchainDB {
 
     function getInterchainFee(uint256 destChainId, address[] memory srcModules) external view returns (uint256) {}
 
-    function getEntry(address writer, uint256 writerNonce) external view returns (InterchainEntry memory) {}
+    function getEntry(uint256 dbNonce) external view returns (InterchainEntry memory) {}
 
-    function getWriterNonce(address writer) external view returns (uint256) {}
+    function getDBNonce() external view returns (uint256) {}
 
     function readEntry(
         address dstModule,

--- a/packages/contracts-communication/test/modules/SynapseModule.Destination.t.sol
+++ b/packages/contracts-communication/test/modules/SynapseModule.Destination.t.sol
@@ -25,8 +25,8 @@ contract SynapseModuleDestinationTest is Test, InterchainModuleEvents, SynapseMo
 
     InterchainEntry public mockEntry = InterchainEntry({
         srcChainId: SRC_CHAIN_ID,
-        srcWriter: bytes32(uint256(2)),
-        writerNonce: 3,
+        dbNonce: 2,
+        srcWriter: bytes32(uint256(3)),
         dataHash: bytes32(uint256(4))
     });
 

--- a/packages/contracts-communication/test/modules/SynapseModule.Source.t.sol
+++ b/packages/contracts-communication/test/modules/SynapseModule.Source.t.sol
@@ -28,8 +28,8 @@ contract SynapseModuleSourceTest is Test, InterchainModuleEvents, SynapseModuleE
 
     InterchainEntry public mockEntry = InterchainEntry({
         srcChainId: SRC_CHAIN_ID,
-        srcWriter: bytes32(uint256(2)),
-        writerNonce: 3,
+        dbNonce: 2,
+        srcWriter: bytes32(uint256(3)),
         dataHash: bytes32(uint256(4))
     });
 


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**
A clear and concise description of the features you're adding in this pull request.

**Additional context**
Add any other context about the problem you're solving.

**Metadata**
- Fixes #[Link to Issue]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `LocalEntry` structure with enhanced fields for better data management.
	- Implemented a new system for entry verification and request processes, improving the interchain communication efficiency.
- **Refactor**
	- Renamed `dbWriterNonce` to `dbNonce` across various contracts for consistency.
	- Overhauled the `InterchainDB` contract, including its storage mappings and function signatures, to accommodate new data structures and logic.
	- Updated event signatures to reflect the renaming of nonce variables.
	- Modified test cases to align with the updated contract logic and structures.
- **Bug Fixes**
	- Adjusted parameter orders and values in test modules to fix inconsistencies with the new contract logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->