### PR TITLE
Fe/vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,9 +3,9 @@
   "[typescript]": {
     "editor.defaultFormatter": "dbaeumer.vscode-eslint"
   },
-    "[typescriptreact]": {
-        "editor.defaultFormatter": "esbenp.prettier-vscode"
-    },
+  "[typescriptreact]": {
+      "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
   "eslint.workingDirectories": [
     { "directory": "packages/contracts", "changeProcessCWD": true }
   ],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,17 +1,20 @@
 {
-    "editor.formatOnSave": true,
-    "[typescript]": {
-      "editor.defaultFormatter": "dbaeumer.vscode-eslint",
+  "editor.formatOnSave": true,
+  "[typescript]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
+    "[typescriptreact]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
-    "eslint.workingDirectories": [
-      {"directory": "packages/contracts", "changeProcessCWD": true }
-    ],
-    "eslint.nodePath": "./node_modules/eslint/bin/",
-    "eslint.format.enable": true,
-    "editorconfig.generateAuto": false,
-    "files.trimTrailingWhitespace": true,
-    "solidity.packageDefaultDependenciesContractsDirectory": "contracts",
-    "solidity.packageDefaultDependenciesDirectory": "lib",
-    "solidity.compileUsingRemoteVersion": "v0.8.17",
-    "solidity.formatter": "prettier"
-  }
+  "eslint.workingDirectories": [
+    { "directory": "packages/contracts", "changeProcessCWD": true }
+  ],
+  "eslint.nodePath": "./node_modules/eslint/bin/",
+  "eslint.format.enable": true,
+  "editorconfig.generateAuto": false,
+  "files.trimTrailingWhitespace": true,
+  "solidity.packageDefaultDependenciesContractsDirectory": "contracts",
+  "solidity.packageDefaultDependenciesDirectory": "lib",
+  "solidity.compileUsingRemoteVersion": "v0.8.17",
+  "solidity.formatter": "prettier"
+}


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**
Add formatter for `typescriptreact` in vscode settings




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated default formatters for TypeScript and TypeScriptReact in the project settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->