### PR TITLE
Showing/hiding rebate based on cap

### DIFF
--- a/packages/synapse-interface/components/Activity/AirdropRewards.tsx
+++ b/packages/synapse-interface/components/Activity/AirdropRewards.tsx
@@ -2,12 +2,11 @@ import _ from 'lodash'
 import Image from 'next/image'
 import Link from 'next/link'
 import numeral from 'numeral'
-import { Address, useAccount } from 'wagmi'
+import { Address } from 'wagmi'
 import { arbitrum } from 'viem/chains'
 import { useAppSelector } from '@/store/hooks'
 import { useState, useEffect, useRef } from 'react'
 import { trimTrailingZeroesAfterDecimal } from '@/utils/trimTrailingZeroesAfterDecimal'
-import { getErc20TokenTransfers } from '@/utils/actions/getErc20TokenTransfers'
 import { formatBigIntToString } from '@/utils/bigint/format'
 import { shortenAddress } from '@/utils/shortenAddress'
 import { ARBITRUM } from '@/constants/chains/master'
@@ -20,7 +19,7 @@ import TransactionArrow from '../icons/TransactionArrow'
 import arbitrumImg from '@assets/chains/arbitrum.svg'
 
 /** ARB Token */
-const ARB = {
+export const ARB = {
   name: 'Arbitrum',
   symbol: 'ARB',
   decimals: 18,
@@ -30,42 +29,16 @@ const ARB = {
   explorerUrl: ARBITRUM.explorerUrl,
 }
 
-/** ARB STIP Rewarder */
-const Rewarder = {
-  address: '0x48fa1ebda1af925898c826c566f5bb015e125ead' as Address,
-  startBlock: 174234366n, // Start of STIP Rewards on Arbitrum
-}
-
 const formatValueWithCommas = (value: string | number) => {
   const format = '0,0.00'
   return numeral(value).format(format)
 }
 
 export const AirdropRewards = () => {
-  const [rewards, setRewards] = useState<string>('0')
-  const [transactions, setTransactions] = useState<any[]>([])
-  const { address: connectedAddress } = useAccount()
   const { arbPrice } = useAppSelector((state) => state.priceData)
 
-  const fetchStipAirdropRewards = async (address: Address) => {
-    const { transactions, cumulativeRewards } = await getArbStipRewards(address)
-
-    const parsedCumulativeRewards = parseTokenValue(
-      cumulativeRewards,
-      ARB.decimals
-    )
-
-    setTransactions(transactions)
-    setRewards(parsedCumulativeRewards)
-  }
-
-  useEffect(() => {
-    if (connectedAddress) {
-      fetchStipAirdropRewards(connectedAddress)
-    } else {
-      setRewards(undefined)
-    }
-  }, [connectedAddress])
+  const { cumulativeRewards, parsedCumulativeRewards, transactions } =
+    useAppSelector((state) => state.feeAndRebate)
 
   /** Dialog state */
   const [open, setOpen] = useState<boolean>(false)
@@ -84,9 +57,9 @@ export const AirdropRewards = () => {
         <div className="flex justify-between flex-1 p-3">
           <RewardsAmountDisplay
             symbol={ARB.symbol}
-            tokenAmount={formatValueWithCommas(rewards)}
+            tokenAmount={formatValueWithCommas(parsedCumulativeRewards)}
             dollarAmount={formatValueWithCommas(
-              convertTokensToDollarValue(rewards, arbPrice)
+              convertTokensToDollarValue(parsedCumulativeRewards, arbPrice)
             )}
           />
 
@@ -109,7 +82,7 @@ export const AirdropRewards = () => {
         setOpen={setOpen}
         onClose={handleClose}
         transactions={transactions}
-        rewards={rewards}
+        rewards={parsedCumulativeRewards}
         tokenPrice={arbPrice}
       />
     </>
@@ -192,6 +165,7 @@ const RewardsDialog = ({
             </Link>{' '}
             for full route and rebate information.
           </p>
+          <p>Note that each address is capped at 2,000 ARB.</p>
 
           <div className="flex flex-wrap-reverse">
             <div className="mr-4 min-w-1/2">
@@ -347,36 +321,7 @@ export const HoverContentIcon = ({ children }) => {
   )
 }
 
-/** Helper Functions */
-const getArbStipRewards = async (connectedAddress: Address) => {
-  const { logs, data } = await getErc20TokenTransfers(
-    ARB.tokenAddress,
-    Rewarder.address,
-    connectedAddress,
-    ARB.network,
-    Rewarder.startBlock
-  )
-
-  const cumulativeRewards = calculateTotalTransferValue(data)
-
-  return {
-    logs: logs ?? [],
-    transactions: data,
-    cumulativeRewards,
-  }
-}
-
-const calculateTotalTransferValue = (data: any[]): bigint => {
-  let total: bigint = 0n
-  for (const item of data) {
-    if (item.transferValue) {
-      total += item.transferValue
-    }
-  }
-  return total
-}
-
-const parseTokenValue = (rawValue: bigint, tokenDecimals: number) => {
+export const parseTokenValue = (rawValue: bigint, tokenDecimals: number) => {
   return trimTrailingZeroesAfterDecimal(
     formatBigIntToString(rawValue, tokenDecimals, 3)
   )

--- a/packages/synapse-interface/components/StateManagedBridge/BridgeExchangeRateInfo.tsx
+++ b/packages/synapse-interface/components/StateManagedBridge/BridgeExchangeRateInfo.tsx
@@ -17,6 +17,8 @@ import { useBridgeState } from '@/slices/bridge/hooks'
 import { EMPTY_BRIDGE_QUOTE } from '@/constants/bridge'
 import { useAppSelector } from '@/store/hooks'
 
+const MAX_ARB_REBATE_PER_ADDRESS = 2000
+
 const BridgeExchangeRateInfo = () => {
   return (
     <div className="py-3.5 px-1 space-y-3 text-sm md:px-6 tracking-wide">
@@ -68,7 +70,15 @@ const RouteEligibility = () => {
   const { isRouteEligible, isActiveRouteEligible, rebate } =
     useStipEligibility()
 
-  if (!isRouteEligible || !rebate) {
+  const { parsedCumulativeRewards } = useAppSelector(
+    (state) => state.feeAndRebate
+  )
+
+  if (
+    !isRouteEligible ||
+    !rebate ||
+    Number(parsedCumulativeRewards) > MAX_ARB_REBATE_PER_ADDRESS
+  ) {
     return (
       <div className="flex justify-between">
         <div className="flex-grow" />
@@ -120,7 +130,15 @@ const RebateText = () => {
 const Rebate = () => {
   const { isRouteEligible, rebate } = useStipEligibility()
 
-  if (!isRouteEligible || !rebate) {
+  const { parsedCumulativeRewards } = useAppSelector(
+    (state) => state.feeAndRebate
+  )
+
+  if (
+    !isRouteEligible ||
+    !rebate ||
+    Number(parsedCumulativeRewards) > MAX_ARB_REBATE_PER_ADDRESS
+  ) {
     return null
   }
 

--- a/packages/synapse-interface/contexts/UserProvider.tsx
+++ b/packages/synapse-interface/contexts/UserProvider.tsx
@@ -22,8 +22,10 @@ import {
 } from '@/slices/priceDataSlice'
 import { isBlacklisted } from '@/utils/isBlacklisted'
 import { screenAddress } from '@/utils/screenAddress'
-import { getCoingeckoPrices } from '@/utils/actions/getPrices'
-import { fetchFeeAndRebate } from '@/slices/feeAndRebateSlice'
+import {
+  fetchArbStipRewards,
+  fetchFeeAndRebate,
+} from '@/slices/feeAndRebateSlice'
 
 const WalletStatusContext = createContext(undefined)
 
@@ -104,6 +106,10 @@ export const UserProvider = ({ children }) => {
         } catch (error) {
           console.error('Failed to fetch and store portfolio balances:', error)
         }
+      }
+
+      if (address) {
+        dispatch(fetchArbStipRewards(address))
       }
 
       if (!address) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced ARB token rewards fetching and display enhancements in the Airdrop Rewards section.
	- Added a maximum ARB rebate limit per address for better management of exchange rates and rebates.

- **Refactor**
	- Streamlined ARB rewards data handling by leveraging Redux state, enhancing token amount and price management.
	- Updated `UserProvider` to include new actions for fetching ARB STIP rewards, improving user experience by preloading relevant data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
00c7a1188b986bb732d06b15b246c470f0f93ff0: [synapse-interface preview link ](https://sanguine-synapse-interface-fsabau8h3-synapsecns.vercel.app)