### PR TITLE
Add `AppConfig` library

### DIFF
--- a/packages/contracts-communication/contracts/InterchainClientV1.sol
+++ b/packages/contracts-communication/contracts/InterchainClientV1.sol
@@ -9,6 +9,7 @@ import {IInterchainApp} from "./interfaces/IInterchainApp.sol";
 import {IInterchainClientV1} from "./interfaces/IInterchainClientV1.sol";
 import {IInterchainDB} from "./interfaces/IInterchainDB.sol";
 
+import {AppConfigV1, AppConfigLib} from "./libs/AppConfig.sol";
 import {InterchainEntry} from "./libs/InterchainEntry.sol";
 import {OptionsLib, OptionsV1} from "./libs/Options.sol";
 import {TypeCasts} from "./libs/TypeCasts.sol";
@@ -20,6 +21,7 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
  * @dev Implements the operations of the Interchain Execution Layer.
  */
 contract InterchainClientV1 is Ownable, InterchainClientV1Events, IInterchainClientV1 {
+    using AppConfigLib for bytes;
     using OptionsLib for bytes;
 
     uint64 public clientNonce;
@@ -155,9 +157,11 @@ contract InterchainClientV1 is Ownable, InterchainClientV1Events, IInterchainCli
         view
         returns (uint256 requiredResponses, uint256 optimisticTimePeriod, address[] memory approvedDstModules)
     {
-        requiredResponses = IInterchainApp(receiverApp).getRequiredResponses();
-        optimisticTimePeriod = IInterchainApp(receiverApp).getOptimisticTimePeriod();
-        approvedDstModules = IInterchainApp(receiverApp).getReceivingModules();
+        bytes memory appConfig;
+        (appConfig, approvedDstModules) = IInterchainApp(receiverApp).getReceivingConfig();
+        AppConfigV1 memory decodedAppConfig = appConfig.decodeAppConfigV1();
+        requiredResponses = decodedAppConfig.requiredResponses;
+        optimisticTimePeriod = decodedAppConfig.optimisticPeriod;
     }
 
     // @inheritdoc IInterchainClientV1

--- a/packages/contracts-communication/contracts/interfaces/IInterchainApp.sol
+++ b/packages/contracts-communication/contracts/interfaces/IInterchainApp.sol
@@ -16,11 +16,7 @@ interface IInterchainApp {
 
     function getSendingModules() external view returns (address[] memory);
 
-    function getReceivingModules() external view returns (address[] memory);
-
-    function getRequiredResponses() external view returns (uint256);
-
-    function getOptimisticTimePeriod() external view returns (uint64);
+    function getReceivingConfig() external view returns (bytes memory appConfig, address[] memory modules);
 
     function send(bytes32 receiver, uint256 dstChainId, bytes calldata message) external payable;
 

--- a/packages/contracts-communication/contracts/libs/AppConfig.sol
+++ b/packages/contracts-communication/contracts/libs/AppConfig.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+struct AppConfigV1 {
+    uint256 requiredResponses;
+    uint256 optimisticPeriod;
+}
+
+using AppConfigLib for AppConfigV1 global;
+
+library AppConfigLib {
+    error AppConfigLib__IncorrectVersion(uint8 version);
+
+    uint8 constant APP_CONFIG_V1 = 1;
+
+    /// @notice Encodes versioned app config into a bytes format.
+    /// @param version      The version of the app config.
+    /// @param appConfig    The app config to encode.
+    function encodeVersionedAppConfig(uint8 version, bytes memory appConfig) internal pure returns (bytes memory) {
+        return abi.encode(version, appConfig);
+    }
+
+    /// @notice Decodes versioned app config from a bytes format back into a version and app config.
+    /// @param data         The versioned app config data in bytes format.
+    /// @return version     The version of the app config.
+    /// @return appConfig   The app config as bytes.
+    function decodeVersionedAppConfig(bytes memory data)
+        internal
+        pure
+        returns (uint8 version, bytes memory appConfig)
+    {
+        (version, appConfig) = abi.decode(data, (uint8, bytes));
+    }
+
+    /// @notice Encodes V1 app config into a bytes format.
+    /// @param appConfig    The AppConfigV1 to encode.
+    function encodeAppConfigV1(AppConfigV1 memory appConfig) internal pure returns (bytes memory) {
+        return encodeVersionedAppConfig(APP_CONFIG_V1, abi.encode(appConfig));
+    }
+
+    /// @notice Decodes app config (V1 or higher) from a bytes format back into an AppConfigV1 struct.
+    /// @param data         The app config data in bytes format.
+    function decodeAppConfigV1(bytes memory data) internal pure returns (AppConfigV1 memory) {
+        (uint8 version, bytes memory appConfig) = decodeVersionedAppConfig(data);
+        if (version < APP_CONFIG_V1) {
+            revert AppConfigLib__IncorrectVersion(version);
+        }
+        // Structs of the same version will always be decoded correctly.
+        // Following versions will be decoded correctly if they have the same fields as the previous version,
+        // and new fields at the end: abi.decode ignores the extra bytes in the decoded payload.
+        return abi.decode(appConfig, (AppConfigV1));
+    }
+}

--- a/packages/contracts-communication/foundry.toml
+++ b/packages/contracts-communication/foundry.toml
@@ -1,4 +1,8 @@
 [profile.default]
+auto_detect_solc = true
+# 2024-01-01
+block_timestamp = 1_704_067_200
+evm_version = "paris"
 src = 'contracts'
 out = 'out'
 libs = ["lib"]

--- a/packages/contracts-communication/test/InterchainClientV1Test.t.sol
+++ b/packages/contracts-communication/test/InterchainClientV1Test.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.20;
 
-import {InterchainClientV1} from "../contracts/InterchainClientV1.sol";
+import {InterchainClientV1, AppConfigV1} from "../contracts/InterchainClientV1.sol";
 import {InterchainDB} from "../contracts/InterchainDB.sol";
 
 import {InterchainEntry} from "../contracts/libs/InterchainEntry.sol";
@@ -26,6 +26,8 @@ contract InterchainClientV1Test is Test {
     InterchainAppMock icApp;
     InterchainModuleMock icModule;
 
+    address[] public mockApprovedModules;
+
     // Use default options of V1, 200k gas limit, 0 gas airdrop
     bytes options = OptionsV1(200_000, 0).encodeOptionsV1();
 
@@ -48,6 +50,7 @@ contract InterchainClientV1Test is Test {
         icApp.setReceivingModule(address(icModule));
         vm.stopPrank();
         mockModuleFee(icModule, 1);
+        mockApprovedModules.push(address(icModule));
     }
 
     /// @dev Mocks a return value of module.getModuleFee(DST_CHAIN_ID)
@@ -135,6 +138,13 @@ contract InterchainClientV1Test is Test {
         bytes32 transactionID =
             keccak256(abi.encode(srcSender, SRC_CHAIN_ID, dstReceiver, DST_CHAIN_ID, message, nonce, options));
 
+        AppConfigV1 memory mockAppConfig = AppConfigV1({requiredResponses: 1, optimisticPeriod: 1 hours});
+        vm.mockCall(
+            address(icApp),
+            abi.encodeCall(icApp.getReceivingConfig, ()),
+            abi.encode(mockAppConfig.encodeAppConfigV1(), mockApprovedModules)
+        );
+
         InterchainEntry memory entry =
             InterchainEntry({srcChainId: SRC_CHAIN_ID, srcWriter: srcSender, dbNonce: 0, dataHash: transactionID});
 
@@ -152,7 +162,7 @@ contract InterchainClientV1Test is Test {
             dbNonce: 0
         });
         // Skip ahead of optimistic period
-        vm.warp(icApp.getOptimisticTimePeriod() + 1 minutes);
+        skip(mockAppConfig.optimisticPeriod + 1);
         icClient.interchainExecute(abi.encode(transaction));
     }
 }

--- a/packages/contracts-communication/test/harnesses/AppConfigLibHarness.sol
+++ b/packages/contracts-communication/test/harnesses/AppConfigLibHarness.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {AppConfigV1, AppConfigLib} from "../../contracts/libs/AppConfig.sol";
+
+contract AppConfigLibHarness {
+    function encodeVersionedAppConfig(uint8 version, bytes calldata appConfig) external pure returns (bytes memory) {
+        return AppConfigLib.encodeVersionedAppConfig(version, appConfig);
+    }
+
+    function decodeVersionedAppConfig(bytes calldata data) external pure returns (uint8, bytes memory) {
+        (uint8 version, bytes memory appConfig) = AppConfigLib.decodeVersionedAppConfig(data);
+        return (version, appConfig);
+    }
+
+    function encodeAppConfigV1(AppConfigV1 memory appConfig) external pure returns (bytes memory) {
+        return AppConfigLib.encodeAppConfigV1(appConfig);
+    }
+
+    function decodeAppConfigV1(bytes calldata data) external pure returns (AppConfigV1 memory) {
+        return AppConfigLib.decodeAppConfigV1(data);
+    }
+}

--- a/packages/contracts-communication/test/libs/AppConfigLib.t.sol
+++ b/packages/contracts-communication/test/libs/AppConfigLib.t.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+
+import {AppConfigLib, AppConfigV1, AppConfigLibHarness} from "../harnesses/AppConfigLibHarness.sol";
+
+contract AppConfigLibTest is Test {
+    struct MockAppConfigV2 {
+        uint256 requiredResponses;
+        uint256 optimisticPeriod;
+        bytes32 newField;
+    }
+
+    AppConfigLibHarness public libHarness;
+
+    function setUp() public {
+        libHarness = new AppConfigLibHarness();
+    }
+
+    function test_encodeVersionedAppConfigRoundtrip(uint8 version, bytes memory appConfig) public {
+        bytes memory encoded = libHarness.encodeVersionedAppConfig(version, appConfig);
+        (uint8 newVersion, bytes memory newAppConfig) = libHarness.decodeVersionedAppConfig(encoded);
+        assertEq(newVersion, version);
+        assertEq(newAppConfig, appConfig);
+    }
+
+    function test_encodeAppConfigV1Roundtrip(AppConfigV1 memory appConfig) public {
+        bytes memory encoded = libHarness.encodeAppConfigV1(appConfig);
+        AppConfigV1 memory decoded = libHarness.decodeAppConfigV1(encoded);
+        assertEq(decoded.requiredResponses, appConfig.requiredResponses);
+        assertEq(decoded.optimisticPeriod, appConfig.optimisticPeriod);
+    }
+
+    function test_decodeAppConfigV1_decodesV2(MockAppConfigV2 memory appConfig) public {
+        bytes memory encoded =
+            libHarness.encodeVersionedAppConfig(AppConfigLib.APP_CONFIG_V1 + 1, abi.encode(appConfig));
+        AppConfigV1 memory decoded = libHarness.decodeAppConfigV1(encoded);
+        assertEq(decoded.requiredResponses, appConfig.requiredResponses);
+        assertEq(decoded.optimisticPeriod, appConfig.optimisticPeriod);
+    }
+
+    function test_decodeAppConfigV1_revertLowerVersion() public {
+        AppConfigV1 memory appConfig = AppConfigV1(3, 100);
+        uint8 incorrectVersion = AppConfigLib.APP_CONFIG_V1 - 1;
+        bytes memory encoded = libHarness.encodeVersionedAppConfig(incorrectVersion, abi.encode(appConfig));
+        vm.expectRevert(abi.encodeWithSelector(AppConfigLib.AppConfigLib__IncorrectVersion.selector, incorrectVersion));
+        libHarness.decodeAppConfigV1(encoded);
+    }
+}

--- a/packages/contracts-communication/test/mocks/InterchainAppMock.sol
+++ b/packages/contracts-communication/test/mocks/InterchainAppMock.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.20;
 
 import {IInterchainApp} from "../../contracts/interfaces/IInterchainApp.sol";
+import {AppConfigV1} from "../../contracts/libs/AppConfig.sol";
 
 contract InterchainAppMock is IInterchainApp {
     address[] public receivingModules;
@@ -27,17 +28,7 @@ contract InterchainAppMock is IInterchainApp {
 
     function getSendingModules() external view virtual override returns (address[] memory) {}
 
-    function getReceivingModules() public view override returns (address[] memory) {
-        return receivingModules;
-    }
-
-    function getRequiredResponses() public pure override returns (uint256) {
-        return 1;
-    }
-
-    function getOptimisticTimePeriod() public pure override returns (uint64) {
-        return 0;
-    }
+    function getReceivingConfig() external view returns (bytes memory appConfig, address[] memory modules) {}
 
     function send(bytes32 receiver, uint256 dstChainId, bytes calldata message) external payable virtual override {}
 


### PR DESCRIPTION
**Description**
Adds a library to deal with versioned app configs.

**Note**
`InterchainApp.sol` isn't currently implementing `IInterchainApp`, which will be fixed in a separate PR.