### PR TITLE
Interchain tx/db nonce

### DIFF
--- a/packages/contracts-communication/contracts/InterchainApp.sol
+++ b/packages/contracts-communication/contracts/InterchainApp.sol
@@ -101,7 +101,7 @@ contract InterchainApp is IInterchainApp {
     }
 
     // TODO: Auth checks based on incoming message
-    function appReceive(uint256 srcChainId, bytes32 sender, uint64 nonce, bytes calldata message) external payable {
+    function appReceive(uint256 srcChainId, bytes32 sender, uint256 dbNonce, bytes calldata message) external payable {
         emit AppMessageRecieve();
     }
 }

--- a/packages/contracts-communication/contracts/InterchainClientV1.sol
+++ b/packages/contracts-communication/contracts/InterchainClientV1.sol
@@ -100,6 +100,7 @@ contract InterchainClientV1 is Ownable, InterchainClientV1Events, IInterchainCli
         IInterchainApp(TypeCasts.bytes32ToAddress(icTx.dstReceiver)).appReceive{gas: gasLimit, value: msg.value}({
             srcChainId: icTx.srcChainId,
             sender: icTx.srcSender,
+            dbNonce: icTx.dbNonce,
             message: icTx.message
         });
         emit InterchainTransactionReceived(

--- a/packages/contracts-communication/contracts/InterchainClientV1.sol
+++ b/packages/contracts-communication/contracts/InterchainClientV1.sol
@@ -28,8 +28,6 @@ contract InterchainClientV1 is Ownable, InterchainClientV1Events, IInterchainCli
     /// @notice Address of the InterchainDB contract, set at the time of deployment.
     address public immutable INTERCHAIN_DB;
 
-    /// @notice Nonce of the next message to be sent by the client
-    uint64 public clientNonce;
     /// @notice Address of the contract that handles execution fees. Can be updated by the owner.
     address public executionFees;
 
@@ -102,7 +100,6 @@ contract InterchainClientV1 is Ownable, InterchainClientV1Events, IInterchainCli
         IInterchainApp(TypeCasts.bytes32ToAddress(icTx.dstReceiver)).appReceive{gas: gasLimit, value: msg.value}({
             srcChainId: icTx.srcChainId,
             sender: icTx.srcSender,
-            nonce: icTx.nonce,
             message: icTx.message
         });
         emit InterchainTransactionReceived(
@@ -164,7 +161,6 @@ contract InterchainClientV1 is Ownable, InterchainClientV1Events, IInterchainCli
                 srcSender: address(0),
                 dstReceiver: 0,
                 dstChainId: dstChainId,
-                nonce: 0,
                 dbNonce: 0,
                 options: options,
                 message: message
@@ -212,7 +208,6 @@ contract InterchainClientV1 is Ownable, InterchainClientV1Events, IInterchainCli
             srcSender: msg.sender,
             dstReceiver: receiver,
             dstChainId: dstChainId,
-            nonce: clientNonce,
             dbNonce: IInterchainDB(INTERCHAIN_DB).getDBNonce(),
             options: options,
             message: message
@@ -243,7 +238,6 @@ contract InterchainClientV1 is Ownable, InterchainClientV1Events, IInterchainCli
         emit InterchainTransactionSent(
             transactionId,
             icTx.dbNonce,
-            icTx.nonce,
             icTx.dstChainId,
             icTx.srcSender,
             icTx.dstReceiver,
@@ -252,8 +246,6 @@ contract InterchainClientV1 is Ownable, InterchainClientV1Events, IInterchainCli
             icTx.options,
             icTx.message
         );
-        // TODO: consider using an app-specific nonces, or remove the nonce entirely
-        clientNonce++;
     }
 
     // ══════════════════════════════════════════════ INTERNAL VIEWS ═══════════════════════════════════════════════════

--- a/packages/contracts-communication/contracts/events/InterchainClientV1Events.sol
+++ b/packages/contracts-communication/contracts/events/InterchainClientV1Events.sol
@@ -7,7 +7,6 @@ abstract contract InterchainClientV1Events {
     event InterchainTransactionSent(
         bytes32 indexed transactionId,
         uint256 indexed dbNonce,
-        uint256 clientNonce,
         uint256 dstChainId,
         bytes32 srcSender,
         bytes32 dstReceiver,

--- a/packages/contracts-communication/contracts/interfaces/IInterchainApp.sol
+++ b/packages/contracts-communication/contracts/interfaces/IInterchainApp.sol
@@ -20,5 +20,5 @@ interface IInterchainApp {
 
     function send(bytes32 receiver, uint256 dstChainId, bytes calldata message) external payable;
 
-    function appReceive(uint256 srcChainId, bytes32 sender, uint64 nonce, bytes calldata message) external payable;
+    function appReceive(uint256 srcChainId, bytes32 sender, uint256 dbNonce, bytes calldata message) external payable;
 }

--- a/packages/contracts-communication/contracts/interfaces/IInterchainClientV1.sol
+++ b/packages/contracts-communication/contracts/interfaces/IInterchainClientV1.sol
@@ -38,6 +38,8 @@ interface IInterchainClientV1 {
      * @param srcModules The source modules involved in the message sending.
      * @param options Execution options for the message sent, encoded as bytes, currently gas limit + native gas drop.
      * @param message The message being sent.
+     * @return transactionId The ID of the transaction that was sent.
+     * @return dbNonce The database nonce of the written entry for the transaction.
      */
     function interchainSend(
         uint256 dstChainId,
@@ -48,7 +50,8 @@ interface IInterchainClientV1 {
         bytes calldata message
     )
         external
-        payable;
+        payable
+        returns (bytes32 transactionId, uint256 dbNonce);
 
     function interchainSendEVM(
         uint256 dstChainId,
@@ -59,7 +62,8 @@ interface IInterchainClientV1 {
         bytes calldata message
     )
         external
-        payable;
+        payable
+        returns (bytes32 transactionId, uint256 dbNonce);
 
     /**
      * @notice Executes a transaction that has been sent via the Interchain.

--- a/packages/contracts-communication/contracts/libs/InterchainTransaction.sol
+++ b/packages/contracts-communication/contracts/libs/InterchainTransaction.sol
@@ -8,7 +8,6 @@ struct InterchainTransaction {
     bytes32 srcSender;
     uint256 dstChainId;
     bytes32 dstReceiver;
-    uint64 nonce;
     uint256 dbNonce;
     bytes options;
     bytes message;
@@ -21,7 +20,6 @@ library InterchainTransactionLib {
         address srcSender,
         uint256 dstChainId,
         bytes32 dstReceiver,
-        uint64 nonce,
         uint256 dbNonce,
         bytes memory options,
         bytes memory message
@@ -35,7 +33,6 @@ library InterchainTransactionLib {
             srcSender: TypeCasts.addressToBytes32(srcSender),
             dstChainId: dstChainId,
             dstReceiver: dstReceiver,
-            nonce: nonce,
             dbNonce: dbNonce,
             options: options,
             message: message

--- a/packages/contracts-communication/test/InterchainClientV1Test.t.sol
+++ b/packages/contracts-communication/test/InterchainClientV1Test.t.sol
@@ -124,20 +124,18 @@ contract InterchainClientV1Test is Test {
         bytes32 srcSender = TypeCasts.addressToBytes32(makeAddr("Sender"));
         vm.prank(contractOwner);
         icClient.setLinkedClient(SRC_CHAIN_ID, srcSender);
-        uint64 nonce = 1;
         uint256 dbNonce = 2;
         InterchainTransaction memory transaction = InterchainTransaction({
             srcSender: srcSender,
             srcChainId: SRC_CHAIN_ID,
             dstReceiver: dstReceiver,
             dstChainId: DST_CHAIN_ID,
-            nonce: nonce,
             dbNonce: dbNonce,
             options: options,
             message: message
         });
         bytes32 transactionID = keccak256(abi.encode(transaction));
-        bytes memory expectedAppCalldata = abi.encodeCall(icApp.appReceive, (SRC_CHAIN_ID, srcSender, nonce, message));
+        bytes memory expectedAppCalldata = abi.encodeCall(icApp.appReceive, (SRC_CHAIN_ID, srcSender, dbNonce, message));
 
         AppConfigV1 memory mockAppConfig = AppConfigV1({requiredResponses: 1, optimisticPeriod: 1 hours});
         vm.mockCall(

--- a/packages/contracts-communication/test/harnesses/InterchainTransactionLibHarness.sol
+++ b/packages/contracts-communication/test/harnesses/InterchainTransactionLibHarness.sol
@@ -8,7 +8,6 @@ contract InterchainTransactionLibHarness {
         address srcSender,
         uint256 dstChainId,
         bytes32 dstReceiver,
-        uint64 nonce,
         uint256 dbNonce,
         bytes memory options,
         bytes memory message
@@ -18,7 +17,7 @@ contract InterchainTransactionLibHarness {
         returns (InterchainTransaction memory transaction)
     {
         return InterchainTransactionLib.constructLocalTransaction(
-            srcSender, dstChainId, dstReceiver, nonce, dbNonce, options, message
+            srcSender, dstChainId, dstReceiver, dbNonce, options, message
         );
     }
 

--- a/packages/contracts-communication/test/libs/InterchainTransaction.t.sol
+++ b/packages/contracts-communication/test/libs/InterchainTransaction.t.sol
@@ -7,6 +7,7 @@ import {
 
 import {Test} from "forge-std/Test.sol";
 
+// solhint-disable func-name-mixedcase
 contract InterchainTransactionLibTest is Test {
     InterchainTransactionLibHarness public libHarness;
 
@@ -19,7 +20,6 @@ contract InterchainTransactionLibTest is Test {
         address srcSender,
         uint256 dstChainId,
         bytes32 dstReceiver,
-        uint64 nonce,
         uint256 dbNonce,
         bytes memory options,
         bytes memory message
@@ -28,12 +28,11 @@ contract InterchainTransactionLibTest is Test {
     {
         vm.chainId(srcChainId);
         InterchainTransaction memory icTx =
-            libHarness.constructLocalTransaction(srcSender, dstChainId, dstReceiver, nonce, dbNonce, options, message);
+            libHarness.constructLocalTransaction(srcSender, dstChainId, dstReceiver, dbNonce, options, message);
         assertEq(icTx.srcChainId, srcChainId, "!srcChainId");
         assertEq(icTx.srcSender, bytes32(uint256(uint160(srcSender))), "!srcSender");
         assertEq(icTx.dstChainId, dstChainId, "!dstChainId");
         assertEq(icTx.dstReceiver, dstReceiver, "!dstReceiver");
-        assertEq(icTx.nonce, nonce, "!nonce");
         assertEq(icTx.dbNonce, dbNonce, "!dbNonce");
         assertEq(icTx.options, options, "!options");
         assertEq(icTx.message, message, "!message");
@@ -46,7 +45,6 @@ contract InterchainTransactionLibTest is Test {
         assertEq(decoded.srcSender, icTx.srcSender, "!srcSender");
         assertEq(decoded.dstChainId, icTx.dstChainId, "!dstChainId");
         assertEq(decoded.dstReceiver, icTx.dstReceiver, "!dstReceiver");
-        assertEq(decoded.nonce, icTx.nonce, "!nonce");
         assertEq(decoded.dbNonce, icTx.dbNonce, "!dbNonce");
         assertEq(decoded.options, icTx.options, "!options");
         assertEq(decoded.message, icTx.message, "!message");

--- a/packages/contracts-communication/test/mocks/InterchainAppMock.sol
+++ b/packages/contracts-communication/test/mocks/InterchainAppMock.sol
@@ -32,5 +32,5 @@ contract InterchainAppMock is IInterchainApp {
 
     function send(bytes32 receiver, uint256 dstChainId, bytes calldata message) external payable virtual override {}
 
-    function appReceive(uint256 srcChainId, bytes32 sender, uint64 nonce, bytes calldata message) external payable {}
+    function appReceive(uint256 srcChainId, bytes32 sender, uint256 dbNonce, bytes calldata message) external payable {}
 }


### PR DESCRIPTION
**Description**
Removes `clientNonce` in Interchain Client, and uses `dbNonce` for transaction uniqueness. 

Includes a breaking change to the `InterchainTransactionSent` event in `InterchainClientV1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced interchain communication capabilities with updated transaction nonce handling, improving reliability and scalability.

- **Refactor**
	- Simplified nonce management in interchain transactions by replacing `uint64 nonce` with `uint256 dbNonce` across various contracts and interfaces.
	- Removed redundant `clientNonce` variable and updated function signatures to support the new nonce format.

- **Tests**
	- Updated test suites to align with the changes in nonce handling, ensuring robustness and consistency in interchain transaction processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->