### PR TITLE
Feat: synapse module cleanup

### DIFF
--- a/packages/contracts-communication/contracts/events/SynapseModuleEvents.sol
+++ b/packages/contracts-communication/contracts/events/SynapseModuleEvents.sol
@@ -8,6 +8,7 @@ abstract contract SynapseModuleEvents {
 
     event FeeCollectorChanged(address feeCollector);
     event GasOracleChanged(address gasOracle);
+    event VerifyGasLimitChanged(uint256 chainId, uint256 gasLimit);
 
     event ClaimFeeFractionChanged(uint256 claimFeeFraction);
     event FeesClaimed(address feeCollector, uint256 collectedFees, address claimer, uint256 claimerFee);

--- a/packages/contracts-communication/contracts/events/SynapseModuleEvents.sol
+++ b/packages/contracts-communication/contracts/events/SynapseModuleEvents.sol
@@ -8,4 +8,7 @@ abstract contract SynapseModuleEvents {
 
     event FeeCollectorChanged(address feeCollector);
     event GasOracleChanged(address gasOracle);
+
+    event ClaimFeeFractionChanged(uint256 claimFeeFraction);
+    event FeesClaimed(address feeCollector, uint256 collectedFees, address claimer, uint256 claimerFee);
 }

--- a/packages/contracts-communication/contracts/interfaces/ISynapseModule.sol
+++ b/packages/contracts-communication/contracts/interfaces/ISynapseModule.sol
@@ -13,10 +13,20 @@ interface ISynapseModule is IInterchainModule {
     /// @param verifier     The address of the verifier to add
     function addVerifier(address verifier) external;
 
+    /// @notice Adds a list of new verifiers to the module.
+    /// @dev Could be only called by the owner. Will revert if any of the verifiers is already added.
+    /// @param verifiers    The list of addresses of the verifiers to add
+    function addVerifiers(address[] calldata verifiers) external;
+
     /// @notice Removes a verifier from the module.
     /// @dev Could be only called by the owner. Will revert if the verifier is not added.
     /// @param verifier     The address of the verifier to remove
     function removeVerifier(address verifier) external;
+
+    /// @notice Removes a list of verifiers from the module.
+    /// @dev Could be only called by the owner. Will revert if any of the verifiers is not added.
+    /// @param verifiers    The list of addresses of the verifiers to remove
+    function removeVerifiers(address[] calldata verifiers) external;
 
     /// @notice Sets the threshold of the module.
     /// @dev Could be only called by the owner. Will revert if the threshold is zero.

--- a/packages/contracts-communication/contracts/interfaces/ISynapseModule.sol
+++ b/packages/contracts-communication/contracts/interfaces/ISynapseModule.sol
@@ -4,7 +4,10 @@ pragma solidity ^0.8.0;
 import {IInterchainModule} from "./IInterchainModule.sol";
 
 interface ISynapseModule is IInterchainModule {
+    error SynapseModule__ClaimFeeFractionExceedsMax(uint256 claimFeeFraction);
+    error SynapseModule__FeeCollectorNotSet();
     error SynapseModule__GasOracleNotContract(address gasOracle);
+    error SynapseModule__NoFeesToClaim();
 
     // ═══════════════════════════════════════════════ PERMISSIONED ════════════════════════════════════════════════════
 
@@ -38,12 +41,25 @@ interface ISynapseModule is IInterchainModule {
     /// @param feeCollector_   The address of the fee collector
     function setFeeCollector(address feeCollector_) external;
 
+    /// @notice Sets the fraction of the accumulated fees to be paid to caller of `claimFees`.
+    /// This encourages rational actors to call the function as soon as claim fee is higher than the gas cost.
+    /// @dev Could be only called by the owner. Could not exceed 1%.
+    /// @param claimFeeFraction The fraction of the fees to be paid to the claimer (100% = 1e18)
+    function setClaimFeeFraction(uint256 claimFeeFraction) external;
+
     /// @notice Sets the address of the gas oracle to be used for estimating the verification fees.
     /// @dev Could be only called by the owner. Will revert if the gas oracle is not a contract.
     /// @param gasOracle_   The address of the gas oracle contract
     function setGasOracle(address gasOracle_) external;
 
     // ══════════════════════════════════════════════ PERMISSIONLESS ═══════════════════════════════════════════════════
+
+    /// @notice Transfers the accumulated fees to the fee collector.
+    /// Message caller receives a percentage of the fees, this ensures that the module is self-sustainable.
+    /// The claim fee amount could be retrieved using `getClaimFeeAmount`. The rest of the fees
+    /// will be transferred to the fee collector.
+    /// @dev Will revert if the fee collector is not set.
+    function claimFees() external;
 
     /// @notice Verifies an entry using a set of verifier signatures.
     /// If the threshold is met, the entry will be marked as verified in the Interchain DataBase.
@@ -56,6 +72,13 @@ interface ISynapseModule is IInterchainModule {
 
     /// @notice Returns the address of the fee collector for the module.
     function feeCollector() external view returns (address);
+
+    /// @notice Returns the current claim fee to be paid to the caller of `claimFees`.
+    function getClaimFeeAmount() external view returns (uint256);
+
+    /// @notice Returns the fraction of the fees to be paid to the caller of `claimFees`.
+    /// The returned value is in the range [0, 1e18], where 1e18 corresponds to 100% of the fees.
+    function getClaimFeeFraction() external view returns (uint256);
 
     /// @notice Returns the address of the gas oracle used for estimating the verification fees.
     function gasOracle() external view returns (address);

--- a/packages/contracts-communication/contracts/interfaces/ISynapseModule.sol
+++ b/packages/contracts-communication/contracts/interfaces/ISynapseModule.sol
@@ -52,6 +52,12 @@ interface ISynapseModule is IInterchainModule {
     /// @param gasOracle_   The address of the gas oracle contract
     function setGasOracle(address gasOracle_) external;
 
+    /// @notice Sets the estimated gas limit for verifying an entry on the given chain.
+    /// @dev Could be only called by the owner.
+    /// @param chainId      The chain ID for which to set the gas limit
+    /// @param gasLimit     The new gas limit
+    function setVerifyGasLimit(uint256 chainId, uint256 gasLimit) external;
+
     // ══════════════════════════════════════════════ PERMISSIONLESS ═══════════════════════════════════════════════════
 
     /// @notice Transfers the accumulated fees to the fee collector.
@@ -92,4 +98,8 @@ interface ISynapseModule is IInterchainModule {
 
     /// @notice Checks if the given account is a verifier for the module.
     function isVerifier(address account) external view returns (bool);
+
+    /// @notice Returns the estimated gas limit for verifying an entry on the given chain.
+    /// Note: this defaults to DEFAULT_VERIFY_GAS_LIMIT if not set.
+    function getVerifyGasLimit(uint256 chainId) external view returns (uint256);
 }

--- a/packages/contracts-communication/contracts/libs/ThresholdECDSA.sol
+++ b/packages/contracts-communication/contracts/libs/ThresholdECDSA.sol
@@ -20,6 +20,7 @@ library ThresholdECDSALib {
     error ThresholdECDSA__NotEnoughSignatures(uint256 threshold);
     error ThresholdECDSA__NotSigner(address account);
     error ThresholdECDSA__RecoveredSignersNotSorted();
+    error ThresholdECDSA__ZeroAddress();
     error ThresholdECDSA__ZeroThreshold();
 
     uint256 private constant SIGNATURE_LENGTH = 65;
@@ -27,6 +28,7 @@ library ThresholdECDSALib {
     /// @notice Adds a new signer to the list of signers.
     /// @dev Will revert if the account is already a signer.
     function addSigner(ThresholdECDSA storage self, address account) internal {
+        if (account == address(0)) revert ThresholdECDSA__ZeroAddress();
         bool added = self._signers.add(account);
         if (!added) {
             revert ThresholdECDSA__AlreadySigner(account);

--- a/packages/contracts-communication/contracts/libs/ThresholdECDSA.sol
+++ b/packages/contracts-communication/contracts/libs/ThresholdECDSA.sol
@@ -11,8 +11,11 @@ struct ThresholdECDSA {
 
 using ThresholdECDSALib for ThresholdECDSA global;
 
+// solhint-disable code-complexity
 library ThresholdECDSALib {
     using EnumerableSet for EnumerableSet.AddressSet;
+
+    uint256 private constant SIGNATURE_LENGTH = 65;
 
     error ThresholdECDSA__AlreadySigner(address account);
     error ThresholdECDSA__IncorrectSignaturesLength(uint256 length);
@@ -22,8 +25,6 @@ library ThresholdECDSALib {
     error ThresholdECDSA__RecoveredSignersNotSorted();
     error ThresholdECDSA__ZeroAddress();
     error ThresholdECDSA__ZeroThreshold();
-
-    uint256 private constant SIGNATURE_LENGTH = 65;
 
     /// @notice Adds a new signer to the list of signers.
     /// @dev Will revert if the account is already a signer.

--- a/packages/contracts-communication/contracts/modules/InterchainModule.sol
+++ b/packages/contracts-communication/contracts/modules/InterchainModule.sol
@@ -38,10 +38,6 @@ abstract contract InterchainModule is InterchainModuleEvents, IInterchainModule 
         emit VerificationRequested(destChainId, encodedEntry, ethSignedEntryHash);
     }
 
-    function decodeEntry(bytes memory entry) external pure returns (InterchainEntry memory) {
-        return abi.decode(entry, (InterchainEntry));
-    }
-
     /// @inheritdoc IInterchainModule
     function getModuleFee(uint256 destChainId) external view returns (uint256) {
         return _getModuleFee(destChainId);

--- a/packages/contracts-communication/contracts/modules/InterchainModule.sol
+++ b/packages/contracts-communication/contracts/modules/InterchainModule.sol
@@ -57,7 +57,8 @@ abstract contract InterchainModule is InterchainModuleEvents, IInterchainModule 
     }
 
     /// @dev Internal logic to request the verification of an entry on the destination chain.
-    function _requestVerification(uint256 destChainId, bytes memory encodedEntry) internal virtual;
+    // solhint-disable-next-line no-empty-blocks
+    function _requestVerification(uint256 destChainId, bytes memory encodedEntry) internal virtual {}
 
     /// @dev Internal logic to get the module fee for verifying an entry on the specified destination chain.
     function _getModuleFee(uint256 destChainId) internal view virtual returns (uint256);

--- a/packages/contracts-communication/contracts/modules/SynapseModule.sol
+++ b/packages/contracts-communication/contracts/modules/SynapseModule.sol
@@ -7,7 +7,6 @@ import {SynapseModuleEvents} from "../events/SynapseModuleEvents.sol";
 import {IGasOracle} from "../interfaces/IGasOracle.sol";
 import {ISynapseModule} from "../interfaces/ISynapseModule.sol";
 
-import {InterchainEntry} from "../libs/InterchainEntry.sol";
 import {ThresholdECDSA} from "../libs/ThresholdECDSA.sol";
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";

--- a/packages/contracts-communication/contracts/modules/SynapseModule.sol
+++ b/packages/contracts-communication/contracts/modules/SynapseModule.sol
@@ -64,12 +64,14 @@ contract SynapseModule is InterchainModule, Ownable, SynapseModuleEvents, ISynap
 
     /// @inheritdoc ISynapseModule
     function setThreshold(uint256 threshold) external onlyOwner {
-        _setThreshold(threshold);
+        _verifiers.modifyThreshold(threshold);
+        emit ThresholdChanged(threshold);
     }
 
     /// @inheritdoc ISynapseModule
     function setFeeCollector(address feeCollector_) external onlyOwner {
-        _setFeeCollector(feeCollector_);
+        feeCollector = feeCollector_;
+        emit FeeCollectorChanged(feeCollector_);
     }
 
     /// @inheritdoc ISynapseModule
@@ -153,19 +155,6 @@ contract SynapseModule is InterchainModule, Ownable, SynapseModuleEvents, ISynap
     function _removeVerifier(address verifier) internal {
         _verifiers.removeSigner(verifier);
         emit VerifierRemoved(verifier);
-    }
-
-    /// @dev Sets the threshold for the module. Permissions should be checked in the calling function.
-    function _setThreshold(uint256 threshold) internal {
-        _verifiers.modifyThreshold(threshold);
-        emit ThresholdChanged(threshold);
-    }
-
-    /// @dev Internal logic to set the address of the fee collector.
-    /// Permissions should be checked in the calling function.
-    function _setFeeCollector(address feeCollector_) internal {
-        feeCollector = feeCollector_;
-        emit FeeCollectorChanged(feeCollector_);
     }
 
     // ══════════════════════════════════════════════ INTERNAL VIEWS ═══════════════════════════════════════════════════

--- a/packages/contracts-communication/contracts/modules/SynapseModule.sol
+++ b/packages/contracts-communication/contracts/modules/SynapseModule.sol
@@ -14,6 +14,8 @@ import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
 contract SynapseModule is InterchainModule, Ownable, SynapseModuleEvents, ISynapseModule {
+    // TODO: make sure this is a good enough default value
+    uint256 public constant DEFAULT_VERIFY_GAS_LIMIT = 100_000;
     uint256 public constant VERIFY_GAS_LIMIT = 100_000;
     uint256 internal constant MAX_CLAIM_FEE_FRACTION = 0.01e18; // 1%
     uint256 internal constant FEE_PRECISION = 1e18;
@@ -92,6 +94,11 @@ contract SynapseModule is InterchainModule, Ownable, SynapseModuleEvents, ISynap
         emit GasOracleChanged(gasOracle_);
     }
 
+    /// @inheritdoc ISynapseModule
+    function setVerifyGasLimit(uint256 chainId, uint256 gasLimit) external onlyOwner {
+        // TODO: implement
+    }
+
     // ══════════════════════════════════════════════ PERMISSIONLESS ═══════════════════════════════════════════════════
 
     /// @inheritdoc ISynapseModule
@@ -141,6 +148,11 @@ contract SynapseModule is InterchainModule, Ownable, SynapseModuleEvents, ISynap
     /// @inheritdoc ISynapseModule
     function getThreshold() public view returns (uint256) {
         return _verifiers.getThreshold();
+    }
+
+    /// @inheritdoc ISynapseModule
+    function getVerifyGasLimit(uint256 chainId) public view override returns (uint256) {
+        // TODO: implement
     }
 
     // ══════════════════════════════════════════════ INTERNAL LOGIC ═══════════════════════════════════════════════════

--- a/packages/contracts-communication/contracts/modules/SynapseModule.sol
+++ b/packages/contracts-communication/contracts/modules/SynapseModule.sol
@@ -34,14 +34,28 @@ contract SynapseModule is InterchainModule, Ownable, SynapseModuleEvents, ISynap
 
     /// @inheritdoc ISynapseModule
     function addVerifier(address verifier) external onlyOwner {
-        _verifiers.addSigner(verifier);
-        emit VerifierAdded(verifier);
+        _addVerifier(verifier);
+    }
+
+    /// @inheritdoc ISynapseModule
+    function addVerifiers(address[] calldata verifiers) external onlyOwner {
+        uint256 length = verifiers.length;
+        for (uint256 i = 0; i < length; ++i) {
+            _addVerifier(verifiers[i]);
+        }
     }
 
     /// @inheritdoc ISynapseModule
     function removeVerifier(address verifier) external onlyOwner {
-        _verifiers.removeSigner(verifier);
-        emit VerifierRemoved(verifier);
+        _removeVerifier(verifier);
+    }
+
+    /// @inheritdoc ISynapseModule
+    function removeVerifiers(address[] calldata verifiers) external onlyOwner {
+        uint256 length = verifiers.length;
+        for (uint256 i = 0; i < length; ++i) {
+            _removeVerifier(verifiers[i]);
+        }
     }
 
     /// @inheritdoc ISynapseModule
@@ -90,6 +104,18 @@ contract SynapseModule is InterchainModule, Ownable, SynapseModuleEvents, ISynap
     }
 
     // ══════════════════════════════════════════════ INTERNAL LOGIC ═══════════════════════════════════════════════════
+
+    /// @dev Adds a verifier to the module. Permissions should be checked in the calling function.
+    function _addVerifier(address verifier) internal {
+        _verifiers.addSigner(verifier);
+        emit VerifierAdded(verifier);
+    }
+
+    /// @dev Removes a verifier from the module. Permissions should be checked in the calling function.
+    function _removeVerifier(address verifier) internal {
+        _verifiers.removeSigner(verifier);
+        emit VerifierRemoved(verifier);
+    }
 
     /// @dev Sets the threshold for the module. Permissions should be checked in the calling function.
     function _setThreshold(uint256 threshold) internal {

--- a/packages/contracts-communication/contracts/modules/SynapseModule.sol
+++ b/packages/contracts-communication/contracts/modules/SynapseModule.sol
@@ -68,6 +68,11 @@ contract SynapseModule is InterchainModule, Ownable, SynapseModuleEvents, ISynap
     }
 
     /// @inheritdoc ISynapseModule
+    function setClaimFeeFraction(uint256 claimFeeFraction) external onlyOwner {
+        // TODO: implement
+    }
+
+    /// @inheritdoc ISynapseModule
     function setGasOracle(address gasOracle_) external onlyOwner {
         if (gasOracle_.code.length == 0) {
             revert SynapseModule__GasOracleNotContract(gasOracle_);
@@ -79,6 +84,11 @@ contract SynapseModule is InterchainModule, Ownable, SynapseModuleEvents, ISynap
     // ══════════════════════════════════════════════ PERMISSIONLESS ═══════════════════════════════════════════════════
 
     /// @inheritdoc ISynapseModule
+    function claimFees() external {
+        // TODO: implement
+    }
+
+    /// @inheritdoc ISynapseModule
     function verifyEntry(bytes calldata encodedEntry, bytes calldata signatures) external {
         bytes32 ethSignedHash = MessageHashUtils.toEthSignedMessageHash(keccak256(encodedEntry));
         _verifiers.verifySignedHash(ethSignedHash, signatures);
@@ -86,6 +96,16 @@ contract SynapseModule is InterchainModule, Ownable, SynapseModuleEvents, ISynap
     }
 
     // ═══════════════════════════════════════════════════ VIEWS ═══════════════════════════════════════════════════════
+
+    /// @inheritdoc ISynapseModule
+    function getClaimFeeAmount() external view returns (uint256) {
+        // TODO: implement
+    }
+
+    /// @inheritdoc ISynapseModule
+    function getClaimFeeFraction() external view returns (uint256) {
+        // TODO: implement
+    }
 
     /// @inheritdoc ISynapseModule
     function getVerifiers() external view returns (address[] memory) {

--- a/packages/contracts-communication/test/libs/ThresholdECDSALib.t.sol
+++ b/packages/contracts-communication/test/libs/ThresholdECDSALib.t.sol
@@ -70,6 +70,10 @@ contract ThresholdECDSALibTest is Test {
         vm.expectRevert(abi.encodeWithSelector(ThresholdECDSALib.ThresholdECDSA__RecoveredSignersNotSorted.selector));
     }
 
+    function expectZeroAddressError() internal {
+        vm.expectRevert(ThresholdECDSALib.ThresholdECDSA__ZeroAddress.selector);
+    }
+
     function expectZeroThresholdError() internal {
         vm.expectRevert(abi.encodeWithSelector(ThresholdECDSALib.ThresholdECDSA__ZeroThreshold.selector));
     }
@@ -192,6 +196,11 @@ contract ThresholdECDSALibTest is Test {
         libHarness.addSigner(SIGNER_1);
         expectAlreadySignerError(SIGNER_2);
         libHarness.addSigner(SIGNER_2);
+    }
+
+    function test_addSigner_revert_zeroAddress() public {
+        expectZeroAddressError();
+        libHarness.addSigner(address(0));
     }
 
     function test_removeSigner_revert_notSigner() public {

--- a/packages/contracts-communication/test/libs/ThresholdECDSALib.t.sol
+++ b/packages/contracts-communication/test/libs/ThresholdECDSALib.t.sol
@@ -5,6 +5,9 @@ import {ThresholdECDSALib, ThresholdECDSALibHarness} from "../harnesses/Threshol
 
 import {Test} from "forge-std/Test.sol";
 
+// solhint-disable func-name-mixedcase
+// solhint-disable ordering
+// solhint-disable var-name-mixedcase
 contract ThresholdECDSALibTest is Test {
     ThresholdECDSALibHarness public libHarness;
 

--- a/packages/contracts-communication/test/modules/SynapseModule.Destination.t.sol
+++ b/packages/contracts-communication/test/modules/SynapseModule.Destination.t.sol
@@ -4,14 +4,17 @@ pragma solidity 0.8.20;
 import {InterchainModuleEvents} from "../../contracts/events/InterchainModuleEvents.sol";
 import {SynapseModuleEvents} from "../../contracts/events/SynapseModuleEvents.sol";
 import {IInterchainModule} from "../../contracts/interfaces/IInterchainModule.sol";
+import {InterchainEntry} from "../../contracts/libs/InterchainEntry.sol";
 import {ThresholdECDSALib} from "../../contracts/libs/ThresholdECDSA.sol";
-import {SynapseModule, InterchainEntry, ISynapseModule} from "../../contracts/modules/SynapseModule.sol";
+import {SynapseModule} from "../../contracts/modules/SynapseModule.sol";
 
 import {GasOracleMock} from "../mocks/GasOracleMock.sol";
 import {InterchainDBMock, IInterchainDB} from "../mocks/InterchainDBMock.sol";
 
 import {Test} from "forge-std/Test.sol";
 
+// solhint-disable func-name-mixedcase
+// solhint-disable ordering
 contract SynapseModuleDestinationTest is Test, InterchainModuleEvents, SynapseModuleEvents {
     SynapseModule public module;
     GasOracleMock public gasOracle;

--- a/packages/contracts-communication/test/modules/SynapseModule.Management.t.sol
+++ b/packages/contracts-communication/test/modules/SynapseModule.Management.t.sol
@@ -233,6 +233,44 @@ contract SynapseModuleManagementTest is Test, SynapseModuleEvents {
         module.setFeeCollector(feeCollector);
     }
 
+    function test_setFeeFraction_setsFeeFraction() public {
+        vm.prank(owner);
+        module.setClaimFeeFraction(0.001e18);
+        assertEq(module.getClaimFeeFraction(), 0.001e18);
+    }
+
+    function test_setFeeFraction_emitsEvent() public {
+        vm.expectEmit(address(module));
+        emit ClaimFeeFractionChanged(0.001e18);
+        vm.prank(owner);
+        module.setClaimFeeFraction(0.001e18);
+    }
+
+    function test_setFeeFraction_exactlyMax() public {
+        uint256 maxFeeFraction = 0.01e18;
+        vm.expectEmit(address(module));
+        emit ClaimFeeFractionChanged(maxFeeFraction);
+        vm.prank(owner);
+        module.setClaimFeeFraction(maxFeeFraction);
+        assertEq(module.getClaimFeeFraction(), maxFeeFraction);
+    }
+
+    function test_setFeeFraction_revert_exceedsMax() public {
+        uint256 fractionTooBig = 0.01e18 + 1;
+        vm.expectRevert(
+            abi.encodeWithSelector(ISynapseModule.SynapseModule__ClaimFeeFractionExceedsMax.selector, fractionTooBig)
+        );
+        vm.prank(owner);
+        module.setClaimFeeFraction(fractionTooBig);
+    }
+
+    function test_setFeeFraction_revert_notOwner(address notOwner) public {
+        vm.assume(notOwner != owner);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, notOwner));
+        vm.prank(notOwner);
+        module.setClaimFeeFraction(0.001e18);
+    }
+
     function test_setGasOracle_setsGasOracle() public {
         vm.prank(owner);
         module.setGasOracle(address(gasOracle));

--- a/packages/contracts-communication/test/modules/SynapseModule.Management.t.sol
+++ b/packages/contracts-communication/test/modules/SynapseModule.Management.t.sol
@@ -301,4 +301,24 @@ contract SynapseModuleManagementTest is Test, SynapseModuleEvents {
         vm.prank(owner);
         module.setGasOracle(notContract);
     }
+
+    function test_setVerifyGasLimit_setsVerifyGasLimit() public {
+        vm.prank(owner);
+        module.setVerifyGasLimit(1, 1000);
+        assertEq(module.getVerifyGasLimit(1), 1000);
+    }
+
+    function test_setVerifyGasLimit_emitsEvent() public {
+        vm.expectEmit(address(module));
+        emit VerifyGasLimitChanged(1, 1000);
+        vm.prank(owner);
+        module.setVerifyGasLimit(1, 1000);
+    }
+
+    function test_setVerifyGasLimit_revert_notOwner(address notOwner) public {
+        vm.assume(notOwner != owner);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, notOwner));
+        vm.prank(notOwner);
+        module.setVerifyGasLimit(1, 1000);
+    }
 }

--- a/packages/contracts-communication/test/modules/SynapseModule.Management.t.sol
+++ b/packages/contracts-communication/test/modules/SynapseModule.Management.t.sol
@@ -62,34 +62,34 @@ contract SynapseModuleManagementTest is Test, SynapseModuleEvents {
         assertEq(verifiers[2], VERIFIER_3);
     }
 
-    function test_addSigner_addsSinger() public {
+    function test_addVerifier_addsVerifier() public {
         vm.prank(owner);
         module.addVerifier(VERIFIER_1);
         assertTrue(module.isVerifier(VERIFIER_1));
     }
 
-    function test_addSigner_emitsEvent() public {
+    function test_addVerifier_emitsEvent() public {
         vm.expectEmit(address(module));
         emit VerifierAdded(VERIFIER_1);
         vm.prank(owner);
         module.addVerifier(VERIFIER_1);
     }
 
-    function test_addSigner_revert_alreadyAdded() public {
+    function test_addVerifier_revert_alreadyAdded() public {
         basicSetup();
         vm.expectRevert(abi.encodeWithSelector(ThresholdECDSALib.ThresholdECDSA__AlreadySigner.selector, VERIFIER_1));
         vm.prank(owner);
         module.addVerifier(VERIFIER_1);
     }
 
-    function test_addSigner_revert_notOwner(address notOwner) public {
+    function test_addVerifier_revert_notOwner(address notOwner) public {
         vm.assume(notOwner != owner);
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, notOwner));
         vm.prank(notOwner);
         module.addVerifier(VERIFIER_1);
     }
 
-    function test_addSigners_addsSigners() public {
+    function test_addVerifiers_addsVerifiers() public {
         vm.prank(owner);
         module.addVerifiers(allVerifiers);
         assertTrue(module.isVerifier(VERIFIER_1));
@@ -97,7 +97,7 @@ contract SynapseModuleManagementTest is Test, SynapseModuleEvents {
         assertTrue(module.isVerifier(VERIFIER_3));
     }
 
-    function test_addSigners_emitsEvents() public {
+    function test_addVerifiers_emitsEvents() public {
         vm.expectEmit(address(module));
         emit VerifierAdded(VERIFIER_1);
         vm.expectEmit(address(module));
@@ -108,7 +108,7 @@ contract SynapseModuleManagementTest is Test, SynapseModuleEvents {
         module.addVerifiers(allVerifiers);
     }
 
-    function test_addSigners_revert_alreadyAdded() public {
+    function test_addVerifiers_revert_alreadyAdded() public {
         vm.prank(owner);
         module.addVerifier(VERIFIER_2);
         vm.expectRevert(abi.encodeWithSelector(ThresholdECDSALib.ThresholdECDSA__AlreadySigner.selector, VERIFIER_2));
@@ -116,21 +116,21 @@ contract SynapseModuleManagementTest is Test, SynapseModuleEvents {
         module.addVerifiers(allVerifiers);
     }
 
-    function test_addSigners_revert_notOwner(address notOwner) public {
+    function test_addVerifiers_revert_notOwner(address notOwner) public {
         vm.assume(notOwner != owner);
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, notOwner));
         vm.prank(notOwner);
         module.addVerifiers(allVerifiers);
     }
 
-    function test_removeSigner_removesSigner() public {
+    function test_removeVerifier_removesVerifier() public {
         basicSetup();
         vm.prank(owner);
         module.removeVerifier(VERIFIER_1);
         assertFalse(module.isVerifier(VERIFIER_1));
     }
 
-    function test_removeSigner_emitsEvent() public {
+    function test_removeVerifier_emitsEvent() public {
         basicSetup();
         vm.expectEmit(address(module));
         emit VerifierRemoved(VERIFIER_1);
@@ -138,20 +138,20 @@ contract SynapseModuleManagementTest is Test, SynapseModuleEvents {
         module.removeVerifier(VERIFIER_1);
     }
 
-    function test_removeSigner_revert_notAdded() public {
+    function test_removeVerifier_revert_notAdded() public {
         vm.expectRevert(abi.encodeWithSelector(ThresholdECDSALib.ThresholdECDSA__NotSigner.selector, VERIFIER_1));
         vm.prank(owner);
         module.removeVerifier(VERIFIER_1);
     }
 
-    function test_removeSigner_revert_notOwner(address notOwner) public {
+    function test_removeVerifier_revert_notOwner(address notOwner) public {
         vm.assume(notOwner != owner);
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, notOwner));
         vm.prank(notOwner);
         module.removeVerifier(VERIFIER_1);
     }
 
-    function test_removeSigners_removesSigners() public {
+    function test_removeVerifiers_removesVerifiers() public {
         basicSetup();
         vm.prank(owner);
         module.removeVerifiers(allVerifiers);
@@ -160,7 +160,7 @@ contract SynapseModuleManagementTest is Test, SynapseModuleEvents {
         assertFalse(module.isVerifier(VERIFIER_3));
     }
 
-    function test_removeSigners_emitsEvents() public {
+    function test_removeVerifiers_emitsEvents() public {
         basicSetup();
         vm.expectEmit(address(module));
         emit VerifierRemoved(VERIFIER_1);
@@ -172,7 +172,7 @@ contract SynapseModuleManagementTest is Test, SynapseModuleEvents {
         module.removeVerifiers(allVerifiers);
     }
 
-    function test_removeSigners_revert_notAdded() public {
+    function test_removeVerifiers_revert_notAdded() public {
         vm.prank(owner);
         module.addVerifier(VERIFIER_2);
         vm.expectRevert(abi.encodeWithSelector(ThresholdECDSALib.ThresholdECDSA__NotSigner.selector, VERIFIER_1));
@@ -180,7 +180,7 @@ contract SynapseModuleManagementTest is Test, SynapseModuleEvents {
         module.removeVerifiers(allVerifiers);
     }
 
-    function test_removeSigners_revert_notOwner(address notOwner) public {
+    function test_removeVerifiers_revert_notOwner(address notOwner) public {
         vm.assume(notOwner != owner);
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, notOwner));
         vm.prank(notOwner);

--- a/packages/contracts-communication/test/modules/SynapseModule.Management.t.sol
+++ b/packages/contracts-communication/test/modules/SynapseModule.Management.t.sol
@@ -123,6 +123,13 @@ contract SynapseModuleManagementTest is Test, SynapseModuleEvents {
         module.addVerifiers(allVerifiers);
     }
 
+    function test_addVerifiers_revert_containsZeroAddress() public {
+        allVerifiers[1] = address(0);
+        vm.expectRevert(ThresholdECDSALib.ThresholdECDSA__ZeroAddress.selector);
+        vm.prank(owner);
+        module.addVerifiers(allVerifiers);
+    }
+
     function test_removeVerifier_removesVerifier() public {
         basicSetup();
         vm.prank(owner);

--- a/packages/contracts-communication/test/modules/SynapseModule.Source.t.sol
+++ b/packages/contracts-communication/test/modules/SynapseModule.Source.t.sol
@@ -5,7 +5,7 @@ import {InterchainModuleEvents} from "../../contracts/events/InterchainModuleEve
 import {SynapseModuleEvents} from "../../contracts/events/SynapseModuleEvents.sol";
 import {IInterchainModule} from "../../contracts/interfaces/IInterchainModule.sol";
 import {InterchainEntry} from "../../contracts/libs/InterchainEntry.sol";
-import {SynapseModule} from "../../contracts/modules/SynapseModule.sol";
+import {SynapseModule, ISynapseModule} from "../../contracts/modules/SynapseModule.sol";
 
 import {GasOracleMock} from "../mocks/GasOracleMock.sol";
 
@@ -20,6 +20,7 @@ contract SynapseModuleSourceTest is Test, InterchainModuleEvents, SynapseModuleE
     address public interchainDB = makeAddr("InterchainDB");
     address public feeCollector = makeAddr("FeeCollector");
     address public owner = makeAddr("Owner");
+    address public claimer = makeAddr("Claimer");
 
     uint256 public constant SRC_CHAIN_ID = 1337;
     uint256 public constant DST_CHAIN_ID = 7331;
@@ -85,9 +86,10 @@ contract SynapseModuleSourceTest is Test, InterchainModuleEvents, SynapseModuleE
         mockRequestVerification(FEE, mockEntry);
     }
 
-    function test_requestVerification_transfersFeeToCollector() public {
+    function test_requestVerification_accumulatesFee() public {
+        deal(address(module), 5 ether);
         mockRequestVerification(FEE, mockEntry);
-        assertEq(feeCollector.balance, FEE);
+        assertEq(address(module).balance, 5 ether + FEE);
     }
 
     function test_requestVerification_feeAboveRequired_emitsEvent() public {
@@ -97,9 +99,10 @@ contract SynapseModuleSourceTest is Test, InterchainModuleEvents, SynapseModuleE
         mockRequestVerification(FEE + 1, mockEntry);
     }
 
-    function test_requestVerification_feeAboveRequired_transfersFeeToCollector() public {
+    function test_requestVerification_feeAboveRequired_accumulatesFee() public {
+        deal(address(module), 5 ether);
         mockRequestVerification(FEE + 1, mockEntry);
-        assertEq(feeCollector.balance, FEE + 1);
+        assertEq(address(module).balance, 5 ether + FEE + 1);
     }
 
     function test_requestVerification_revert_feeBelowRequired() public {
@@ -107,6 +110,103 @@ contract SynapseModuleSourceTest is Test, InterchainModuleEvents, SynapseModuleE
             abi.encodeWithSelector(IInterchainModule.InterchainModule__InsufficientFee.selector, FEE - 1, FEE)
         );
         mockRequestVerification(FEE - 1, mockEntry);
+    }
+
+    function test_claimFees_zeroClaimFee_emitsEvent() public {
+        deal(address(module), 5 ether);
+        vm.expectEmit(address(module));
+        emit FeesClaimed(feeCollector, 5 ether, claimer, 0);
+        vm.prank(claimer);
+        module.claimFees();
+    }
+
+    function test_claimFees_zeroClaimFee_distributesFees() public {
+        deal(address(module), 5 ether);
+        vm.prank(claimer);
+        module.claimFees();
+        assertEq(feeCollector.balance, 5 ether);
+        assertEq(claimer.balance, 0);
+    }
+
+    function test_claimFees_zeroClaimFee_revert_feeCollectorNotSet() public {
+        vm.prank(owner);
+        module.setFeeCollector(address(0));
+        vm.expectRevert(abi.encodeWithSelector(ISynapseModule.SynapseModule__FeeCollectorNotSet.selector));
+        vm.prank(claimer);
+        module.claimFees();
+    }
+
+    function test_claimFees_zeroClaimFee_revert_noFeesToClaim() public {
+        vm.expectRevert(abi.encodeWithSelector(ISynapseModule.SynapseModule__NoFeesToClaim.selector));
+        vm.prank(claimer);
+        module.claimFees();
+    }
+
+    function test_claimFees_nonZeroClaimFee_emitsEvent() public {
+        // Set claim fee to 0.1%
+        vm.prank(owner);
+        module.setClaimFeeFraction(0.001e18);
+        deal(address(module), 5 ether);
+        vm.expectEmit(address(module));
+        emit FeesClaimed(feeCollector, 4.995 ether, claimer, 0.005 ether);
+        vm.prank(claimer);
+        module.claimFees();
+    }
+
+    function test_claimFees_nonZeroClaimFee_distributesFees() public {
+        // Set claim fee to 0.1%
+        vm.prank(owner);
+        module.setClaimFeeFraction(0.001e18);
+        deal(address(module), 5 ether);
+        vm.prank(claimer);
+        module.claimFees();
+        assertEq(feeCollector.balance, 4.995 ether);
+        assertEq(claimer.balance, 0.005 ether);
+    }
+
+    function test_claimFees_nonZeroClaimFee_revert_feeCollectorNotSet() public {
+        // Set claim fee to 0.1%
+        vm.startPrank(owner);
+        module.setFeeCollector(address(0));
+        module.setClaimFeeFraction(0.001e18);
+        vm.stopPrank();
+        deal(address(module), 5 ether);
+        vm.expectRevert(abi.encodeWithSelector(ISynapseModule.SynapseModule__FeeCollectorNotSet.selector));
+        vm.prank(claimer);
+        module.claimFees();
+    }
+
+    function test_claimFees_nonZeroClaimFee_revert_noFeesToClaim() public {
+        // Set claim fee to 0.1%
+        vm.prank(owner);
+        module.setClaimFeeFraction(0.001e18);
+        vm.expectRevert(abi.encodeWithSelector(ISynapseModule.SynapseModule__NoFeesToClaim.selector));
+        vm.prank(claimer);
+        module.claimFees();
+    }
+
+    function test_getClaimFeeAmount_zeroFees_zeroClaimFee() public {
+        assertEq(module.getClaimFeeAmount(), 0);
+    }
+
+    function test_getClaimFeeAmount_zeroFees_nonZeroClaimFee() public {
+        // Set claim fee to 0.1%
+        vm.prank(owner);
+        module.setClaimFeeFraction(0.001e18);
+        assertEq(module.getClaimFeeAmount(), 0);
+    }
+
+    function test_getClaimFeeAmount_zeroClaimFee() public {
+        deal(address(module), 5 ether);
+        assertEq(module.getClaimFeeAmount(), 0);
+    }
+
+    function test_getClaimFeeAmount_nonZeroClaimFee() public {
+        // Set claim fee to 0.1%
+        vm.prank(owner);
+        module.setClaimFeeFraction(0.001e18);
+        deal(address(module), 5 ether);
+        assertEq(module.getClaimFeeAmount(), 0.005 ether);
     }
 
     function test_getModuleFee_thresholdTwo() public {

--- a/packages/contracts-communication/test/modules/SynapseModule.Source.t.sol
+++ b/packages/contracts-communication/test/modules/SynapseModule.Source.t.sol
@@ -4,12 +4,15 @@ pragma solidity 0.8.20;
 import {InterchainModuleEvents} from "../../contracts/events/InterchainModuleEvents.sol";
 import {SynapseModuleEvents} from "../../contracts/events/SynapseModuleEvents.sol";
 import {IInterchainModule} from "../../contracts/interfaces/IInterchainModule.sol";
-import {SynapseModule, InterchainEntry, ISynapseModule} from "../../contracts/modules/SynapseModule.sol";
+import {InterchainEntry} from "../../contracts/libs/InterchainEntry.sol";
+import {SynapseModule} from "../../contracts/modules/SynapseModule.sol";
 
 import {GasOracleMock} from "../mocks/GasOracleMock.sol";
 
 import {Test} from "forge-std/Test.sol";
 
+// solhint-disable func-name-mixedcase
+// solhint-disable ordering
 contract SynapseModuleSourceTest is Test, InterchainModuleEvents, SynapseModuleEvents {
     SynapseModule public module;
     GasOracleMock public gasOracle;


### PR DESCRIPTION
**Description**
- Added the ability to add and remove multiple verifiers at the same time.
- General cleanup.
- Gas limit for `verifyEntry()` is not configurable, with a default value of 100k gas units.
  - This makes the verification fee setting a bit easier.
- Changed the fee collection workflow:
  - On every verification request the verification fees are accumulated by `SynapseModule`
  - Anyone could call `claimFees()` to transfer the accumulated fees to `feeCollector` (assuming it's been set)
  - There is a configurable claim fee paid to the caller of `claimFees()` function to incentivize claiming by the third parties.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new events for gas limit verification and claim fee fraction changes.
	- Added functionality for adding and removing multiple verifiers.
	- Implemented new settings for claim fee fraction and gas limits.
- **Enhancements**
	- Refined fee claiming, entry verification, and transaction cost estimation processes.
- **Refactor**
	- Significant updates to the `SynapseModule` contract for improved management of verifiers and fees.
	- Removed the `decodeEntry` function for efficiency.
- **Tests**
	- Updated and added tests for verifier management, fee setting, and gas limit adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->