### PR TITLE
Adding blast to graphql query -- Explorer FE support

### DIFF
--- a/packages/explorer-ui/graphql/queries/index.ts
+++ b/packages/explorer-ui/graphql/queries/index.ts
@@ -208,6 +208,7 @@ export const DAILY_STATISTICS_BY_CHAIN = gql`
       canto
       dogechain
       base
+      blast
       total
     }
   }


### PR DESCRIPTION
Small edit to graphql query that adds blast support to the explorer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the daily statistics feature by including the `blast` field in the data available for each blockchain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
bd20f311b01155d6613204fa877d069dcaadc9b0: [explorer-ui preview link ](https://sanguine-5vxbkmysm-synapsecns.vercel.app)