### PR TITLE
Remove bridge fee

### DIFF
--- a/packages/synapse-interface/components/StateManagedBridge/BridgeExchangeRateInfo.tsx
+++ b/packages/synapse-interface/components/StateManagedBridge/BridgeExchangeRateInfo.tsx
@@ -26,7 +26,7 @@ const BridgeExchangeRateInfo = () => {
       <section className="p-2 space-y-1 text-sm border rounded-sm border-[#504952] text-secondary font-light">
         <GasDropLabel />
         <Router />
-        <Fee />
+        {/* <Fee /> */}
         <Rebate />
         <Slippage />
       </section>

--- a/packages/synapse-interface/components/StateManagedBridge/BridgeExchangeRateInfo.tsx
+++ b/packages/synapse-interface/components/StateManagedBridge/BridgeExchangeRateInfo.tsx
@@ -26,7 +26,6 @@ const BridgeExchangeRateInfo = () => {
       <section className="p-2 space-y-1 text-sm border rounded-sm border-[#504952] text-secondary font-light">
         <GasDropLabel />
         <Router />
-        {/* <Fee /> */}
         <Rebate />
         <Slippage />
       </section>
@@ -146,42 +145,6 @@ const Rebate = () => {
     <div className="flex items-center justify-between">
       <div className="text-green-300">Rebate</div>
       <RebateText />
-    </div>
-  )
-}
-
-const Fee = () => {
-  const {
-    debouncedFromValue,
-    fromToken,
-    fromChainId,
-    isLoading,
-    bridgeQuote: { feeAmount, originQuery },
-  } = useBridgeState()
-
-  if (!originQuery || originQuery.minAmountOut === 0n) return
-
-  const adjustedFeeAmount =
-    (BigInt(feeAmount) *
-      stringToBigInt(
-        `${debouncedFromValue}`,
-        fromToken?.decimals[fromChainId]
-      )) /
-    BigInt(originQuery?.minAmountOut)
-
-  const feeString = formatBigIntToString(
-    adjustedFeeAmount,
-    fromToken?.decimals[fromChainId],
-    4
-  )
-
-  return (
-    <div className="flex items-center justify-between">
-      <div>Fee</div>
-      <div className="text-primaryTextColor">
-        {isLoading ? '-' : feeString}{' '}
-        <span className="e">{fromToken?.symbol}</span>
-      </div>
     </div>
   )
 }

--- a/packages/synapse-interface/components/StateManagedBridge/BridgeExchangeRateInfo.tsx
+++ b/packages/synapse-interface/components/StateManagedBridge/BridgeExchangeRateInfo.tsx
@@ -1,21 +1,18 @@
 import numeral from 'numeral'
-import { useMemo } from 'react'
-import {
-  formatBigIntToPercentString,
-  stringToBigInt,
-} from '@/utils/bigint/format'
-import { CHAINS_BY_ID } from '@constants/chains'
-import * as CHAINS from '@constants/chains/master'
-import { useCoingeckoPrice } from '@hooks/useCoingeckoPrice'
 import Image from 'next/image'
-import { formatBigIntToString } from '@/utils/bigint/format'
+import { useMemo } from 'react'
+import { useAppSelector } from '@/store/hooks'
+import { useBridgeState } from '@/slices/bridge/hooks'
+import { useCoingeckoPrice } from '@hooks/useCoingeckoPrice'
 import {
   ELIGIBILITY_DEFAULT_TEXT,
   useStipEligibility,
 } from '@/utils/hooks/useStipEligibility'
-import { useBridgeState } from '@/slices/bridge/hooks'
+import { formatBigIntToString } from '@/utils/bigint/format'
+import { formatBigIntToPercentString } from '@/utils/bigint/format'
 import { EMPTY_BRIDGE_QUOTE } from '@/constants/bridge'
-import { useAppSelector } from '@/store/hooks'
+import { CHAINS_BY_ID } from '@constants/chains'
+import * as CHAINS from '@constants/chains/master'
 
 const MAX_ARB_REBATE_PER_ADDRESS = 2000
 


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**
Hides Bridge Fee temporarily until we figure out better way to display fees involved in breakdown


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Temporarily removed the display of fees in the Bridge Exchange Rate Information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
d15d243b5320bd43cace32bcf0c64843b4de4d6f: [synapse-interface preview link ](https://sanguine-synapse-interface-d3houluch-synapsecns.vercel.app)
ddb4a1dd3d269f65d7464fe3ec14c112630fe0d9: [synapse-interface preview link ](https://sanguine-synapse-interface-6vlfed9y3-synapsecns.vercel.app)
5600e7c6c529be3ee057ba7ab8da0ea52c93a170: [synapse-interface preview link ](https://sanguine-synapse-interface-o4bvc7uph-synapsecns.vercel.app)