### PR TITLE
RFQ relayer checks gas before committing to request

### DIFF
--- a/services/rfq/relayer/service/statushandler.go
+++ b/services/rfq/relayer/service/statushandler.go
@@ -70,7 +70,7 @@ func (r *Relayer) requestToHandler(ctx context.Context, req reldb.QuoteRequest) 
 		claimCache:     r.claimCache,
 	}
 
-	qr.handlers[reldb.Seen] = r.deadlineMiddleware(qr.handleSeen)
+	qr.handlers[reldb.Seen] = r.deadlineMiddleware(r.gasMiddleware(qr.handleSeen))
 	qr.handlers[reldb.CommittedPending] = r.deadlineMiddleware(qr.handleCommitPending)
 	qr.handlers[reldb.CommittedConfirmed] = r.deadlineMiddleware(qr.handleCommitConfirmed)
 	// no more need for deadline middleware now, we already relayed.

--- a/services/rfq/relayer/service/statushandler.go
+++ b/services/rfq/relayer/service/statushandler.go
@@ -71,10 +71,10 @@ func (r *Relayer) requestToHandler(ctx context.Context, req reldb.QuoteRequest) 
 	}
 
 	qr.handlers[reldb.Seen] = r.deadlineMiddleware(r.gasMiddleware(qr.handleSeen))
-	qr.handlers[reldb.CommittedPending] = r.deadlineMiddleware(qr.handleCommitPending)
-	qr.handlers[reldb.CommittedConfirmed] = r.deadlineMiddleware(qr.handleCommitConfirmed)
+	qr.handlers[reldb.CommittedPending] = r.deadlineMiddleware(r.gasMiddleware(qr.handleCommitPending))
+	qr.handlers[reldb.CommittedConfirmed] = r.deadlineMiddleware(r.gasMiddleware(qr.handleCommitConfirmed))
 	// no more need for deadline middleware now, we already relayed.
-	qr.handlers[reldb.RelayCompleted] = r.gasMiddleware(qr.handleRelayCompleted)
+	qr.handlers[reldb.RelayCompleted] = qr.handleRelayCompleted
 	qr.handlers[reldb.ProvePosted] = qr.handleProofPosted
 
 	// error handlers only


### PR DESCRIPTION
**Description**
RFQ relayer should only process a request and mark as `CommittedPending` if the request passes gas sufficiency checks. We accomplish this by wrapping the `handleSeen` handler with `gasMiddleware`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
    - Enhanced gas management for improved request handling process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->