### PR TITLE
Remove `gasMiddleware` from `handleRelayCompleted` call

### DIFF
--- a/services/rfq/relayer/service/statushandler.go
+++ b/services/rfq/relayer/service/statushandler.go
@@ -74,7 +74,7 @@ func (r *Relayer) requestToHandler(ctx context.Context, req reldb.QuoteRequest) 
 	qr.handlers[reldb.CommittedPending] = r.deadlineMiddleware(qr.handleCommitPending)
 	qr.handlers[reldb.CommittedConfirmed] = r.deadlineMiddleware(qr.handleCommitConfirmed)
 	// no more need for deadline middleware now, we already relayed.
-	qr.handlers[reldb.RelayCompleted] = r.gasMiddleware(qr.handleRelayCompleted)
+	qr.handlers[reldb.RelayCompleted] = qr.handleRelayCompleted
 	qr.handlers[reldb.ProvePosted] = qr.handleProofPosted
 
 	// error handlers only


### PR DESCRIPTION
**Description**
Once a tx is relayed we should call `prove()` regardless of gas on either origin or destination.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Optimized the handling of relay completion processes for enhanced efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->