### PR TITLE
feat(solidity-devops): print init code hash before CREATE2 deployment

### DIFF
--- a/packages/solidity-devops/src/deploy/Deployer.sol
+++ b/packages/solidity-devops/src/deploy/Deployer.sol
@@ -95,6 +95,8 @@ abstract contract Deployer is ChainAwareReader, Logger {
     {
         bytes memory initCode = getInitCode(contractName, constructorArgs);
         bytes32 salt = getDeploymentSalt();
+        // Print init code hash for potential vanity address mining
+        printLogWithIndent(StringUtils.concat("Init code hash: ", vm.toString(keccak256(initCode))));
         printLogWithIndent(StringUtils.concat("Using salt: ", vm.toString(salt)));
         deployedAt = factoryDeployCreate2(getCreate2Factory(), initCode, getDeploymentSalt());
         // Erase single-use salt


### PR DESCRIPTION
**Description**
Init code hash is now printed before all CREATE2 deployments. This allows to dry run the script, and use this value for mining the vanity address, if required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **New Features**
	- Added logging of the init code hash in the `Deployer` contract for enhanced vanity address mining capabilities.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->