### PR TITLE
fix(synapse-interface): m.USDC priority ranking for display

### DIFF
--- a/packages/synapse-interface/constants/tokens/bridgeable.ts
+++ b/packages/synapse-interface/constants/tokens/bridgeable.ts
@@ -47,6 +47,7 @@ import * as CHAINS from '@/constants/chains/master'
 // Priority ranks:
 // 100-102: Major stablecoins (native USDC, USDT, DAI)
 // 105: ETH
+// 106-109: Chain's core stablecoin
 // 110: nUSD
 // 115: nETH
 // 120: SYN
@@ -446,7 +447,7 @@ export const METISUSDC = new Token({
   logo: usdcLogo,
   swapableType: 'USD',
   color: 'blue',
-  priorityRank: 125,
+  priorityRank: 109,
   routeSymbol: 'm.USDC',
 })
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the priority rank of `METISUSDC` token to align with the core stablecoin range for improved token management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
d6b82203377b37a36e44e14b1193ffd4bd1858ec: [synapse-interface preview link ](https://sanguine-synapse-interface-1a5b8xyat-synapsecns.vercel.app)