### PR TITLE
fix(synapse-interface): Adds back time estimate

### DIFF
--- a/packages/synapse-interface/components/StateManagedBridge/BridgeExchangeRateInfo.tsx
+++ b/packages/synapse-interface/components/StateManagedBridge/BridgeExchangeRateInfo.tsx
@@ -20,6 +20,7 @@ const BridgeExchangeRateInfo = () => {
   return (
     <div className="py-3.5 px-1 space-y-3 text-sm md:px-6 tracking-wide">
       {/* <RouteEligibility /> */}
+      <TimeEstimate />
       <section className="p-2 space-y-1 text-sm border rounded-sm border-[#504952] text-secondary font-light">
         <GasDropLabel />
         <Router />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a time estimate display in the bridge exchange rate information section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
abac9444c32535c27d4d3cc890cf5fd526aa69f6: [synapse-interface preview link ](https://sanguine-synapse-interface-1tlulvqn4-synapsecns.vercel.app)