### PR TITLE
Updating to use SnowScan

### DIFF
--- a/packages/synapse-constants/constants/chains/master.ts
+++ b/packages/synapse-constants/constants/chains/master.ts
@@ -119,8 +119,8 @@ export const AVALANCHE: Chain = {
     fallback: 'https://1rpc.io/avax/c',
   },
   nativeCurrency: { name: 'Avax', symbol: 'AVAX', decimals: 18 },
-  explorerUrl: 'https://avascan.info/blockchain/c/',
-  explorerName: 'Avascan',
+  explorerUrl: 'https://snowscan.xyz/',
+  explorerName: 'SnowScan',
   explorerImg: avalancheExplorerImg,
   color: 'red',
 }

--- a/packages/synapse-constants/package.json
+++ b/packages/synapse-constants/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-constants",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "This is an npm package that maintains all synapse constants",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/synapse-interface/constants/chains/master.tsx
+++ b/packages/synapse-interface/constants/chains/master.tsx
@@ -123,8 +123,8 @@ export const AVALANCHE: Chain = {
     fallback: 'https://1rpc.io/avax/c',
   },
   nativeCurrency: { name: 'Avax', symbol: 'AVAX', decimals: 18 },
-  explorerUrl: 'https://snowtrace.io/',
-  explorerName: 'Snowtrace',
+  explorerUrl: 'https://snowscan.xyz/',
+  explorerName: 'SnowScan',
   explorerImg: avalancheExplorerImg,
   color: 'red',
 }


### PR DESCRIPTION
Updates the explorer and synapse-interface to use https://snowscan.xyz/. 

Didnt touch the widget because we will need to republish

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the Avalanche chain explorer URL and name to 'https://snowscan.xyz/' and 'SnowScan', respectively, enhancing user experience with up-to-date information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->