### PR TITLE
feat(synapse-interface): Pausing Metis bridging (3/14 02:00 UTC)

### DIFF
--- a/packages/synapse-interface/components/Banner.tsx
+++ b/packages/synapse-interface/components/Banner.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 
-const BANNER_VERSION = '4'
+const BANNER_VERSION = '5'
 
 export const Banner = () => {
   const [hasMounted, setHasMounted] = useState(false)
@@ -225,14 +225,9 @@ export const InterruptedServiceBanner = () => {
           <div className="container mx-auto">
             <p className="text-md">
               <div>
-                Synapse Explorer and the transaction watcher may not appear
-                during planned maintenance on 2023-11-01 from 5am - 7pm UTC.
-                <br className="block lg:hidden" />
-                <br className="block lg:hidden" />
-                <div className="hidden lg:inline"> </div>
-                Transactions will still go through as expected. Please confirm
-                transactions using the native explorer for your destination
-                chain during this time.
+                The Bridge + RFQ will be globally offline 15mins ahead of the
+                Dencun upgrade (March 13, 13:55 UTC, 9:55 EST). Will be back
+                online about 15 - 30 mins after Dencun.
               </div>
             </p>
           </div>

--- a/packages/synapse-interface/components/Banner.tsx
+++ b/packages/synapse-interface/components/Banner.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 
-const BANNER_VERSION = '5'
+const BANNER_VERSION = '6'
 
 export const Banner = () => {
   const [hasMounted, setHasMounted] = useState(false)
@@ -225,9 +225,9 @@ export const InterruptedServiceBanner = () => {
           <div className="container mx-auto">
             <p className="text-md">
               <div>
-                The Bridge + RFQ will be globally offline 15mins ahead of the
-                Dencun upgrade (March 13, 13:55 UTC, 9:55 EST). Will be back
-                online about 15 - 30 mins after Dencun.
+                Optimism + Base Bridging and RFQ will be paused 10 minutes ahead
+                of Ecotone (March 14, 00:00 UTC), and unpause about 10 minutes
+                after the upgrade.
               </div>
             </p>
           </div>

--- a/packages/synapse-interface/components/Banner.tsx
+++ b/packages/synapse-interface/components/Banner.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 
-const BANNER_VERSION = '6'
+const BANNER_VERSION = '7'
 
 export const Banner = () => {
   const [hasMounted, setHasMounted] = useState(false)
@@ -225,9 +225,9 @@ export const InterruptedServiceBanner = () => {
           <div className="container mx-auto">
             <p className="text-md">
               <div>
-                Optimism + Base Bridging and RFQ will be paused 10 minutes ahead
-                of Ecotone (March 14, 00:00 UTC), and unpause about 10 minutes
-                after the upgrade.
+                Due to a Metis upgrade, bridging to and from Metis will pause 30
+                minutes ahead of March 14, 02:00 UTC, and stay paused for ~12
+                hours.
               </div>
             </p>
           </div>

--- a/packages/synapse-interface/components/StateManagedBridge/BridgeTransactionButton.tsx
+++ b/packages/synapse-interface/components/StateManagedBridge/BridgeTransactionButton.tsx
@@ -6,17 +6,16 @@ import { RootState } from '@/store/store'
 import { useAccount, useNetwork, useSwitchNetwork } from 'wagmi'
 import { useEffect, useState } from 'react'
 import { isAddress } from '@ethersproject/address'
-import {} from 'wagmi'
 
-import {
-  useConnectModal,
-  useAccountModal,
-  useChainModal,
-} from '@rainbow-me/rainbowkit'
+import { useConnectModal } from '@rainbow-me/rainbowkit'
 import { stringToBigInt } from '@/utils/bigint/format'
 import { useBridgeState } from '@/slices/bridge/hooks'
 import { usePortfolioBalances } from '@/slices/portfolio/hooks'
-import { PAUSED_FROM_CHAIN_IDS, PAUSED_TO_CHAIN_IDS } from '@/constants/chains'
+import {
+  PAUSED_FROM_CHAIN_IDS,
+  PAUSED_GLOBAL_BRIDGE,
+  PAUSED_TO_CHAIN_IDS,
+} from '@/constants/chains'
 
 export const BridgeTransactionButton = ({
   approveTxn,
@@ -27,9 +26,9 @@ export const BridgeTransactionButton = ({
   const { openConnectModal } = useConnectModal()
 
   const { chain } = useNetwork()
-  const { chains, error, pendingChainId, switchNetwork } = useSwitchNetwork()
+  const { chains, switchNetwork } = useSwitchNetwork()
 
-  const { address, isConnected: isConnectedInit } = useAccount({
+  const { isConnected: isConnectedInit } = useAccount({
     onDisconnect() {
       setIsConnected(false)
     },
@@ -76,7 +75,8 @@ export const BridgeTransactionButton = ({
     (showDestinationAddress && !destinationAddress) ||
     (isConnected && !sufficientBalance) ||
     PAUSED_FROM_CHAIN_IDS.includes(fromChainId) ||
-    PAUSED_TO_CHAIN_IDS.includes(toChainId)
+    PAUSED_TO_CHAIN_IDS.includes(toChainId) ||
+    PAUSED_GLOBAL_BRIDGE
 
   let buttonProperties
 
@@ -87,7 +87,12 @@ export const BridgeTransactionButton = ({
     return fromTokenDecimals ? stringToBigInt(fromValue, fromTokenDecimals) : 0
   }, [fromValue, fromTokenDecimals])
 
-  if (!fromChainId) {
+  if (PAUSED_GLOBAL_BRIDGE) {
+    buttonProperties = {
+      label: 'Bridged paused',
+      onClick: null,
+    }
+  } else if (!fromChainId) {
     buttonProperties = {
       label: 'Please select Origin network',
       onClick: null,

--- a/packages/synapse-interface/components/StateManagedBridge/BridgeTransactionButton.tsx
+++ b/packages/synapse-interface/components/StateManagedBridge/BridgeTransactionButton.tsx
@@ -107,7 +107,7 @@ export const BridgeTransactionButton = ({
     PAUSED_TO_CHAIN_IDS.includes(toChainId)
   ) {
     buttonProperties = {
-      label: `Bridge unavailable`,
+      label: `Bridge on selected chain unavailable`,
       onClick: null,
     }
   } else if (!fromToken) {

--- a/packages/synapse-interface/constants/chains/index.tsx
+++ b/packages/synapse-interface/constants/chains/index.tsx
@@ -40,8 +40,8 @@ export const CHAINS_BY_ID = getChainsByID()
 export const ORDERED_CHAINS_BY_ID = CHAINS_ARR.map((chain) => String(chain.id))
 
 export const PAUSED_GLOBAL_BRIDGE = false
-export const PAUSED_FROM_CHAIN_IDS = [all.OPTIMISM.id, all.BASE.id]
-export const PAUSED_TO_CHAIN_IDS = [all.DOGE.id, all.OPTIMISM.id, all.BASE.id]
+export const PAUSED_FROM_CHAIN_IDS = [all.METIS.id]
+export const PAUSED_TO_CHAIN_IDS = [all.DOGE.id, all.METIS.id]
 
 export const ChainId = {
   ETH: 1,

--- a/packages/synapse-interface/constants/chains/index.tsx
+++ b/packages/synapse-interface/constants/chains/index.tsx
@@ -39,6 +39,7 @@ export const CHAIN_IDS = getids() // used to be ids
 export const CHAINS_BY_ID = getChainsByID()
 export const ORDERED_CHAINS_BY_ID = CHAINS_ARR.map((chain) => String(chain.id))
 
+export const PAUSED_GLOBAL_BRIDGE = true
 export const PAUSED_FROM_CHAIN_IDS = []
 export const PAUSED_TO_CHAIN_IDS = [all.DOGE.id]
 

--- a/packages/synapse-interface/constants/chains/index.tsx
+++ b/packages/synapse-interface/constants/chains/index.tsx
@@ -39,9 +39,9 @@ export const CHAIN_IDS = getids() // used to be ids
 export const CHAINS_BY_ID = getChainsByID()
 export const ORDERED_CHAINS_BY_ID = CHAINS_ARR.map((chain) => String(chain.id))
 
-export const PAUSED_GLOBAL_BRIDGE = true
-export const PAUSED_FROM_CHAIN_IDS = []
-export const PAUSED_TO_CHAIN_IDS = [all.DOGE.id]
+export const PAUSED_GLOBAL_BRIDGE = false
+export const PAUSED_FROM_CHAIN_IDS = [all.OPTIMISM.id, all.BASE.id]
+export const PAUSED_TO_CHAIN_IDS = [all.DOGE.id, all.OPTIMISM.id, all.BASE.id]
 
 export const ChainId = {
   ETH: 1,

--- a/packages/synapse-interface/cypress/fixtures/bridge.json
+++ b/packages/synapse-interface/cypress/fixtures/bridge.json
@@ -1,12 +1,13 @@
 {
   "defaultOriginToken": "ETH",
   "defaultDestinationToken": "ETH",
-  "totalAvailableNetworks": 18,
+  "totalAvailableNetworks": 19,
   "availableNetworks": [
     "Arbitrum",
     "Aurora",
     "Avalanche",
     "BNB Chain",
+    "Base",
     "Blast",
     "Boba Chain",
     "Canto",
@@ -17,9 +18,9 @@
     "Fantom",
     "Harmony",
     "Klaytn",
-    "Metis",
     "Moonbeam",
     "Moonriver",
+    "Optimism",
     "Polygon"
   ]
 }

--- a/packages/synapse-interface/cypress/fixtures/bridge.json
+++ b/packages/synapse-interface/cypress/fixtures/bridge.json
@@ -1,13 +1,12 @@
 {
   "defaultOriginToken": "ETH",
   "defaultDestinationToken": "ETH",
-  "totalAvailableNetworks": 20,
+  "totalAvailableNetworks": 18,
   "availableNetworks": [
     "Arbitrum",
     "Aurora",
     "Avalanche",
     "BNB Chain",
-    "Base",
     "Blast",
     "Boba Chain",
     "Canto",
@@ -21,7 +20,6 @@
     "Metis",
     "Moonbeam",
     "Moonriver",
-    "Optimism",
     "Polygon"
   ]
 }

--- a/packages/synapse-interface/pages/index.tsx
+++ b/packages/synapse-interface/pages/index.tsx
@@ -1,4 +1,4 @@
-import { Banner } from '@/components/Banner'
+import { Banner, InterruptedServiceBanner } from '@/components/Banner'
 import StateManagedBridge from './state-managed-bridge'
 import { Portfolio } from '@/components/Portfolio/Portfolio'
 import { LandingPageWrapper } from '@/components/layouts/LandingPageWrapper'
@@ -20,7 +20,8 @@ const Home = () => {
         data-test-id="bridge-page"
         className="relative z-0 flex-1 h-full overflow-y-auto focus:outline-none"
       >
-        <Banner />
+        {/* <Banner /> */}
+        <InterruptedServiceBanner />
         <div className="flex flex-col-reverse justify-center gap-16 px-4 py-20 mx-auto lg:flex-row 2xl:w-3/4 sm:mt-6 sm:px-8 md:px-12">
           <Portfolio />
           <StateManagedBridge />


### PR DESCRIPTION
null
947f18bc1ecb8906751a0ae7c7ac7055dd255f13: [synapse-interface preview link ](https://sanguine-synapse-interface-quz1nr5gu-synapsecns.vercel.app)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the content of the Interrupted Service Banner for the Metis upgrade schedule.

- **Bug Fixes**
	- Updated bridge transaction logic to reflect global pause states and provide specific messages for unavailable scenarios.

- **Chores**
	- Updated network availability, removing "Metis" from the list of available networks.
	- Adjusted constants related to bridge pause states and specific chain IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
67741288e1b2259ac678c0ebd4af2ba7712ce4d3: [synapse-interface preview link ](https://sanguine-synapse-interface-dzsakwycq-synapsecns.vercel.app)