### PR TITLE
RFQ relayer pauses relays if API is offline

### DIFF
--- a/services/rfq/relayer/quoter/export_test.go
+++ b/services/rfq/relayer/quoter/export_test.go
@@ -25,3 +25,7 @@ func (m *Manager) GetDestAmount(ctx context.Context, quoteAmount *big.Int, chain
 func (m *Manager) SetConfig(cfg relconfig.Config) {
 	m.config = cfg
 }
+
+func (m *Manager) SetRelayPaused(relayPaused bool) {
+	m.relayPaused = relayPaused
+}

--- a/services/rfq/relayer/quoter/quoter.go
+++ b/services/rfq/relayer/quoter/quoter.go
@@ -249,7 +249,9 @@ func (m *Manager) prepareAndSubmitQuotes(ctx context.Context, inv map[int]map[co
 				attribute.String("dest_amount", quote.DestAmount),
 			))
 			m.relayPaused = true
-			return err
+
+			// Suppress error so that we can continue submitting quotes
+			return nil
 		}
 	}
 

--- a/services/rfq/relayer/quoter/quoter_test.go
+++ b/services/rfq/relayer/quoter/quoter_test.go
@@ -100,13 +100,13 @@ func (s *QuoterSuite) TestGenerateQuotesForNativeToken() {
 }
 
 func (s *QuoterSuite) TestShouldProcess() {
-	// Set different numbers of decimals for origin / dest tokens; should never process this.
+	// Should process a valid quote.
 	balance := big.NewInt(1000_000_000) // 1000 USDC
 	fee := big.NewInt(100_050_000)      // 100.05 USDC
 	quote := reldb.QuoteRequest{
 		BlockNumber:         1,
 		OriginTokenDecimals: 6,
-		DestTokenDecimals:   18,
+		DestTokenDecimals:   6,
 		Transaction: fastbridge.IFastBridgeBridgeTransaction{
 			OriginChainId: s.origin,
 			DestChainId:   s.destination,
@@ -116,6 +116,10 @@ func (s *QuoterSuite) TestShouldProcess() {
 			DestAmount:    new(big.Int).Sub(balance, fee),
 		},
 	}
+	s.True(s.manager.ShouldProcess(s.GetTestContext(), quote))
+
+	// Set different numbers of decimals for origin / dest tokens; should never process this.
+	quote.DestTokenDecimals = 18
 	s.False(s.manager.ShouldProcess(s.GetTestContext(), quote))
 
 	// Toggle insufficient gas; should not process.

--- a/services/rfq/relayer/quoter/quoter_test.go
+++ b/services/rfq/relayer/quoter/quoter_test.go
@@ -119,12 +119,15 @@ func (s *QuoterSuite) TestShouldProcess() {
 	s.True(s.manager.ShouldProcess(s.GetTestContext(), quote))
 
 	// Set different numbers of decimals for origin / dest tokens; should never process this.
-	quote.DestTokenDecimals = 18
-	s.False(s.manager.ShouldProcess(s.GetTestContext(), quote))
+	badQuote := quote
+	badQuote.DestTokenDecimals = 18
+	s.False(s.manager.ShouldProcess(s.GetTestContext(), badQuote))
 
-	// Toggle insufficient gas; should not process.
-	s.setGasSufficiency(false)
+	// Toggle relayPaused
+	s.manager.SetRelayPaused(true)
 	s.False(s.manager.ShouldProcess(s.GetTestContext(), quote))
+	s.manager.SetRelayPaused(false)
+	s.True(s.manager.ShouldProcess(s.GetTestContext(), quote))
 }
 
 func (s *QuoterSuite) TestIsProfitable() {


### PR DESCRIPTION
**Description**
Adds a `relayPaused` flag to the RFQ quoter that blocks relays from being processed.

This flag is set when a quote submission fails, and is reset when all quote submissions succeed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
    - Enhanced the `Manager` struct with a new field to indicate RFQ API offline status, affecting quote processing methods.
- **Bug Fixes**
    - Improved error handling during quote submission when the RFQ API is offline.
- **Tests**
    - Updated test coverage to handle various token decimal and relay status scenarios.
    - Implemented testing functionality to simulate pausing and resuming the relay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->