### PR TITLE
feat(widget): More robust ethers v5 provider support

### DIFF
--- a/packages/widget/src/components/Transaction.tsx
+++ b/packages/widget/src/components/Transaction.tsx
@@ -4,7 +4,6 @@ import { Chain } from 'types'
 import { useAppDispatch } from '@/state/hooks'
 import { getTxBlockExplorerLink } from '@/utils/getTxBlockExplorerLink'
 import { getExplorerAddressUrl } from '@/utils/getExplorerAddressLink'
-import { getTxSynapseExplorerLink } from '@/utils/getTxSynapseExplorerLink'
 import { useBridgeTxStatus } from '@/hooks/useBridgeTxStatus'
 import { isNull } from '@/utils/isNull'
 import {

--- a/packages/widget/src/components/Widget.tsx
+++ b/packages/widget/src/components/Widget.tsx
@@ -271,8 +271,9 @@ export const Widget = ({
           signer,
         })
       )
+
       /** Fetch allowance on successful approval tx */
-      if (tx?.payload?.hash) {
+      if (tx?.payload?.hash || tx?.payload?.transactionHash) {
         dispatch(
           fetchAndStoreAllowance({
             spenderAddress: bridgeQuote?.routerAddress,

--- a/packages/widget/src/state/slices/bridgeTransaction/hooks.ts
+++ b/packages/widget/src/state/slices/bridgeTransaction/hooks.ts
@@ -42,46 +42,50 @@ export const executeBridgeTxn = createAsyncThunk(
     signer: any
     synapseSDK: any
   }) => {
-    const data = await synapseSDK.bridge(
-      destinationAddress,
-      originRouterAddress,
-      originChainId,
-      destinationChainId,
-      tokenAddress,
-      amount,
-      originQuery,
-      destQuery
-    )
+    try {
+      const data = await synapseSDK.bridge(
+        destinationAddress,
+        originRouterAddress,
+        originChainId,
+        destinationChainId,
+        tokenAddress,
+        amount,
+        originQuery,
+        destQuery
+      )
 
-    const payload =
-      tokenAddress === ZeroAddress
-        ? {
-            data: data.data,
-            to: data.to,
-            value: amount,
-          }
-        : {
-            data: data.data,
-            to: data.to,
-          }
+      const payload =
+        tokenAddress === ZeroAddress
+          ? {
+              data: data.data,
+              to: data.to,
+              value: amount,
+            }
+          : {
+              data: data.data,
+              to: data.to,
+            }
 
-    const tx = await signer.sendTransaction(payload)
+      const tx = await signer.sendTransaction(payload)
 
-    const receipt = await tx.wait()
+      const receipt = await tx.wait()
 
-    const txHash = receipt?.hash
+      const txHash = receipt?.hash ?? receipt?.transactionHash
 
-    const timestamp = getTimeMinutesFromNow(0)
+      const timestamp = getTimeMinutesFromNow(0)
 
-    return {
-      txHash,
-      bridgeModuleName,
-      parsedOriginAmount,
-      originTokenSymbol,
-      originChainId,
-      destinationChainId,
-      estimatedTime,
-      timestamp,
+      return {
+        txHash,
+        bridgeModuleName,
+        parsedOriginAmount,
+        originTokenSymbol,
+        originChainId,
+        destinationChainId,
+        estimatedTime,
+        timestamp,
+      }
+    } catch (error) {
+      console.error('Error executing bridge: ', error)
     }
   }
 )


### PR DESCRIPTION
- ethers v5 and v6 have slightly different return types and params (`transactionHash` vs `hash` and `ContractTransactionResponse` vs `TransactionResponse`). This causes using `new ethers.Contract` issues, so instead we directly encode for approvals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Enhanced error handling for bridge transactions for improved stability.
	- Updated transaction verification logic for increased accuracy.
- **Chores**
	- Expanded ERC20 token approval process to support newer Ethereum provider versions, ensuring wider compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->