### PR TITLE
Add MinRebalanceAmount to RFQ relayer

### DIFF
--- a/services/rfq/relayer/inventory/manager.go
+++ b/services/rfq/relayer/inventory/manager.go
@@ -370,7 +370,7 @@ func (i *inventoryManagerImpl) Rebalance(parentCtx context.Context, chainID int,
 	if err != nil {
 		return fmt.Errorf("could not get rebalance: %w", err)
 	}
-	if rebalance == nil {
+	if rebalance == nil || rebalance.Amount.Cmp(big.NewInt(0)) <= 0 {
 		return nil
 	}
 	span.SetAttributes(

--- a/services/rfq/relayer/inventory/manager.go
+++ b/services/rfq/relayer/inventory/manager.go
@@ -472,10 +472,12 @@ func getRebalance(span trace.Span, cfg relconfig.Config, tokens map[int]map[comm
 		return nil, nil
 	}
 
-	// clip the rebalance amount by the configured min
+	// filter the rebalance amount by the configured min
 	minAmount := cfg.GetMinRebalanceAmount(maxTokenData.ChainID, maxTokenData.Addr)
 	if amount.Cmp(minAmount) < 0 {
-		amount = minAmount
+		// no need to rebalance
+		//nolint:nilnil
+		return nil, nil
 	}
 
 	// clip the rebalance amount by the configured max

--- a/services/rfq/relayer/inventory/manager.go
+++ b/services/rfq/relayer/inventory/manager.go
@@ -472,6 +472,12 @@ func getRebalance(span trace.Span, cfg relconfig.Config, tokens map[int]map[comm
 		return nil, nil
 	}
 
+	// clip the rebalance amount by the configured min
+	minAmount := cfg.GetMinRebalanceAmount(maxTokenData.ChainID, maxTokenData.Addr)
+	if amount.Cmp(minAmount) < 0 {
+		amount = minAmount
+	}
+
 	// clip the rebalance amount by the configured max
 	maxAmount := cfg.GetMaxRebalanceAmount(maxTokenData.ChainID, maxTokenData.Addr)
 	if amount.Cmp(maxAmount) > 0 {

--- a/services/rfq/relayer/inventory/manager.go
+++ b/services/rfq/relayer/inventory/manager.go
@@ -466,8 +466,8 @@ func getRebalance(span trace.Span, cfg relconfig.Config, tokens map[int]map[comm
 	initialThresh, _ := new(big.Float).Mul(new(big.Float).SetInt(totalBalance), big.NewFloat(initialPct/100)).Int(nil)
 	amount := new(big.Int).Sub(maxTokenData.Balance, initialThresh)
 
-	// no need to rebalance since amount would be negative
-	if amount.Cmp(big.NewInt(0)) < 0 {
+	// no need to rebalance since amount would not be positive
+	if amount.Cmp(big.NewInt(0)) <= 0 {
 		//nolint:nilnil
 		return nil, nil
 	}

--- a/services/rfq/relayer/inventory/manager_test.go
+++ b/services/rfq/relayer/inventory/manager_test.go
@@ -162,12 +162,7 @@ func (i *InventoryTestSuite) TestGetRebalance() {
 	cfgWithMax := getConfig("10", "1000000000")
 	rebalance, err = inventory.GetRebalance(cfgWithMax, tokens, origin, usdcDataOrigin.Addr)
 	i.NoError(err)
-	expected = &inventory.RebalanceData{
-		OriginMetadata: &usdcDataOrigin,
-		DestMetadata:   &usdcDataDest,
-		Amount:         big.NewInt(1e7),
-	}
-	i.Equal(expected, rebalance)
+	i.Nil(rebalance)
 
 	// Set max rebalance amount
 	cfgWithMax = getConfig("0", "1.1")

--- a/services/rfq/relayer/inventory/manager_test.go
+++ b/services/rfq/relayer/inventory/manager_test.go
@@ -139,6 +139,13 @@ func (i *InventoryTestSuite) TestGetRebalance() {
 	i.NoError(err)
 	i.Nil(rebalance)
 
+	// Set balances to zero
+	usdcDataOrigin.Balance = big.NewInt(0)
+	usdcDataDest.Balance = big.NewInt(0)
+	rebalance, err = inventory.GetRebalance(cfg, tokens, origin, usdcDataOrigin.Addr)
+	i.NoError(err)
+	i.Nil(rebalance)
+
 	// Set origin balance below maintenance threshold; need rebalance
 	usdcDataOrigin.Balance = big.NewInt(9e6)
 	usdcDataDest.Balance = big.NewInt(1e6)

--- a/services/rfq/relayer/relconfig/config.go
+++ b/services/rfq/relayer/relconfig/config.go
@@ -102,6 +102,8 @@ type TokenConfig struct {
 	MaintenanceBalancePct float64 `yaml:"maintenance_balance_pct"`
 	// InitialBalancePct is the percentage of the total balance to retain when triggering a rebalance.
 	InitialBalancePct float64 `yaml:"initial_balance_pct"`
+	// MinRebalanceAmount is the minimum amount to rebalance in human-readable units.
+	MinRebalanceAmount string `yaml:"min_rebalance_amount"`
 	// MaxRebalanceAmount is the maximum amount to rebalance in human-readable units.
 	MaxRebalanceAmount string `yaml:"max_rebalance_amount"`
 }

--- a/services/rfq/relayer/relconfig/config.go
+++ b/services/rfq/relayer/relconfig/config.go
@@ -95,6 +95,7 @@ type TokenConfig struct {
 	// For now, specify the USD price of the token in the config.
 	PriceUSD float64 `yaml:"price_usd"`
 	// MinQuoteAmount is the minimum amount to quote for this token in human-readable units.
+	// for USDC-through-cctp pairs this defualts to $1,000.
 	MinQuoteAmount string `yaml:"min_quote_amount"`
 	// RebalanceMethod is the method to use for rebalancing.
 	RebalanceMethod string `yaml:"rebalance_method"`

--- a/services/rfq/relayer/relconfig/config.go
+++ b/services/rfq/relayer/relconfig/config.go
@@ -95,7 +95,6 @@ type TokenConfig struct {
 	// For now, specify the USD price of the token in the config.
 	PriceUSD float64 `yaml:"price_usd"`
 	// MinQuoteAmount is the minimum amount to quote for this token in human-readable units.
-	// for USDC-through-cctp pairs this defualts to $1,000.
 	MinQuoteAmount string `yaml:"min_quote_amount"`
 	// RebalanceMethod is the method to use for rebalancing.
 	RebalanceMethod string `yaml:"rebalance_method"`
@@ -104,6 +103,7 @@ type TokenConfig struct {
 	// InitialBalancePct is the percentage of the total balance to retain when triggering a rebalance.
 	InitialBalancePct float64 `yaml:"initial_balance_pct"`
 	// MinRebalanceAmount is the minimum amount to rebalance in human-readable units.
+	// For USDC-through-cctp pairs this defaults to $1,000.
 	MinRebalanceAmount string `yaml:"min_rebalance_amount"`
 	// MaxRebalanceAmount is the maximum amount to rebalance in human-readable units.
 	MaxRebalanceAmount string `yaml:"max_rebalance_amount"`

--- a/services/rfq/relayer/relconfig/getters.go
+++ b/services/rfq/relayer/relconfig/getters.go
@@ -547,6 +547,38 @@ func (c Config) GetMinQuoteAmount(chainID int, addr common.Address) *big.Int {
 	return quoteAmountScaled
 }
 
+var defaultMinRebalanceAmount = big.NewInt(1000)
+
+// GetMinRebalanceAmount returns the min rebalance amount for the given chain and address.
+// Note that this getter returns the value in native token decimals.
+func (c Config) GetMinRebalanceAmount(chainID int, addr common.Address) *big.Int {
+	chainCfg, ok := c.Chains[chainID]
+	if !ok {
+		return defaultMinRebalanceAmount
+	}
+
+	var tokenCfg *TokenConfig
+	for _, cfg := range chainCfg.Tokens {
+		if common.HexToAddress(cfg.Address).Hex() == addr.Hex() {
+			cfgCopy := cfg
+			tokenCfg = &cfgCopy
+			break
+		}
+	}
+	if tokenCfg == nil {
+		return defaultMinRebalanceAmount
+	}
+	rebalanceAmountFlt, ok := new(big.Float).SetString(tokenCfg.MinRebalanceAmount)
+	if !ok || rebalanceAmountFlt == nil {
+		return defaultMinRebalanceAmount
+	}
+
+	// Scale by the token decimals.
+	denomDecimalsFactor := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(tokenCfg.Decimals)), nil)
+	minRebalanceAmountScaled, _ := new(big.Float).Mul(rebalanceAmountFlt, new(big.Float).SetInt(denomDecimalsFactor)).Int(nil)
+	return minRebalanceAmountScaled
+}
+
 var defaultMaxRebalanceAmount = abi.MaxInt256
 
 // GetMaxRebalanceAmount returns the max rebalance amount for the given chain and address.

--- a/services/rfq/relayer/relconfig/getters.go
+++ b/services/rfq/relayer/relconfig/getters.go
@@ -554,21 +554,9 @@ var defaultMinRebalanceAmount = big.NewInt(1000)
 //
 //nolint:dupl
 func (c Config) GetMinRebalanceAmount(chainID int, addr common.Address) *big.Int {
-	chainCfg, ok := c.Chains[chainID]
-	if !ok {
-		return defaultMinRebalanceAmount
-	}
-
-	var tokenCfg *TokenConfig
-	for _, cfg := range chainCfg.Tokens {
-		if common.HexToAddress(cfg.Address).Hex() == addr.Hex() {
-			cfgCopy := cfg
-			tokenCfg = &cfgCopy
-			break
-		}
-	}
-	if tokenCfg == nil {
-		return defaultMinRebalanceAmount
+	tokenCfg, _, err := c.getTokenConfigByAddr(chainID, addr.Hex())
+	if err != nil {
+		return defaultMaxRebalanceAmount
 	}
 	rebalanceAmountFlt, ok := new(big.Float).SetString(tokenCfg.MinRebalanceAmount)
 	if !ok || rebalanceAmountFlt == nil {
@@ -588,20 +576,8 @@ var defaultMaxRebalanceAmount = abi.MaxInt256
 //
 //nolint:dupl
 func (c Config) GetMaxRebalanceAmount(chainID int, addr common.Address) *big.Int {
-	chainCfg, ok := c.Chains[chainID]
-	if !ok {
-		return defaultMaxRebalanceAmount
-	}
-
-	var tokenCfg *TokenConfig
-	for _, cfg := range chainCfg.Tokens {
-		if common.HexToAddress(cfg.Address).Hex() == addr.Hex() {
-			cfgCopy := cfg
-			tokenCfg = &cfgCopy
-			break
-		}
-	}
-	if tokenCfg == nil {
+	tokenCfg, _, err := c.getTokenConfigByAddr(chainID, addr.Hex())
+	if err != nil {
 		return defaultMaxRebalanceAmount
 	}
 	rebalanceAmountFlt, ok := new(big.Float).SetString(tokenCfg.MaxRebalanceAmount)

--- a/services/rfq/relayer/relconfig/getters.go
+++ b/services/rfq/relayer/relconfig/getters.go
@@ -551,6 +551,8 @@ var defaultMinRebalanceAmount = big.NewInt(1000)
 
 // GetMinRebalanceAmount returns the min rebalance amount for the given chain and address.
 // Note that this getter returns the value in native token decimals.
+//
+//nolint:dupl
 func (c Config) GetMinRebalanceAmount(chainID int, addr common.Address) *big.Int {
 	chainCfg, ok := c.Chains[chainID]
 	if !ok {
@@ -583,6 +585,8 @@ var defaultMaxRebalanceAmount = abi.MaxInt256
 
 // GetMaxRebalanceAmount returns the max rebalance amount for the given chain and address.
 // Note that this getter returns the value in native token decimals.
+//
+//nolint:dupl
 func (c Config) GetMaxRebalanceAmount(chainID int, addr common.Address) *big.Int {
 	chainCfg, ok := c.Chains[chainID]
 	if !ok {


### PR DESCRIPTION
**Description**
Adds `MinRebalanceAmount` which puts a floor on the rebalance size.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced inventory management with a minimum threshold for rebalance amounts.
- **Refactor**
	- Updated logic to consider minimum and maximum rebalance amounts.
	- Improved configuration handling for rebalance amounts with new minimum threshold settings.
- **Tests**
	- Expanded testing suite to cover new minimum rebalance amount configurations and logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->