### PR TITLE
feat(synapse-interface): add back rebate

### DIFF
--- a/packages/synapse-interface/components/StateManagedBridge/BridgeExchangeRateInfo.tsx
+++ b/packages/synapse-interface/components/StateManagedBridge/BridgeExchangeRateInfo.tsx
@@ -24,7 +24,7 @@ const BridgeExchangeRateInfo = () => {
       <section className="p-2 space-y-1 text-sm border rounded-sm border-[#504952] text-secondary font-light">
         <GasDropLabel />
         <Router />
-        {/* <Rebate /> */}
+        <Rebate />
         <Slippage />
       </section>
     </div>


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**
Add back bridge receipt rebate


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enabled the display of the `<Rebate />` component within the Bridge Exchange Rate Information section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
87d551c2ee1bfc42384e96d2b1ca729e7385ceba: [synapse-interface preview link ](https://sanguine-synapse-interface-75lmdoz8b-synapsecns.vercel.app)