### PR TITLE
remove vercel analytics

### DIFF
--- a/packages/synapse-interface/package.json
+++ b/packages/synapse-interface/package.json
@@ -51,7 +51,6 @@
     "@types/react": "18.0.28",
     "@types/react-dom": "18.0.11",
     "@types/web3": "^1.2.2",
-    "@vercel/analytics": "^1.0.2",
     "@visx/chord": "^3.0.0",
     "@visx/shape": "^3.0.0",
     "@wagmi/core": "^1.4.12",

--- a/packages/synapse-interface/pages/_app.tsx
+++ b/packages/synapse-interface/pages/_app.tsx
@@ -3,7 +3,6 @@ import '@rainbow-me/rainbowkit/styles.css'
 import type { AppProps } from 'next/app'
 import Head from 'next/head'
 import '@/patch'
-import { Analytics } from '@vercel/analytics/react'
 import { PersistGate } from 'redux-persist/integration/react'
 import LogRocket from 'logrocket'
 import setupLogRocketReact from 'logrocket-react'
@@ -53,7 +52,6 @@ const App = ({ Component, pageProps }: AppProps) => {
                     <BackgroundListenerProvider>
                       <Component {...pageProps} />
                     </BackgroundListenerProvider>
-                    <Analytics />
                     <CustomToaster />
                   </UserProvider>
                 </SegmentAnalyticsProvider>


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**

Vercel analytics will not work with the site hosted on cloudflare since the analytics backend goes through serverles so in production, we 404 on this url: `https://www.synapseprotocol.com/_vercel/insights/script.js`

Suggesting this to be removed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed the dependency on external analytics, enhancing privacy and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
1be919a7e93cb6be99b492535adf22a9a11e35b6: [synapse-interface preview link ](https://sanguine-synapse-interface-h162hig6m-synapsecns.vercel.app)