### PR TITLE
feat(synapse-interface): switch to previous rebate version

### DIFF
--- a/packages/synapse-interface/components/StateManagedBridge/BridgeExchangeRateInfo.tsx
+++ b/packages/synapse-interface/components/StateManagedBridge/BridgeExchangeRateInfo.tsx
@@ -19,12 +19,12 @@ const MAX_ARB_REBATE_PER_ADDRESS = 2000
 const BridgeExchangeRateInfo = () => {
   return (
     <div className="py-3.5 px-1 space-y-3 text-sm md:px-6 tracking-wide">
-      {/* <RouteEligibility /> */}
-      <TimeEstimate />
+      <RouteEligibility />
+      {/* <TimeEstimate /> */}
       <section className="p-2 space-y-1 text-sm border rounded-sm border-[#504952] text-secondary font-light">
         <GasDropLabel />
         <Router />
-        <Rebate />
+        {/* <Rebate /> */}
         <Slippage />
       </section>
     </div>


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**
Use bridge rebate display (one on same line as time estimate) in favor of displaying within Bridge Receipt

f1be8fddd852affe3b11dc26f1ee4ec31d884de3: [synapse-interface preview link ](https://sanguine-synapse-interface-p8hxdxdp5-synapsecns.vercel.app)