### PR TITLE
feat(synapse-interface): use both rebate displays in bridge card

### DIFF
--- a/packages/synapse-interface/components/StateManagedBridge/BridgeExchangeRateInfo.tsx
+++ b/packages/synapse-interface/components/StateManagedBridge/BridgeExchangeRateInfo.tsx
@@ -19,12 +19,12 @@ const MAX_ARB_REBATE_PER_ADDRESS = 2000
 const BridgeExchangeRateInfo = () => {
   return (
     <div className="py-3.5 px-1 space-y-3 text-sm md:px-6 tracking-wide">
-      {/* <RouteEligibility /> */}
-      <TimeEstimate />
+      <RouteEligibility />
+      {/* <TimeEstimate /> */}
       <section className="p-2 space-y-1 text-sm border rounded-sm border-[#504952] text-secondary font-light">
         <GasDropLabel />
         <Router />
-        <Rebate />
+        {/* <Rebate /> */}
         <Slippage />
       </section>
     </div>

--- a/packages/synapse-interface/components/StateManagedBridge/BridgeExchangeRateInfo.tsx
+++ b/packages/synapse-interface/components/StateManagedBridge/BridgeExchangeRateInfo.tsx
@@ -24,7 +24,7 @@ const BridgeExchangeRateInfo = () => {
       <section className="p-2 space-y-1 text-sm border rounded-sm border-[#504952] text-secondary font-light">
         <GasDropLabel />
         <Router />
-        {/* <Rebate /> */}
+        <Rebate />
         <Slippage />
       </section>
     </div>


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**
Show both rebate versions in Bridge Card
a5835069174d070a387c610b6e6a4e29b6be7c0f: [synapse-interface preview link ](https://sanguine-synapse-interface-kk8jc78a0-synapsecns.vercel.app)