### PR TITLE
resetting synapse-constants bridge map for canto eth

### DIFF
--- a/packages/synapse-constants/constants/bridgeMap.ts
+++ b/packages/synapse-constants/constants/bridgeMap.ts
@@ -1025,7 +1025,7 @@ export const BRIDGE_MAP = {
       symbol: 'nETH',
       origin: ['nETH'],
       destination: ['nETH'],
-      swappable: ['0x5FD55A1B9FC24967C4dB09C513C3BA0DFa7FF687'],
+      swappable: [],
     },
     '0x4e71A2E537B7f9D9413D3991D37958c0b5e1e503': {
       decimals: 18,
@@ -1044,13 +1044,6 @@ export const BRIDGE_MAP = {
       origin: ['SYN'],
       destination: ['SYN'],
       swappable: [],
-    },
-    '0x5FD55A1B9FC24967C4dB09C513C3BA0DFa7FF687': {
-      decimals: 18,
-      symbol: 'ETH',
-      origin: ['nETH'],
-      destination: ['nETH'],
-      swappable: ['0x09fEC30669d63A13c666d2129230dD5588E2e240'],
     },
     '0x80b5a32E4F032B2a058b4F29EC95EEfEEB87aDcd': {
       decimals: 6,

--- a/packages/synapse-constants/constants/tokens/bridgeMap.ts
+++ b/packages/synapse-constants/constants/tokens/bridgeMap.ts
@@ -1025,7 +1025,7 @@ export const BRIDGE_MAP = {
       symbol: 'nETH',
       origin: ['nETH'],
       destination: ['nETH'],
-      swappable: ['0x5FD55A1B9FC24967C4dB09C513C3BA0DFa7FF687'],
+      swappable: [],
     },
     '0x4e71A2E537B7f9D9413D3991D37958c0b5e1e503': {
       decimals: 18,
@@ -1044,13 +1044,6 @@ export const BRIDGE_MAP = {
       origin: ['SYN'],
       destination: ['SYN'],
       swappable: [],
-    },
-    '0x5FD55A1B9FC24967C4dB09C513C3BA0DFa7FF687': {
-      decimals: 18,
-      symbol: 'ETH',
-      origin: ['nETH'],
-      destination: ['nETH'],
-      swappable: ['0x09fEC30669d63A13c666d2129230dD5588E2e240'],
     },
     '0x80b5a32E4F032B2a058b4F29EC95EEfEEB87aDcd': {
       decimals: 6,

--- a/packages/synapse-constants/package.json
+++ b/packages/synapse-constants/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-constants",
-  "version": "1.3.3",
+  "version": "1.3.5",
   "description": "This is an npm package that maintains all synapse constants",
   "main": "dist/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
Edits the synapse-constants package to remove canto ETH from bridgeMap. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the `synapse-constants` package version to 1.3.5.
- **Refactor**
	- Removed an entry from the `BRIDGE_MAP` and updated the `swappable` field for another entry to enhance data accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->