### PR TITLE
Add Jobs board

### DIFF
--- a/packages/synapse-interface/components/layouts/LandingPageWrapper/PageFooter.tsx
+++ b/packages/synapse-interface/components/layouts/LandingPageWrapper/PageFooter.tsx
@@ -16,6 +16,7 @@ import {
   TELEGRAM_URL,
   TERMS_OF_SERVICE_PATH,
   TWITTER_URL,
+  JOBS_URL,
 } from '@/constants/urls'
 import { SynapseTitleLogo } from '.'
 
@@ -65,9 +66,9 @@ const developersList: FooterDataProps[] = [
     url: null,
   },
   {
-    text: 'Build on Synapse',
+    text: 'Careers',
     type: FooterType.URL,
-    url: BUILD_ON_URL,
+    url: JOBS_URL,
   },
   {
     text: 'Documentation',

--- a/packages/synapse-interface/constants/urls/index.tsx
+++ b/packages/synapse-interface/constants/urls/index.tsx
@@ -32,6 +32,7 @@ export const TERMS_OF_SERVICE_PATH =
 export const PRIVACY_POLICY_PATH =
   'https://explorer.synapseprotocol.com/privacy'
 export const SYNAPSE_PFP_PATH = '/returntomonke'
+export const JOBS_URL = 'https://jobs.ashbyhq.com/Synapse%20Labs'
 
 /** Synapse Social Links */
 export const DISCORD_URL = 'https://discord.gg/synapseprotocol'


### PR DESCRIPTION
Adding the job board as a link the footer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the footer link text to "Careers" and directed it to the new job listings page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
4920f1c898bfecac77ee34cfd95c08ce4e01166e: [synapse-interface preview link ](https://sanguine-synapse-interface-57ec6rl57-synapsecns.vercel.app)