### PR TITLE
feat(synapse-interface): improve maintenance event template, remove Metis pause

### DIFF
--- a/packages/synapse-interface/components/Maintenance/Events/example/EcotoneForkUpgrade.tsx
+++ b/packages/synapse-interface/components/Maintenance/Events/example/EcotoneForkUpgrade.tsx
@@ -1,6 +1,6 @@
 import { useBridgeState } from '@/slices/bridge/hooks'
 import { useIntervalTimer } from '@/utils/hooks/useIntervalTimer'
-import { METIS } from '@/constants/chains/master'
+import { OPTIMISM, BASE } from '@/constants/chains/master'
 import {
   useEventCountdownProgressBar,
   getCountdownTimeStatus,
@@ -19,10 +19,12 @@ import { WarningMessage } from '../../../Warning'
  * End: 50 min after start of Ecotone Fork Upgrade Time
  */
 export const ECOTONE_FORK_BANNERS_START = new Date(
-  Date.UTC(2024, 2, 20, 16, 0, 0)
+  Date.UTC(2024, 2, 13, 23, 20, 0)
 )
-export const ECOTONE_FORK_START_DATE = new Date(Date.UTC(2024, 2, 20, 18, 0, 0))
-export const ECOTONE_FORK_END_DATE = new Date(Date.UTC(2024, 2, 20, 21, 0, 0))
+export const ECOTONE_FORK_START_DATE = new Date(
+  Date.UTC(2024, 2, 13, 23, 35, 0)
+)
+export const ECOTONE_FORK_END_DATE = new Date(Date.UTC(2024, 2, 14, 0, 25, 0))
 
 /** Previous implementation can be seen here: https://github.com/synapsecns/sanguine/pull/2294/files#diff-bbe6298d3dfbc80e46e2ff8b399a3e1822cede80f392b1af91875145ad4eeb19R19 */
 export const EcotoneForkUpgradeBanner = () => {
@@ -35,9 +37,13 @@ export const EcotoneForkUpgradeBanner = () => {
 
   return (
     <AnnouncementBanner
-      bannerId="03202024-metis-pause"
+      bannerId="03142024-ecotone-fork"
       bannerContents={
-        <>Metis Bridging is paused. Will be back online shortly.</>
+        <>
+          Optimism + Base Bridging will be paused 10 minutes ahead of Ecotone
+          (March 14, 00:00 UTC, 20:00 EST). Will be back online shortly
+          following the network upgrade.
+        </>
       }
       startDate={ECOTONE_FORK_BANNERS_START}
       endDate={ECOTONE_FORK_END_DATE}
@@ -54,14 +60,18 @@ export const EcotoneForkUpgradeBanner = () => {
 export const EcotoneForkWarningMessage = () => {
   const { fromChainId, toChainId } = useBridgeState()
 
-  const isToChainMetis = toChainId === METIS.id
+  const isChainOptimism = [fromChainId, toChainId].includes(OPTIMISM.id)
+  const isChainBase = [fromChainId, toChainId].includes(BASE.id)
 
-  if (isToChainMetis) {
+  if (isChainOptimism || isChainBase) {
     return (
       <WarningMessage
         message={
           <>
-            <p>Metis Chain bridging are paused.</p>
+            <p>
+              Optimism Chain and Base Chain bridging are paused until the
+              Ecotone Fork upgrade completes.
+            </p>
           </>
         }
       />
@@ -95,22 +105,23 @@ export const EcotoneForkWarningMessage = () => {
 export const useEcotoneForkCountdownProgress = () => {
   const { fromChainId, toChainId } = useBridgeState()
 
-  const isToChainMetis = toChainId === METIS.id
+  const isChainOptimism = [fromChainId, toChainId].includes(OPTIMISM.id)
+  const isChainBase = [fromChainId, toChainId].includes(BASE.id)
 
   const {
     isPending: isEcotoneForkUpgradePending,
     EventCountdownProgressBar: EcotoneForkCountdownProgressBar,
   } = useEventCountdownProgressBar(
-    'Metis Bridging is paused',
+    'Ecotone Fork upgrade in progress',
     ECOTONE_FORK_START_DATE, // Countdown Bar will automatically appear after start time
     ECOTONE_FORK_END_DATE // Countdown Bar will automatically disappear when end time is reached
   )
 
   return {
     isEcotoneForkUpgradePending,
-    isCurrentChainDisabled: isToChainMetis, // Used to pause Bridge
-    EcotoneForkCountdownProgressBar: isToChainMetis
-      ? EcotoneForkCountdownProgressBar
-      : null,
+    isCurrentChainDisabled:
+      (isChainOptimism || isChainBase) && isEcotoneForkUpgradePending, // Used to pause Bridge
+    EcotoneForkCountdownProgressBar:
+      isChainOptimism || isChainBase ? EcotoneForkCountdownProgressBar : null,
   }
 }

--- a/packages/synapse-interface/components/Maintenance/Events/template/MaintenanceEvent.tsx
+++ b/packages/synapse-interface/components/Maintenance/Events/template/MaintenanceEvent.tsx
@@ -16,11 +16,11 @@ import { WarningMessage } from '../../../Warning'
  */
 
 /** Banner start time */
-const MAINTENANCE_BANNERS_START = new Date(Date.UTC(2024, 2, 13, 23, 20, 0))
+const MAINTENANCE_BANNERS_START = new Date(Date.UTC(2024, 2, 20, 20, 20, 0))
 /** Countdown Progress Bar, Bridge Warning Message + Bridge Pause start time */
-const MAINTENANCE_START_DATE = new Date(Date.UTC(2024, 2, 13, 23, 35, 0))
+const MAINTENANCE_START_DATE = new Date(Date.UTC(2024, 2, 20, 20, 20, 0))
 /** Ends Banner, Countdown Progress Bar, Bridge Warning Message, Bridge Pause */
-const MAINTENANCE_END_DATE = new Date(Date.UTC(2024, 2, 14, 0, 25, 0))
+const MAINTENANCE_END_DATE = new Date(Date.UTC(2024, 2, 20, 22, 0, 0))
 
 export const MaintenanceBanner = () => {
   const { isComplete } = getCountdownTimeStatus(
@@ -32,10 +32,12 @@ export const MaintenanceBanner = () => {
 
   return (
     <AnnouncementBanner
-      bannerId="03142024-ecotone-fork"
+      bannerId="03202024-maintenance-banner"
       bannerContents={
         <>
-          <p>Bridging is paused until maintenance is complete.</p>
+          <p className="m-auto">
+            Bridging is paused until maintenance is complete.
+          </p>
         </>
       }
       startDate={MAINTENANCE_BANNERS_START}

--- a/packages/synapse-interface/components/Maintenance/Events/template/MaintenanceEvent.tsx
+++ b/packages/synapse-interface/components/Maintenance/Events/template/MaintenanceEvent.tsx
@@ -1,0 +1,117 @@
+import { useBridgeState } from '@/slices/bridge/hooks'
+import { useIntervalTimer } from '@/utils/hooks/useIntervalTimer'
+import { OPTIMISM, BASE } from '@/constants/chains/master'
+import {
+  useEventCountdownProgressBar,
+  getCountdownTimeStatus,
+} from '../../EventCountdownProgressBar'
+import { AnnouncementBanner } from '../../AnnouncementBanner'
+import { WarningMessage } from '../../../Warning'
+
+/**
+ * Edit this file for Website Maintenance, components already placed on Bridge page
+ *
+ * If require multiple maintenance events, create another file using this file as a template
+ * and add another instance of components on relevant pages
+ */
+
+/** Banner start time */
+const MAINTENANCE_BANNERS_START = new Date(Date.UTC(2024, 2, 13, 23, 20, 0))
+/** Countdown Progress Bar, Bridge Warning Message + Bridge Pause start time */
+const MAINTENANCE_START_DATE = new Date(Date.UTC(2024, 2, 13, 23, 35, 0))
+/** Ends Banner, Countdown Progress Bar, Bridge Warning Message, Bridge Pause */
+const MAINTENANCE_END_DATE = new Date(Date.UTC(2024, 2, 14, 0, 25, 0))
+
+export const MaintenanceBanner = () => {
+  const { isComplete } = getCountdownTimeStatus(
+    MAINTENANCE_BANNERS_START, // Banner will automatically appear after start time
+    MAINTENANCE_END_DATE // Banner will automatically disappear when end time is reached
+  )
+
+  useIntervalTimer(60000, isComplete)
+
+  return (
+    <AnnouncementBanner
+      bannerId="03142024-ecotone-fork"
+      bannerContents={
+        <>
+          Optimism + Base Bridging will be paused 10 minutes ahead of Ecotone
+          (March 14, 00:00 UTC, 20:00 EST). Will be back online shortly
+          following the network upgrade.
+        </>
+      }
+      startDate={MAINTENANCE_BANNERS_START}
+      endDate={MAINTENANCE_END_DATE}
+    />
+  )
+}
+
+export const BridgeWarningMessage = () => {
+  const { fromChainId, toChainId } = useBridgeState()
+
+  const isWarningChain = isChainIncluded(
+    [fromChainId, toChainId],
+    [OPTIMISM.id, BASE.id] // Update for Chains to show warning on
+  )
+
+  const { isComplete } = getCountdownTimeStatus(
+    MAINTENANCE_BANNERS_START, // Banner will automatically appear after start time
+    MAINTENANCE_END_DATE // Banner will automatically disappear when end time is reached
+  )
+
+  if (isComplete) return null
+
+  if (isWarningChain) {
+    return (
+      <WarningMessage
+        message={
+          <>
+            <p>
+              Optimism Chain and Base Chain bridging are paused until the
+              Ecotone Fork upgrade completes.
+            </p>
+          </>
+        }
+      />
+    )
+  }
+
+  return null
+}
+
+export const useMaintenanceCountdownProgress = () => {
+  const { fromChainId, toChainId } = useBridgeState()
+
+  const isCurrentChain = isChainIncluded(
+    [fromChainId, toChainId],
+    [OPTIMISM.id, BASE.id] // Update for Chains to show maintenance on
+  )
+
+  const {
+    isPending: isMaintenancePending,
+    EventCountdownProgressBar: MaintenanceCountdownProgressBar,
+  } = useEventCountdownProgressBar(
+    'Ecotone Fork upgrade in progress',
+    MAINTENANCE_START_DATE, // Countdown Bar will automatically appear after start time
+    MAINTENANCE_END_DATE // Countdown Bar will automatically disappear when end time is reached
+  )
+
+  return {
+    isMaintenancePending,
+    isCurrentChainDisabled: isCurrentChain && isMaintenancePending, // Used to pause Bridge
+    EcotoneForkCountdownProgressBar: isCurrentChain
+      ? MaintenanceCountdownProgressBar
+      : null,
+  }
+}
+
+/**
+ * Checks if any of the chain IDs in `hasChains` are found within the `chainList` array.
+ *
+ * @param {number[]} chainList - The array of chain IDs to check against.
+ * @param {number[]} hasChains - The array of chain IDs to find within `checkChains`.
+ * @returns {boolean} - True if any chain ID from `hasChains` is found in `checkChains`, otherwise false.
+ */
+const isChainIncluded = (chainList: number[], hasChains: number[]) => {
+  return hasChains.some((chainId) => chainList.includes(chainId))
+}

--- a/packages/synapse-interface/components/Maintenance/Events/template/MaintenanceEvent.tsx
+++ b/packages/synapse-interface/components/Maintenance/Events/template/MaintenanceEvent.tsx
@@ -35,9 +35,7 @@ export const MaintenanceBanner = () => {
       bannerId="03142024-ecotone-fork"
       bannerContents={
         <>
-          Optimism + Base Bridging will be paused 10 minutes ahead of Ecotone
-          (March 14, 00:00 UTC, 20:00 EST). Will be back online shortly
-          following the network upgrade.
+          <p>Bridging is paused until maintenance is complete.</p>
         </>
       }
       startDate={MAINTENANCE_BANNERS_START}
@@ -46,7 +44,7 @@ export const MaintenanceBanner = () => {
   )
 }
 
-export const BridgeWarningMessage = () => {
+export const MaintenanceWarningMessage = () => {
   const { fromChainId, toChainId } = useBridgeState()
 
   const isWarningChain = isChainIncluded(
@@ -66,10 +64,7 @@ export const BridgeWarningMessage = () => {
       <WarningMessage
         message={
           <>
-            <p>
-              Optimism Chain and Base Chain bridging are paused until the
-              Ecotone Fork upgrade completes.
-            </p>
+            <p>Bridging is paused until maintenance is complete.</p>
           </>
         }
       />
@@ -91,7 +86,7 @@ export const useMaintenanceCountdownProgress = () => {
     isPending: isMaintenancePending,
     EventCountdownProgressBar: MaintenanceCountdownProgressBar,
   } = useEventCountdownProgressBar(
-    'Ecotone Fork upgrade in progress',
+    'Maintenance in progress',
     MAINTENANCE_START_DATE, // Countdown Bar will automatically appear after start time
     MAINTENANCE_END_DATE // Countdown Bar will automatically disappear when end time is reached
   )
@@ -99,7 +94,7 @@ export const useMaintenanceCountdownProgress = () => {
   return {
     isMaintenancePending,
     isCurrentChainDisabled: isCurrentChain && isMaintenancePending, // Used to pause Bridge
-    EcotoneForkCountdownProgressBar: isCurrentChain
+    MaintenanceCountdownProgressBar: isCurrentChain
       ? MaintenanceCountdownProgressBar
       : null,
   }

--- a/packages/synapse-interface/pages/index.tsx
+++ b/packages/synapse-interface/pages/index.tsx
@@ -3,7 +3,7 @@ import { Portfolio } from '@/components/Portfolio/Portfolio'
 import { LandingPageWrapper } from '@/components/layouts/LandingPageWrapper'
 import ReactGA from 'react-ga'
 import useSyncQueryParamsWithBridgeState from '@/utils/hooks/useSyncQueryParamsWithBridgeState'
-import { EcotoneForkUpgradeBanner } from '@/components/Maintenance/Events/example/EcotoneForkUpgrade'
+import { MaintenanceBanner } from '@/components/Maintenance/Events/template/MaintenanceEvent'
 
 // TODO: someone should add this to the .env, disable if blank, etc.
 // this is being added as a hotfix to assess user load on the synapse explorer api
@@ -16,7 +16,7 @@ const Home = () => {
 
   return (
     <>
-      <EcotoneForkUpgradeBanner />
+      <MaintenanceBanner />
       <LandingPageWrapper>
         <main
           data-test-id="bridge-page"

--- a/packages/synapse-interface/pages/state-managed-bridge/index.tsx
+++ b/packages/synapse-interface/pages/state-managed-bridge/index.tsx
@@ -86,10 +86,6 @@ import {
 import { isTransactionReceiptError } from '@/utils/isTransactionReceiptError'
 import { SwitchButton } from '@/components/buttons/SwitchButton'
 import {
-  EcotoneForkWarningMessage,
-  useEcotoneForkCountdownProgress,
-} from '@/components/Maintenance/Events/example/EcotoneForkUpgrade'
-import {
   MaintenanceWarningMessage,
   useMaintenanceCountdownProgress,
 } from '@/components/Maintenance/Events/template/MaintenanceEvent'

--- a/packages/synapse-interface/pages/state-managed-bridge/index.tsx
+++ b/packages/synapse-interface/pages/state-managed-bridge/index.tsx
@@ -89,6 +89,10 @@ import {
   EcotoneForkWarningMessage,
   useEcotoneForkCountdownProgress,
 } from '@/components/Maintenance/Events/example/EcotoneForkUpgrade'
+import {
+  MaintenanceWarningMessage,
+  useMaintenanceCountdownProgress,
+} from '@/components/Maintenance/Events/template/MaintenanceEvent'
 
 const StateManagedBridge = () => {
   const { address } = useAccount()
@@ -522,10 +526,10 @@ const StateManagedBridge = () => {
     '-mt-4 fixed z-50 w-full h-full bg-opacity-50 bg-[#343036]'
 
   const {
-    isEcotoneForkUpgradePending,
+    isMaintenancePending,
     isCurrentChainDisabled,
-    EcotoneForkCountdownProgressBar,
-  } = useEcotoneForkCountdownProgress()
+    MaintenanceCountdownProgressBar,
+  } = useMaintenanceCountdownProgress()
 
   return (
     <div className="flex flex-col w-full max-w-lg mx-auto lg:mx-0">
@@ -564,7 +568,7 @@ const StateManagedBridge = () => {
             transition-all duration-100 transform rounded-md
           `}
         >
-          {EcotoneForkCountdownProgressBar}
+          {MaintenanceCountdownProgressBar}
           <div ref={bridgeDisplayRef}>
             <Transition show={showSettingsSlideOver} {...TRANSITION_PROPS}>
               <animated.div>
@@ -602,6 +606,7 @@ const StateManagedBridge = () => {
             />
             <OutputContainer />
             <Warning />
+            {isMaintenancePending && <MaintenanceWarningMessage />}
             <Transition
               appear={true}
               unmount={false}


### PR DESCRIPTION
Improving the process for throwing up maintenance components (Banners, Bridge Pause, Bridge Warning, Event Countdown Progress Bar) quickly when we need to pause Bridge. 

Created a [MaintenanceEvent component](https://github.com/synapsecns/sanguine/blob/fe/abstract-maintenance/packages/synapse-interface/components/Maintenance/Events/template/MaintenanceEvent.tsx/#L1-L115) that makes it easier to update for new maintenance events, with required components already installed onto Bridge pages. 

To spin up new Maintenance notifications around the Bridge experience, next time we just need to update [these start/end times](https://github.com/synapsecns/sanguine/blob/fe/abstract-maintenance/packages/synapse-interface/components/Maintenance/Events/template/MaintenanceEvent.tsx/#L17-L23) and messages to be shown in Banner, Warning, and Event Countdown Progress Bar.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new maintenance event management functionality, including banners and countdown progress bars.
- **Enhancements**
	- Updated the Ecotone Fork event with new chain constants, adjusted dates, and banner content.
	- Enhanced logic to handle bridging pauses for Optimism and Base chains during upgrades.
	- Replaced Ecotone Fork-specific components with generic maintenance event components for better flexibility and maintenance handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
801eabea661ccd42a5e5c8e08d846f107770ee85: [synapse-interface preview link ](https://sanguine-synapse-interface-bnf4aixuc-synapsecns.vercel.app)