### PR TITLE
fix golangci-lint

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -329,9 +329,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          # see: https://github.com/golangci/golangci-lint/issues/3420, moving to go 1.20 requires a new golangci-lint version
-          # TODO: with this being 3 behind this should be done sooner rather than later.
-          go-version: 1.19.x
+          go-version: 1.21.x
 
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**

Supercedes #2333, master should be merged into communication after this at some point to fix this issue


Context: on #2234 and child branches golangci-lint has been failing. This [comment](https://github.com/golangci/golangci-lint/discussions/1920#discussioncomment-8664443) hints this was a result of old go version.

We were stopped from updating this because of golangci/golangci-lint#3420 (see regression in: #534/#532), but that was fixed w/ the upgrade in #2204.

