### PR TITLE
Add integration tests for `contracts-communication`

### DIFF
--- a/packages/contracts-communication/test/InterchainClientV1.Dst.t.sol
+++ b/packages/contracts-communication/test/InterchainClientV1.Dst.t.sol
@@ -82,6 +82,7 @@ contract InterchainClientV1DestinationTest is InterchainClientV1BaseTest {
     uint256 public constant JUST_NOW = INITIAL_TS - 1;
 
     function setUp() public override {
+        vm.warp(INITIAL_TS);
         super.setUp();
         setLinkedClient(REMOTE_CHAIN_ID, MOCK_REMOTE_CLIENT);
         dstReceiver = address(new InterchainAppMock());

--- a/packages/contracts-communication/test/integration/ICIntegration.t.sol
+++ b/packages/contracts-communication/test/integration/ICIntegration.t.sol
@@ -7,6 +7,7 @@ import {InterchainClientV1Events} from "../../contracts/events/InterchainClientV
 import {InterchainDBEvents} from "../../contracts/events/InterchainDBEvents.sol";
 import {InterchainModuleEvents} from "../../contracts/events/InterchainModuleEvents.sol";
 
+import {IInterchainApp} from "../../contracts/interfaces/IInterchainApp.sol";
 import {InterchainBatch} from "../../contracts/libs/InterchainBatch.sol";
 import {InterchainEntry} from "../../contracts/libs/InterchainEntry.sol";
 import {InterchainTransaction, InterchainTxDescriptor} from "../../contracts/libs/InterchainTransaction.sol";
@@ -144,6 +145,19 @@ abstract contract ICIntegrationTest is
     function expectPingPongEventPingSent(uint256 counter, InterchainTxDescriptor memory desc) internal {
         vm.expectEmit(address(pingPongApp));
         emit PingSent(counter, desc.dbNonce, desc.entryIndex);
+    }
+
+    function expectPingPongCall(InterchainTransaction memory icTx, OptionsV1 memory options) internal {
+        bytes memory expectedCalldata = abi.encodeCall(
+            IInterchainApp.appReceive, (icTx.srcChainId, icTx.srcSender, icTx.dbNonce, icTx.entryIndex, icTx.message)
+        );
+        vm.expectCall({
+            callee: address(pingPongApp),
+            msgValue: options.gasAirdrop,
+            gas: uint64(options.gasLimit),
+            data: expectedCalldata,
+            count: 1
+        });
     }
 
     // ═══════════════════════════════════════════ COMPLEX SERIES CHECKS ═══════════════════════════════════════════════

--- a/packages/contracts-communication/test/integration/ICIntegration.t.sol
+++ b/packages/contracts-communication/test/integration/ICIntegration.t.sol
@@ -34,6 +34,20 @@ abstract contract ICIntegrationTest is
     event PingReceived(uint256 counter, uint256 dbNonce, uint64 entryIndex);
     event PingSent(uint256 counter, uint256 dbNonce, uint64 entryIndex);
 
+    function assertEq(InterchainBatch memory batch, InterchainBatch memory expected) internal  {
+        assertEq(batch.srcChainId, expected.srcChainId);
+        assertEq(batch.dbNonce, expected.dbNonce);
+        assertEq(batch.batchRoot, expected.batchRoot);
+    }
+
+    function assertEq(InterchainEntry memory entry, InterchainEntry memory expected) internal  {
+        assertEq(entry.srcChainId, expected.srcChainId);
+        assertEq(entry.dbNonce, expected.dbNonce);
+        assertEq(entry.entryIndex, expected.entryIndex);
+        assertEq(entry.srcWriter, expected.srcWriter);
+        assertEq(entry.dataHash, expected.dataHash);
+    }
+
     function expectFeesEventExecutionFeeAdded(bytes32 transactionId, uint256 totalFee) internal {
         vm.expectEmit(address(executionFees));
         emit ExecutionFeeAdded({dstChainId: remoteChainId(), transactionId: transactionId, totalFee: totalFee});

--- a/packages/contracts-communication/test/integration/ICIntegration.t.sol
+++ b/packages/contracts-communication/test/integration/ICIntegration.t.sol
@@ -8,6 +8,7 @@ import {InterchainDBEvents} from "../../contracts/events/InterchainDBEvents.sol"
 import {InterchainModuleEvents} from "../../contracts/events/InterchainModuleEvents.sol";
 
 import {IInterchainApp} from "../../contracts/interfaces/IInterchainApp.sol";
+import {IInterchainClientV1} from "../../contracts/interfaces/IInterchainClientV1.sol";
 import {InterchainBatch} from "../../contracts/libs/InterchainBatch.sol";
 import {InterchainEntry} from "../../contracts/libs/InterchainEntry.sol";
 import {InterchainTransaction, InterchainTxDescriptor} from "../../contracts/libs/InterchainTransaction.sol";
@@ -158,6 +159,24 @@ abstract contract ICIntegrationTest is
             data: expectedCalldata,
             count: 1
         });
+    }
+
+    // ══════════════════════════════════════════════ EXPECT REVERTS ═══════════════════════════════════════════════════
+
+    function expectClientRevertNotEnoughResponses(uint256 actual, uint256 required) internal {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IInterchainClientV1.InterchainClientV1__NotEnoughResponses.selector, actual, required
+            )
+        );
+    }
+
+    function expectClientRevertTxAlreadyExecuted(InterchainTxDescriptor memory desc) internal {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IInterchainClientV1.InterchainClientV1__TxAlreadyExecuted.selector, desc.transactionId
+            )
+        );
     }
 
     // ═══════════════════════════════════════════ COMPLEX SERIES CHECKS ═══════════════════════════════════════════════

--- a/packages/contracts-communication/test/integration/ICIntegration.t.sol
+++ b/packages/contracts-communication/test/integration/ICIntegration.t.sol
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {ExecutionFeesEvents} from "../../contracts/events/ExecutionFeesEvents.sol";
+import {ExecutionServiceEvents} from "../../contracts/events/ExecutionServiceEvents.sol";
+import {InterchainClientV1Events} from "../../contracts/events/InterchainClientV1Events.sol";
+import {InterchainDBEvents} from "../../contracts/events/InterchainDBEvents.sol";
+import {InterchainModuleEvents} from "../../contracts/events/InterchainModuleEvents.sol";
+
+import {InterchainBatch} from "../../contracts/libs/InterchainBatch.sol";
+import {InterchainEntry} from "../../contracts/libs/InterchainEntry.sol";
+import {InterchainTransaction} from "../../contracts/libs/InterchainTransaction.sol";
+import {ModuleBatchLib} from "../../contracts/libs/ModuleBatch.sol";
+import {OptionsV1} from "../../contracts/libs/Options.sol";
+
+import {ICSetup, TypeCasts} from "./ICSetup.t.sol";
+
+// solhint-disable custom-errors
+// solhint-disable ordering
+abstract contract ICIntegrationTest is
+    ICSetup,
+    ExecutionFeesEvents,
+    ExecutionServiceEvents,
+    InterchainClientV1Events,
+    InterchainDBEvents,
+    InterchainModuleEvents
+{
+    using TypeCasts for address;
+
+    uint256 public constant COUNTER = 42;
+
+    OptionsV1 public ppOptions = OptionsV1({gasLimit: 500_000, gasAirdrop: 0});
+
+    function expectFeesEventExecutionFeeAdded(bytes32 transactionId, uint256 totalFee) internal {
+        vm.expectEmit(address(executionFees));
+        emit ExecutionFeeAdded({dstChainId: remoteChainId(), transactionId: transactionId, totalFee: totalFee});
+    }
+
+    function expectServiceEventExecutionRequested(bytes32 transactionId) internal {
+        vm.expectEmit(address(executionService));
+        emit ExecutionRequested({transactionId: transactionId, client: address(icClient)});
+    }
+
+    function expectClientEventInterchainTransactionSent(
+        InterchainTransaction memory icTx,
+        uint256 verificationFee,
+        uint256 executionFee
+    )
+        internal
+    {
+        vm.expectEmit(address(icClient));
+        emit InterchainTransactionSent({
+            transactionId: icTx.transactionId(),
+            dbNonce: icTx.dbNonce,
+            entryIndex: icTx.entryIndex,
+            dstChainId: icTx.dstChainId,
+            srcSender: icTx.srcSender,
+            dstReceiver: icTx.dstReceiver,
+            verificationFee: verificationFee,
+            executionFee: executionFee,
+            options: icTx.options,
+            message: icTx.message
+        });
+    }
+
+    function expectClientEventInterchainTransactionReceived(InterchainTransaction memory icTx) internal {
+        vm.expectEmit(address(icClient));
+        emit InterchainTransactionReceived({
+            transactionId: icTx.transactionId(),
+            dbNonce: icTx.dbNonce,
+            entryIndex: icTx.entryIndex,
+            srcChainId: icTx.srcChainId,
+            srcSender: icTx.srcSender,
+            dstReceiver: icTx.dstReceiver
+        });
+    }
+
+    function expectDatabaseEventInterchainEntryWritten(InterchainEntry memory entry) internal {
+        vm.expectEmit(address(icDB));
+        emit InterchainEntryWritten({
+            srcChainId: entry.srcChainId,
+            dbNonce: entry.dbNonce,
+            srcWriter: entry.srcWriter,
+            dataHash: entry.dataHash
+        });
+    }
+
+    function expectDatabaseEventInterchainBatchVerified(InterchainBatch memory batch) internal {
+        vm.expectEmit(address(icDB));
+        emit InterchainBatchVerified({
+            module: address(module),
+            srcChainId: batch.srcChainId,
+            dbNonce: batch.dbNonce,
+            batchRoot: batch.batchRoot
+        });
+    }
+
+    function expectDatabaseEventInterchainBatchVerificationRequested(InterchainBatch memory batch) internal {
+        vm.expectEmit(address(icDB));
+        emit InterchainBatchVerificationRequested({
+            dstChainId: remoteChainId(),
+            dbNonce: batch.dbNonce,
+            batchRoot: batch.batchRoot,
+            srcModules: toArray(address(module))
+        });
+    }
+
+    function expectModuleEventBatchVerificationRequested(InterchainBatch memory batch) internal {
+        bytes memory encodedBatch = getModuleBatch(batch);
+        bytes32 digest = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", keccak256(encodedBatch)));
+        vm.expectEmit(address(module));
+        emit BatchVerificationRequested({dstChainId: remoteChainId(), batch: encodedBatch, ethSignedBatchHash: digest});
+    }
+
+    function expectModuleEventBatchVerified(InterchainBatch memory batch) internal {
+        bytes memory encodedBatch = getModuleBatch(batch);
+        bytes32 digest = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", keccak256(encodedBatch)));
+        vm.expectEmit(address(module));
+        emit BatchVerified({srcChainId: batch.srcChainId, batch: encodedBatch, ethSignedBatchHash: digest});
+    }
+
+    // ═══════════════════════════════════════════════ DATA HELPERS ════════════════════════════════════════════════════
+
+    function getModuleBatch(InterchainBatch memory batch) internal pure returns (bytes memory) {
+        return ModuleBatchLib.encodeModuleBatch(batch, new bytes(0));
+    }
+
+    function getInterchainBatch(InterchainEntry memory entry) internal pure returns (InterchainBatch memory) {
+        return InterchainBatch({
+            srcChainId: entry.srcChainId,
+            dbNonce: entry.dbNonce,
+            batchRoot: keccak256(abi.encode(entry.srcWriter, entry.dataHash))
+        });
+    }
+
+    function getSrcInterchainEntry() internal view returns (InterchainEntry memory) {
+        return InterchainEntry({
+            srcChainId: SRC_CHAIN_ID,
+            dbNonce: SRC_INITIAL_DB_NONCE,
+            entryIndex: 0,
+            srcWriter: address(icClient).addressToBytes32(),
+            dataHash: getSrcTransaction().transactionId()
+        });
+    }
+
+    function getDstInterchainEntry() internal view returns (InterchainEntry memory) {
+        return InterchainEntry({
+            srcChainId: DST_CHAIN_ID,
+            dbNonce: DST_INITIAL_DB_NONCE,
+            entryIndex: 0,
+            srcWriter: address(icClient).addressToBytes32(),
+            dataHash: getDstTransaction().transactionId()
+        });
+    }
+
+    function getSrcTransaction() internal view returns (InterchainTransaction memory) {
+        return InterchainTransaction({
+            srcChainId: SRC_CHAIN_ID,
+            srcSender: address(pingPongApp).addressToBytes32(),
+            dstChainId: DST_CHAIN_ID,
+            dstReceiver: address(pingPongApp).addressToBytes32(),
+            dbNonce: SRC_INITIAL_DB_NONCE,
+            entryIndex: 0,
+            options: ppOptions.encodeOptionsV1(),
+            message: getPingPongSrcMessage()
+        });
+    }
+
+    function getDstTransaction() internal view returns (InterchainTransaction memory) {
+        return InterchainTransaction({
+            srcChainId: DST_CHAIN_ID,
+            srcSender: address(pingPongApp).addressToBytes32(),
+            dstChainId: SRC_CHAIN_ID,
+            dstReceiver: address(pingPongApp).addressToBytes32(),
+            dbNonce: DST_INITIAL_DB_NONCE,
+            entryIndex: 0,
+            options: ppOptions.encodeOptionsV1(),
+            message: getPingPongDstMessage()
+        });
+    }
+
+    /// @notice Message that source chain PingPongApp sends to destination chain.
+    function getPingPongSrcMessage() internal pure returns (bytes memory) {
+        return abi.encode(COUNTER);
+    }
+
+    /// @notice Message that destination chain PingPongApp sends back to source chain.
+    function getPingPongDstMessage() internal pure returns (bytes memory) {
+        return abi.encode(COUNTER - 1);
+    }
+
+    function toArray(address addr) internal pure returns (address[] memory arr) {
+        arr = new address[](1);
+        arr[0] = addr;
+    }
+}

--- a/packages/contracts-communication/test/integration/ICSetup.t.sol
+++ b/packages/contracts-communication/test/integration/ICSetup.t.sol
@@ -29,6 +29,8 @@ abstract contract ICSetup is Test {
 
     uint256 public constant APP_OPTIMISTIC_PERIOD = 10 minutes;
 
+    uint256 public constant INITIAL_TS = 1_704_067_200; // 2024-01-01 00:00:00 UTC
+
     ExecutionFees public executionFees;
     ExecutionService public executionService;
     InterchainClientV1 public icClient;
@@ -49,6 +51,7 @@ abstract contract ICSetup is Test {
 
     function setUp() public virtual {
         vm.chainId(localChainId());
+        vm.warp(INITIAL_TS);
         deployInterchainContracts();
         configureInterchainContracts();
         initDBNonce();

--- a/packages/contracts-communication/test/integration/ICSetup.t.sol
+++ b/packages/contracts-communication/test/integration/ICSetup.t.sol
@@ -15,6 +15,7 @@ import {TypeCasts} from "../../contracts/libs/TypeCasts.sol";
 import {Test} from "forge-std/Test.sol";
 
 // solhint-disable custom-errors
+// solhint-disable ordering
 abstract contract ICSetup is Test {
     using TypeCasts for address;
 
@@ -23,6 +24,8 @@ abstract contract ICSetup is Test {
 
     uint256 public constant SRC_INITIAL_DB_NONCE = 10;
     uint256 public constant DST_INITIAL_DB_NONCE = 20;
+
+    uint256 public constant PING_PONG_BALANCE = 1000 ether;
 
     uint256 public constant APP_OPTIMISTIC_PERIOD = 10 minutes;
 
@@ -49,6 +52,7 @@ abstract contract ICSetup is Test {
         deployInterchainContracts();
         configureInterchainContracts();
         initDBNonce();
+        dealEther();
     }
 
     function deployInterchainContracts() internal virtual {
@@ -126,6 +130,10 @@ abstract contract ICSetup is Test {
         require(icDB.getDBNonce() == end, "DB nonce not increased");
     }
 
+    function dealEther() internal virtual {
+        deal(address(pingPongApp), PING_PONG_BALANCE);
+    }
+
     function getGasDataFixture(uint256 chainId)
         internal
         view
@@ -147,7 +155,7 @@ abstract contract ICSetup is Test {
         return isSourceChain(localChainId());
     }
 
-    function isSourceChain(uint256 chainId) internal view returns (bool) {
+    function isSourceChain(uint256 chainId) internal pure returns (bool) {
         if (chainId == SRC_CHAIN_ID) {
             return true;
         } else if (chainId == DST_CHAIN_ID) {

--- a/packages/contracts-communication/test/integration/ICSetup.t.sol
+++ b/packages/contracts-communication/test/integration/ICSetup.t.sol
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {ExecutionFees} from "../../contracts/ExecutionFees.sol";
+import {ExecutionService} from "../../contracts/ExecutionService.sol";
+import {InterchainClientV1} from "../../contracts/InterchainClientV1.sol";
+import {InterchainDB} from "../../contracts/InterchainDB.sol";
+import {PingPongApp} from "../../contracts/apps/PingPongApp.sol";
+import {AppConfigV1} from "../../contracts/libs/AppConfig.sol";
+import {SynapseModule} from "../../contracts/modules/SynapseModule.sol";
+import {SynapseGasOracleV1, ISynapseGasOracleV1} from "../../contracts/oracles/SynapseGasOracleV1.sol";
+
+import {TypeCasts} from "../../contracts/libs/TypeCasts.sol";
+
+import {Test} from "forge-std/Test.sol";
+
+// solhint-disable custom-errors
+abstract contract ICSetup is Test {
+    using TypeCasts for address;
+
+    uint256 public constant SRC_CHAIN_ID = 1337;
+    uint256 public constant DST_CHAIN_ID = 7331;
+
+    uint256 public constant SRC_INITIAL_DB_NONCE = 10;
+    uint256 public constant DST_INITIAL_DB_NONCE = 20;
+
+    uint256 public constant APP_OPTIMISTIC_PERIOD = 10 minutes;
+
+    ExecutionFees public executionFees;
+    ExecutionService public executionService;
+    InterchainClientV1 public icClient;
+    InterchainDB public icDB;
+
+    SynapseModule public module;
+    SynapseGasOracleV1 public gasOracle;
+
+    PingPongApp public pingPongApp;
+
+    address public executor = makeAddr("Executor");
+    address public feeCollector = makeAddr("FeeCollector");
+    // Signer public keys, sorted by their address:
+    // 2000 -> 0x5793e629c061e7FD642ab6A1b4d552CeC0e2D606
+    // 1000 -> 0x7F1d642DbfD62aD4A8fA9810eA619707d09825D0
+    // 3000 -> 0xf6c0eB696e44d15E8dceb3B63A6535e469Be6C62
+    uint256[3] public signerPKs = [2000, 1000, 3000];
+
+    function setUp() public virtual {
+        vm.chainId(localChainId());
+        deployInterchainContracts();
+        configureInterchainContracts();
+        initDBNonce();
+    }
+
+    function deployInterchainContracts() internal virtual {
+        executionFees = new ExecutionFees(address(this));
+        executionService = new ExecutionService(address(this));
+        icDB = new InterchainDB();
+        icClient = new InterchainClientV1({interchainDB: address(icDB), owner_: address(this)});
+        module = new SynapseModule({interchainDB: address(icDB), owner_: address(this)});
+        gasOracle = new SynapseGasOracleV1(address(this));
+        pingPongApp = new PingPongApp(address(this));
+    }
+
+    function configureInterchainContracts() internal virtual {
+        configureExecutionFees();
+        configureExecutionService();
+        configureInterchainClient();
+        configureSynapseModule();
+        configureSynapseGasOracle();
+        configurePingPongApp();
+    }
+
+    function configureExecutionFees() internal virtual {
+        // Adding InterchainClientV1 as Recorder
+        executionFees.grantRole(executionFees.RECORDER_ROLE(), address(icClient));
+    }
+
+    function configureExecutionService() internal virtual {
+        executionService.setExecutorEOA(executor);
+        executionService.setGasOracle(address(gasOracle));
+        executionService.setInterchainClient(address(icClient));
+    }
+
+    function configureInterchainClient() internal virtual {
+        // For simplicity, we assume that the clients are deployed to the same address on both chains.
+        bytes32 linkedClient = address(icClient).addressToBytes32();
+        icClient.setLinkedClient(remoteChainId(), linkedClient);
+        icClient.setExecutionFees(address(executionFees));
+    }
+
+    function configureSynapseModule() internal virtual {
+        module.setClaimFeeFraction(0.01e18); // 1%
+        module.setFeeCollector(feeCollector);
+        module.setGasOracle(address(gasOracle));
+        module.setThreshold(signerPKs.length);
+        for (uint256 i = 0; i < signerPKs.length; i++) {
+            module.addVerifier(vm.addr(signerPKs[i]));
+        }
+    }
+
+    function configureSynapseGasOracle() internal virtual {
+        gasOracle.setLocalNativePrice(getGasDataFixture(localChainId()).nativePrice);
+        gasOracle.setRemoteGasData(remoteChainId(), getGasDataFixture(remoteChainId()));
+    }
+
+    function configurePingPongApp() internal virtual {
+        // For simplicity, we assume that the apps are deployed to the same address on both chains.
+        pingPongApp.linkRemoteAppEVM(remoteChainId(), address(pingPongApp));
+        pingPongApp.addTrustedModule(address(module));
+        pingPongApp.setAppConfigV1(AppConfigV1({requiredResponses: 1, optimisticPeriod: APP_OPTIMISTIC_PERIOD}));
+        pingPongApp.setExecutionService(address(executionService));
+        pingPongApp.setInterchainClient(address(icClient));
+    }
+
+    function initDBNonce() internal virtual {
+        // Write some random data to the DB to increase the nonce.
+        uint256 start = icDB.getDBNonce();
+        uint256 end = isSourceChainTest() ? SRC_INITIAL_DB_NONCE : DST_INITIAL_DB_NONCE;
+        for (uint256 i = start; i < end; i++) {
+            address writer = makeAddr(string.concat("Writer ", vm.toString(localChainId()), "-", vm.toString(i)));
+            bytes32 data = keccak256(abi.encode(localChainId(), i));
+            vm.prank(writer);
+            icDB.writeEntry(data);
+        }
+        // Sanity check
+        require(icDB.getDBNonce() == end, "DB nonce not increased");
+    }
+
+    function getGasDataFixture(uint256 chainId)
+        internal
+        view
+        virtual
+        returns (ISynapseGasOracleV1.RemoteGasData memory gasFixture)
+    {
+        if (isSourceChain(chainId)) {
+            gasFixture.calldataPrice = 100 gwei;
+            gasFixture.gasPrice = 1 gwei;
+            gasFixture.nativePrice = 0.1 ether;
+        } else {
+            gasFixture.calldataPrice = 0.1 gwei;
+            gasFixture.gasPrice = 50 gwei;
+            gasFixture.nativePrice = 1 ether;
+        }
+    }
+
+    function isSourceChainTest() internal view returns (bool) {
+        return isSourceChain(localChainId());
+    }
+
+    function isSourceChain(uint256 chainId) internal view returns (bool) {
+        if (chainId == SRC_CHAIN_ID) {
+            return true;
+        } else if (chainId == DST_CHAIN_ID) {
+            return false;
+        } else {
+            revert("Invalid chainId");
+        }
+    }
+
+    /// @notice Should return either `SRC_CHAIN_ID` or `DST_CHAIN_ID`.
+    function localChainId() internal view virtual returns (uint256);
+    /// @notice Should return either `SRC_CHAIN_ID` or `DST_CHAIN_ID`.
+    function remoteChainId() internal view virtual returns (uint256);
+}

--- a/packages/contracts-communication/test/integration/PingPong.Dst.t.sol
+++ b/packages/contracts-communication/test/integration/PingPong.Dst.t.sol
@@ -193,6 +193,38 @@ contract PingPongDstIntegrationTest is ICIntegrationTest {
         executeTx(ppOptions);
     }
 
+    function test_isExecutable() public {
+        module.verifyRemoteBatch(moduleBatch, moduleSignatures);
+        skip(APP_OPTIMISTIC_PERIOD + 1);
+        assertTrue(icClient.isExecutable(encodedSrcTx, new bytes32[](0)));
+    }
+
+    function test_isExecutable_revert_notConfirmed() public {
+        expectClientRevertNotEnoughResponses({actual: 0, required: 1});
+        icClient.isExecutable(encodedSrcTx, new bytes32[](0));
+    }
+
+    function test_isExecutable_revert_confirmed_sameBlock() public {
+        module.verifyRemoteBatch(moduleBatch, moduleSignatures);
+        expectClientRevertNotEnoughResponses({actual: 0, required: 1});
+        icClient.isExecutable(encodedSrcTx, new bytes32[](0));
+    }
+
+    function test_isExecutable_revert_confirmed_periodMinusOneSecond() public {
+        module.verifyRemoteBatch(moduleBatch, moduleSignatures);
+        skip(APP_OPTIMISTIC_PERIOD);
+        expectClientRevertNotEnoughResponses({actual: 0, required: 1});
+        icClient.isExecutable(encodedSrcTx, new bytes32[](0));
+    }
+
+    function test_isExecutable_revert_alreadyExecuted() public {
+        module.verifyRemoteBatch(moduleBatch, moduleSignatures);
+        skip(APP_OPTIMISTIC_PERIOD + 1);
+        executeTx(ppOptions);
+        expectClientRevertTxAlreadyExecuted(srcDesc);
+        icClient.isExecutable(encodedSrcTx, new bytes32[](0));
+    }
+
     function localChainId() internal pure override returns (uint256) {
         return DST_CHAIN_ID;
     }

--- a/packages/contracts-communication/test/integration/PingPong.Dst.t.sol
+++ b/packages/contracts-communication/test/integration/PingPong.Dst.t.sol
@@ -166,6 +166,33 @@ contract PingPongDstIntegrationTest is ICIntegrationTest {
         assertEq(address(module).balance, dstVerificationFee);
     }
 
+    function test_interchainExecute_revert_notConfirmed() public {
+        // No module signatures
+        expectClientRevertNotEnoughResponses({actual: 0, required: 1});
+        executeTx(ppOptions);
+    }
+
+    function test_interchainExecute_revert_confirmed_sameBlock() public {
+        module.verifyRemoteBatch(moduleBatch, moduleSignatures);
+        expectClientRevertNotEnoughResponses({actual: 0, required: 1});
+        executeTx(ppOptions);
+    }
+
+    function test_interchainExecute_revert_confirmed_periodMinusOneSecond() public {
+        module.verifyRemoteBatch(moduleBatch, moduleSignatures);
+        skip(APP_OPTIMISTIC_PERIOD);
+        expectClientRevertNotEnoughResponses({actual: 0, required: 1});
+        executeTx(ppOptions);
+    }
+
+    function test_interchainExecute_revert_alreadyExecuted() public {
+        module.verifyRemoteBatch(moduleBatch, moduleSignatures);
+        skip(APP_OPTIMISTIC_PERIOD + 1);
+        executeTx(ppOptions);
+        expectClientRevertTxAlreadyExecuted(srcDesc);
+        executeTx(ppOptions);
+    }
+
     function localChainId() internal pure override returns (uint256) {
         return DST_CHAIN_ID;
     }

--- a/packages/contracts-communication/test/integration/PingPong.Dst.t.sol
+++ b/packages/contracts-communication/test/integration/PingPong.Dst.t.sol
@@ -90,6 +90,31 @@ contract PingPongDstIntegrationTest is ICIntegrationTest {
         assertEq(icDB.checkVerification(address(module), srcEntry, new bytes32[](0)), INITIAL_TS);
     }
 
+    function test_interchainExecute_callPingPongApp() public {
+        module.verifyRemoteBatch(moduleBatch, moduleSignatures);
+        skip(APP_OPTIMISTIC_PERIOD + 1);
+        expectPingPongCall(srcTx, ppOptions);
+        executeTx(ppOptions);
+    }
+
+    function test_interchainExecute_callPingPongApp_lowerGas() public {
+        OptionsV1 memory options = OptionsV1({gasLimit: ppOptions.gasLimit / 2, gasAirdrop: ppOptions.gasAirdrop});
+        module.verifyRemoteBatch(moduleBatch, moduleSignatures);
+        skip(APP_OPTIMISTIC_PERIOD + 1);
+        // Should use the requested gas limit
+        expectPingPongCall(srcTx, ppOptions);
+        executeTx(options);
+    }
+
+    function test_interchainExecute_callPingPongApp_higherGas() public {
+        OptionsV1 memory options = OptionsV1({gasLimit: 2 * ppOptions.gasLimit, gasAirdrop: ppOptions.gasAirdrop});
+        module.verifyRemoteBatch(moduleBatch, moduleSignatures);
+        skip(APP_OPTIMISTIC_PERIOD + 1);
+        // Should allow to use higher gas limit
+        expectPingPongCall(srcTx, options);
+        executeTx(options);
+    }
+
     function test_interchainExecute_events() public {
         module.verifyRemoteBatch(moduleBatch, moduleSignatures);
         skip(APP_OPTIMISTIC_PERIOD + 1);

--- a/packages/contracts-communication/test/integration/PingPong.Dst.t.sol
+++ b/packages/contracts-communication/test/integration/PingPong.Dst.t.sol
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {ModuleBatchLib} from "../../contracts/libs/ModuleBatch.sol";
+
+import {
+    ICIntegrationTest,
+    InterchainBatch,
+    InterchainEntry,
+    InterchainTransaction,
+    InterchainTxDescriptor
+} from "./ICIntegration.t.sol";
+
+// solhint-disable func-name-mixedcase
+// solhint-disable ordering
+contract PingPongDstIntegrationTest is ICIntegrationTest {
+    uint256 public constant LONG_PERIOD = 1 weeks;
+
+    InterchainBatch public srcBatch;
+    InterchainEntry public srcEntry;
+    InterchainTransaction public srcTx;
+    InterchainTxDescriptor public srcDesc;
+
+    InterchainBatch public dstBatch;
+    InterchainEntry public dstEntry;
+    InterchainTransaction public dstTx;
+    InterchainTxDescriptor public dstDesc;
+
+    uint256 public dstPingFee;
+    uint256 public dstVerificationFee;
+    uint256 public dstExecutionFee;
+
+    bytes public moduleBatch;
+    bytes public moduleSignatures;
+
+    function setUp() public override {
+        super.setUp();
+        srcTx = getSrcTransaction();
+        srcEntry = getSrcInterchainEntry();
+        srcDesc = getInterchainTxDescriptor(srcEntry);
+        srcBatch = getInterchainBatch(srcEntry);
+
+        moduleBatch = getModuleBatch(srcBatch);
+        moduleSignatures = getModuleSignatures(srcBatch);
+
+        dstTx = getDstTransaction();
+        dstEntry = getDstInterchainEntry();
+        dstDesc = getInterchainTxDescriptor(dstEntry);
+        dstBatch = getInterchainBatch(dstEntry);
+
+        dstPingFee = pingPongApp.getPingFee(SRC_CHAIN_ID);
+        dstVerificationFee = icDB.getInterchainFee(SRC_CHAIN_ID, toArray(address(module)));
+        dstExecutionFee = executionService.getExecutionFee({
+            dstChainId: SRC_CHAIN_ID,
+            txPayloadSize: abi.encode(dstTx).length,
+            options: ppOptions.encodeOptionsV1()
+        });
+    }
+
+    function test_verifyRemoteBatch_events() public {
+        expectDatabaseEventInterchainBatchVerified(srcBatch);
+        expectModuleEventBatchVerified(srcBatch);
+        module.verifyRemoteBatch(moduleBatch, moduleSignatures);
+    }
+
+    function test_verifyRemoteBatch_state_client() public {
+        module.verifyRemoteBatch(moduleBatch, moduleSignatures);
+        skip(APP_OPTIMISTIC_PERIOD + 1);
+        assertEq(icClient.getExecutor(encodedSrcTx), address(0));
+        assertEq(icClient.getExecutorById(srcDesc.transactionId), address(0));
+        assertTrue(icClient.isExecutable(encodedSrcTx, new bytes32[](0)));
+    }
+
+    function test_verifyRemoteBatch_state_db() public {
+        module.verifyRemoteBatch(moduleBatch, moduleSignatures);
+        skip(LONG_PERIOD);
+        assertEq(icDB.checkVerification(address(module), srcEntry, new bytes32[](0)), INITIAL_TS);
+    }
+
+    function localChainId() internal pure override returns (uint256) {
+        return DST_CHAIN_ID;
+    }
+
+    function remoteChainId() internal pure override returns (uint256) {
+        return SRC_CHAIN_ID;
+    }
+}

--- a/packages/contracts-communication/test/integration/PingPong.Src.t.sol
+++ b/packages/contracts-communication/test/integration/PingPong.Src.t.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {
+    ICIntegrationTest,
+    InterchainBatch,
+    InterchainEntry,
+    InterchainTransaction,
+    InterchainTxDescriptor
+} from "./ICIntegration.t.sol";
+
+// solhint-disable func-name-mixedcase
+contract PingPongSrcIntegrationTest is ICIntegrationTest {
+    InterchainBatch public batch;
+    InterchainEntry public entry;
+    InterchainTransaction public icTx;
+    InterchainTxDescriptor public desc;
+
+    uint256 public pingFee;
+    uint256 public verificationFee;
+    uint256 public executionFee;
+
+    function setUp() public override {
+        super.setUp();
+        icTx = getSrcTransaction();
+        entry = getSrcInterchainEntry();
+        desc = getInterchainTxDescriptor(entry);
+        batch = getInterchainBatch(entry);
+        pingFee = pingPongApp.getPingFee(DST_CHAIN_ID);
+        verificationFee = icDB.getInterchainFee(DST_CHAIN_ID, toArray(address(module)));
+        executionFee = executionService.getExecutionFee({
+            dstChainId: DST_CHAIN_ID,
+            txPayloadSize: abi.encode(icTx).length,
+            options: ppOptions.encodeOptionsV1()
+        });
+    }
+
+    function test_startPingPong_events() public {
+        expectDatabaseEventInterchainEntryWritten(entry);
+        expectModuleEventBatchVerificationRequested(batch);
+        expectDatabaseEventInterchainBatchVerificationRequested(batch);
+        expectFeesEventExecutionFeeAdded(desc.transactionId, executionFee);
+        expectServiceEventExecutionRequested(desc.transactionId);
+        expectClientEventInterchainTransactionSent(icTx, verificationFee, executionFee);
+        expectPingPongEventPingSent(COUNTER, desc);
+        pingPongApp.startPingPong(DST_CHAIN_ID, COUNTER);
+    }
+
+    function localChainId() internal pure override returns (uint256) {
+        return SRC_CHAIN_ID;
+    }
+
+    function remoteChainId() internal pure override returns (uint256) {
+        return DST_CHAIN_ID;
+    }
+}

--- a/packages/contracts-communication/test/integration/PingPong.Src.t.sol
+++ b/packages/contracts-communication/test/integration/PingPong.Src.t.sol
@@ -36,37 +36,14 @@ contract PingPongSrcIntegrationTest is ICIntegrationTest {
         });
     }
 
-    function checkBatchLeafs(bytes32[] memory leafs) internal {
-        assertEq(leafs.length, 1);
-        assertEq(leafs[0], batch.batchRoot);
-    }
-
     function test_startPingPong_events() public {
-        expectDatabaseEventInterchainEntryWritten(entry);
-        expectModuleEventBatchVerificationRequested(batch);
-        expectDatabaseEventInterchainBatchVerificationRequested(batch);
-        expectFeesEventExecutionFeeAdded(desc.transactionId, executionFee);
-        expectServiceEventExecutionRequested(desc.transactionId);
-        expectClientEventInterchainTransactionSent(icTx, verificationFee, executionFee);
-        expectPingPongEventPingSent(COUNTER, desc);
+        expectEventsPingSent(COUNTER, icTx, entry, verificationFee, executionFee);
         pingPongApp.startPingPong(DST_CHAIN_ID, COUNTER);
     }
 
     function test_startPingPong_state_db() public {
         pingPongApp.startPingPong(DST_CHAIN_ID, COUNTER);
-        // Check getters related to the txs' dbNonce
-        assertEq(desc.dbNonce, SRC_INITIAL_DB_NONCE);
-        checkBatchLeafs(icDB.getBatchLeafs(desc.dbNonce));
-        checkBatchLeafs(icDB.getBatchLeafsPaginated(desc.dbNonce, 0, 1));
-        assertEq(icDB.getBatchSize(desc.dbNonce), 1);
-        assertEq(icDB.getBatch(desc.dbNonce), batch);
-        assertEq(icDB.getEntry(desc.dbNonce, 0), entry);
-        assertEq(icDB.getEntryProof(desc.dbNonce, 0).length, 0);
-        // Check getters related to the next dbNonce
-        assertEq(icDB.getDBNonce(), desc.dbNonce + 1);
-        (uint256 dbNonce, uint64 entryIndex) = icDB.getNextEntryIndex();
-        assertEq(dbNonce, desc.dbNonce + 1);
-        assertEq(entryIndex, 0);
+        checkDatabaseStatePingSent(entry, SRC_INITIAL_DB_NONCE);
     }
 
     function test_startPingPong_state_execFees() public {


### PR DESCRIPTION
**Description**
Integration tests currently cover these workflows:
- Sending a Ping message using `PingPongApp`
- `SynapseModule` verifying a remote batch
- Receiving a Ping message by `PingPongApp`
  - Sending back a Pong message
- Various revert scenarios in `InterchainClient`:
  - Trying to execute non-verified tx, or the one that hasn't passed the optimistic period.
  - Trying to execute the same transaction twice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced `PingPongApp` with additional event parameters for improved tracking and communication.
- **Tests**
	- Added new integration tests for interchain communication, including setup, transaction execution, and event handling.
	- Implemented adjustments in test setups to accommodate time-sensitive operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->