### PR TITLE
fix(synapse-interface): adds ETH to RFQ for rebates

### DIFF
--- a/packages/synapse-interface/utils/hooks/useStipEligibility.ts
+++ b/packages/synapse-interface/utils/hooks/useStipEligibility.ts
@@ -236,10 +236,10 @@ export const isRfqEligible = (
 
   return (
     (bridgeQuote.bridgeModuleName === BridgeModules.SYNAPSE_RFQ &&
-      token.swapableType === 'USD' &&
+      (token.swapableType === 'USD' || token.routeSymbol === 'ETH') &&
       toChainId === ARBITRUM.id) ||
     (bridgeQuote.bridgeModuleName === BridgeModules.SYNAPSE_RFQ &&
-      token.swapableType === 'USD' &&
+      (token.swapableType === 'USD' || token.routeSymbol === 'ETH') &&
       fromChainId === ARBITRUM.id &&
       toChainId === ETH.id)
   )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the eligibility conditions for token swaps, now considering both the route symbol and swapable type to determine eligibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
8a329c133a31bc89e0432fea03024d12d2322864: [synapse-interface preview link ](https://sanguine-synapse-interface-l9xzj8enf-synapsecns.vercel.app)