### PR TITLE
Feat: Integrate revert reason/error resolver when reverted traction found is…

### DIFF
--- a/ethergo/backends/base/README.md
+++ b/ethergo/backends/base/README.md
@@ -1,0 +1,17 @@
+# Revert Resolver
+
+This is a tool for parsing a revert message from a raw trace error corresponding to the hash of a custom error type. Sometimes this hash is not useful because we don't know the actual revert reason. For example, if when running `cast run <hash>`, we encounter this error:
+
+`0xeb9266`
+
+Then we can run the function findAndPrintReverts:
+
+` findAndPrintReverts("../../../packages/contracts-core","0xeb9266")`
+
+which will resolve to the reason:
+
+```
+UnformattedAttestation(): 0xeb92662c687ecb0d91cd0350e030a511efe609e0ecfff5618dd8fbce75158ce1 (File: contracts/libs/memory/Attestation.sol, Line: 103)
+```
+
+This tool is currently limited to error emits that don't take any parameters. A future version will use the abigen'd info.

--- a/ethergo/backends/base/base.go
+++ b/ethergo/backends/base/base.go
@@ -229,7 +229,7 @@ type ConfirmationClient interface {
 // nolint: cyclop
 func WaitForConfirmation(ctx context.Context, client ConfirmationClient, transaction *types.Transaction, timeout time.Duration) {
 	// if tx is nil , we should panic here so we can see the call context
-	_ = transaction.Hash()
+	hash := transaction.Hash().String()
 
 	const debugTimeout = time.Second * 5
 
@@ -277,6 +277,7 @@ func WaitForConfirmation(ctx context.Context, client ConfirmationClient, transac
 			if err != nil {
 				if receipt.Status == types.ReceiptStatusFailed {
 					rawJSON, _ := transaction.MarshalJSON()
+					findAndPrintReverts("../../../packages/contracts-core", hash)
 					logger.Errorf("transaction %s with body %s reverted", transaction, string(rawJSON))
 				}
 			}

--- a/ethergo/backends/base/revertresolver.go
+++ b/ethergo/backends/base/revertresolver.go
@@ -1,0 +1,64 @@
+package base
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+func extractRevertStrings(line string) []string {
+	re := regexp.MustCompile(`\brevert\s+([\w\d_]+)\s*\(\s*\)`)
+	matches := re.FindAllStringSubmatch(line, -1)
+	var result []string
+	for _, match := range matches {
+		result = append(result, match[1])
+	}
+	return result
+}
+
+func keccak256Hash(input string) string {
+	hash := crypto.Keccak256Hash([]byte(input + "()"))
+	return hash.Hex()
+}
+
+func processFile(file string, filter string) {
+	//nolint: gosec
+	content, err := os.ReadFile(file)
+	if err != nil {
+		fmt.Printf("Error reading file %s: %s\n", file, err)
+		return
+	}
+
+	lines := strings.Split(string(content), "\n")
+	for i, line := range lines {
+		revertStrings := extractRevertStrings(line)
+		for _, revertString := range revertStrings {
+			hashedString := keccak256Hash(revertString)
+			if filter == "" || strings.HasPrefix(hashedString, filter) {
+				fmt.Printf("%s(): %s (File: %s, Line: %d)\n", revertString, hashedString, file, i+1)
+			}
+		}
+	}
+}
+
+func findAndPrintReverts(path, filter string) {
+	err := filepath.Walk(path, func(filePath string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !info.IsDir() && filepath.Ext(filePath) == ".sol" {
+			processFile(filePath, filter)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		fmt.Println("Error walking the path:", err)
+	}
+}


### PR DESCRIPTION
issue #2318 

/claim #2318

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**
For now when we find a reverted transaction, we cannot debug it due to lack of fetching of revert reason.
**Additional context**
To solve this, we can use a tool that is already present in the tools/revertresolver section to be able to print the errors for better debugging

**Metadata**
- Fixes #2318


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Updated a file path in a command within the README to reflect changes in the project structure.

- **New Features**
	- Enhanced transaction confirmation process to include detection and printing of revert reasons in transactions.

- **Refactor**
	- Renamed package and removed the `main` function along with its flag parsing and execution logic in `revertresolver.go` for better integration and code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->