### PR TITLE
Fixes chain symbol

### DIFF
--- a/packages/synapse-interface/constants/chains/master.tsx
+++ b/packages/synapse-interface/constants/chains/master.tsx
@@ -400,7 +400,7 @@ export const DOGE: Chain = {
 export const BASE: Chain = {
   priorityRank: 90,
   id: 8453,
-  chainSymbol: 'ETH',
+  chainSymbol: 'BASE',
   name: 'Base',
   codeName: 'base',
   chainImg: baseImg,
@@ -425,7 +425,7 @@ export const BASE: Chain = {
 export const BLAST: Chain = {
   priorityRank: 90,
   id: 81457,
-  chainSymbol: 'ETH',
+  chainSymbol: 'BLAST',
   name: 'Blast',
   codeName: 'blast',
   chainImg: blastImg,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the symbols for the `BASE` and `BLAST` chains to more accurately reflect their identities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
6d7ec87cc18911c4333d0701026dd01ccd049057: [synapse-interface preview link ](https://sanguine-synapse-interface-q4dql7m69-synapsecns.vercel.app)