### PR TITLE
Submitter sets tx attributes upon reprocess

### DIFF
--- a/ethergo/submitter/chain_queue.go
+++ b/ethergo/submitter/chain_queue.go
@@ -206,7 +206,8 @@ func (c *chainQueue) bumpTX(parentCtx context.Context, ogTx db.TX) {
 			return fmt.Errorf("could not sign tx: %w", err)
 		}
 
-		span.AddEvent("add to reprocess queue", trace.WithAttributes(txToAttributes(tx, ogTx.UUID)...))
+		span.AddEvent("add to reprocess queue")
+		span.SetAttributes(txToAttributes(tx, ogTx.UUID)...)
 
 		c.addToReprocessQueue(db.TX{
 			UUID:        ogTx.UUID,


### PR DESCRIPTION
**Description**
Allows transaction attributes to be searchable in the parent trace instead of an event (where the attributes are not searchable).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved how transaction attributes are handled in the system for enhanced clarity and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->