### PR TITLE
Feat: legacy `MessageBus`

### DIFF
--- a/packages/contracts-communication/contracts/legacy/MessageBus.sol
+++ b/packages/contracts-communication/contracts/legacy/MessageBus.sol
@@ -84,9 +84,9 @@ contract MessageBus is ICAppV1, MessageBusEvents, IMessageBus {
     /// @dev Internal logic for receiving messages. At this point the validity of the message is already checked.
     function _receiveMessage(
         uint256 srcChainId,
-        bytes32 sender,
-        uint256 dbNonce,
-        uint64 entryIndex,
+        bytes32, // sender
+        uint256, // dbNonce
+        uint64, // entryIndex
         bytes calldata encodedLegacyMsg
     )
         internal
@@ -111,7 +111,8 @@ contract MessageBus is ICAppV1, MessageBusEvents, IMessageBus {
         });
     }
 
-    function _icOptionsV1(bytes calldata options) internal view returns (OptionsV1 memory) {
+    /// @dev Convert legacy MessageBus options to Interchain OptionsV1.
+    function _icOptionsV1(bytes calldata options) internal pure returns (OptionsV1 memory) {
         return OptionsV1({gasLimit: LegacyOptionsLib.decodeLegacyOptions(options), gasAirdrop: 0});
     }
 }

--- a/packages/contracts-communication/contracts/legacy/MessageBus.sol
+++ b/packages/contracts-communication/contracts/legacy/MessageBus.sol
@@ -67,14 +67,14 @@ contract MessageBus is ICAppV1, MessageBusEvents, IMessageBus {
 
     /// @inheritdoc IMessageBus
     function estimateFee(uint256 dstChainId, bytes calldata options) external view returns (uint256) {
-        return estimateFeeExact(dstChainId, messageLengthEstimate, options);
+        return estimateFeeExact(dstChainId, options, messageLengthEstimate);
     }
 
     /// @inheritdoc IMessageBus
     function estimateFeeExact(
         uint256 dstChainId,
-        uint256 messageLen,
-        bytes calldata options
+        bytes calldata options,
+        uint256 messageLen
     )
         public
         view

--- a/packages/contracts-communication/contracts/legacy/MessageBus.sol
+++ b/packages/contracts-communication/contracts/legacy/MessageBus.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {MessageBusEvents} from "./events/MessageBusEvents.sol";
+import {IMessageBus} from "./interfaces/IMessageBus.sol";
+
+import {ICAppV1} from "../apps/ICAppV1.sol";
+
+contract MessageBus is ICAppV1, MessageBusEvents, IMessageBus {
+    uint256 public messageLengthEstimate;
+
+    constructor(address admin) ICAppV1(admin) {}
+
+    /// @inheritdoc IMessageBus
+    function sendMessage(
+        bytes32 receiver,
+        uint256 dstChainId,
+        bytes calldata message,
+        bytes calldata options
+    )
+        external
+        payable
+    {
+        // TODO: implement
+    }
+
+    /// @inheritdoc IMessageBus
+    function setMessageLengthEstimate(uint256 length) external {
+        // TODO: implement
+    }
+
+    /// @inheritdoc IMessageBus
+    function estimateFee(uint256 dstChainId, bytes calldata options) external view returns (uint256) {
+        // TODO: implement
+    }
+
+    /// @inheritdoc IMessageBus
+    function estimateFeeExact(
+        uint256 dstChainId,
+        uint256 messageLen,
+        bytes calldata options
+    )
+        external
+        view
+        returns (uint256)
+    {
+        // TODO: implement
+    }
+
+    /// @dev Internal logic for receiving messages. At this point the validity of the message is already checked.
+    function _receiveMessage(
+        uint256 srcChainId,
+        bytes32 sender,
+        uint256 dbNonce,
+        uint64 entryIndex,
+        bytes calldata message
+    )
+        internal
+        override
+    {
+        // TODO: implement
+    }
+}

--- a/packages/contracts-communication/contracts/legacy/MessageBus.sol
+++ b/packages/contracts-communication/contracts/legacy/MessageBus.sol
@@ -8,6 +8,7 @@ import {ICAppV1} from "../apps/ICAppV1.sol";
 
 contract MessageBus is ICAppV1, MessageBusEvents, IMessageBus {
     uint256 public messageLengthEstimate;
+    uint64 public nonce;
 
     constructor(address admin) ICAppV1(admin) {}
 

--- a/packages/contracts-communication/contracts/legacy/events/MessageBusEvents.sol
+++ b/packages/contracts-communication/contracts/legacy/events/MessageBusEvents.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+abstract contract MessageBusEvents {
+    enum TxStatus {
+        Null,
+        Success,
+        Fail
+    }
+
+    event Executed(
+        bytes32 indexed messageId, TxStatus status, address indexed dstAddress, uint64 srcChainId, uint64 srcNonce
+    );
+
+    event MessageSent(
+        address indexed sender,
+        uint256 srcChainID,
+        bytes32 receiver,
+        uint256 indexed dstChainId,
+        bytes message,
+        uint64 nonce,
+        bytes options,
+        uint256 fee,
+        bytes32 indexed messageId
+    );
+
+    event MessageLengthEstimateSet(uint256 length);
+}

--- a/packages/contracts-communication/contracts/legacy/interfaces/ILegacyReceiver.sol
+++ b/packages/contracts-communication/contracts/legacy/interfaces/ILegacyReceiver.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface ILegacyReceiver {
+    function executeMessage(bytes32 srcAddress, uint256 srcChainId, bytes memory message, address executor) external;
+}

--- a/packages/contracts-communication/contracts/legacy/interfaces/IMessageBus.sol
+++ b/packages/contracts-communication/contracts/legacy/interfaces/IMessageBus.sol
@@ -47,4 +47,7 @@ interface IMessageBus {
         external
         view
         returns (uint256);
+
+    /// @notice Returns the nonce of MessageBus: the amount of sent messages so far.
+    function nonce() external view returns (uint64);
 }

--- a/packages/contracts-communication/contracts/legacy/interfaces/IMessageBus.sol
+++ b/packages/contracts-communication/contracts/legacy/interfaces/IMessageBus.sol
@@ -37,12 +37,12 @@ interface IMessageBus {
     /// @notice Returns srcGasToken fee to charge in wei for the cross-chain message based on the message length
     /// and the gas limit.
     /// @param dstChainId   The destination chain ID - typically, standard EVM chain ID, but differs on nonEVM chains
-    /// @param messageLen   The length of the message to be sent in bytes
     /// @param options      Versioned struct used to instruct relayer on how to proceed with gas limits
+    /// @param messageLen   The length of the message to be sent in bytes
     function estimateFeeExact(
         uint256 dstChainId,
-        uint256 messageLen,
-        bytes memory options
+        bytes memory options,
+        uint256 messageLen
     )
         external
         view

--- a/packages/contracts-communication/contracts/legacy/interfaces/IMessageBus.sol
+++ b/packages/contracts-communication/contracts/legacy/interfaces/IMessageBus.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IMessageBus {
+    error MessageBus__NotEVMReceiver(bytes32 receiver);
+
+    /// @notice Sends a message to a receiving contract address on another chain.
+    /// Sender must make sure that the message is unique and not a duplicate message.
+    /// @dev Legacy MessageBus only supports V1 of the options format, which specifies only the gas limit.
+    /// @param receiver     The bytes32 address of the destination contract to be called
+    /// @param dstChainId   The destination chain ID - typically, standard EVM chain ID, but differs on nonEVM chains
+    /// @param message      The arbitrary payload to pass to the destination chain receiver
+    /// @param options      Versioned struct used to instruct relayer on how to proceed with gas limits
+    function sendMessage(
+        bytes32 receiver,
+        uint256 dstChainId,
+        bytes memory message,
+        bytes memory options
+    )
+        external
+        payable;
+
+    /// @notice Allows the Interchain Governor to set the message length in bytes to be used for fee estimation.
+    /// This does not affect the sendMessage function, but only the fee estimation.
+    function setMessageLengthEstimate(uint256 length) external;
+
+    /// @notice Returns the preset message length in bytes used for fee estimation.
+    function messageLengthEstimate() external view returns (uint256);
+
+    /// @notice Returns srcGasToken fee to charge in wei for the cross-chain message based on the gas limit.
+    /// @dev This function is using the preset message length to estimate the gas fee. This should cover most cases,
+    /// if the message length is lower than the preset value. For more accurate fee estimation, use estimateFeeExact.
+    /// @param dstChainId   The destination chain ID - typically, standard EVM chain ID, but differs on nonEVM chains
+    /// @param options      Versioned struct used to instruct relayer on how to proceed with gas limits
+    function estimateFee(uint256 dstChainId, bytes memory options) external view returns (uint256);
+
+    /// @notice Returns srcGasToken fee to charge in wei for the cross-chain message based on the message length
+    /// and the gas limit.
+    /// @param dstChainId   The destination chain ID - typically, standard EVM chain ID, but differs on nonEVM chains
+    /// @param messageLen   The length of the message to be sent in bytes
+    /// @param options      Versioned struct used to instruct relayer on how to proceed with gas limits
+    function estimateFeeExact(
+        uint256 dstChainId,
+        uint256 messageLen,
+        bytes memory options
+    )
+        external
+        view
+        returns (uint256);
+}

--- a/packages/contracts-communication/contracts/legacy/libs/LegacyMessage.sol
+++ b/packages/contracts-communication/contracts/legacy/libs/LegacyMessage.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+library LegacyMessageLib {
+    /// @notice Encodes a message to be sent through the Legacy MessageBus.
+    /// @param srcSender    The address of the sender on the source chain
+    /// @param dstReceiver  The address of the receiver on the destination chain
+    /// @param srcNonce     The nonce of the message on the source chain
+    /// @param message      The arbitrary payload to pass to the destination chain receiver
+    /// @return legacyMsg   The encoded legacy message
+    function encodeLegacyMessage(
+        address srcSender,
+        address dstReceiver,
+        uint64 srcNonce,
+        bytes memory message
+    )
+        internal
+        pure
+        returns (bytes memory legacyMsg)
+    {
+        // TODO: implement
+    }
+
+    /// @notice Decodes a message received by the Legacy MessageBus.
+    /// @param legacyMsg    The encoded legacy message
+    /// @return srcSender   The address of the sender on the source chain
+    /// @return dstReceiver The address of the receiver on the destination chain
+    /// @return srcNonce    The nonce of the message on the source chain
+    /// @return message     The arbitrary payload to pass to the destination chain receiver
+    function decodeLegacyMessage(bytes calldata legacyMsg)
+        internal
+        pure
+        returns (address srcSender, address dstReceiver, uint64 srcNonce, bytes memory message)
+    {
+        // TODO: implement
+    }
+}

--- a/packages/contracts-communication/contracts/legacy/libs/LegacyMessage.sol
+++ b/packages/contracts-communication/contracts/legacy/libs/LegacyMessage.sol
@@ -18,7 +18,7 @@ library LegacyMessageLib {
         pure
         returns (bytes memory legacyMsg)
     {
-        // TODO: implement
+        return abi.encode(srcSender, dstReceiver, srcNonce, message);
     }
 
     /// @notice Decodes a message received by the Legacy MessageBus.
@@ -32,6 +32,6 @@ library LegacyMessageLib {
         pure
         returns (address srcSender, address dstReceiver, uint64 srcNonce, bytes memory message)
     {
-        // TODO: implement
+        return abi.decode(legacyMsg, (address, address, uint64, bytes));
     }
 }

--- a/packages/contracts-communication/contracts/legacy/libs/LegacyOptions.sol
+++ b/packages/contracts-communication/contracts/legacy/libs/LegacyOptions.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+library LegacyOptionsLib {
+    uint16 internal constant LEGACY_OPTIONS_VERSION = 1;
+
+    error LegacyOptionsLib__InvalidOptions(bytes legacyOpts);
+
+    /// @notice Encodes the gas limit into a legacy options format.
+    /// @param gasLimit     The gas limit to encode.
+    /// @return legacyOpts  The encoded legacy options
+    function encodeLegacyOptions(uint256 gasLimit) internal pure returns (bytes memory legacyOpts) {
+        // TODO: Implement
+    }
+
+    /// @notice Decodes the gas limit from a legacy options format.
+    /// @param legacyOpts   The encoded legacy options
+    /// @return gasLimit    The gas limit
+    function decodeLegacyOptions(bytes calldata legacyOpts) internal pure returns (uint256 gasLimit) {
+        // TODO: Implement
+    }
+}

--- a/packages/contracts-communication/contracts/legacy/libs/LegacyOptions.sol
+++ b/packages/contracts-communication/contracts/legacy/libs/LegacyOptions.sol
@@ -2,7 +2,12 @@
 pragma solidity ^0.8.0;
 
 library LegacyOptionsLib {
+    /// @notice Supported version of the legacy options format.
     uint16 internal constant LEGACY_OPTIONS_VERSION = 1;
+    /// @dev The length of the legacy options format: 2 bytes for the version and 32 bytes for the gas limit.
+    uint256 private constant LEGACY_OPTIONS_LENGTH = 34;
+    /// @dev The offset of the gas limit in the legacy options format.
+    uint256 private constant GAS_LIMIT_OFFSET = 2;
 
     error LegacyOptionsLib__InvalidOptions(bytes legacyOpts);
 
@@ -10,13 +15,20 @@ library LegacyOptionsLib {
     /// @param gasLimit     The gas limit to encode.
     /// @return legacyOpts  The encoded legacy options
     function encodeLegacyOptions(uint256 gasLimit) internal pure returns (bytes memory legacyOpts) {
-        // TODO: Implement
+        return abi.encodePacked(LEGACY_OPTIONS_VERSION, gasLimit);
     }
 
     /// @notice Decodes the gas limit from a legacy options format.
     /// @param legacyOpts   The encoded legacy options
     /// @return gasLimit    The gas limit
     function decodeLegacyOptions(bytes calldata legacyOpts) internal pure returns (uint256 gasLimit) {
-        // TODO: Implement
+        if (legacyOpts.length != LEGACY_OPTIONS_LENGTH) {
+            revert LegacyOptionsLib__InvalidOptions(legacyOpts);
+        }
+        uint16 version = uint16(bytes2(legacyOpts[:GAS_LIMIT_OFFSET]));
+        if (version != LEGACY_OPTIONS_VERSION) {
+            revert LegacyOptionsLib__InvalidOptions(legacyOpts);
+        }
+        gasLimit = uint256(bytes32(legacyOpts[GAS_LIMIT_OFFSET:]));
     }
 }

--- a/packages/contracts-communication/test/legacy/MessageBus.Base.t.sol
+++ b/packages/contracts-communication/test/legacy/MessageBus.Base.t.sol
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {MessageBusEvents} from "../../contracts/legacy/events/MessageBusEvents.sol";
+import {LegacyOptionsLib} from "../../contracts/legacy/libs/LegacyOptions.sol";
+import {MessageBus, IMessageBus} from "../../contracts/legacy/MessageBus.sol";
+import {AppConfigV1} from "../../contracts/libs/AppConfig.sol";
+import {OptionsV1} from "../../contracts/libs/Options.sol";
+import {TypeCasts} from "../../contracts/libs/TypeCasts.sol";
+
+import {LegacyMessage, LegacyMessageLib} from "./libs/LegacyMessage.t.sol";
+import {LegacyReceiverMock} from "./mocks/LegacyReceiverMock.sol";
+import {ExecutionServiceMock} from "../mocks/ExecutionServiceMock.sol";
+import {InterchainClientV1Mock} from "../mocks/InterchainClientV1Mock.sol";
+import {InterchainModuleMock} from "../mocks/InterchainModuleMock.sol";
+
+import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
+import {Test} from "forge-std/Test.sol";
+
+// solhint-disable ordering
+abstract contract MessageBusBaseTest is MessageBusEvents, Test {
+    bytes32 public constant IC_GOVERNOR_ROLE = keccak256("IC_GOVERNOR_ROLE");
+
+    uint256 public constant LOCAL_CHAIN_ID = 1337;
+    uint256 public constant REMOTE_CHAIN_ID = 7331;
+    uint256 public constant BUS_OPTIMISTIC_PERIOD = 1 minutes;
+    uint256 public constant MOCK_FEE = 0.001 ether;
+    uint256 public constant MOCK_GAS_LIMIT = 400_000;
+
+    uint64 public constant MOCK_NONCE = 42;
+    bytes public constant MESSAGE = "One small step for man, one giant leap for mankind.";
+
+    bytes public legacyOptions = LegacyOptionsLib.encodeLegacyOptions(MOCK_GAS_LIMIT);
+    bytes public icOptions = OptionsV1({gasLimit: MOCK_GAS_LIMIT, gasAirdrop: 0}).encodeOptionsV1();
+
+    MessageBus public messageBus;
+    address public remoteMessageBus = makeAddr("RemoteMessageBus");
+    bytes32 public remoteMessageBusBytes32 = TypeCasts.addressToBytes32(remoteMessageBus);
+    address public icClient;
+    address public srcSender;
+    bytes32 public srcSenderBytes32;
+    address public dstReceiver;
+    bytes32 public dstReceiverBytes32;
+    address public execService;
+    address public icModule;
+    address[] public icModules;
+
+    AppConfigV1 public appConfig = AppConfigV1({requiredResponses: 1, optimisticPeriod: BUS_OPTIMISTIC_PERIOD});
+
+    address public admin = makeAddr("Admin");
+    address public governor = makeAddr("Governor");
+
+    function setUp() public virtual {
+        vm.chainId(LOCAL_CHAIN_ID);
+        messageBus = new MessageBus(admin);
+        icClient = address(new InterchainClientV1Mock());
+        icModule = address(new InterchainModuleMock());
+        icModules.push(icModule);
+        execService = address(new ExecutionServiceMock());
+        srcSender = address(new LegacyReceiverMock());
+        dstReceiver = address(new LegacyReceiverMock());
+        srcSenderBytes32 = TypeCasts.addressToBytes32(srcSender);
+        dstReceiverBytes32 = TypeCasts.addressToBytes32(dstReceiver);
+        configureMessageBus();
+    }
+
+    function configureMessageBus() internal virtual {
+        bytes32 icGovernorRole = messageBus.IC_GOVERNOR_ROLE();
+        vm.prank(admin);
+        messageBus.grantRole(icGovernorRole, governor);
+        vm.startPrank(governor);
+        messageBus.addInterchainClient({client: icClient, updateLatest: true});
+        messageBus.linkRemoteAppEVM({chainId: REMOTE_CHAIN_ID, remoteApp: remoteMessageBus});
+        messageBus.addTrustedModule(icModule);
+        messageBus.setAppConfigV1(appConfig);
+        messageBus.setExecutionService(execService);
+        vm.stopPrank();
+    }
+
+    function encodeLegacyMessage(LegacyMessage memory legacyMsg) internal pure returns (bytes memory) {
+        return LegacyMessageLib.encodeLegacyMessage(
+            legacyMsg.srcSender, legacyMsg.dstReceiver, legacyMsg.srcNonce, legacyMsg.message
+        );
+    }
+
+    function expectEventExecuted(uint256 srcChainId, LegacyMessage memory legacyMsg) internal {
+        bytes32 messageId = keccak256(encodeLegacyMessage(legacyMsg));
+        vm.expectEmit(address(messageBus));
+        emit Executed({
+            messageId: messageId,
+            status: TxStatus.Success,
+            dstAddress: legacyMsg.dstReceiver,
+            srcChainId: uint64(srcChainId),
+            srcNonce: legacyMsg.srcNonce
+        });
+    }
+
+    function expectEventMessageSent(uint256 srcChainId, uint256 dstChainId, LegacyMessage memory legacyMsg) internal {
+        bytes32 messageId = keccak256(encodeLegacyMessage(legacyMsg));
+        vm.expectEmit(address(messageBus));
+        emit MessageSent({
+            sender: legacyMsg.srcSender,
+            srcChainID: srcChainId,
+            receiver: TypeCasts.addressToBytes32(legacyMsg.dstReceiver),
+            dstChainId: dstChainId,
+            message: legacyMsg.message,
+            nonce: legacyMsg.srcNonce,
+            options: legacyOptions,
+            fee: MOCK_FEE,
+            messageId: messageId
+        });
+    }
+
+    function expectEventMessageLengthEstimateSet(uint256 length) internal {
+        vm.expectEmit(address(messageBus));
+        emit MessageLengthEstimateSet(length);
+    }
+
+    function expectRevertNotEVMReceiver(bytes32 receiver) internal {
+        vm.expectRevert(abi.encodeWithSelector(IMessageBus.MessageBus__NotEVMReceiver.selector, receiver));
+    }
+
+    function expectRevertInvalidOptions(bytes memory legacyOpts) internal {
+        vm.expectRevert(abi.encodeWithSelector(LegacyOptionsLib.LegacyOptionsLib__InvalidOptions.selector, legacyOpts));
+    }
+
+    function expectRevertUnauthorizedGovernor(address caller) internal {
+        vm.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, caller, IC_GOVERNOR_ROLE)
+        );
+    }
+}

--- a/packages/contracts-communication/test/legacy/MessageBus.Base.t.sol
+++ b/packages/contracts-communication/test/legacy/MessageBus.Base.t.sol
@@ -17,6 +17,7 @@ import {InterchainModuleMock} from "../mocks/InterchainModuleMock.sol";
 import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
 import {Test} from "forge-std/Test.sol";
 
+// solhint-disable max-states-count
 // solhint-disable ordering
 abstract contract MessageBusBaseTest is MessageBusEvents, Test {
     bytes32 public constant IC_GOVERNOR_ROLE = keccak256("IC_GOVERNOR_ROLE");

--- a/packages/contracts-communication/test/legacy/MessageBus.Dst.t.sol
+++ b/packages/contracts-communication/test/legacy/MessageBus.Dst.t.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {MessageBusBaseTest, LegacyMessage, LegacyReceiverMock} from "./MessageBus.Base.t.sol";
+
+// solhint-disable func-name-mixedcase
+// solhint-disable ordering
+contract MessageBusDstTest is MessageBusBaseTest {
+    uint256 public constant MOCK_DB_NONCE = 1_234_567;
+    uint64 public constant MOCK_ENTRY_INDEX = 4321;
+
+    LegacyMessage public legacyMsg;
+    bytes public encodedLegacyMsg;
+
+    function setUp() public override {
+        super.setUp();
+        legacyMsg =
+            LegacyMessage({srcSender: srcSender, dstReceiver: dstReceiver, srcNonce: MOCK_NONCE, message: MESSAGE});
+        encodedLegacyMsg = encodeLegacyMessage(legacyMsg);
+    }
+
+    function messageBusAppReceive() internal {
+        vm.prank(icClient);
+        messageBus.appReceive({
+            srcChainId: REMOTE_CHAIN_ID,
+            sender: remoteMessageBusBytes32,
+            dbNonce: MOCK_DB_NONCE,
+            entryIndex: MOCK_ENTRY_INDEX,
+            message: encodedLegacyMsg
+        });
+    }
+
+    function test_appReceive_callsReceiver() public {
+        bytes memory expectedCalldata =
+            abi.encodeCall(LegacyReceiverMock.executeMessage, (srcSenderBytes32, REMOTE_CHAIN_ID, MESSAGE, icClient));
+        vm.expectCall({callee: dstReceiver, msgValue: 0, data: expectedCalldata, count: 1});
+        messageBusAppReceive();
+    }
+
+    function test_appReceive_emitsEvent() public {
+        expectEventExecuted({srcChainId: REMOTE_CHAIN_ID, legacyMsg: legacyMsg});
+        messageBusAppReceive();
+    }
+}

--- a/packages/contracts-communication/test/legacy/MessageBus.Management.t.sol
+++ b/packages/contracts-communication/test/legacy/MessageBus.Management.t.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {MessageBusBaseTest, InterchainClientV1Mock} from "./MessageBus.Base.t.sol";
+
+// solhint-disable ordering
+contract MessageBusManagementTest is MessageBusBaseTest {
+    uint256 public constant LENGTH_ESTIMATE = 100;
+
+    function mockInterchainFees(uint256 length) internal {
+        bytes memory expectedCalldata = abi.encodeCall(
+            InterchainClientV1Mock.getInterchainFee,
+            (REMOTE_CHAIN_ID, execService, icModules, icOptions, new bytes(length))
+        );
+        vm.mockCall(icClient, expectedCalldata, abi.encode(MOCK_FEE));
+    }
+
+    function test_setMessageLengthEstimate_emitsEvent() public {
+        expectEventMessageLengthEstimateSet(LENGTH_ESTIMATE);
+        vm.prank(governor);
+        messageBus.setMessageLengthEstimate(LENGTH_ESTIMATE);
+    }
+
+    function test_setMessageLengthEstimate_setsLength() public {
+        vm.prank(governor);
+        messageBus.setMessageLengthEstimate(LENGTH_ESTIMATE);
+        assertEq(messageBus.messageLengthEstimate(), LENGTH_ESTIMATE);
+    }
+
+    function test_setMessageLengthEstimate_revert_notGovernor(address caller) public {
+        vm.assume(caller != governor);
+        expectRevertUnauthorizedGovernor(caller);
+        vm.prank(caller);
+        messageBus.setMessageLengthEstimate(LENGTH_ESTIMATE);
+    }
+
+    function test_estimateFee_usesLengthEstimate() public {
+        mockInterchainFees(LENGTH_ESTIMATE);
+        vm.prank(governor);
+        messageBus.setMessageLengthEstimate(LENGTH_ESTIMATE);
+        uint256 fee = messageBus.estimateFee(REMOTE_CHAIN_ID, legacyOptions);
+        assertEq(fee, MOCK_FEE);
+    }
+
+    function test_estimateFeeExact() public {
+        mockInterchainFees(2 * LENGTH_ESTIMATE);
+        vm.prank(governor);
+        messageBus.setMessageLengthEstimate(LENGTH_ESTIMATE);
+        uint256 fee = messageBus.estimateFeeExact(REMOTE_CHAIN_ID, 2 * LENGTH_ESTIMATE, legacyOptions);
+        assertEq(fee, MOCK_FEE);
+    }
+}

--- a/packages/contracts-communication/test/legacy/MessageBus.Management.t.sol
+++ b/packages/contracts-communication/test/legacy/MessageBus.Management.t.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.20;
 
 import {MessageBusBaseTest, InterchainClientV1Mock} from "./MessageBus.Base.t.sol";
 
+// solhint-disable func-name-mixedcase
 // solhint-disable ordering
 contract MessageBusManagementTest is MessageBusBaseTest {
     uint256 public constant LENGTH_ESTIMATE = 100;

--- a/packages/contracts-communication/test/legacy/MessageBus.Management.t.sol
+++ b/packages/contracts-communication/test/legacy/MessageBus.Management.t.sol
@@ -46,7 +46,7 @@ contract MessageBusManagementTest is MessageBusBaseTest {
         mockInterchainFees(2 * LENGTH_ESTIMATE);
         vm.prank(governor);
         messageBus.setMessageLengthEstimate(LENGTH_ESTIMATE);
-        uint256 fee = messageBus.estimateFeeExact(REMOTE_CHAIN_ID, 2 * LENGTH_ESTIMATE, legacyOptions);
+        uint256 fee = messageBus.estimateFeeExact(REMOTE_CHAIN_ID, legacyOptions, 2 * LENGTH_ESTIMATE);
         assertEq(fee, MOCK_FEE);
     }
 }

--- a/packages/contracts-communication/test/legacy/MessageBus.Src.t.sol
+++ b/packages/contracts-communication/test/legacy/MessageBus.Src.t.sol
@@ -91,12 +91,12 @@ contract MessageBusSrcTest is MessageBusBaseTest {
         vm.assume(version != LegacyOptionsLib.LEGACY_OPTIONS_VERSION);
         bytes memory invalidOpts = abi.encodePacked(version, uint256(1));
         expectRevertInvalidOptions(invalidOpts);
-        messageBus.estimateFeeExact(REMOTE_CHAIN_ID, MESSAGE.length, invalidOpts);
+        messageBus.estimateFeeExact(REMOTE_CHAIN_ID, invalidOpts, MESSAGE.length);
     }
 
     function test_estimateFeeExact_revert_incorrectOptionsLength(bytes memory invalidOpts) public {
         vm.assume(invalidOpts.length != legacyOptions.length);
         expectRevertInvalidOptions(invalidOpts);
-        messageBus.estimateFeeExact(REMOTE_CHAIN_ID, MESSAGE.length, invalidOpts);
+        messageBus.estimateFeeExact(REMOTE_CHAIN_ID, invalidOpts, MESSAGE.length);
     }
 }

--- a/packages/contracts-communication/test/legacy/MessageBus.Src.t.sol
+++ b/packages/contracts-communication/test/legacy/MessageBus.Src.t.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {MessageBusBaseTest, InterchainClientV1Mock, LegacyMessage, LegacyOptionsLib} from "./MessageBus.Base.t.sol";
+
+// solhint-disable func-name-mixedcase
+// solhint-disable ordering
+contract MessageBusSrcTest is MessageBusBaseTest {
+    LegacyMessage public legacyMsg;
+    bytes public encodedLegacyMsg;
+
+    function setUp() public override {
+        super.setUp();
+        for (uint256 i = 0; i < MOCK_NONCE; ++i) {
+            vm.prank(srcSender);
+            messageBus.sendMessage({
+                receiver: dstReceiverBytes32,
+                dstChainId: REMOTE_CHAIN_ID,
+                message: "",
+                options: legacyOptions
+            });
+        }
+        legacyMsg =
+            LegacyMessage({srcSender: srcSender, dstReceiver: dstReceiver, srcNonce: MOCK_NONCE, message: MESSAGE});
+        encodedLegacyMsg = encodeLegacyMessage(legacyMsg);
+        deal(srcSender, MOCK_FEE);
+    }
+
+    function messageBusSendMessage(bytes32 receiver, bytes memory options) internal {
+        vm.prank(srcSender);
+        messageBus.sendMessage{value: MOCK_FEE}({
+            receiver: receiver,
+            dstChainId: REMOTE_CHAIN_ID,
+            message: MESSAGE,
+            options: options
+        });
+    }
+
+    function test_sendMessage_callsClient() public {
+        bytes memory expectedCalldata = abi.encodeCall(
+            InterchainClientV1Mock.interchainSend,
+            (REMOTE_CHAIN_ID, remoteMessageBusBytes32, execService, icModules, icOptions, encodedLegacyMsg)
+        );
+        vm.expectCall({callee: icClient, msgValue: MOCK_FEE, data: expectedCalldata, count: 1});
+        messageBusSendMessage(dstReceiverBytes32, legacyOptions);
+    }
+
+    function test_sendMessage_emitsEvent() public {
+        expectEventMessageSent({srcChainId: LOCAL_CHAIN_ID, dstChainId: REMOTE_CHAIN_ID, legacyMsg: legacyMsg});
+        messageBusSendMessage(dstReceiverBytes32, legacyOptions);
+    }
+
+    function test_sendMessage_increasesNonce() public {
+        messageBusSendMessage(dstReceiverBytes32, legacyOptions);
+        assertEq(messageBus.nonce(), MOCK_NONCE + 1);
+    }
+
+    function test_sendMessage_revert_notEVMReceiver() public {
+        bytes32 receiver = keccak256("GM");
+        expectRevertNotEVMReceiver(receiver);
+        messageBusSendMessage(receiver, legacyOptions);
+    }
+
+    function test_sendMessage_revert_incorrectOptionsVersion(uint16 version) public {
+        vm.assume(version != LegacyOptionsLib.LEGACY_OPTIONS_VERSION);
+        bytes memory invalidOpts = abi.encodePacked(version, uint256(1));
+        expectRevertInvalidOptions(invalidOpts);
+        messageBusSendMessage(dstReceiverBytes32, invalidOpts);
+    }
+
+    function test_sendMessage_revert_incorrectOptionsLength(bytes memory invalidOpts) public {
+        vm.assume(invalidOpts.length != legacyOptions.length);
+        expectRevertInvalidOptions(invalidOpts);
+        messageBusSendMessage(dstReceiverBytes32, invalidOpts);
+    }
+
+    function test_estimateFee_revert_incorrectOptionsVersion(uint16 version) public {
+        vm.assume(version != LegacyOptionsLib.LEGACY_OPTIONS_VERSION);
+        bytes memory invalidOpts = abi.encodePacked(version, uint256(1));
+        expectRevertInvalidOptions(invalidOpts);
+        messageBus.estimateFee(REMOTE_CHAIN_ID, invalidOpts);
+    }
+
+    function test_estimateFee_revert_incorrectOptionsLength(bytes memory invalidOpts) public {
+        vm.assume(invalidOpts.length != legacyOptions.length);
+        expectRevertInvalidOptions(invalidOpts);
+        messageBus.estimateFee(REMOTE_CHAIN_ID, invalidOpts);
+    }
+
+    function test_estimateFeeExact_revert_incorrectOptionsVersion(uint16 version) public {
+        vm.assume(version != LegacyOptionsLib.LEGACY_OPTIONS_VERSION);
+        bytes memory invalidOpts = abi.encodePacked(version, uint256(1));
+        expectRevertInvalidOptions(invalidOpts);
+        messageBus.estimateFeeExact(REMOTE_CHAIN_ID, MESSAGE.length, invalidOpts);
+    }
+
+    function test_estimateFeeExact_revert_incorrectOptionsLength(bytes memory invalidOpts) public {
+        vm.assume(invalidOpts.length != legacyOptions.length);
+        expectRevertInvalidOptions(invalidOpts);
+        messageBus.estimateFeeExact(REMOTE_CHAIN_ID, MESSAGE.length, invalidOpts);
+    }
+}

--- a/packages/contracts-communication/test/legacy/harnesses/LegacyMessageLibHarness.sol
+++ b/packages/contracts-communication/test/legacy/harnesses/LegacyMessageLibHarness.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {LegacyMessageLib} from "../../../contracts/legacy/libs/LegacyMessage.sol";
+
+contract LegacyMessageLibHarness {
+    function encodeLegacyMessage(
+        address srcSender,
+        address dstReceiver,
+        uint64 srcNonce,
+        bytes memory message
+    )
+        public
+        pure
+        returns (bytes memory legacyMsg)
+    {
+        return LegacyMessageLib.encodeLegacyMessage(srcSender, dstReceiver, srcNonce, message);
+    }
+
+    function decodeLegacyMessage(bytes calldata legacyMsg)
+        public
+        pure
+        returns (address srcSender, address dstReceiver, uint64 srcNonce, bytes memory message)
+    {
+        return LegacyMessageLib.decodeLegacyMessage(legacyMsg);
+    }
+}

--- a/packages/contracts-communication/test/legacy/harnesses/LegacyOptionsLibHarness.sol
+++ b/packages/contracts-communication/test/legacy/harnesses/LegacyOptionsLibHarness.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {LegacyOptionsLib} from "../../../contracts/legacy/libs/LegacyOptions.sol";
+
+contract LegacyOptionsLibHarness {
+    function encodeLegacyOptions(uint256 gasLimit) external pure returns (bytes memory) {
+        return LegacyOptionsLib.encodeLegacyOptions(gasLimit);
+    }
+
+    function decodeLegacyOptions(bytes calldata legacyOpts) external pure returns (uint256) {
+        return LegacyOptionsLib.decodeLegacyOptions(legacyOpts);
+    }
+}

--- a/packages/contracts-communication/test/legacy/libs/LegacyMessage.t.sol
+++ b/packages/contracts-communication/test/legacy/libs/LegacyMessage.t.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {LegacyMessageLibHarness, LegacyMessageLib} from "../harnesses/LegacyMessageLibHarness.sol";
+
+import {Test} from "forge-std/Test.sol";
+
+// solhint-disable func-name-mixedcase
+// solhint-disable ordering
+contract LegacyMessageLibTest is Test {
+    struct LegacyMessage {
+        address srcSender;
+        address dstReceiver;
+        uint64 srcNonce;
+        bytes message;
+    }
+
+    LegacyMessageLibHarness public libHarness;
+
+    function setUp() public {
+        libHarness = new LegacyMessageLibHarness();
+    }
+
+    function test_encodeLegacyMessage() public {
+        address srcSender = makeAddr("Sender");
+        address dstReceiver = makeAddr("Receiver");
+        uint64 srcNonce = 1337;
+        bytes memory message = new bytes(512);
+        bytes memory encoded = libHarness.encodeLegacyMessage(srcSender, dstReceiver, srcNonce, message);
+        (address newSrcSender, address newDstReceiver, uint64 newSrcNonce, bytes memory newMessage) =
+            libHarness.decodeLegacyMessage(encoded);
+        assertEq(newSrcSender, srcSender);
+        assertEq(newDstReceiver, dstReceiver);
+        assertEq(newSrcNonce, srcNonce);
+        assertEq(newMessage, message);
+    }
+
+    function test_encodeLegacyMessage_short() public {
+        address srcSender = makeAddr("Sender");
+        address dstReceiver = makeAddr("Receiver");
+        uint64 srcNonce = 1337;
+        bytes memory message = "Hello, World!";
+        bytes memory encoded = libHarness.encodeLegacyMessage(srcSender, dstReceiver, srcNonce, message);
+        (address newSrcSender, address newDstReceiver, uint64 newSrcNonce, bytes memory newMessage) =
+            libHarness.decodeLegacyMessage(encoded);
+        assertEq(newSrcSender, srcSender);
+        assertEq(newDstReceiver, dstReceiver);
+        assertEq(newSrcNonce, srcNonce);
+        assertEq(newMessage, message);
+    }
+
+    function test_encodeLegacyMessageRoundtrip(LegacyMessage memory legacyMsg) public {
+        bytes memory encoded = libHarness.encodeLegacyMessage(
+            legacyMsg.srcSender, legacyMsg.dstReceiver, legacyMsg.srcNonce, legacyMsg.message
+        );
+        (address newSrcSender, address newDstReceiver, uint64 newSrcNonce, bytes memory newMessage) =
+            libHarness.decodeLegacyMessage(encoded);
+        assertEq(newSrcSender, legacyMsg.srcSender);
+        assertEq(newDstReceiver, legacyMsg.dstReceiver);
+        assertEq(newSrcNonce, legacyMsg.srcNonce);
+        assertEq(newMessage, legacyMsg.message);
+    }
+}

--- a/packages/contracts-communication/test/legacy/libs/LegacyMessage.t.sol
+++ b/packages/contracts-communication/test/legacy/libs/LegacyMessage.t.sol
@@ -5,16 +5,16 @@ import {LegacyMessageLibHarness, LegacyMessageLib} from "../harnesses/LegacyMess
 
 import {Test} from "forge-std/Test.sol";
 
+struct LegacyMessage {
+    address srcSender;
+    address dstReceiver;
+    uint64 srcNonce;
+    bytes message;
+}
+
 // solhint-disable func-name-mixedcase
 // solhint-disable ordering
 contract LegacyMessageLibTest is Test {
-    struct LegacyMessage {
-        address srcSender;
-        address dstReceiver;
-        uint64 srcNonce;
-        bytes message;
-    }
-
     LegacyMessageLibHarness public libHarness;
 
     function setUp() public {

--- a/packages/contracts-communication/test/legacy/libs/LegacyOptions.t.sol
+++ b/packages/contracts-communication/test/legacy/libs/LegacyOptions.t.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {LegacyOptionsLibHarness, LegacyOptionsLib} from "../harnesses/LegacyOptionsLibHarness.sol";
+
+import {Test} from "forge-std/Test.sol";
+
+// solhint-disable func-name-mixedcase
+// solhint-disable ordering
+contract LegacyOptionsLibTest is Test {
+    bytes public constant LEGACY_OPTIONS_FIXTURE =
+        hex"000100000000000000000000000000000000000000000000000000000000003d0900";
+    uint256 public constant GAS_LIMIT_FIXTURE = 4_000_000;
+
+    LegacyOptionsLibHarness public libHarness;
+
+    function setUp() public {
+        libHarness = new LegacyOptionsLibHarness();
+    }
+
+    function expectRevertInvalidOptions(bytes memory legacyOpts) internal {
+        vm.expectRevert(abi.encodeWithSelector(LegacyOptionsLib.LegacyOptionsLib__InvalidOptions.selector, legacyOpts));
+    }
+
+    function test_encodeLegacyOptions() public {
+        bytes memory encoded = libHarness.encodeLegacyOptions(GAS_LIMIT_FIXTURE);
+        assertEq(encoded, LEGACY_OPTIONS_FIXTURE);
+    }
+
+    function test_decodeLegacyOptions() public {
+        uint256 gasLimit = libHarness.decodeLegacyOptions(LEGACY_OPTIONS_FIXTURE);
+        assertEq(gasLimit, GAS_LIMIT_FIXTURE);
+    }
+
+    function test_encodeLegacyOptionsRoundtrip(uint256 gasLimit) public {
+        bytes memory encoded = libHarness.encodeLegacyOptions(gasLimit);
+        uint256 newGasLimit = libHarness.decodeLegacyOptions(encoded);
+        assertEq(newGasLimit, gasLimit);
+    }
+
+    function test_decodeLegacyOptions_revert_invalidVersion(uint16 version) public {
+        vm.assume(version != LegacyOptionsLib.LEGACY_OPTIONS_VERSION);
+        bytes memory invalidOpts = abi.encodePacked(version, uint256(1));
+        expectRevertInvalidOptions(invalidOpts);
+        libHarness.decodeLegacyOptions(invalidOpts);
+    }
+
+    function test_decodeLegacyOptions_revert_incorrectLength(bytes memory invalidOpts) public {
+        vm.assume(invalidOpts.length != LEGACY_OPTIONS_FIXTURE.length);
+        expectRevertInvalidOptions(invalidOpts);
+        libHarness.decodeLegacyOptions(invalidOpts);
+    }
+}

--- a/packages/contracts-communication/test/legacy/mocks/LegacyReceiverMock.sol
+++ b/packages/contracts-communication/test/legacy/mocks/LegacyReceiverMock.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {ILegacyReceiver} from "../../../contracts/legacy/interfaces/ILegacyReceiver.sol";
+
+// solhint-disable no-empty-blocks
+contract LegacyReceiverMock is ILegacyReceiver {
+    function executeMessage(bytes32 srcAddress, uint256 srcChainId, bytes memory message, address executor) external {}
+}


### PR DESCRIPTION
**Description**
Adds implementation of the legacy `MessageBus` contract as an Interchain App. This allows older apps to update the Message Bus address in their config and take advantage of the new interchain contracts w/o having to update/redeploy contracts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new `MessageBus` contract for facilitating message passing between different blockchain chains, including features for sending messages, estimating message lengths and fees, and message execution.
	- Added events related to message bus functionality, enhancing observability of message execution, sending, and settings adjustments.
	- Implemented interfaces and libraries for encoding and decoding messages and options, supporting legacy interchain communication.
- **Tests**
	- Developed comprehensive test suites for the `MessageBus` system, including encoding/decoding messages, managing messages, and interchain communication testing.
	- Added mock contracts and test harnesses for rigorous testing of new functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->