### PR TITLE
feat(synapse-interface): remove blast swap pause banner

### DIFF
--- a/packages/synapse-interface/pages/swap/index.tsx
+++ b/packages/synapse-interface/pages/swap/index.tsx
@@ -360,12 +360,6 @@ const StateManagedSwap = () => {
 
   return (
     <LandingPageWrapper>
-      <AnnouncementBanner
-        bannerId="2024-03-26-blast-swap-pause"
-        bannerContents="Swapping on Blast paused."
-        startDate={new Date(Date.UTC(2024, 2, 20, 20, 20, 0))}
-        endDate={new Date(Date.UTC(2026, 2, 20, 22, 0, 0))}
-      />
       <div className="flex justify-center px-4 py-16 mx-auto lg:mx-0">
         <div className="flex flex-col">
           <div className="flex items-center justify-between">

--- a/packages/synapse-interface/pages/swap/index.tsx
+++ b/packages/synapse-interface/pages/swap/index.tsx
@@ -5,9 +5,7 @@ import toast from 'react-hot-toast'
 import { animated } from 'react-spring'
 import { useRouter } from 'next/router'
 import { segmentAnalyticsEvent } from '@/contexts/SegmentAnalyticsProvider'
-
 import { setIsLoading } from '@/slices/swap/reducer'
-
 import { useSynapseContext } from '@/utils/providers/SynapseProvider'
 import { getErc20TokenAllowance } from '@/actions/getErc20TokenAllowance'
 import { commify } from '@ethersproject/units'
@@ -47,7 +45,6 @@ import { SwapToTokenListOverlay } from '@/components/StateManagedSwap/SwapToToke
 import { LandingPageWrapper } from '@/components/layouts/LandingPageWrapper'
 import useSyncQueryParamsWithSwapState from '@/utils/hooks/useSyncQueryParamsWithSwapState'
 import { isTransactionReceiptError } from '@/utils/isTransactionReceiptError'
-import { AnnouncementBanner } from '@/components/Maintenance/AnnouncementBanner'
 
 const StateManagedSwap = () => {
   const { address } = useAccount()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
    - Updated the visual presentation by removing the `AnnouncementBanner` component related to swapping being paused on Blast.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
076f40d00bdfb05eaee56669e95abc275ca9b2e4: [synapse-interface preview link ](https://sanguine-synapse-interface-4ygegji04-synapsecns.vercel.app)
048177591fef0d0c6788292a8fe7a27db33d6f22: [synapse-interface preview link ](https://sanguine-synapse-interface-4d9pc8vxs-synapsecns.vercel.app)