### PR TITLE
feat(contracts-communication): Interchain versioning for batches

### DIFF
--- a/packages/contracts-communication/contracts/interfaces/IInterchainDB.sol
+++ b/packages/contracts-communication/contracts/interfaces/IInterchainDB.sol
@@ -19,6 +19,7 @@ interface IInterchainDB {
     error InterchainDB__ConflictingBatches(address module, bytes32 existingBatchRoot, InterchainBatch newBatch);
     error InterchainDB__EntryIndexOutOfRange(uint256 dbNonce, uint64 entryIndex, uint64 batchSize);
     error InterchainDB__IncorrectFeeAmount(uint256 actualFee, uint256 expectedFee);
+    error InterchainDB__InvalidBatchVersion(uint16 version);
     error InterchainDB__InvalidEntryRange(uint256 dbNonce, uint64 start, uint64 end);
     error InterchainDB__NoModulesSpecified();
     error InterchainDB__SameChainId(uint256 chainId);
@@ -68,8 +69,9 @@ interface IInterchainDB {
         returns (uint256 dbNonce, uint64 entryIndex);
 
     /// @notice Allows the Interchain Module to verify the batch coming from the remote chain.
-    /// @param batch        The Interchain Batch to confirm
-    function verifyRemoteBatch(InterchainBatch memory batch) external;
+    /// Note: The DB will only accept the batch of the same version as the DB itself.
+    /// @param versionedBatch   The versioned Interchain Batch to verify
+    function verifyRemoteBatch(bytes memory versionedBatch) external;
 
     // ═══════════════════════════════════════════════════ VIEWS ═══════════════════════════════════════════════════════
 

--- a/packages/contracts-communication/contracts/interfaces/IInterchainModule.sol
+++ b/packages/contracts-communication/contracts/interfaces/IInterchainModule.sol
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {IInterchainDB} from "./IInterchainDB.sol";
-import {InterchainBatch} from "../libs/InterchainBatch.sol";
-
 /// @notice Every Module may opt a different method to confirm the verified entries on destination chain,
 /// therefore this is not a part of a common interface.
 interface IInterchainModule {
@@ -19,9 +16,9 @@ interface IInterchainModule {
     /// Note: this will eventually trigger `InterchainDB.verifyRemoteBatch(batch)` function on destination chain,
     /// with no guarantee of ordering.
     /// @dev Could be only called by the Interchain DataBase contract.
-    /// @param dstChainId   The chain id of the destination chain
-    /// @param batch        The batch to verify
-    function requestBatchVerification(uint256 dstChainId, InterchainBatch memory batch) external payable;
+    /// @param dstChainId       The chain id of the destination chain
+    /// @param versionedBatch   The versioned batch to verify
+    function requestBatchVerification(uint256 dstChainId, bytes memory versionedBatch) external payable;
 
     /// @notice Get the Module fee for verifying a batch on the specified destination chain.
     /// @param dstChainId   The chain id of the destination chain

--- a/packages/contracts-communication/contracts/libs/InterchainBatch.sol
+++ b/packages/contracts-communication/contracts/libs/InterchainBatch.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import {VersionedPayloadLib} from "./VersionedPayload.sol";
+
 /// @notice Struct representing a batch of entries in the Interchain DataBase.
 /// Batched entries are put together in a Merkle tree, which root is saved.
 /// Batch has a globally unique identifier (key) and a value.
@@ -17,6 +19,8 @@ struct InterchainBatch {
 }
 
 library InterchainBatchLib {
+    using VersionedPayloadLib for bytes;
+
     /// @notice Constructs an InterchainBatch struct to be saved on the local chain.
     /// @param dbNonce      The database nonce of the batch
     /// @param batchRoot    The root of the Merkle tree containing the batched entries
@@ -30,6 +34,48 @@ library InterchainBatchLib {
         returns (InterchainBatch memory batch)
     {
         return InterchainBatch({srcChainId: block.chainid, dbNonce: dbNonce, batchRoot: batchRoot});
+    }
+
+    /// @notice Decodes the versioned batch payload from memory into version and InterchainBatch struct.
+    /// @dev See `VersionedPayloadLib` for more details about calldata/memory locations.
+    /// @param versionedBatch   The versioned batch payload
+    /// @return dbVersion       The version of the InterchainDB contract that created the batch
+    /// @return batch           The InterchainBatch struct
+    function decodeVersionedBatchFromMemory(bytes memory versionedBatch)
+        internal
+        view
+        returns (uint16 dbVersion, InterchainBatch memory batch)
+    {
+        dbVersion = versionedBatch.getVersionFromMemory();
+        batch = abi.decode(versionedBatch.getPayloadFromMemory(), (InterchainBatch));
+    }
+
+    /// @notice Decodes the versioned batch payload into version and InterchainBatch struct.
+    /// @param versionedBatch   The versioned batch payload
+    /// @return dbVersion       The version of the InterchainDB contract that created the batch
+    /// @return batch           The InterchainBatch struct
+    function decodeVersionedBatch(bytes calldata versionedBatch)
+        internal
+        pure
+        returns (uint16 dbVersion, InterchainBatch memory batch)
+    {
+        dbVersion = versionedBatch.getVersion();
+        batch = abi.decode(versionedBatch.getPayload(), (InterchainBatch));
+    }
+
+    /// @notice Encodes the InterchainBatch struct into a versioned batch payload.
+    /// @param dbVersion        The version of the InterchainDB contract that created the batch
+    /// @param batch            The InterchainBatch struct
+    /// @return versionedBatch  The versioned batch payload
+    function encodeVersionedBatch(
+        uint16 dbVersion,
+        InterchainBatch memory batch
+    )
+        internal
+        pure
+        returns (bytes memory versionedBatch)
+    {
+        versionedBatch = VersionedPayloadLib.encodeVersionedPayload(dbVersion, abi.encode(batch));
     }
 
     /// @notice Returns the globally unique identifier of the batch

--- a/packages/contracts-communication/contracts/libs/ModuleBatch.sol
+++ b/packages/contracts-communication/contracts/libs/ModuleBatch.sol
@@ -29,4 +29,31 @@ library ModuleBatchLib {
     {
         return abi.decode(encodedModuleBatch, (InterchainBatch, bytes));
     }
+
+    /// @notice Encodes the versioned batch and the auxiliary module data into a single bytes array
+    /// @param versionedBatch       The versioned batch to encode
+    /// @param moduleData           The auxiliary module data to encode
+    /// @return encodedModuleBatch  The encoded versioned module batch
+    function encodeVersionedModuleBatch(
+        bytes memory versionedBatch,
+        bytes memory moduleData
+    )
+        internal
+        pure
+        returns (bytes memory encodedModuleBatch)
+    {
+        return abi.encode(versionedBatch, moduleData);
+    }
+
+    /// @notice Decodes the bytes array into the versioned batch and the auxiliary module data
+    /// @param encodedModuleBatch   The bytes array to decode
+    /// @return versionedBatch      The decoded versioned batch
+    /// @return moduleData          The decoded auxiliary module data
+    function decodeVersionedModuleBatch(bytes memory encodedModuleBatch)
+        internal
+        pure
+        returns (bytes memory versionedBatch, bytes memory moduleData)
+    {
+        return abi.decode(encodedModuleBatch, (bytes, bytes));
+    }
 }

--- a/packages/contracts-communication/contracts/modules/InterchainModule.sol
+++ b/packages/contracts-communication/contracts/modules/InterchainModule.sol
@@ -18,10 +18,12 @@ abstract contract InterchainModule is InterchainModuleEvents, IInterchainModule 
     }
 
     /// @inheritdoc IInterchainModule
-    function requestBatchVerification(uint256 dstChainId, InterchainBatch memory batch) external payable {
+    function requestBatchVerification(uint256 dstChainId, bytes calldata versionedBatch) external payable {
         if (msg.sender != INTERCHAIN_DB) {
             revert InterchainModule__NotInterchainDB(msg.sender);
         }
+        // TODO: Implement the logic to handle versioned batches
+        InterchainBatch memory batch;
         if (dstChainId == block.chainid) {
             revert InterchainModule__SameChainId(block.chainid);
         }
@@ -51,7 +53,8 @@ abstract contract InterchainModule is InterchainModuleEvents, IInterchainModule 
         if (batch.srcChainId == block.chainid) {
             revert InterchainModule__SameChainId(block.chainid);
         }
-        IInterchainDB(INTERCHAIN_DB).verifyRemoteBatch(batch);
+        // TODO: finish the implementation
+        IInterchainDB(INTERCHAIN_DB).verifyRemoteBatch("");
         _receiveModuleData(batch.srcChainId, batch.dbNonce, moduleData);
         emit BatchVerified(
             batch.srcChainId, encodedBatch, MessageHashUtils.toEthSignedMessageHash(keccak256(encodedBatch))

--- a/packages/contracts-communication/test/harnesses/InterchainBatchLibHarness.sol
+++ b/packages/contracts-communication/test/harnesses/InterchainBatchLibHarness.sol
@@ -8,6 +8,33 @@ contract InterchainBatchLibHarness {
         return InterchainBatchLib.constructLocalBatch(dbNonce, batchRoot);
     }
 
+    function decodeVersionedBatchFromMemory(bytes memory versionedBatch)
+        external
+        view
+        returns (uint16, InterchainBatch memory)
+    {
+        return InterchainBatchLib.decodeVersionedBatchFromMemory(versionedBatch);
+    }
+
+    function decodeVersionedBatch(bytes calldata versionedBatch)
+        external
+        pure
+        returns (uint16, InterchainBatch memory)
+    {
+        return InterchainBatchLib.decodeVersionedBatch(versionedBatch);
+    }
+
+    function encodeVersionedBatch(
+        uint16 dbVersion,
+        InterchainBatch memory batch
+    )
+        external
+        pure
+        returns (bytes memory)
+    {
+        return InterchainBatchLib.encodeVersionedBatch(dbVersion, batch);
+    }
+
     function batchKey(InterchainBatch memory batch) external pure returns (bytes32) {
         return InterchainBatchLib.batchKey(batch);
     }

--- a/packages/contracts-communication/test/harnesses/ModuleBatchLibHarness.sol
+++ b/packages/contracts-communication/test/harnesses/ModuleBatchLibHarness.sol
@@ -22,4 +22,23 @@ contract ModuleBatchLibHarness {
     {
         return ModuleBatchLib.decodeModuleBatch(encodedModuleBatch);
     }
+
+    function encodeVersionedModuleBatch(
+        bytes memory versionedBatch,
+        bytes memory moduleData
+    )
+        external
+        pure
+        returns (bytes memory)
+    {
+        return ModuleBatchLib.encodeVersionedModuleBatch(versionedBatch, moduleData);
+    }
+
+    function decodeVersionedModuleBatch(bytes memory encodedModuleBatch)
+        external
+        pure
+        returns (bytes memory, bytes memory)
+    {
+        return ModuleBatchLib.decodeVersionedModuleBatch(encodedModuleBatch);
+    }
 }

--- a/packages/contracts-communication/test/integration/ICIntegration.t.sol
+++ b/packages/contracts-communication/test/integration/ICIntegration.t.sol
@@ -9,7 +9,7 @@ import {InterchainModuleEvents} from "../../contracts/events/InterchainModuleEve
 
 import {IInterchainApp} from "../../contracts/interfaces/IInterchainApp.sol";
 import {IInterchainClientV1} from "../../contracts/interfaces/IInterchainClientV1.sol";
-import {InterchainBatch} from "../../contracts/libs/InterchainBatch.sol";
+import {InterchainBatch, InterchainBatchLib} from "../../contracts/libs/InterchainBatch.sol";
 import {InterchainEntry} from "../../contracts/libs/InterchainEntry.sol";
 import {InterchainTransaction, InterchainTxDescriptor} from "../../contracts/libs/InterchainTransaction.sol";
 import {ModuleBatchLib} from "../../contracts/libs/ModuleBatch.sol";
@@ -241,7 +241,8 @@ abstract contract ICIntegrationTest is
     }
 
     function getModuleBatch(InterchainBatch memory batch) internal pure returns (bytes memory) {
-        return ModuleBatchLib.encodeModuleBatch(batch, new bytes(0));
+        bytes memory versionedBatch = InterchainBatchLib.encodeVersionedBatch(DB_VERSION, batch);
+        return ModuleBatchLib.encodeVersionedModuleBatch(versionedBatch, new bytes(0));
     }
 
     function getInterchainBatch(InterchainEntry memory entry) internal pure returns (InterchainBatch memory) {

--- a/packages/contracts-communication/test/integration/ICSetup.t.sol
+++ b/packages/contracts-communication/test/integration/ICSetup.t.sol
@@ -22,6 +22,8 @@ abstract contract ICSetup is ProxyTest {
     uint256 public constant SRC_CHAIN_ID = 1337;
     uint256 public constant DST_CHAIN_ID = 7331;
 
+    uint16 public constant DB_VERSION = 1;
+
     uint256 public constant SRC_INITIAL_DB_NONCE = 10;
     uint256 public constant DST_INITIAL_DB_NONCE = 20;
 

--- a/packages/contracts-communication/test/libs/InterchainBatchLib.t.sol
+++ b/packages/contracts-communication/test/libs/InterchainBatchLib.t.sol
@@ -47,4 +47,18 @@ contract InterchainBatchLibTest is Test {
         bytes32 actual = libHarness.batchKey(batch);
         assertEq(actual, expected);
     }
+
+    function test_encodeVersionedBatchFromMemory_roundTrip(uint16 dbVersion, InterchainBatch memory batch) public {
+        bytes memory versionedBatch = libHarness.encodeVersionedBatch(dbVersion, batch);
+        (uint16 dbVersion_, InterchainBatch memory batch_) = libHarness.decodeVersionedBatchFromMemory(versionedBatch);
+        assertEq(dbVersion_, dbVersion);
+        assertEq(batch_, batch);
+    }
+
+    function test_encodeVersionedBatch_roundTrip(uint16 dbVersion, InterchainBatch memory batch) public {
+        bytes memory versionedBatch = libHarness.encodeVersionedBatch(dbVersion, batch);
+        (uint16 dbVersion_, InterchainBatch memory batch_) = libHarness.decodeVersionedBatch(versionedBatch);
+        assertEq(dbVersion_, dbVersion);
+        assertEq(batch_, batch);
+    }
 }

--- a/packages/contracts-communication/test/libs/ModuleBatchLib.t.sol
+++ b/packages/contracts-communication/test/libs/ModuleBatchLib.t.sol
@@ -25,4 +25,12 @@ contract ModuleBatchLibTest is Test {
         assertEq(decodedBatch, batch);
         assertEq(decodedModuleData, moduleData);
     }
+
+    function test_encodeVersionedModuleBatch_roundTrip(bytes memory versionedBatch, bytes memory moduleData) public {
+        bytes memory encoded = libHarness.encodeVersionedModuleBatch(versionedBatch, moduleData);
+        (bytes memory decodedVersionedBatch, bytes memory decodedModuleData) =
+            libHarness.decodeVersionedModuleBatch(encoded);
+        assertEq(decodedVersionedBatch, versionedBatch);
+        assertEq(decodedModuleData, moduleData);
+    }
 }

--- a/packages/contracts-communication/test/mocks/InterchainDBMock.sol
+++ b/packages/contracts-communication/test/mocks/InterchainDBMock.sol
@@ -26,7 +26,7 @@ contract InterchainDBMock is IInterchainDB {
         returns (uint256 writerNonce, uint64 entryIndex)
     {}
 
-    function verifyRemoteBatch(InterchainBatch memory batch) external {}
+    function verifyRemoteBatch(bytes calldata versionedBatch) external {}
 
     function getInterchainFee(uint256 dstChainId, address[] memory srcModules) external view returns (uint256) {}
 

--- a/packages/contracts-communication/test/mocks/InterchainModuleMock.sol
+++ b/packages/contracts-communication/test/mocks/InterchainModuleMock.sol
@@ -1,16 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.20;
 
-import {InterchainBatch, IInterchainDB, IInterchainModule} from "../../contracts/interfaces/IInterchainModule.sol";
+import {IInterchainModule} from "../../contracts/interfaces/IInterchainModule.sol";
+import {IInterchainDB} from "../../contracts/interfaces/IInterchainDB.sol";
 
 // solhint-disable ordering
 // solhint-disable no-empty-blocks
 contract InterchainModuleMock is IInterchainModule {
-    function requestBatchVerification(uint256 dstChainId, InterchainBatch memory batch) external payable {}
+    function requestBatchVerification(uint256 dstChainId, bytes calldata versionedBatch) external payable {}
 
     function getModuleFee(uint256 dstChainId, uint256 dbNonce) external view returns (uint256) {}
 
-    function mockVerifyRemoteBatch(address interchainDB, InterchainBatch memory batch) external {
-        IInterchainDB(interchainDB).verifyRemoteBatch(batch);
+    function mockVerifyRemoteBatch(address interchainDB, bytes calldata versionedBatch) external {
+        IInterchainDB(interchainDB).verifyRemoteBatch(versionedBatch);
     }
 }


### PR DESCRIPTION
**Description**
- `InterchainDB` contract is now versioned.
- Batches produced by `InterchainDB` have the same version.
- `InterchainDB` now only accepts batches of the same version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced versioning for Interchain Batch data to enhance compatibility and validation across different chain IDs.
	- Added new error handling for invalid batch versions to improve system reliability.

- **Refactor**
	- Updated various contracts and libraries to support the encoding and decoding of versioned batch data, ensuring backward compatibility and future-proofing the system.
	- Modified testing harnesses and integration tests to accommodate the new versioned batch functionality, ensuring robustness and consistency across the platform.

- **Tests**
	- Implemented new test cases for encoding and decoding versioned batches, ensuring the integrity and reliability of batch processing.
	- Enhanced test coverage for versioned batch verification, including tests for version mismatches, to safeguard against potential data inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->