### PR TITLE
fix(contracts-communication): deploy proxy script

### DIFF
--- a/packages/contracts-communication/script/deploy/DeployProxy.s.sol
+++ b/packages/contracts-communication/script/deploy/DeployProxy.s.sol
@@ -41,8 +41,8 @@ abstract contract DeployProxy is SynapseScript {
                 constructorArgs: ""
             });
         }
-        // Save the ProxyAdmin artifact as ContractName.ProxyAdmin
-        string memory proxyAdminAlias = contractName.concat(".ProxyAdmin");
+        // Save the ProxyAdmin artifact as ProxyAdmin.ContractName
+        string memory proxyAdminAlias = string.concat("ProxyAdmin.", contractName);
         if (!isDeployed(proxyAdminAlias)) {
             saveDeployment({
                 contractName: "ProxyAdmin",

--- a/packages/contracts-communication/script/deploy/DeployProxy.s.sol
+++ b/packages/contracts-communication/script/deploy/DeployProxy.s.sol
@@ -25,10 +25,10 @@ abstract contract DeployProxy is SynapseScript {
     {
         require(implementation != address(0), "No implementation provided");
         require(proxyAdminOwner != address(0), "No proxy admin owner provided");
-        // Deploy the proxy and save the artifact with Proxy ABI as ContractName.Proxy
+        // Deploy the proxy and save the artifact with Proxy ABI as TransparentUpgradeableProxy.ContractName
         deployedAt = deployAndSaveAs({
             contractName: "TransparentUpgradeableProxy",
-            contractAlias: contractName.concat(".Proxy"),
+            contractAlias: string.concat("TransparentUpgradeableProxy.", contractName),
             constructorArgs: abi.encode(implementation, proxyAdminOwner, initData),
             deployCodeFunc: cdDeployTransparentUpgradeableProxy
         });


### PR DESCRIPTION
**Description**
Adjusted the names for saved deployment artifacts to follow the naming convention: `ContractName.Alias`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated naming conventions for deployed contract artifacts to be more descriptive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->