### PR TITLE
feat(contracts-communication): Interchain versioning for transactions

### DIFF
--- a/packages/contracts-communication/contracts/interfaces/IInterchainClientV1.sol
+++ b/packages/contracts-communication/contracts/interfaces/IInterchainClientV1.sol
@@ -7,6 +7,7 @@ interface IInterchainClientV1 {
     error InterchainClientV1__FeeAmountTooLow(uint256 actual, uint256 required);
     error InterchainClientV1__IncorrectDstChainId(uint256 chainId);
     error InterchainClientV1__IncorrectMsgValue(uint256 actual, uint256 required);
+    error InterchainClientV1__InvalidTransactionVersion(uint16 version);
     error InterchainClientV1__NoLinkedClient(uint256 chainId);
     error InterchainClientV1__NotEnoughResponses(uint256 actual, uint256 required);
     error InterchainClientV1__NotEVMClient(bytes32 client);

--- a/packages/contracts-communication/contracts/libs/InterchainTransaction.sol
+++ b/packages/contracts-communication/contracts/libs/InterchainTransaction.sol
@@ -53,14 +53,6 @@ library InterchainTransactionLib {
         });
     }
 
-    function encodeTransaction(InterchainTransaction memory transaction) internal pure returns (bytes memory) {
-        return abi.encode(transaction);
-    }
-
-    function decodeTransaction(bytes memory encodedTx) internal pure returns (InterchainTransaction memory) {
-        return abi.decode(encodedTx, (InterchainTransaction));
-    }
-
     function encodeVersionedTransaction(
         uint16 clientVersion,
         InterchainTransaction memory transaction
@@ -87,9 +79,5 @@ library InterchainTransactionLib {
         // abi.encode() also prepends the global offset (which is always 0x20) if there's a dynamic field, making it 354
         // Both options and message are dynamic fields, which are padded up to 32 bytes
         return 354 + optionsLen.roundUpToWord() + messageLen.roundUpToWord();
-    }
-
-    function transactionId(InterchainTransaction memory transaction) internal pure returns (bytes32) {
-        return keccak256(abi.encode(transaction));
     }
 }

--- a/packages/contracts-communication/contracts/libs/InterchainTransaction.sol
+++ b/packages/contracts-communication/contracts/libs/InterchainTransaction.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.13;
 
 import {MathLib} from "./Math.sol";
 import {TypeCasts} from "./TypeCasts.sol";
+import {VersionedPayloadLib} from "./VersionedPayload.sol";
 
 struct InterchainTransaction {
     uint256 srcChainId;
@@ -25,6 +26,7 @@ using InterchainTransactionLib for InterchainTransaction global;
 
 library InterchainTransactionLib {
     using MathLib for uint256;
+    using VersionedPayloadLib for bytes;
 
     function constructLocalTransaction(
         address srcSender,
@@ -59,11 +61,32 @@ library InterchainTransactionLib {
         return abi.decode(encodedTx, (InterchainTransaction));
     }
 
+    function encodeVersionedTransaction(
+        uint16 clientVersion,
+        InterchainTransaction memory transaction
+    )
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return VersionedPayloadLib.encodeVersionedPayload(clientVersion, abi.encode(transaction));
+    }
+
+    function decodeVersionedTransaction(bytes calldata versionedTx)
+        internal
+        pure
+        returns (uint16 clientVersion, InterchainTransaction memory transaction)
+    {
+        clientVersion = versionedTx.getVersion();
+        transaction = abi.decode(versionedTx.getPayload(), (InterchainTransaction));
+    }
+
     function payloadSize(uint256 optionsLen, uint256 messageLen) internal pure returns (uint256) {
-        // 8 fields * 32 bytes (6 values for static, 2 offsets for dynamic) + 2 * 32 bytes (lengths for dynamic) = 320
-        // abi.encode() also prepends the global offset (which is always 0x20) if there's a dynamic field, making it 352
+        // 2 bytes are reserved for the transaction version
+        // + 8 fields * 32 bytes (6 values for static, 2 offsets for dynamic) + 2 * 32 bytes (lengths for dynamic) = 322
+        // abi.encode() also prepends the global offset (which is always 0x20) if there's a dynamic field, making it 354
         // Both options and message are dynamic fields, which are padded up to 32 bytes
-        return 352 + optionsLen.roundUpToWord() + messageLen.roundUpToWord();
+        return 354 + optionsLen.roundUpToWord() + messageLen.roundUpToWord();
     }
 
     function transactionId(InterchainTransaction memory transaction) internal pure returns (bytes32) {

--- a/packages/contracts-communication/test/InterchainClientV1.Base.t.sol
+++ b/packages/contracts-communication/test/InterchainClientV1.Base.t.sol
@@ -2,7 +2,11 @@
 pragma solidity 0.8.20;
 
 import {InterchainClientV1, InterchainClientV1Events, IInterchainClientV1} from "../contracts/InterchainClientV1.sol";
-import {InterchainTxDescriptor, InterchainTransaction} from "../contracts/libs/InterchainTransaction.sol";
+import {
+    InterchainTxDescriptor,
+    InterchainTransaction,
+    InterchainTransactionLib
+} from "../contracts/libs/InterchainTransaction.sol";
 import {OptionsLib} from "../contracts/libs/Options.sol";
 
 import {ExecutionFeesMock} from "./mocks/ExecutionFeesMock.sol";
@@ -20,6 +24,7 @@ abstract contract InterchainClientV1BaseTest is Test, InterchainClientV1Events {
     uint256 public constant REMOTE_CHAIN_ID = 7331;
     uint256 public constant UNKNOWN_CHAIN_ID = 42;
     bytes32 public constant MOCK_REMOTE_CLIENT = keccak256("RemoteClient");
+    uint16 public constant CLIENT_VERSION = 1;
 
     address public mockRemoteClientEVM = makeAddr("RemoteClientEVM");
     bytes32 public mockRemoteClientEVMBytes32 = bytes32(uint256(uint160(mockRemoteClientEVM)));
@@ -71,6 +76,12 @@ abstract contract InterchainClientV1BaseTest is Test, InterchainClientV1Events {
     function expectRevertIncorrectMsgValue(uint256 actual, uint256 required) internal {
         vm.expectRevert(
             abi.encodeWithSelector(IInterchainClientV1.InterchainClientV1__IncorrectMsgValue.selector, actual, required)
+        );
+    }
+
+    function expectRevertInvalidTransactionVersion(uint16 version) internal {
+        vm.expectRevert(
+            abi.encodeWithSelector(IInterchainClientV1.InterchainClientV1__InvalidTransactionVersion.selector, version)
         );
     }
 
@@ -204,7 +215,7 @@ abstract contract InterchainClientV1BaseTest is Test, InterchainClientV1Events {
     function assertCorrectDescriptor(InterchainTransaction memory icTx, InterchainTxDescriptor memory desc) internal {
         assertEq(desc.dbNonce, icTx.dbNonce, "!desc.dbNonce");
         assertEq(desc.entryIndex, icTx.entryIndex, "!desc.entryIndex");
-        assertEq(desc.transactionId, icTx.transactionId(), "!desc.transactionId");
+        assertEq(desc.transactionId, keccak256(getEncodedTx(icTx)), "!desc.transactionId");
     }
 
     function assertEq(InterchainTransaction memory icTx, InterchainTransaction memory expected) internal {
@@ -216,6 +227,10 @@ abstract contract InterchainClientV1BaseTest is Test, InterchainClientV1Events {
         assertEq(icTx.entryIndex, expected.entryIndex, "!entryIndex");
         assertEq(icTx.options, expected.options, "!options");
         assertEq(icTx.message, expected.message, "!message");
+    }
+
+    function getEncodedTx(InterchainTransaction memory icTx) internal pure returns (bytes memory) {
+        return InterchainTransactionLib.encodeVersionedTransaction(CLIENT_VERSION, icTx);
     }
 
     // ═══════════════════════════════════════════════════ UTILS ═══════════════════════════════════════════════════════

--- a/packages/contracts-communication/test/InterchainClientV1.Dst.t.sol
+++ b/packages/contracts-communication/test/InterchainClientV1.Dst.t.sol
@@ -7,9 +7,7 @@ import {OptionsV1} from "../contracts/libs/Options.sol";
 import {VersionedPayloadLib} from "../contracts/libs/VersionedPayload.sol";
 
 import {
-    InterchainClientV1BaseTest,
-    InterchainTransaction,
-    InterchainTxDescriptor
+    InterchainClientV1BaseTest, InterchainTransaction, InterchainTxDescriptor
 } from "./InterchainClientV1.Base.t.sol";
 
 import {InterchainAppMock} from "./mocks/InterchainAppMock.sol";

--- a/packages/contracts-communication/test/InterchainClientV1.Dst.t.sol
+++ b/packages/contracts-communication/test/InterchainClientV1.Dst.t.sol
@@ -7,7 +7,6 @@ import {OptionsV1} from "../contracts/libs/Options.sol";
 import {VersionedPayloadLib} from "../contracts/libs/VersionedPayload.sol";
 
 import {
-    InterchainClientV1,
     InterchainClientV1BaseTest,
     InterchainTransaction,
     InterchainTxDescriptor

--- a/packages/contracts-communication/test/InterchainClientV1.Dst.t.sol
+++ b/packages/contracts-communication/test/InterchainClientV1.Dst.t.sol
@@ -151,7 +151,7 @@ contract InterchainClientV1DestinationTest is InterchainClientV1BaseTest {
         desc = InterchainTxDescriptor({
             dbNonce: MOCK_DB_NONCE,
             entryIndex: MOCK_ENTRY_INDEX,
-            transactionId: icTx.transactionId()
+            transactionId: keccak256(getEncodedTx(icTx))
         });
     }
 
@@ -172,7 +172,7 @@ contract InterchainClientV1DestinationTest is InterchainClientV1BaseTest {
     }
 
     function assertExecutorSaved(InterchainTransaction memory icTx, InterchainTxDescriptor memory desc) internal {
-        assertEq(icClient.getExecutor(abi.encode(icTx)), executor, "!getExecutor");
+        assertEq(icClient.getExecutor(getEncodedTx(icTx)), executor, "!getExecutor");
         assertEq(icClient.getExecutorById(desc.transactionId), executor, "!getExecutorById");
     }
 
@@ -183,7 +183,7 @@ contract InterchainClientV1DestinationTest is InterchainClientV1BaseTest {
     )
         internal
     {
-        bytes memory encodedTx = abi.encode(icTx);
+        bytes memory encodedTx = getEncodedTx(icTx);
         deal(executor, options.gasAirdrop);
         vm.prank(executor);
         icClient.interchainExecute{value: options.gasAirdrop}(options.gasLimit, encodedTx, proof);
@@ -233,7 +233,7 @@ contract InterchainClientV1DestinationTest is InterchainClientV1BaseTest {
     {
         expectAppReceiveCall(options);
         expectEventInterchainTransactionReceived(icTx, desc);
-        assertTrue(icClient.isExecutable(abi.encode(icTx), proof));
+        assertTrue(icClient.isExecutable(getEncodedTx(icTx), proof));
         executeTransaction(icTx, options, proof);
         assertExecutorSaved(icTx, desc);
     }
@@ -287,8 +287,9 @@ contract InterchainClientV1DestinationTest is InterchainClientV1BaseTest {
             modules: oneModuleA,
             verificationTimes: verificationTimes
         });
+        bytes memory encodedTx = getEncodedTx(icTx);
         expectRevertNotEnoughResponses({actual: actualConfirmations, required: appConfig.requiredResponses});
-        icClient.isExecutable(abi.encode(icTx), emptyProof);
+        icClient.isExecutable(encodedTx, emptyProof);
         expectRevertNotEnoughResponses({actual: actualConfirmations, required: appConfig.requiredResponses});
         executeTransaction(icTx, options, emptyProof);
     }
@@ -308,8 +309,9 @@ contract InterchainClientV1DestinationTest is InterchainClientV1BaseTest {
             modules: twoModules,
             verificationTimes: verificationTimes
         });
+        bytes memory encodedTx = getEncodedTx(icTx);
         expectRevertNotEnoughResponses({actual: actualConfirmations, required: appConfig.requiredResponses});
-        icClient.isExecutable(abi.encode(icTx), emptyProof);
+        icClient.isExecutable(encodedTx, emptyProof);
         expectRevertNotEnoughResponses({actual: actualConfirmations, required: appConfig.requiredResponses});
         executeTransaction(icTx, options, emptyProof);
     }
@@ -764,10 +766,26 @@ contract InterchainClientV1DestinationTest is InterchainClientV1BaseTest {
         InterchainTxDescriptor memory desc = InterchainTxDescriptor({
             dbNonce: icTx.dbNonce,
             entryIndex: icTx.entryIndex,
-            transactionId: icTx.transactionId()
+            transactionId: keccak256(getEncodedTx(icTx))
         });
         mockReceivingConfig(oneConfWithOP, oneModuleA);
         mockCheckVerification(icModuleA, desc, new bytes32[](0), JUST_VERIFIED);
+    }
+
+    function test_interchainExecute_revert_invalidTransactionVersion(uint16 version) public {
+        vm.assume(version != CLIENT_VERSION);
+        (InterchainTransaction memory icTx,) = constructInterchainTx(optionsNoAirdrop.encodeOptionsV1());
+        bytes memory invalidVersionTx = VersionedPayloadLib.encodeVersionedPayload(version, abi.encode(icTx));
+        InterchainTxDescriptor memory desc = InterchainTxDescriptor({
+            dbNonce: icTx.dbNonce,
+            entryIndex: icTx.entryIndex,
+            transactionId: keccak256(invalidVersionTx)
+        });
+        mockReceivingConfig(oneConfWithOP, oneModuleA);
+        mockCheckVerification(icModuleA, desc, new bytes32[](0), JUST_VERIFIED);
+        expectRevertInvalidTransactionVersion(version);
+        vm.prank(executor);
+        icClient.interchainExecute(optionsNoAirdrop.gasLimit, invalidVersionTx, new bytes32[](0));
     }
 
     function test_interchainExecute_revert_srcChainNotRemote() public {
@@ -893,58 +911,73 @@ contract InterchainClientV1DestinationTest is InterchainClientV1BaseTest {
         executeTransaction(icTx, optionsNoAirdrop, emptyProof);
     }
 
+    function test_isExecutable_revert_invalidTransactionVersion(uint16 version) public {
+        vm.assume(version != CLIENT_VERSION);
+        (InterchainTransaction memory icTx,) = constructInterchainTx(optionsNoAirdrop.encodeOptionsV1());
+        bytes memory invalidVersionTx = VersionedPayloadLib.encodeVersionedPayload(version, abi.encode(icTx));
+        expectRevertInvalidTransactionVersion(version);
+        icClient.isExecutable(invalidVersionTx, emptyProof);
+    }
+
     function test_isExecutable_revert_srcChainNotRemote() public {
         (InterchainTransaction memory icTx,) = constructInterchainTx(optionsNoAirdrop.encodeOptionsV1());
         mockReceivingConfig(oneConfWithOP, oneModuleA);
         icTx.srcChainId = LOCAL_CHAIN_ID;
+        bytes memory encodedTx = getEncodedTx(icTx);
         expectRevertNotRemoteChainId(LOCAL_CHAIN_ID);
-        icClient.isExecutable(abi.encode(icTx), emptyProof);
+        icClient.isExecutable(encodedTx, emptyProof);
     }
 
     function test_isExecutable_revert_srcChainNotLinked() public {
         (InterchainTransaction memory icTx,) = constructInterchainTx(optionsNoAirdrop.encodeOptionsV1());
         mockReceivingConfig(oneConfWithOP, oneModuleA);
         icTx.srcChainId = UNKNOWN_CHAIN_ID;
+        bytes memory encodedTx = getEncodedTx(icTx);
         expectRevertNoLinkedClient(UNKNOWN_CHAIN_ID);
-        icClient.isExecutable(abi.encode(icTx), emptyProof);
+        icClient.isExecutable(encodedTx, emptyProof);
     }
 
     function test_isExecutable_revert_dstChainIncorrect() public {
         (InterchainTransaction memory icTx,) = constructInterchainTx(optionsNoAirdrop.encodeOptionsV1());
         mockReceivingConfig(oneConfWithOP, oneModuleA);
         icTx.dstChainId = UNKNOWN_CHAIN_ID;
+        bytes memory encodedTx = getEncodedTx(icTx);
         expectRevertIncorrectDstChainId(UNKNOWN_CHAIN_ID);
-        icClient.isExecutable(abi.encode(icTx), emptyProof);
+        icClient.isExecutable(encodedTx, emptyProof);
     }
 
     function test_isExecutable_revert_emptyOptions() public {
         (InterchainTransaction memory icTx,) = constructInterchainTx("");
+        bytes memory encodedTx = getEncodedTx(icTx);
         prepareExecutableTx(icTx);
         // OptionsLib doesn't have a specific error for this case, so we expect a generic revert during decoding.
         vm.expectRevert();
-        icClient.isExecutable(abi.encode(icTx), emptyProof);
+        icClient.isExecutable(encodedTx, emptyProof);
     }
 
     function test_isExecutable_revert_invalidOptionsV0() public {
         (InterchainTransaction memory icTx,) = constructInterchainTx(invalidOptionsV0);
+        bytes memory encodedTx = getEncodedTx(icTx);
         prepareExecutableTx(icTx);
         expectRevertIncorrectVersion(0);
-        icClient.isExecutable(abi.encode(icTx), emptyProof);
+        icClient.isExecutable(encodedTx, emptyProof);
     }
 
     function test_isExecutable_revert_invalidOptionsV1() public {
         (InterchainTransaction memory icTx,) = constructInterchainTx(invalidOptionsV1);
+        bytes memory encodedTx = getEncodedTx(icTx);
         prepareExecutableTx(icTx);
         // OptionsLib doesn't have a specific error for this case, so we expect a generic revert during decoding.
         vm.expectRevert();
-        icClient.isExecutable(abi.encode(icTx), emptyProof);
+        icClient.isExecutable(encodedTx, emptyProof);
     }
 
     function test_isExecutable_revert_alreadyExecuted() public {
         (InterchainTransaction memory icTx, InterchainTxDescriptor memory desc) =
             prepareAlreadyExecutedTest(optionsNoAirdrop);
+        bytes memory encodedTx = getEncodedTx(icTx);
         expectRevertTxAlreadyExecuted(desc.transactionId);
-        icClient.isExecutable(abi.encode(icTx), emptyProof);
+        icClient.isExecutable(encodedTx, emptyProof);
     }
 
     function test_isExecutable_revert_zeroRequiredResponses() public {
@@ -957,8 +990,9 @@ contract InterchainClientV1DestinationTest is InterchainClientV1BaseTest {
             modules: oneModuleA,
             verificationTimes: toArray(JUST_VERIFIED)
         });
+        bytes memory encodedTx = getEncodedTx(icTx);
         expectRevertZeroRequiredResponses();
-        icClient.isExecutable(abi.encode(icTx), emptyProof);
+        icClient.isExecutable(encodedTx, emptyProof);
     }
 
     // ═══════════════════════════════════════ TESTS: WRITE EXECUTION PROOF ════════════════════════════════════════════

--- a/packages/contracts-communication/test/InterchainClientV1.GenericViews.t.sol
+++ b/packages/contracts-communication/test/InterchainClientV1.GenericViews.t.sol
@@ -3,15 +3,19 @@ pragma solidity 0.8.20;
 
 import {OptionsV1} from "../contracts/libs/Options.sol";
 
-import {InterchainClientV1, InterchainClientV1BaseTest, InterchainTransaction} from "./InterchainClientV1.Base.t.sol";
+import {InterchainClientV1BaseTest, InterchainTransaction} from "./InterchainClientV1.Base.t.sol";
+import {InterchainTransactionLibHarness} from "./harnesses/InterchainTransactionLibHarness.sol";
 
 // solhint-disable func-name-mixedcase
 // solhint-disable ordering
 contract InterchainClientV1GenericViewsTest is InterchainClientV1BaseTest {
+    InterchainTransactionLibHarness public libHarness;
+
     function setUp() public override {
         super.setUp();
         setExecutionFees(execFees);
         setLinkedClient(REMOTE_CHAIN_ID, MOCK_REMOTE_CLIENT);
+        libHarness = new InterchainTransactionLibHarness();
     }
 
     function test_getLinkedClient_chainIdKnown() public {
@@ -48,7 +52,8 @@ contract InterchainClientV1GenericViewsTest is InterchainClientV1BaseTest {
 
     function test_encodeTransaction(InterchainTransaction memory icTx) public {
         bytes memory encoded = icClient.encodeTransaction(icTx);
-        InterchainTransaction memory decoded = abi.decode(encoded, (InterchainTransaction));
+        (uint16 version, InterchainTransaction memory decoded) = libHarness.decodeVersionedTransaction(encoded);
+        assertEq(version, CLIENT_VERSION);
         assertEq(decoded, icTx);
     }
 

--- a/packages/contracts-communication/test/InterchainClientV1.Management.t.sol
+++ b/packages/contracts-communication/test/InterchainClientV1.Management.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.20;
 
-import {InterchainClientV1, InterchainClientV1BaseTest} from "./InterchainClientV1.Base.t.sol";
+import {InterchainClientV1BaseTest} from "./InterchainClientV1.Base.t.sol";
 
 // solhint-disable func-name-mixedcase
 // solhint-disable ordering

--- a/packages/contracts-communication/test/InterchainClientV1.Src.t.sol
+++ b/packages/contracts-communication/test/InterchainClientV1.Src.t.sol
@@ -5,10 +5,7 @@ import {OptionsV1} from "../contracts/libs/Options.sol";
 import {VersionedPayloadLib} from "../contracts/libs/VersionedPayload.sol";
 
 import {
-    InterchainClientV1,
-    InterchainClientV1BaseTest,
-    InterchainTransaction,
-    InterchainTxDescriptor
+    InterchainClientV1BaseTest, InterchainTransaction, InterchainTxDescriptor
 } from "./InterchainClientV1.Base.t.sol";
 
 import {ExecutionFeesMock} from "./mocks/ExecutionFeesMock.sol";
@@ -78,7 +75,7 @@ contract InterchainClientV1SourceTest is InterchainClientV1BaseTest {
 
     /// @dev Override the ExecutionService's returned execution fee for the given destination chain and transaction.
     function mockExecutionFee(uint256 dstChainId, InterchainTransaction memory icTx, uint256 executionFee) internal {
-        uint256 txPayloadSize = abi.encode(icTx).length;
+        uint256 txPayloadSize = getEncodedTx(icTx).length;
         vm.mockCall(
             execService,
             abi.encodeCall(ExecutionServiceMock.getExecutionFee, (dstChainId, txPayloadSize, icTx.options)),
@@ -112,7 +109,7 @@ contract InterchainClientV1SourceTest is InterchainClientV1BaseTest {
             message: message
         });
         desc = InterchainTxDescriptor({
-            transactionId: icTx.transactionId(),
+            transactionId: keccak256(getEncodedTx(icTx)),
             dbNonce: MOCK_DB_NONCE,
             entryIndex: MOCK_ENTRY_INDEX
         });
@@ -161,7 +158,7 @@ contract InterchainClientV1SourceTest is InterchainClientV1BaseTest {
     )
         internal
     {
-        uint256 txPayloadSize = abi.encode(icTx).length;
+        uint256 txPayloadSize = getEncodedTx(icTx).length;
         bytes memory expectedCalldata = abi.encodeCall(
             ExecutionServiceMock.requestExecution,
             (icTx.dstChainId, txPayloadSize, desc.transactionId, executionFee, icTx.options)

--- a/packages/contracts-communication/test/harnesses/InterchainTransactionLibHarness.sol
+++ b/packages/contracts-communication/test/harnesses/InterchainTransactionLibHarness.sol
@@ -22,14 +22,6 @@ contract InterchainTransactionLibHarness {
         );
     }
 
-    function encodeTransaction(InterchainTransaction memory transaction) external pure returns (bytes memory) {
-        return InterchainTransactionLib.encodeTransaction(transaction);
-    }
-
-    function decodeTransaction(bytes memory encodedTx) external pure returns (InterchainTransaction memory) {
-        return InterchainTransactionLib.decodeTransaction(encodedTx);
-    }
-
     function encodeVersionedTransaction(
         uint16 clientVersion,
         InterchainTransaction memory transaction
@@ -51,9 +43,5 @@ contract InterchainTransactionLibHarness {
 
     function payloadSize(uint256 optionsLen, uint256 messageLen) external pure returns (uint256) {
         return InterchainTransactionLib.payloadSize(optionsLen, messageLen);
-    }
-
-    function transactionId(InterchainTransaction memory transaction) external pure returns (bytes32) {
-        return InterchainTransactionLib.transactionId(transaction);
     }
 }

--- a/packages/contracts-communication/test/harnesses/InterchainTransactionLibHarness.sol
+++ b/packages/contracts-communication/test/harnesses/InterchainTransactionLibHarness.sol
@@ -30,6 +30,25 @@ contract InterchainTransactionLibHarness {
         return InterchainTransactionLib.decodeTransaction(encodedTx);
     }
 
+    function encodeVersionedTransaction(
+        uint16 clientVersion,
+        InterchainTransaction memory transaction
+    )
+        external
+        pure
+        returns (bytes memory)
+    {
+        return InterchainTransactionLib.encodeVersionedTransaction(clientVersion, transaction);
+    }
+
+    function decodeVersionedTransaction(bytes calldata encodedTx)
+        external
+        pure
+        returns (uint16, InterchainTransaction memory)
+    {
+        return InterchainTransactionLib.decodeVersionedTransaction(encodedTx);
+    }
+
     function payloadSize(uint256 optionsLen, uint256 messageLen) external pure returns (uint256) {
         return InterchainTransactionLib.payloadSize(optionsLen, messageLen);
     }

--- a/packages/contracts-communication/test/integration/ICIntegration.t.sol
+++ b/packages/contracts-communication/test/integration/ICIntegration.t.sol
@@ -12,6 +12,7 @@ import {IInterchainClientV1} from "../../contracts/interfaces/IInterchainClientV
 import {InterchainBatch} from "../../contracts/libs/InterchainBatch.sol";
 import {InterchainEntry} from "../../contracts/libs/InterchainEntry.sol";
 import {InterchainTransaction, InterchainTxDescriptor} from "../../contracts/libs/InterchainTransaction.sol";
+import {VersionedPayloadLib} from "../../contracts/libs/VersionedPayload.sol";
 import {ModuleBatchLib} from "../../contracts/libs/ModuleBatch.sol";
 import {OptionsV1} from "../../contracts/libs/Options.sol";
 
@@ -69,7 +70,7 @@ abstract contract ICIntegrationTest is
     {
         vm.expectEmit(address(icClient));
         emit InterchainTransactionSent({
-            transactionId: icTx.transactionId(),
+            transactionId: getTxId(icTx),
             dbNonce: icTx.dbNonce,
             entryIndex: icTx.entryIndex,
             dstChainId: icTx.dstChainId,
@@ -85,7 +86,7 @@ abstract contract ICIntegrationTest is
     function expectClientEventInterchainTransactionReceived(InterchainTransaction memory icTx) internal {
         vm.expectEmit(address(icClient));
         emit InterchainTransactionReceived({
-            transactionId: icTx.transactionId(),
+            transactionId: getTxId(icTx),
             dbNonce: icTx.dbNonce,
             entryIndex: icTx.entryIndex,
             srcChainId: icTx.srcChainId,
@@ -270,7 +271,7 @@ abstract contract ICIntegrationTest is
             dbNonce: SRC_INITIAL_DB_NONCE,
             entryIndex: 0,
             srcWriter: address(icClient).addressToBytes32(),
-            dataHash: getSrcTransaction().transactionId()
+            dataHash: getTxId(getSrcTransaction())
         });
     }
 
@@ -280,8 +281,16 @@ abstract contract ICIntegrationTest is
             dbNonce: DST_INITIAL_DB_NONCE,
             entryIndex: 0,
             srcWriter: address(icClient).addressToBytes32(),
-            dataHash: getDstTransaction().transactionId()
+            dataHash: getTxId(getDstTransaction())
         });
+    }
+
+    function getTxId(InterchainTransaction memory icTx) internal pure returns (bytes32) {
+        return keccak256(getEncodedTx(icTx));
+    }
+
+    function getEncodedTx(InterchainTransaction memory icTx) internal pure returns (bytes memory) {
+        return VersionedPayloadLib.encodeVersionedPayload(CLIENT_VERSION, abi.encode(icTx));
     }
 
     function getSrcTransaction() internal view returns (InterchainTransaction memory) {

--- a/packages/contracts-communication/test/integration/ICSetup.t.sol
+++ b/packages/contracts-communication/test/integration/ICSetup.t.sol
@@ -22,6 +22,8 @@ abstract contract ICSetup is ProxyTest {
     uint256 public constant SRC_CHAIN_ID = 1337;
     uint256 public constant DST_CHAIN_ID = 7331;
 
+    uint16 public constant CLIENT_VERSION = 1;
+
     uint256 public constant SRC_INITIAL_DB_NONCE = 10;
     uint256 public constant DST_INITIAL_DB_NONCE = 20;
 

--- a/packages/contracts-communication/test/integration/PingPong.Dst.t.sol
+++ b/packages/contracts-communication/test/integration/PingPong.Dst.t.sol
@@ -42,7 +42,7 @@ contract PingPongDstIntegrationTest is ICIntegrationTest {
         srcEntry = getSrcInterchainEntry();
         srcDesc = getInterchainTxDescriptor(srcEntry);
         srcBatch = getInterchainBatch(srcEntry);
-        encodedSrcTx = abi.encode(srcTx);
+        encodedSrcTx = getEncodedTx(srcTx);
 
         moduleBatch = getModuleBatch(srcBatch);
         moduleSignatures = getModuleSignatures(srcBatch);
@@ -56,7 +56,7 @@ contract PingPongDstIntegrationTest is ICIntegrationTest {
         dstVerificationFee = icDB.getInterchainFee(SRC_CHAIN_ID, toArray(address(module)));
         dstExecutionFee = executionService.getExecutionFee({
             dstChainId: SRC_CHAIN_ID,
-            txPayloadSize: abi.encode(dstTx).length,
+            txPayloadSize: getEncodedTx(dstTx).length,
             options: ppOptions.encodeOptionsV1()
         });
     }

--- a/packages/contracts-communication/test/integration/PingPong.Src.t.sol
+++ b/packages/contracts-communication/test/integration/PingPong.Src.t.sol
@@ -31,7 +31,7 @@ contract PingPongSrcIntegrationTest is ICIntegrationTest {
         verificationFee = icDB.getInterchainFee(DST_CHAIN_ID, toArray(address(module)));
         executionFee = executionService.getExecutionFee({
             dstChainId: DST_CHAIN_ID,
-            txPayloadSize: abi.encode(icTx).length,
+            txPayloadSize: getEncodedTx(icTx).length,
             options: ppOptions.encodeOptionsV1()
         });
     }

--- a/packages/contracts-communication/test/libs/InterchainTransaction.t.sol
+++ b/packages/contracts-communication/test/libs/InterchainTransaction.t.sol
@@ -41,19 +41,6 @@ contract InterchainTransactionLibTest is Test {
         assertEq(icTx.message, message, "!message");
     }
 
-    function test_encodeRoundtrip(InterchainTransaction memory icTx) public {
-        bytes memory encoded = libHarness.encodeTransaction(icTx);
-        InterchainTransaction memory decoded = libHarness.decodeTransaction(encoded);
-        assertEq(decoded.srcChainId, icTx.srcChainId, "!srcChainId");
-        assertEq(decoded.srcSender, icTx.srcSender, "!srcSender");
-        assertEq(decoded.dstChainId, icTx.dstChainId, "!dstChainId");
-        assertEq(decoded.dstReceiver, icTx.dstReceiver, "!dstReceiver");
-        assertEq(decoded.dbNonce, icTx.dbNonce, "!dbNonce");
-        assertEq(decoded.entryIndex, icTx.entryIndex, "!entryIndex");
-        assertEq(decoded.options, icTx.options, "!options");
-        assertEq(decoded.message, icTx.message, "!message");
-    }
-
     function test_encodeVersionedTransaction_roundTrip(uint16 version, InterchainTransaction memory icTx) public {
         bytes memory encoded = libHarness.encodeVersionedTransaction(version, icTx);
         (uint16 version_, InterchainTransaction memory decoded) = libHarness.decodeVersionedTransaction(encoded);
@@ -66,11 +53,6 @@ contract InterchainTransactionLibTest is Test {
         assertEq(decoded.entryIndex, icTx.entryIndex, "!entryIndex");
         assertEq(decoded.options, icTx.options, "!options");
         assertEq(decoded.message, icTx.message, "!message");
-    }
-
-    function test_transactionId(InterchainTransaction memory icTx) public {
-        bytes32 expected = keccak256(abi.encode(icTx));
-        assertEq(libHarness.transactionId(icTx), expected);
     }
 
     function test_payloadSize(InterchainTransaction memory icTx) public {

--- a/packages/contracts-communication/test/libs/InterchainTransaction.t.sol
+++ b/packages/contracts-communication/test/libs/InterchainTransaction.t.sol
@@ -54,6 +54,20 @@ contract InterchainTransactionLibTest is Test {
         assertEq(decoded.message, icTx.message, "!message");
     }
 
+    function test_encodeVersionedTransaction_roundTrip(uint16 version, InterchainTransaction memory icTx) public {
+        bytes memory encoded = libHarness.encodeVersionedTransaction(version, icTx);
+        (uint16 version_, InterchainTransaction memory decoded) = libHarness.decodeVersionedTransaction(encoded);
+        assertEq(version_, version, "!version");
+        assertEq(decoded.srcChainId, icTx.srcChainId, "!srcChainId");
+        assertEq(decoded.srcSender, icTx.srcSender, "!srcSender");
+        assertEq(decoded.dstChainId, icTx.dstChainId, "!dstChainId");
+        assertEq(decoded.dstReceiver, icTx.dstReceiver, "!dstReceiver");
+        assertEq(decoded.dbNonce, icTx.dbNonce, "!dbNonce");
+        assertEq(decoded.entryIndex, icTx.entryIndex, "!entryIndex");
+        assertEq(decoded.options, icTx.options, "!options");
+        assertEq(decoded.message, icTx.message, "!message");
+    }
+
     function test_transactionId(InterchainTransaction memory icTx) public {
         bytes32 expected = keccak256(abi.encode(icTx));
         assertEq(libHarness.transactionId(icTx), expected);
@@ -61,7 +75,7 @@ contract InterchainTransactionLibTest is Test {
 
     function test_payloadSize(InterchainTransaction memory icTx) public {
         uint256 size = libHarness.payloadSize(icTx.options.length, icTx.message.length);
-        uint256 expectedSize = abi.encode(icTx).length;
+        uint256 expectedSize = libHarness.encodeVersionedTransaction(0, icTx).length;
         assertEq(size, expectedSize);
     }
 


### PR DESCRIPTION
**Description**
- `InterchainClientV1` contract is now versioned.
- Transactions sent through the client have the same version.
- Client only accepts transactions of the same version as itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced versioning for `InterchainClient` transactions to ensure compatibility and integrity.
	- Added new encoding and decoding functions to support versioned transactions.
- **Refactor**
	- Improved transaction verification logic with version checks.
	- Updated existing functions to utilize versioned transaction encoding and decoding.
- **Bug Fixes**
	- Fixed transaction encoding issues by integrating versioned transaction logic.
- **Tests**
	- Enhanced test suites to cover versioned transaction functionality and encoding/decoding processes.
- **Documentation**
	- Added error documentation for invalid transaction versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->