### PR TITLE
Set submitter DefaultGasBumpPercentage to 10

### DIFF
--- a/ethergo/submitter/config/config.go
+++ b/ethergo/submitter/config/config.go
@@ -57,7 +57,8 @@ const (
 	DefaultBumpIntervalSeconds = 30
 
 	// DefaultGasBumpPercentage is the default percentage to bump the gas price by.
-	DefaultGasBumpPercentage = 5
+	// See: https://github.com/ethereum/go-ethereum/blob/8c5576b1ac89473c7ec15c9b03d1ca02e9499dcc/core/txpool/legacypool/legacypool.go#L146
+	DefaultGasBumpPercentage = 10
 
 	// DefaultGasEstimate is the default gas estimate to use for transactions.
 	DefaultGasEstimate = uint64(1200000)


### PR DESCRIPTION
**Description**
Sets gas bump to 10% in accordance with geth spec.

**Metadata**
- Addresses task in #2410 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Increased the default gas bump percentage to improve transaction processing efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->