### PR TITLE
Submitter: check gas balance when setting gas price

### DIFF
--- a/ethergo/submitter/config/config.go
+++ b/ethergo/submitter/config/config.go
@@ -57,7 +57,8 @@ const (
 	DefaultBumpIntervalSeconds = 30
 
 	// DefaultGasBumpPercentage is the default percentage to bump the gas price by.
-	DefaultGasBumpPercentage = 5
+	// See: https://github.com/ethereum/go-ethereum/blob/8c5576b1ac89473c7ec15c9b03d1ca02e9499dcc/core/txpool/legacypool/legacypool.go#L146
+	DefaultGasBumpPercentage = 10
 
 	// DefaultGasEstimate is the default gas estimate to use for transactions.
 	DefaultGasEstimate = uint64(1200000)

--- a/ethergo/submitter/submitter.go
+++ b/ethergo/submitter/submitter.go
@@ -358,6 +358,11 @@ func (t *txSubmitterImpl) setGasPrice(ctx context.Context, client client.EVM,
 			transactor.GasFeeCap = maxPrice
 		}
 
+		span.SetAttributes(
+			attribute.String("gas_price", bigPtrToString(transactor.GasPrice)),
+			attribute.String("gas_fee_cap", bigPtrToString(transactor.GasFeeCap)),
+			attribute.String("gas_tip_cap", bigPtrToString(transactor.GasTipCap)),
+		)
 		metrics.EndSpanWithErr(span, err)
 	}()
 
@@ -372,6 +377,7 @@ func (t *txSubmitterImpl) setGasPrice(ctx context.Context, client client.EVM,
 		if transactor.GasFeeCap.Cmp(maxPrice) > 0 {
 			transactor.GasFeeCap = maxPrice
 			shouldBump = false
+			span.AddEvent("not bumping fee cap since max price is reached")
 		}
 
 		transactor.GasTipCap, err = client.SuggestGasTipCap(ctx)

--- a/ethergo/submitter/submitter_test.go
+++ b/ethergo/submitter/submitter_test.go
@@ -44,7 +44,7 @@ func (s *SubmitterSuite) TestSetGasPrice() {
 	maxPrice := new(big.Int).Add(gasPrice, new(big.Int).SetUint64(1))
 	cfg.SetGlobalMaxGasPrice(maxPrice)
 
-	client.On(testsuite.GetFunctionName(client.SuggestGasPrice), mock.Anything).Twice().Return(gasPrice, nil)
+	client.On(testsuite.GetFunctionName(client.SuggestGasPrice), mock.Anything).Times(3).Return(gasPrice, nil)
 	err = ts.SetGasPrice(s.GetTestContext(), client, transactor, chainID, nil)
 	s.Require().NoError(err)
 


### PR DESCRIPTION
**Description**
Adds an extra `checkGasBalance()` call to make sure the submitter wallet has enough gas to pay for the given transaction.

**Metadata**
- Addresses #2410 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced transaction fee calculation to dynamically adjust fees within a set maximum limit.
	- Transactions can now have their gas price bumped based on their current nonce, improving transaction processing efficiency.
	- Support for EIP-1559 in setting gas prices and fee caps, ensuring compatibility with the latest Ethereum standards.
- **Improvements**
	- Increased the default gas bump percentage to better align with current network conditions.
	- Added a verification step to check for sufficient gas balance before submitting a transaction.
- **Tests**
	- Updated unit tests to reflect changes in gas price setting logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->