### PR TITLE
RFQ: failed rebalance does not block chain listener

### DIFF
--- a/ethergo/listener/listener.go
+++ b/ethergo/listener/listener.go
@@ -206,7 +206,7 @@ func (c chainListener) getMetadata(parentCtx context.Context) (startBlock, chain
 }
 
 // TODO: consider some kind of backoff here in case rpcs are down at boot.
-// this becomes more of an issue as we add more chains
+// this becomes more of an issue as we add more chains.
 func (c chainListener) getLastIndexed(ctx context.Context, chainID uint64) (lastIndexed uint64, err error) {
 	lastIndexed, err = c.store.LatestBlockForChain(ctx, chainID)
 	// Workaround: TODO remove

--- a/ethergo/listener/listener.go
+++ b/ethergo/listener/listener.go
@@ -7,7 +7,7 @@ import (
 	"math/big"
 	"time"
 
-	db2 "github.com/synapsecns/sanguine/ethergo/listener/db"
+	listenerDB "github.com/synapsecns/sanguine/ethergo/listener/db"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
@@ -40,7 +40,7 @@ type chainListener struct {
 	client       client.EVM
 	address      common.Address
 	initialBlock uint64
-	store        db2.ChainListenerDB
+	store        listenerDB.ChainListenerDB
 	handler      metrics.Handler
 	backoff      *backoff.Backoff
 	// IMPORTANT! These fields cannot be used until they has been set. They are NOT
@@ -53,11 +53,11 @@ type chainListener struct {
 var (
 	logger = log.Logger("chainlistener-logger")
 	// ErrNoLatestBlockForChainID is returned when no block exists for the chain.
-	ErrNoLatestBlockForChainID = db2.ErrNoLatestBlockForChainID
+	ErrNoLatestBlockForChainID = listenerDB.ErrNoLatestBlockForChainID
 )
 
 // NewChainListener creates a new chain listener.
-func NewChainListener(omnirpcClient client.EVM, store db2.ChainListenerDB, address common.Address, initialBlock uint64, handler metrics.Handler) (ContractListener, error) {
+func NewChainListener(omnirpcClient client.EVM, store listenerDB.ChainListenerDB, address common.Address, initialBlock uint64, handler metrics.Handler) (ContractListener, error) {
 	return &chainListener{
 		handler:      handler,
 		address:      address,

--- a/services/rfq/relayer/service/chainindexer.go
+++ b/services/rfq/relayer/service/chainindexer.go
@@ -205,7 +205,7 @@ type decimalsRes struct {
 func (r *Relayer) handleDepositClaimed(ctx context.Context, event *fastbridge.FastBridgeBridgeDepositClaimed, chainID int) error {
 	err := r.inventory.Rebalance(ctx, chainID, event.Token)
 	if err != nil {
-		return fmt.Errorf("could not rebalance: %w", err)
+		logger.Errorf("could not rebalance: %w", err)
 	}
 	err = r.db.UpdateQuoteRequestStatus(ctx, event.TransactionId, reldb.ClaimCompleted)
 	if err != nil {


### PR DESCRIPTION
**Description**
If we encounter an error when rebalancing, we should only log the error instead of returning it, since a bubbled-up error results in reprocessing a log range.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Enhanced error handling and logging in the blockchain event listener.
	- Improved clarity and efficiency in blockchain event processing.

- **Bug Fixes**
	- Corrected typos in error messages for improved user understanding.
	- Reordered imports and updated package references for better organization.
	- Renamed a package reference for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->