### PR TITLE
Allow metrics to be sync

### DIFF
--- a/core/metrics/README.md
+++ b/core/metrics/README.md
@@ -27,11 +27,12 @@ Pass in the `PYROSCOPE_ENDPOINT` environment variable
 
 The metrics endpoint is exposed on `/metrics` on port `8080` by default and is compatible with prometheus. The following options control the metrics endpoint:
 
-| Enviornment Variable   | Description                                   | Default    |
-|------------------------|-----------------------------------------------|------------|
-| `METRICS_PORT_ENABLED` | Wether or not to enable the metrics endpoint. | `true`     |
-| `METRICS_PORT`         | Port to serve metrics on.                     | `8080`     |
-| `METRICS_PATH`         | Path to serve metrics on                      | `/metrics` |
+| Enviornment Variable   | Description                                                                 | Default    |
+|------------------------|-----------------------------------------------------------------------------|------------|
+| `METRICS_PORT_ENABLED` | Wether or not to enable the metrics endpoint.                               | `true`     |
+| `METRICS_PORT`         | Port to serve metrics on.                                                   | `8080`     |
+| `METRICS_PATH`         | Path to serve metrics on                                                    | `/metrics` |
+| `METRICS_ALWAYS_SYNC`  | Wether or not to wait until metrics have been exported before ending a span | `false`    |
 
 **Note: this server failing to bind to `METRICS_PORT` will not cause the application to fail to start. The error will be logged.**
 

--- a/core/metrics/base.go
+++ b/core/metrics/base.go
@@ -194,6 +194,10 @@ func newBaseHandler(buildInfo config.BuildInfo, extraOpts ...tracesdk.TracerProv
 		logger.Warn("could not merge resources", "error", err)
 	}
 
+	if core.GetEnvBool("METRICS_ALWAYS_SYNC", false) {
+		extraOpts = append(extraOpts, tracesdk.WithSampler(tracesdk.AlwaysSample()))
+	}
+
 	opts := append([]tracesdk.TracerProviderOption{tracesdk.WithResource(rsr)}, extraOpts...)
 
 	// TODO: add a way for users to pass in extra pyroscope options


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**

Allow spans to be sync by setting an environment variable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an environment variable to control metric synchronization behavior, enhancing the flexibility of metric exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->