### PR TITLE
fix(solidity-devops): skip 0.2.0

### DIFF
--- a/packages/solidity-devops/package.json
+++ b/packages/solidity-devops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synapsecns/solidity-devops",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "description": "A collection of utils to effortlessly test, deploy and maintain the smart contracts on EVM compatible blockchains",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
**Description**
Skips tag that was mistakenly created and overriden a while ago:

- https://github.com/synapsecns/sanguine/releases/tag/%40synapsecns%2Fsolidity-devops%400.2.0