### PR TITLE
fix(solidity-devops): set only priority fee until foundry bug is fixed

### DIFF
--- a/packages/solidity-devops/js/utils/chain.js
+++ b/packages/solidity-devops/js/utils/chain.js
@@ -92,11 +92,20 @@ const applyAutoFillGasPrice = (chainName, options) => {
       return options.replace(OPTION_AUTO_FILL_GAS_PRICE_1559, '')
     }
     const priorityFee = gasPrice - baseFee
+    /* 
+    TODO: reenable this once the foundry bug is fixed: https://github.com/foundry-rs/foundry/issues/7486
+    Currently the maxGasPrice is used for both base and priority, rendering the setting of priority fee useless.
+
     // Use 2*base + priority as the max gas price
     const maxGasPrice = 2 * baseFee + priorityFee
     return options.replace(
       OPTION_AUTO_FILL_GAS_PRICE_1559,
       `--with-gas-price ${maxGasPrice} --priority-gas-price ${priorityFee}`
+    )
+    */
+    return options.replace(
+      OPTION_AUTO_FILL_GAS_PRICE_1559,
+      `--priority-gas-price ${priorityFee}`
     )
   }
   return options


### PR DESCRIPTION
**Description**
Temp fix to prevent sending txs with `maxGasFee = maxPriority`, like this one:
- https://sepolia.etherscan.io/tx/0xf8dc43c60ce79d213bd07ba9d615d6030c6345a5a24d8562f1b914b10330047d

**Additional context**
- Caused by https://github.com/foundry-rs/foundry/issues/7486
