### PR TITLE
Adds private to covg aggregator

### DIFF
--- a/packages/coverage-aggregator/package.json
+++ b/packages/coverage-aggregator/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@synapsecns/coverage-aggregator",
-  "version": "1.0.2",
+  "version": "1.0.3",
+  "private": true,
   "description": "Aggregates coverage from js/ts packages",
   "author": "Trajan0x <trajan0x@users.noreply.github.com>",
   "homepage": "https://github.com/synapsecns/sanguine/tree/main/packages/coverage-aggregator#readme",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Marked the `@synapsecns/coverage-aggregator` package as private to prevent unintended publication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->