### PR TITLE
Fe/hide interchain link

### DIFF
--- a/packages/synapse-interface/constants/routes.ts
+++ b/packages/synapse-interface/constants/routes.ts
@@ -53,6 +53,7 @@ export const NAVIGATION: RouteObject = {
     text: 'Explorer',
     match: null,
   },
+  /* Also re-add "Interchain Network" to navigation.json (called from navigation.cy.ts) when turning back on */
   // Contracts: {
   //   path: INTERCHAIN_LINK,
   //   text: 'Interchain Network',

--- a/packages/synapse-interface/constants/routes.ts
+++ b/packages/synapse-interface/constants/routes.ts
@@ -6,7 +6,7 @@ import {
   POOL_PATH,
   LANDING_PATH,
   BRIDGE_PATH,
-  INTERCHAIN_LINK,
+  // INTERCHAIN_LINK,
   SOLANA_BRIDGE_LINK,
 } from './urls'
 
@@ -53,11 +53,11 @@ export const NAVIGATION: RouteObject = {
     text: 'Explorer',
     match: null,
   },
-  Contracts: {
-    path: INTERCHAIN_LINK,
-    text: 'Interchain Network',
-    match: null,
-  },
+  // Contracts: {
+  //   path: INTERCHAIN_LINK,
+  //   text: 'Interchain Network',
+  //   match: null,
+  // },
   Solana: {
     path: SOLANA_BRIDGE_LINK,
     text: 'Solana Bridge',

--- a/packages/synapse-interface/cypress/fixtures/navigation.json
+++ b/packages/synapse-interface/cypress/fixtures/navigation.json
@@ -6,7 +6,6 @@
     "Pools",
     "Stake",
     "Explorer",
-    "Interchain Network",
     "Solana Bridge"
   ]
 }


### PR DESCRIPTION
Hides broken "Interchain Network" link from nav

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Temporarily removed "Interchain Network" from the navigation menu for future re-enablement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
899af9c01a09b4e1488eecd84a961e8fb17a3876: [synapse-interface preview link ](https://sanguine-synapse-interface-7jotunhix-synapsecns.vercel.app)