### PR TITLE
Unify jest versions

### DIFF
--- a/packages/coverage-aggregator/package.json
+++ b/packages/coverage-aggregator/package.json
@@ -28,14 +28,14 @@
     "lint:fix": "npm run lint:check --fix"
   },
   "devDependencies": {
-    "eslint": "^8.16.0",
-    "jest": "^28.1.3"
+    "eslint": "^8.16.0"
   },
   "dependencies": {
     "glob": "^8.0.3",
     "path": "^0.12.7",
-    "ts-jest": "^29.0.5",
-    "yargs": "^17.6.2"
+    "yargs": "^17.6.2",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.2"
   },
   "bin": {
     "aggregate-coverage": "./bin/aggregate-coverage.js"

--- a/packages/synapse-interface/package.json
+++ b/packages/synapse-interface/package.json
@@ -103,8 +103,8 @@
     "@testing-library/react": "^14.0.0",
     "@types/redux-persist": "^4.3.1",
     "dayjs": "^1.11.7",
-    "jest": "^29.6.1",
-    "jest-environment-jsdom": "^29.6.1",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
     "start-server-and-test": "^2.0.0",
     "vercel": "^33.6.2"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6288,14 +6288,7 @@
     "@sentry/types" "5.30.0"
     tslib "^1.9.3"
 
-"@sideway/address@^4.1.3":
-  version "4.1.4"
-  resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.4.tgz#03dccebc6ea47fdc226f7d3d1ad512955d4783f0"
-  integrity sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==
-  dependencies:
-    "@hapi/hoek" "^9.0.0"
-
-"@sideway/address@^4.1.5":
+"@sideway/address@^4.1.3", "@sideway/address@^4.1.5":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.5.tgz#4bc149a0076623ced99ca8208ba780d65a99b9d5"
   integrity sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==
@@ -8458,8 +8451,9 @@
   version "1.0.4"
   dependencies:
     glob "^8.0.3"
+    jest "^29.7.0"
     path "^0.12.7"
-    ts-jest "^29.0.5"
+    ts-jest "^29.1.2"
     yargs "^17.6.2"
 
 "@synapsecns/solidity-devops@^0.1.5":
@@ -21593,18 +21587,18 @@ jest-environment-jsdom@^25.5.0:
     jest-util "^25.5.0"
     jsdom "^15.2.1"
 
-jest-environment-jsdom@^29.6.1:
-  version "29.6.2"
-  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-29.6.2.tgz#4fc68836a7774a771819a2f980cb47af3b1629da"
-  integrity sha512-7oa/+266AAEgkzae8i1awNEfTfjwawWKLpiw2XesZmaoVVj9u9t8JOYx18cG29rbPNtkUlZ8V4b5Jb36y/VxoQ==
+jest-environment-jsdom@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz#d206fa3551933c3fd519e5dfdb58a0f5139a837f"
+  integrity sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==
   dependencies:
-    "@jest/environment" "^29.6.2"
-    "@jest/fake-timers" "^29.6.2"
-    "@jest/types" "^29.6.1"
+    "@jest/environment" "^29.7.0"
+    "@jest/fake-timers" "^29.7.0"
+    "@jest/types" "^29.6.3"
     "@types/jsdom" "^20.0.0"
     "@types/node" "*"
-    jest-mock "^29.6.2"
-    jest-util "^29.6.2"
+    jest-mock "^29.7.0"
+    jest-util "^29.7.0"
     jsdom "^20.0.0"
 
 jest-environment-node@^25.5.0:
@@ -22225,15 +22219,15 @@ jest@^25.3.0:
     import-local "^3.0.2"
     jest-cli "^25.5.4"
 
-jest@^29.6.1:
-  version "29.6.2"
-  resolved "https://registry.yarnpkg.com/jest/-/jest-29.6.2.tgz#3bd55b9fd46a161b2edbdf5f1d1bd0d1eab76c42"
-  integrity sha512-8eQg2mqFbaP7CwfsTpCxQ+sHzw1WuNWL5UUvjnWP4hx2riGz9fPSzYOaU5q8/GqWn1TfgZIVTqYJygbGbWAANg==
+jest@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-29.7.0.tgz#994676fc24177f088f1c5e3737f5697204ff2613"
+  integrity sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==
   dependencies:
-    "@jest/core" "^29.6.2"
-    "@jest/types" "^29.6.1"
+    "@jest/core" "^29.7.0"
+    "@jest/types" "^29.6.3"
     import-local "^3.0.2"
-    jest-cli "^29.6.2"
+    jest-cli "^29.7.0"
 
 jiti@^1.17.1, jiti@^1.18.2:
   version "1.19.1"
@@ -31665,10 +31659,10 @@ ts-jest@^25.3.1:
     semver "6.x"
     yargs-parser "18.x"
 
-ts-jest@^29.0.5:
-  version "29.1.1"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-29.1.1.tgz#f58fe62c63caf7bfcc5cc6472082f79180f0815b"
-  integrity sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==
+ts-jest@^29.1.2:
+  version "29.1.2"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-29.1.2.tgz#7613d8c81c43c8cb312c6904027257e814c40e09"
+  integrity sha512-br6GJoH/WUX4pu7FbZXuWGKGNDuU7b8Uj77g/Sp7puZV6EXzuByl6JrECvm0MzVzSTkSHWTihsXt+5XYER5b+g==
   dependencies:
     bs-logger "0.x"
     fast-json-stable-stringify "2.x"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Jest and ts-jest to their latest versions for improved testing capabilities.
	- Removed unused `eslint` dependency to streamline development dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
d4d5e7d526714128548f597ce0be49adee985377: [synapse-interface preview link ](https://sanguine-synapse-interface-cug96el5v-synapsecns.vercel.app)