### PR TITLE
fix(contracts-communication): Integration tests for message bus, testnet deployment

### DIFF
--- a/packages/contracts-communication/configs/global/LegacyPingPong.testnet.json
+++ b/packages/contracts-communication/configs/global/LegacyPingPong.testnet.json
@@ -1,0 +1,4 @@
+{
+  "chains": ["arb_sepolia", "eth_sepolia"],
+  "gasLimit": 500000
+}

--- a/packages/contracts-communication/configs/global/MessageBus.testnet.json
+++ b/packages/contracts-communication/configs/global/MessageBus.testnet.json
@@ -1,0 +1,12 @@
+{
+  "chains": ["arb_sepolia", "eth_sepolia"],
+  "interchainClients": ["InterchainClientV1"],
+  "latestInterchainClient": "InterchainClientV1",
+  "trustedModules": ["SynapseModule"],
+  "appConfig": {
+    "0_requiredResponses": 1,
+    "1_optimisticPeriod": 30
+  },
+  "messageLengthEstimate": 1024
+}
+

--- a/packages/contracts-communication/contracts/legacy/LegacyPingPong.sol
+++ b/packages/contracts-communication/contracts/legacy/LegacyPingPong.sol
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {LegacyOptionsLib} from "./libs/LegacyOptions.sol";
+import {LegacyReceiver} from "./LegacyReceiver.sol";
+
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+/// @notice A simple app that sends a message to the remote PingPongApp, which will respond with a message back.
+/// This app can be loaded with a native asset, which will be used to pay for the messages sent.
+/// Note: we deal with uint256 chain IDs in this contract as the legacy MessageBus contract is using uint256 chain IDs.
+contract PingPongApp is LegacyReceiver {
+    uint256 internal constant MESSAGE_LENGTH = 32;
+    uint256 internal constant DEFAULT_GAS_LIMIT = 500_000;
+    uint256 public gasLimit;
+
+    event GasLimitSet(uint256 gasLimit);
+    event PingDisrupted(uint256 counter);
+    event PingReceived(uint256 counter);
+    event PingSent(uint256 counter);
+
+    constructor(address owner_) LegacyReceiver(owner_) {
+        _setGasLimit(DEFAULT_GAS_LIMIT);
+    }
+
+    /// @notice Enables the contract to accept native asset.
+    receive() external payable {}
+
+    /// @notice Allows the Owner to set the gas limit for the interchain messages.
+    function setGasLimit(uint256 gasLimit_) external onlyOwner {
+        _setGasLimit(gasLimit_);
+    }
+
+    /// @notice Allows the Owner to withdraw the native asset from the contract.
+    function withdraw() external onlyOwner {
+        Address.sendValue(payable(msg.sender), address(this).balance);
+    }
+
+    /// @notice Starts the ping-pong message exchange with the remote PingPongApp.
+    function startPingPong(uint256 dstChainId, uint256 counter) external {
+        _sendPingPongMessage({dstChainId: dstChainId, counter: counter, lowBalanceRevert: true});
+    }
+
+    /// @notice Returns the fee to send a single ping message to the remote PingPongApp.
+    function getPingFee(uint256 dstChainId) public view returns (uint256) {
+        return _getMessageFee({dstChainId: dstChainId, gasLimit: gasLimit, messageLen: MESSAGE_LENGTH});
+    }
+
+    /// @dev Handle the verified message.
+    function _handleMessage(
+        bytes32, // srcAddress
+        uint256 srcChainId,
+        bytes calldata message,
+        address // executor
+    )
+        internal
+        override
+    {
+        uint256 counter = abi.decode(message, (uint256));
+        emit PingReceived(counter);
+        if (counter > 0) {
+            _sendPingPongMessage({dstChainId: srcChainId, counter: counter - 1, lowBalanceRevert: false});
+        }
+    }
+
+    /// @dev Sends a message to the PingPongApp on the remote chain.
+    /// If `counter > 0`, the remote app will respond with a message to this app, decrementing the counter.
+    /// Once the counter reaches 0, the remote app will not respond.
+    function _sendPingPongMessage(uint256 dstChainId, uint256 counter, bool lowBalanceRevert) internal {
+        uint256 pingFee = getPingFee(dstChainId);
+        if (address(this).balance < pingFee && !lowBalanceRevert) {
+            emit PingDisrupted(counter);
+            return;
+        }
+        bytes memory message = abi.encode(counter);
+        _sendMessage({dstChainId: dstChainId, messageFee: pingFee, gasLimit: gasLimit, message: message});
+        emit PingSent(counter);
+    }
+
+    /// @dev Sets the gas limit for the interchain messages.
+    function _setGasLimit(uint256 gasLimit_) internal {
+        gasLimit = gasLimit_;
+        emit GasLimitSet(gasLimit_);
+    }
+}

--- a/packages/contracts-communication/contracts/legacy/LegacyPingPong.sol
+++ b/packages/contracts-communication/contracts/legacy/LegacyPingPong.sol
@@ -9,7 +9,7 @@ import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 /// @notice A simple app that sends a message to the remote PingPongApp, which will respond with a message back.
 /// This app can be loaded with a native asset, which will be used to pay for the messages sent.
 /// Note: we deal with uint256 chain IDs in this contract as the legacy MessageBus contract is using uint256 chain IDs.
-contract PingPongApp is LegacyReceiver {
+contract LegacyPingPong is LegacyReceiver {
     uint256 internal constant MESSAGE_LENGTH = 32;
     uint256 internal constant DEFAULT_GAS_LIMIT = 500_000;
     uint256 public gasLimit;

--- a/packages/contracts-communication/contracts/legacy/LegacyReceiver.sol
+++ b/packages/contracts-communication/contracts/legacy/LegacyReceiver.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {LegacyReceiverEvents} from "./events/LegacyReceiverEvents.sol";
+import {ILegacyReceiver} from "./interfaces/ILegacyReceiver.sol";
+import {IMessageBus} from "./interfaces/IMessageBus.sol";
+import {LegacyOptionsLib} from "./libs/LegacyOptions.sol";
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+abstract contract LegacyReceiver is Ownable, LegacyReceiverEvents, ILegacyReceiver {
+    address public messageBus;
+    mapping(uint256 chainId => bytes32 trustedRemote) public trustedRemotes;
+
+    error LegacyReceiver__BalanceTooLow(uint256 actual, uint256 required);
+    error LegacyReceiver__NotMessageBus(address caller);
+    error LegacyReceiver__NotTrustedRemote(uint256 chainId, bytes32 srcCaller);
+    error LegacyReceiver__SameChainId(uint256 chainId);
+    error LegacyReceiver__TrustedRemoteNotSet(uint256 chainId);
+
+    constructor(address owner_) Ownable(owner_) {}
+
+    function setMessageBus(address messageBus_) external onlyOwner {
+        messageBus = messageBus_;
+        emit MessageBusSet(messageBus_);
+    }
+
+    function setTrustedRemote(uint256 remoteChainId, bytes32 remoteApp) external onlyOwner {
+        if (remoteChainId == block.chainid) {
+            revert LegacyReceiver__SameChainId(remoteChainId);
+        }
+        trustedRemotes[remoteChainId] = remoteApp;
+        emit TrustedRemoteSet(remoteChainId, remoteApp);
+    }
+
+    function executeMessage(
+        bytes32 srcAddress,
+        uint256 srcChainId,
+        bytes calldata message,
+        address executor
+    )
+        external
+    {
+        if (msg.sender != messageBus) {
+            revert LegacyReceiver__NotMessageBus(msg.sender);
+        }
+        if (trustedRemotes[srcChainId] != srcAddress) {
+            revert LegacyReceiver__NotTrustedRemote(srcChainId, srcAddress);
+        }
+        _handleMessage(srcAddress, srcChainId, message, executor);
+    }
+
+    /// @dev Handle the verified message.
+    function _handleMessage(
+        bytes32 srcAddress,
+        uint256 srcChainId,
+        bytes calldata message,
+        address executor
+    )
+        internal
+        virtual;
+
+    /// @dev Sends a message to the trusted remote app.
+    function _sendMessage(uint256 dstChainId, uint256 messageFee, uint256 gasLimit, bytes memory message) internal {
+        bytes32 dstRemote = trustedRemotes[dstChainId];
+        if (dstRemote == 0) {
+            revert LegacyReceiver__TrustedRemoteNotSet(dstChainId);
+        }
+        if (address(this).balance < messageFee) {
+            revert LegacyReceiver__BalanceTooLow(address(this).balance, messageFee);
+        }
+        bytes memory options = LegacyOptionsLib.encodeLegacyOptions(gasLimit);
+        IMessageBus(messageBus).sendMessage{value: messageFee}({
+            receiver: dstRemote,
+            dstChainId: dstChainId,
+            message: message,
+            options: options
+        });
+    }
+
+    /// @notice Calculates the fee to send a message to the remote app.
+    function _getMessageFee(
+        uint256 dstChainId,
+        uint256 gasLimit,
+        uint256 messageLen
+    )
+        internal
+        view
+        returns (uint256 fee)
+    {
+        bytes memory options = LegacyOptionsLib.encodeLegacyOptions(gasLimit);
+        fee = IMessageBus(messageBus).estimateFeeExact(dstChainId, options, messageLen);
+    }
+}

--- a/packages/contracts-communication/contracts/legacy/MessageBus.sol
+++ b/packages/contracts-communication/contracts/legacy/MessageBus.sol
@@ -80,7 +80,8 @@ contract MessageBus is ICAppV1, MessageBusEvents, IMessageBus {
         view
         returns (uint256)
     {
-        return _getMessageFee({dstChainId: dstChainId, options: _icOptionsV1(options), messageLen: messageLen});
+        uint256 legacyMsgLen = LegacyMessageLib.payloadSize(messageLen);
+        return _getMessageFee({dstChainId: dstChainId, options: _icOptionsV1(options), messageLen: legacyMsgLen});
     }
 
     /// @dev Internal logic for receiving messages. At this point the validity of the message is already checked.

--- a/packages/contracts-communication/contracts/legacy/events/LegacyReceiverEvents.sol
+++ b/packages/contracts-communication/contracts/legacy/events/LegacyReceiverEvents.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+abstract contract LegacyReceiverEvents {
+    event MessageBusSet(address messageBus);
+    event TrustedRemoteSet(uint256 chainId, bytes32 trustedRemote);
+}

--- a/packages/contracts-communication/contracts/legacy/libs/LegacyMessage.sol
+++ b/packages/contracts-communication/contracts/legacy/libs/LegacyMessage.sol
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import {MathLib} from "../../libs/Math.sol";
+
 library LegacyMessageLib {
+    using MathLib for uint256;
+
     /// @notice Encodes a message to be sent through the Legacy MessageBus.
     /// @param srcSender    The address of the sender on the source chain
     /// @param dstReceiver  The address of the receiver on the destination chain
@@ -33,5 +37,13 @@ library LegacyMessageLib {
         returns (address srcSender, address dstReceiver, uint64 srcNonce, bytes memory message)
     {
         return abi.decode(legacyMsg, (address, address, uint64, bytes));
+    }
+
+    /// @notice Returns the length of encoded legacy message, that has message field of given length.
+    /// @param messageLen   The length of the message field
+    function payloadSize(uint256 messageLen) internal pure returns (uint256) {
+        // 4 fields * 32 bytes (3 values for static, 1 offset for dynamic) + 1 * 32 bytes (message length)
+        // message is dynamic field, which is padded up to 32 bytes
+        return 160 + messageLen.roundUpToWord();
     }
 }

--- a/packages/contracts-communication/deployments/arb_sepolia/LegacyPingPong.json
+++ b/packages/contracts-communication/deployments/arb_sepolia/LegacyPingPong.json
@@ -1,0 +1,425 @@
+{
+  "address": "0x9E801D4Ca57c3cC4C6Cc0ec24DDFd26e354a08C4",
+  "constructorArgs": "0x000000000000000000000000e7353bedc72d29f99d6ca5cde69f807cce5d57e4",
+  "receipt": {
+    "hash": "0xe302839855735a2a22e17b5a1613a94b42332a2d50137718f1d5f8ba6c801c0d",
+    "blockNumber": 30708907
+  },
+  "abi": [
+    {
+      "type": "constructor",
+      "inputs": [
+        {
+          "name": "owner_",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "receive",
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "executeMessage",
+      "inputs": [
+        {
+          "name": "srcAddress",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        },
+        {
+          "name": "srcChainId",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "message",
+          "type": "bytes",
+          "internalType": "bytes"
+        },
+        {
+          "name": "executor",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "gasLimit",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getPingFee",
+      "inputs": [
+        {
+          "name": "dstChainId",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "messageBus",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "owner",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "renounceOwnership",
+      "inputs": [],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setGasLimit",
+      "inputs": [
+        {
+          "name": "gasLimit_",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setMessageBus",
+      "inputs": [
+        {
+          "name": "messageBus_",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setTrustedRemote",
+      "inputs": [
+        {
+          "name": "remoteChainId",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "remoteApp",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "startPingPong",
+      "inputs": [
+        {
+          "name": "dstChainId",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "counter",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "transferOwnership",
+      "inputs": [
+        {
+          "name": "newOwner",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "trustedRemotes",
+      "inputs": [
+        {
+          "name": "chainId",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "trustedRemote",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "withdraw",
+      "inputs": [],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "event",
+      "name": "GasLimitSet",
+      "inputs": [
+        {
+          "name": "gasLimit",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "MessageBusSet",
+      "inputs": [
+        {
+          "name": "messageBus",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "OwnershipTransferred",
+      "inputs": [
+        {
+          "name": "previousOwner",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "newOwner",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "PingDisrupted",
+      "inputs": [
+        {
+          "name": "counter",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "PingReceived",
+      "inputs": [
+        {
+          "name": "counter",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "PingSent",
+      "inputs": [
+        {
+          "name": "counter",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "TrustedRemoteSet",
+      "inputs": [
+        {
+          "name": "chainId",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "trustedRemote",
+          "type": "bytes32",
+          "indexed": false,
+          "internalType": "bytes32"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "error",
+      "name": "AddressInsufficientBalance",
+      "inputs": [
+        {
+          "name": "account",
+          "type": "address",
+          "internalType": "address"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "FailedInnerCall",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "LegacyReceiver__BalanceTooLow",
+      "inputs": [
+        {
+          "name": "actual",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "required",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "LegacyReceiver__NotMessageBus",
+      "inputs": [
+        {
+          "name": "caller",
+          "type": "address",
+          "internalType": "address"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "LegacyReceiver__NotTrustedRemote",
+      "inputs": [
+        {
+          "name": "chainId",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "srcCaller",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "LegacyReceiver__SameChainId",
+      "inputs": [
+        {
+          "name": "chainId",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "LegacyReceiver__TrustedRemoteNotSet",
+      "inputs": [
+        {
+          "name": "chainId",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "OwnableInvalidOwner",
+      "inputs": [
+        {
+          "name": "owner",
+          "type": "address",
+          "internalType": "address"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "OwnableUnauthorizedAccount",
+      "inputs": [
+        {
+          "name": "account",
+          "type": "address",
+          "internalType": "address"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/contracts-communication/deployments/arb_sepolia/MessageBus.json
+++ b/packages/contracts-communication/deployments/arb_sepolia/MessageBus.json
@@ -1,0 +1,1132 @@
+{
+  "address": "0x08DE617d00e0D6533d2CaB4a67caB268000dec54",
+  "constructorArgs": "0x000000000000000000000000e7353bedc72d29f99d6ca5cde69f807cce5d57e4",
+  "receipt": {
+    "hash": "0x260f57e7cf093dcf92a420007fbd34a848f179d2b8be44ce73a41024bd5199ca",
+    "blockNumber": 30708802
+  },
+  "abi": [
+    {
+      "type": "constructor",
+      "inputs": [
+        {
+          "name": "admin",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "DEFAULT_ADMIN_ROLE",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "IC_GOVERNOR_ROLE",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "addInterchainClient",
+      "inputs": [
+        {
+          "name": "client",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "updateLatest",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "addTrustedModule",
+      "inputs": [
+        {
+          "name": "module",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "appReceive",
+      "inputs": [
+        {
+          "name": "srcChainId",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "sender",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        },
+        {
+          "name": "dbNonce",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "entryIndex",
+          "type": "uint64",
+          "internalType": "uint64"
+        },
+        {
+          "name": "message",
+          "type": "bytes",
+          "internalType": "bytes"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "estimateFee",
+      "inputs": [
+        {
+          "name": "dstChainId",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "options",
+          "type": "bytes",
+          "internalType": "bytes"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "estimateFeeExact",
+      "inputs": [
+        {
+          "name": "dstChainId",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "options",
+          "type": "bytes",
+          "internalType": "bytes"
+        },
+        {
+          "name": "messageLen",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getAppConfigV1",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct AppConfigV1",
+          "components": [
+            {
+              "name": "requiredResponses",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "optimisticPeriod",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getExecutionService",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getInterchainClients",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address[]",
+          "internalType": "address[]"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getLatestInterchainClient",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getLinkedApp",
+      "inputs": [
+        {
+          "name": "chainId",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getLinkedAppEVM",
+      "inputs": [
+        {
+          "name": "chainId",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "linkedAppEVM",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getModules",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address[]",
+          "internalType": "address[]"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getReceivingConfig",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "appConfig",
+          "type": "bytes",
+          "internalType": "bytes"
+        },
+        {
+          "name": "modules",
+          "type": "address[]",
+          "internalType": "address[]"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getRoleAdmin",
+      "inputs": [
+        {
+          "name": "role",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getRoleMember",
+      "inputs": [
+        {
+          "name": "role",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        },
+        {
+          "name": "index",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getRoleMemberCount",
+      "inputs": [
+        {
+          "name": "role",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "grantRole",
+      "inputs": [
+        {
+          "name": "role",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        },
+        {
+          "name": "account",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "hasRole",
+      "inputs": [
+        {
+          "name": "role",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        },
+        {
+          "name": "account",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "linkRemoteApp",
+      "inputs": [
+        {
+          "name": "chainId",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "remoteApp",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "linkRemoteAppEVM",
+      "inputs": [
+        {
+          "name": "chainId",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "remoteApp",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "messageLengthEstimate",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "nonce",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint64",
+          "internalType": "uint64"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "removeInterchainClient",
+      "inputs": [
+        {
+          "name": "client",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "removeTrustedModule",
+      "inputs": [
+        {
+          "name": "module",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "renounceRole",
+      "inputs": [
+        {
+          "name": "role",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        },
+        {
+          "name": "callerConfirmation",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "revokeRole",
+      "inputs": [
+        {
+          "name": "role",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        },
+        {
+          "name": "account",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "sendMessage",
+      "inputs": [
+        {
+          "name": "receiver",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        },
+        {
+          "name": "dstChainId",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "message",
+          "type": "bytes",
+          "internalType": "bytes"
+        },
+        {
+          "name": "options",
+          "type": "bytes",
+          "internalType": "bytes"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "setAppConfigV1",
+      "inputs": [
+        {
+          "name": "appConfig",
+          "type": "tuple",
+          "internalType": "struct AppConfigV1",
+          "components": [
+            {
+              "name": "requiredResponses",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "optimisticPeriod",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setExecutionService",
+      "inputs": [
+        {
+          "name": "executionService",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setLatestInterchainClient",
+      "inputs": [
+        {
+          "name": "client",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setMessageLengthEstimate",
+      "inputs": [
+        {
+          "name": "length",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "supportsInterface",
+      "inputs": [
+        {
+          "name": "interfaceId",
+          "type": "bytes4",
+          "internalType": "bytes4"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "event",
+      "name": "AppConfigV1Set",
+      "inputs": [
+        {
+          "name": "requiredResponses",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "optimisticPeriod",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "AppLinked",
+      "inputs": [
+        {
+          "name": "chainId",
+          "type": "uint256",
+          "indexed": true,
+          "internalType": "uint256"
+        },
+        {
+          "name": "remoteApp",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "Executed",
+      "inputs": [
+        {
+          "name": "messageId",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "status",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "enum MessageBusEvents.TxStatus"
+        },
+        {
+          "name": "dstAddress",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "srcChainId",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        },
+        {
+          "name": "srcNonce",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ExecutionServiceSet",
+      "inputs": [
+        {
+          "name": "executionService",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "InterchainClientAdded",
+      "inputs": [
+        {
+          "name": "client",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "InterchainClientRemoved",
+      "inputs": [
+        {
+          "name": "client",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "LatestClientSet",
+      "inputs": [
+        {
+          "name": "client",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "MessageLengthEstimateSet",
+      "inputs": [
+        {
+          "name": "length",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "MessageSent",
+      "inputs": [
+        {
+          "name": "sender",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "srcChainID",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "receiver",
+          "type": "bytes32",
+          "indexed": false,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "dstChainId",
+          "type": "uint256",
+          "indexed": true,
+          "internalType": "uint256"
+        },
+        {
+          "name": "message",
+          "type": "bytes",
+          "indexed": false,
+          "internalType": "bytes"
+        },
+        {
+          "name": "nonce",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        },
+        {
+          "name": "options",
+          "type": "bytes",
+          "indexed": false,
+          "internalType": "bytes"
+        },
+        {
+          "name": "fee",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "messageId",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "RoleAdminChanged",
+      "inputs": [
+        {
+          "name": "role",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "previousAdminRole",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "newAdminRole",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "RoleGranted",
+      "inputs": [
+        {
+          "name": "role",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "account",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "sender",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "RoleRevoked",
+      "inputs": [
+        {
+          "name": "role",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "account",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "sender",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "TrustedModuleAdded",
+      "inputs": [
+        {
+          "name": "module",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "TrustedModuleRemoved",
+      "inputs": [
+        {
+          "name": "module",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "error",
+      "name": "AccessControlBadConfirmation",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "AccessControlUnauthorizedAccount",
+      "inputs": [
+        {
+          "name": "account",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "neededRole",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "InterchainApp__AlreadyLatestClient",
+      "inputs": [
+        {
+          "name": "client",
+          "type": "address",
+          "internalType": "address"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "InterchainApp__AppZeroAddress",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "InterchainApp__BalanceTooLow",
+      "inputs": [
+        {
+          "name": "actual",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "required",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "InterchainApp__ClientAlreadyAdded",
+      "inputs": [
+        {
+          "name": "client",
+          "type": "address",
+          "internalType": "address"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "InterchainApp__InterchainClientZeroAddress",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "InterchainApp__InvalidAppConfig",
+      "inputs": [
+        {
+          "name": "requiredResponses",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "optimisticPeriod",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "InterchainApp__ModuleAlreadyAdded",
+      "inputs": [
+        {
+          "name": "module",
+          "type": "address",
+          "internalType": "address"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "InterchainApp__ModuleNotAdded",
+      "inputs": [
+        {
+          "name": "module",
+          "type": "address",
+          "internalType": "address"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "InterchainApp__ModuleZeroAddress",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "InterchainApp__NotEVMLinkedApp",
+      "inputs": [
+        {
+          "name": "linkedApp",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "InterchainApp__NotInterchainClient",
+      "inputs": [
+        {
+          "name": "account",
+          "type": "address",
+          "internalType": "address"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "InterchainApp__ReceiverNotSet",
+      "inputs": [
+        {
+          "name": "chainId",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "InterchainApp__SameChainId",
+      "inputs": [
+        {
+          "name": "chainId",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "InterchainApp__SenderNotAllowed",
+      "inputs": [
+        {
+          "name": "srcChainId",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "sender",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "LegacyOptionsLib__InvalidOptions",
+      "inputs": [
+        {
+          "name": "legacyOpts",
+          "type": "bytes",
+          "internalType": "bytes"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "MessageBus__NotEVMReceiver",
+      "inputs": [
+        {
+          "name": "receiver",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/contracts-communication/deployments/eth_sepolia/LegacyPingPong.json
+++ b/packages/contracts-communication/deployments/eth_sepolia/LegacyPingPong.json
@@ -1,0 +1,425 @@
+{
+  "address": "0xA98D97728FBF57dBCFcd045DC2b41A91e571A4bA",
+  "constructorArgs": "0x000000000000000000000000e7353bedc72d29f99d6ca5cde69f807cce5d57e4",
+  "receipt": {
+    "hash": "0xc31165d3a89fb5e87de597f0ab49901f12c726449e0e31e6f46403d86d65813b",
+    "blockNumber": 5637309
+  },
+  "abi": [
+    {
+      "type": "constructor",
+      "inputs": [
+        {
+          "name": "owner_",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "receive",
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "executeMessage",
+      "inputs": [
+        {
+          "name": "srcAddress",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        },
+        {
+          "name": "srcChainId",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "message",
+          "type": "bytes",
+          "internalType": "bytes"
+        },
+        {
+          "name": "executor",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "gasLimit",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getPingFee",
+      "inputs": [
+        {
+          "name": "dstChainId",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "messageBus",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "owner",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "renounceOwnership",
+      "inputs": [],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setGasLimit",
+      "inputs": [
+        {
+          "name": "gasLimit_",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setMessageBus",
+      "inputs": [
+        {
+          "name": "messageBus_",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setTrustedRemote",
+      "inputs": [
+        {
+          "name": "remoteChainId",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "remoteApp",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "startPingPong",
+      "inputs": [
+        {
+          "name": "dstChainId",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "counter",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "transferOwnership",
+      "inputs": [
+        {
+          "name": "newOwner",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "trustedRemotes",
+      "inputs": [
+        {
+          "name": "chainId",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "trustedRemote",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "withdraw",
+      "inputs": [],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "event",
+      "name": "GasLimitSet",
+      "inputs": [
+        {
+          "name": "gasLimit",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "MessageBusSet",
+      "inputs": [
+        {
+          "name": "messageBus",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "OwnershipTransferred",
+      "inputs": [
+        {
+          "name": "previousOwner",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "newOwner",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "PingDisrupted",
+      "inputs": [
+        {
+          "name": "counter",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "PingReceived",
+      "inputs": [
+        {
+          "name": "counter",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "PingSent",
+      "inputs": [
+        {
+          "name": "counter",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "TrustedRemoteSet",
+      "inputs": [
+        {
+          "name": "chainId",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "trustedRemote",
+          "type": "bytes32",
+          "indexed": false,
+          "internalType": "bytes32"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "error",
+      "name": "AddressInsufficientBalance",
+      "inputs": [
+        {
+          "name": "account",
+          "type": "address",
+          "internalType": "address"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "FailedInnerCall",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "LegacyReceiver__BalanceTooLow",
+      "inputs": [
+        {
+          "name": "actual",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "required",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "LegacyReceiver__NotMessageBus",
+      "inputs": [
+        {
+          "name": "caller",
+          "type": "address",
+          "internalType": "address"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "LegacyReceiver__NotTrustedRemote",
+      "inputs": [
+        {
+          "name": "chainId",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "srcCaller",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "LegacyReceiver__SameChainId",
+      "inputs": [
+        {
+          "name": "chainId",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "LegacyReceiver__TrustedRemoteNotSet",
+      "inputs": [
+        {
+          "name": "chainId",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "OwnableInvalidOwner",
+      "inputs": [
+        {
+          "name": "owner",
+          "type": "address",
+          "internalType": "address"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "OwnableUnauthorizedAccount",
+      "inputs": [
+        {
+          "name": "account",
+          "type": "address",
+          "internalType": "address"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/contracts-communication/deployments/eth_sepolia/MessageBus.json
+++ b/packages/contracts-communication/deployments/eth_sepolia/MessageBus.json
@@ -1,0 +1,1132 @@
+{
+  "address": "0xCCD3DC75EBFe4aa1a4792D9c1730786651Bcf4C5",
+  "constructorArgs": "0x000000000000000000000000e7353bedc72d29f99d6ca5cde69f807cce5d57e4",
+  "receipt": {
+    "hash": "0xdda9ee83ee443d52ba54cd831badc5f9ef00bf5d5cbfe9cff988130b49d68db7",
+    "blockNumber": 5637304
+  },
+  "abi": [
+    {
+      "type": "constructor",
+      "inputs": [
+        {
+          "name": "admin",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "DEFAULT_ADMIN_ROLE",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "IC_GOVERNOR_ROLE",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "addInterchainClient",
+      "inputs": [
+        {
+          "name": "client",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "updateLatest",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "addTrustedModule",
+      "inputs": [
+        {
+          "name": "module",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "appReceive",
+      "inputs": [
+        {
+          "name": "srcChainId",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "sender",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        },
+        {
+          "name": "dbNonce",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "entryIndex",
+          "type": "uint64",
+          "internalType": "uint64"
+        },
+        {
+          "name": "message",
+          "type": "bytes",
+          "internalType": "bytes"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "estimateFee",
+      "inputs": [
+        {
+          "name": "dstChainId",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "options",
+          "type": "bytes",
+          "internalType": "bytes"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "estimateFeeExact",
+      "inputs": [
+        {
+          "name": "dstChainId",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "options",
+          "type": "bytes",
+          "internalType": "bytes"
+        },
+        {
+          "name": "messageLen",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getAppConfigV1",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct AppConfigV1",
+          "components": [
+            {
+              "name": "requiredResponses",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "optimisticPeriod",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getExecutionService",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getInterchainClients",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address[]",
+          "internalType": "address[]"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getLatestInterchainClient",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getLinkedApp",
+      "inputs": [
+        {
+          "name": "chainId",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getLinkedAppEVM",
+      "inputs": [
+        {
+          "name": "chainId",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "linkedAppEVM",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getModules",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address[]",
+          "internalType": "address[]"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getReceivingConfig",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "appConfig",
+          "type": "bytes",
+          "internalType": "bytes"
+        },
+        {
+          "name": "modules",
+          "type": "address[]",
+          "internalType": "address[]"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getRoleAdmin",
+      "inputs": [
+        {
+          "name": "role",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getRoleMember",
+      "inputs": [
+        {
+          "name": "role",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        },
+        {
+          "name": "index",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getRoleMemberCount",
+      "inputs": [
+        {
+          "name": "role",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "grantRole",
+      "inputs": [
+        {
+          "name": "role",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        },
+        {
+          "name": "account",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "hasRole",
+      "inputs": [
+        {
+          "name": "role",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        },
+        {
+          "name": "account",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "linkRemoteApp",
+      "inputs": [
+        {
+          "name": "chainId",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "remoteApp",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "linkRemoteAppEVM",
+      "inputs": [
+        {
+          "name": "chainId",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "remoteApp",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "messageLengthEstimate",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "nonce",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint64",
+          "internalType": "uint64"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "removeInterchainClient",
+      "inputs": [
+        {
+          "name": "client",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "removeTrustedModule",
+      "inputs": [
+        {
+          "name": "module",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "renounceRole",
+      "inputs": [
+        {
+          "name": "role",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        },
+        {
+          "name": "callerConfirmation",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "revokeRole",
+      "inputs": [
+        {
+          "name": "role",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        },
+        {
+          "name": "account",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "sendMessage",
+      "inputs": [
+        {
+          "name": "receiver",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        },
+        {
+          "name": "dstChainId",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "message",
+          "type": "bytes",
+          "internalType": "bytes"
+        },
+        {
+          "name": "options",
+          "type": "bytes",
+          "internalType": "bytes"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "setAppConfigV1",
+      "inputs": [
+        {
+          "name": "appConfig",
+          "type": "tuple",
+          "internalType": "struct AppConfigV1",
+          "components": [
+            {
+              "name": "requiredResponses",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "optimisticPeriod",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setExecutionService",
+      "inputs": [
+        {
+          "name": "executionService",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setLatestInterchainClient",
+      "inputs": [
+        {
+          "name": "client",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setMessageLengthEstimate",
+      "inputs": [
+        {
+          "name": "length",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "supportsInterface",
+      "inputs": [
+        {
+          "name": "interfaceId",
+          "type": "bytes4",
+          "internalType": "bytes4"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "event",
+      "name": "AppConfigV1Set",
+      "inputs": [
+        {
+          "name": "requiredResponses",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "optimisticPeriod",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "AppLinked",
+      "inputs": [
+        {
+          "name": "chainId",
+          "type": "uint256",
+          "indexed": true,
+          "internalType": "uint256"
+        },
+        {
+          "name": "remoteApp",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "Executed",
+      "inputs": [
+        {
+          "name": "messageId",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "status",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "enum MessageBusEvents.TxStatus"
+        },
+        {
+          "name": "dstAddress",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "srcChainId",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        },
+        {
+          "name": "srcNonce",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ExecutionServiceSet",
+      "inputs": [
+        {
+          "name": "executionService",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "InterchainClientAdded",
+      "inputs": [
+        {
+          "name": "client",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "InterchainClientRemoved",
+      "inputs": [
+        {
+          "name": "client",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "LatestClientSet",
+      "inputs": [
+        {
+          "name": "client",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "MessageLengthEstimateSet",
+      "inputs": [
+        {
+          "name": "length",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "MessageSent",
+      "inputs": [
+        {
+          "name": "sender",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "srcChainID",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "receiver",
+          "type": "bytes32",
+          "indexed": false,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "dstChainId",
+          "type": "uint256",
+          "indexed": true,
+          "internalType": "uint256"
+        },
+        {
+          "name": "message",
+          "type": "bytes",
+          "indexed": false,
+          "internalType": "bytes"
+        },
+        {
+          "name": "nonce",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        },
+        {
+          "name": "options",
+          "type": "bytes",
+          "indexed": false,
+          "internalType": "bytes"
+        },
+        {
+          "name": "fee",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "messageId",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "RoleAdminChanged",
+      "inputs": [
+        {
+          "name": "role",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "previousAdminRole",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "newAdminRole",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "RoleGranted",
+      "inputs": [
+        {
+          "name": "role",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "account",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "sender",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "RoleRevoked",
+      "inputs": [
+        {
+          "name": "role",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "account",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "sender",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "TrustedModuleAdded",
+      "inputs": [
+        {
+          "name": "module",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "TrustedModuleRemoved",
+      "inputs": [
+        {
+          "name": "module",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "error",
+      "name": "AccessControlBadConfirmation",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "AccessControlUnauthorizedAccount",
+      "inputs": [
+        {
+          "name": "account",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "neededRole",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "InterchainApp__AlreadyLatestClient",
+      "inputs": [
+        {
+          "name": "client",
+          "type": "address",
+          "internalType": "address"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "InterchainApp__AppZeroAddress",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "InterchainApp__BalanceTooLow",
+      "inputs": [
+        {
+          "name": "actual",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "required",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "InterchainApp__ClientAlreadyAdded",
+      "inputs": [
+        {
+          "name": "client",
+          "type": "address",
+          "internalType": "address"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "InterchainApp__InterchainClientZeroAddress",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "InterchainApp__InvalidAppConfig",
+      "inputs": [
+        {
+          "name": "requiredResponses",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "optimisticPeriod",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "InterchainApp__ModuleAlreadyAdded",
+      "inputs": [
+        {
+          "name": "module",
+          "type": "address",
+          "internalType": "address"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "InterchainApp__ModuleNotAdded",
+      "inputs": [
+        {
+          "name": "module",
+          "type": "address",
+          "internalType": "address"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "InterchainApp__ModuleZeroAddress",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "InterchainApp__NotEVMLinkedApp",
+      "inputs": [
+        {
+          "name": "linkedApp",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "InterchainApp__NotInterchainClient",
+      "inputs": [
+        {
+          "name": "account",
+          "type": "address",
+          "internalType": "address"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "InterchainApp__ReceiverNotSet",
+      "inputs": [
+        {
+          "name": "chainId",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "InterchainApp__SameChainId",
+      "inputs": [
+        {
+          "name": "chainId",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "InterchainApp__SenderNotAllowed",
+      "inputs": [
+        {
+          "name": "srcChainId",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "sender",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "LegacyOptionsLib__InvalidOptions",
+      "inputs": [
+        {
+          "name": "legacyOpts",
+          "type": "bytes",
+          "internalType": "bytes"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "MessageBus__NotEVMReceiver",
+      "inputs": [
+        {
+          "name": "receiver",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/contracts-communication/script/config/ConfigureAppV1.s.sol
+++ b/packages/contracts-communication/script/config/ConfigureAppV1.s.sol
@@ -8,8 +8,6 @@ import {TypeCasts} from "../../contracts/libs/TypeCasts.sol";
 
 import {stdJson, SynapseScript} from "@synapsecns/solidity-devops/src/SynapseScript.sol";
 
-// solhint-disable code-complexity
-// solhint-disable custom-errors
 abstract contract ConfigureAppV1 is SynapseScript {
     using stdJson for string;
 
@@ -24,6 +22,7 @@ abstract contract ConfigureAppV1 is SynapseScript {
 
     function run(string memory environment) external virtual broadcastWithHooks {
         loadConfig(environment);
+        beforeAppConfigured();
         linkRemoteChains();
         syncTrustedModules();
         setAppConfig();
@@ -175,6 +174,9 @@ abstract contract ConfigureAppV1 is SynapseScript {
             printLog(string.concat("Added ", vm.toString(added), " clients, removed ", vm.toString(removed)));
         }
     }
+
+    // solhint-disable-next-line no-empty-blocks
+    function beforeAppConfigured() internal virtual {}
 
     // solhint-disable-next-line no-empty-blocks
     function afterAppConfigured() internal virtual {}

--- a/packages/contracts-communication/script/config/legacy/ConfigureLegacyPingPong.s.sol
+++ b/packages/contracts-communication/script/config/legacy/ConfigureLegacyPingPong.s.sol
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {LegacyPingPong} from "../../../contracts/legacy/LegacyPingPong.sol";
+import {TypeCasts} from "../../../contracts/libs/TypeCasts.sol";
+
+import {stdJson, SynapseScript} from "@synapsecns/solidity-devops/src/SynapseScript.sol";
+
+contract ConfigureLegacyPingPong is SynapseScript {
+    using stdJson for string;
+
+    string public constant NAME = "LegacyPingPong";
+
+    string public config;
+    LegacyPingPong public legacyPingPong;
+
+    function run(string memory environment) external broadcastWithHooks {
+        loadConfig(environment);
+        setMessageBus();
+        setTrustedRemotes();
+        setGasLimit();
+    }
+
+    function loadConfig(string memory environment) internal {
+        config = readGlobalDeployConfig({contractName: NAME, globalProperty: environment, revertIfNotFound: true});
+        address deployment = getDeploymentAddress({contractName: NAME, revertIfNotFound: true});
+        legacyPingPong = LegacyPingPong(payable(deployment));
+    }
+
+    function setMessageBus() internal {
+        printLog("Setting MessageBus");
+        address messageBus = getDeploymentAddress({contractName: "MessageBus", revertIfNotFound: true});
+        if (legacyPingPong.messageBus() != messageBus) {
+            legacyPingPong.setMessageBus(messageBus);
+            printSuccessWithIndent(string.concat("Set MessageBus to ", vm.toString(messageBus)));
+        } else {
+            printSkipWithIndent(string.concat("already set to ", vm.toString(messageBus)));
+        }
+    }
+
+    function setTrustedRemotes() internal {
+        printLog("Setting trusted remotes");
+        string[] memory chains = config.readStringArray(".chains");
+        for (uint256 i = 0; i < chains.length; i++) {
+            string memory chain = chains[i];
+            uint256 chainId = chainIds[chain];
+            require(chainId != 0, string.concat("Chain not found: ", chain));
+            // Skip current chain
+            if (chainId == blockChainId()) continue;
+            address remotePingPong = getDeploymentAddress({chain: chain, contractName: NAME, revertIfNotFound: true});
+            bytes32 remotePingPongBytes32 = TypeCasts.addressToBytes32(remotePingPong);
+            bytes32 trustedRemote = legacyPingPong.trustedRemotes(chainId);
+            if (remotePingPongBytes32 != trustedRemote) {
+                legacyPingPong.setTrustedRemote(chainId, remotePingPongBytes32);
+                printSuccessWithIndent(
+                    string.concat("Set trusted remote to ", vm.toString(remotePingPong), " on ", chain)
+                );
+            } else {
+                printSkipWithIndent(string.concat("already set to ", vm.toString(remotePingPong), " on ", chain));
+            }
+        }
+    }
+
+    function setGasLimit() internal {
+        printLog("Setting gas limit");
+        uint256 gasLimit = config.readUint(".gasLimit");
+        if (legacyPingPong.gasLimit() != gasLimit) {
+            legacyPingPong.setGasLimit(gasLimit);
+            printSuccessWithIndent(string.concat("Set gas limit to ", vm.toString(gasLimit)));
+        } else {
+            printSkipWithIndent(string.concat("already set to ", vm.toString(gasLimit)));
+        }
+    }
+}

--- a/packages/contracts-communication/script/config/legacy/ConfigureMessageBus.s.sol
+++ b/packages/contracts-communication/script/config/legacy/ConfigureMessageBus.s.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {MessageBus} from "../../../contracts/legacy/MessageBus.sol";
+import {TypeCasts} from "../../../contracts/libs/TypeCasts.sol";
+
+import {stdJson, ConfigureAppV1} from "../ConfigureAppV1.s.sol";
+
+contract ConfigureMessageBus is ConfigureAppV1 {
+    using stdJson for string;
+
+    constructor() ConfigureAppV1("MessageBus") {}
+
+    function beforeAppConfigured() internal override {
+        setInterchainGovernor();
+    }
+
+    function afterAppConfigured() internal override {
+        setMessageLengthEstimate();
+    }
+
+    function setInterchainGovernor() internal {
+        printLog("Setting Interchain Governor");
+        bytes32 icGovernorRole = app.IC_GOVERNOR_ROLE();
+        if (!app.hasRole(icGovernorRole, msg.sender)) {
+            app.grantRole(icGovernorRole, msg.sender);
+            printSuccessWithIndent("Granted IC_GOVERNOR_ROLE");
+        } else {
+            printSkipWithIndent("IC_GOVERNOR_ROLE already granted");
+        }
+    }
+
+    function setMessageLengthEstimate() internal {
+        printLog("Setting message length estimate");
+        MessageBus messageBus = MessageBus(payable(address(app)));
+        uint256 messageLengthEstimate = config.readUint(".messageLengthEstimate");
+        if (messageBus.messageLengthEstimate() != messageLengthEstimate) {
+            messageBus.setMessageLengthEstimate(messageLengthEstimate);
+            printSuccessWithIndent(string.concat("Set to ", vm.toString(messageLengthEstimate)));
+        } else {
+            printSkipWithIndent(string.concat("already set to ", vm.toString(messageLengthEstimate)));
+        }
+    }
+}

--- a/packages/contracts-communication/script/testnet-config.sh
+++ b/packages/contracts-communication/script/testnet-config.sh
@@ -21,3 +21,6 @@ yarn fsr-str script/config/ConfigureClientV1.s.sol "$chainName" "$walletName" te
 yarn fsr script/config/ConfigureExecutionFees.s.sol "$chainName" "$walletName" "$@"
 # Ping-Pong App
 yarn fsr-str script/config/ConfigurePingPongApp.s.sol "$chainName" "$walletName" testnet "$@"
+# Legacy contracts
+yarn fsr-str script/config/legacy/ConfigureMessageBus.s.sol "$chainName" "$walletName" testnet "$@"
+yarn fsr-str script/config/legacy/ConfigureLegacyPingPong.s.sol "$chainName" "$walletName" testnet "$@"

--- a/packages/contracts-communication/script/testnet-config.sh
+++ b/packages/contracts-communication/script/testnet-config.sh
@@ -13,11 +13,11 @@ fi
 # Get the rest of the options
 shift 2
 # Synapse contracts
-yarn fsr-str script/config/ConfigureSynapseModule.s.sol "$chainName" "$walletName" "testnet" "$@"
-yarn fsr-str script/config/ConfigureSynapseExecutionServiceV1.s.sol "$chainName" "$walletName" "testnet" "$@"
-yarn fsr-str script/config/ConfigureSynapseGasOracleV1.s.sol "$chainName" "$walletName" "testnet" "$@"
+yarn fsr-str script/config/ConfigureSynapseModule.s.sol "$chainName" "$walletName" testnet "$@"
+yarn fsr-str script/config/ConfigureSynapseExecutionServiceV1.s.sol "$chainName" "$walletName" testnet "$@"
+yarn fsr-str script/config/ConfigureSynapseGasOracleV1.s.sol "$chainName" "$walletName" testnet "$@"
 # Client contracts
-yarn fsr-str script/config/ConfigureClientV1.s.sol "$chainName" "$walletName" "testnet" "$@"
+yarn fsr-str script/config/ConfigureClientV1.s.sol "$chainName" "$walletName" testnet "$@"
 yarn fsr script/config/ConfigureExecutionFees.s.sol "$chainName" "$walletName" "$@"
 # Ping-Pong App
-yarn fsr-str script/config/ConfigurePingPongApp.s.sol "$chainName" "$walletName" "testnet" "$@"
+yarn fsr-str script/config/ConfigurePingPongApp.s.sol "$chainName" "$walletName" testnet "$@"

--- a/packages/contracts-communication/script/testnet-deploy.sh
+++ b/packages/contracts-communication/script/testnet-deploy.sh
@@ -25,3 +25,6 @@ yarn fsr script/deploy/DeployInterchainClientV1.s.sol "$chainName" "$walletName"
 yarn fsr-str script/deploy/DeployWithMsgSender.s.sol "$chainName" "$walletName" ExecutionFees "$@"
 # Ping-Pong App
 yarn fsr-str script/deploy/DeployWithMsgSender.s.sol "$chainName" "$walletName" PingPongApp "$@"
+# Legacy contracts
+yarn fsr-str script/deploy/DeployWithMsgSender.s.sol "$chainName" "$walletName" MessageBus "$@"
+yarn fsr-str script/deploy/DeployWithMsgSender.s.sol "$chainName" "$walletName" LegacyPingPong "$@"

--- a/packages/contracts-communication/script/testnet-deploy.sh
+++ b/packages/contracts-communication/script/testnet-deploy.sh
@@ -13,15 +13,15 @@ fi
 # Get the rest of the options
 shift 2
 # Permisionless DB w/o governance
-yarn fsr-str script/deploy/DeployNoArgs.s.sol "$chainName" "$walletName" "InterchainDB" "$@"
+yarn fsr-str script/deploy/DeployNoArgs.s.sol "$chainName" "$walletName" InterchainDB "$@"
 # Synapse contracts
 yarn fsr script/deploy/DeploySynapseModule.s.sol "$chainName" "$walletName" "$@"
 yarn fsr script/deploy/DeploySynapseExecutionServiceV1.s.sol "$chainName" "$walletName" "$@"
-yarn fsr-str script/deploy/DeployWithMsgSender.s.sol "$chainName" "$walletName" "SynapseGasOracleV1" "$@"
+yarn fsr-str script/deploy/DeployWithMsgSender.s.sol "$chainName" "$walletName" SynapseGasOracleV1 "$@"
 # Verify Proxy on Etherscan
 yarn vp "$chainName" SynapseExecutionServiceV1
 # Client contracts
 yarn fsr script/deploy/DeployInterchainClientV1.s.sol "$chainName" "$walletName" "$@"
-yarn fsr-str script/deploy/DeployWithMsgSender.s.sol "$chainName" "$walletName" "ExecutionFees" "$@"
+yarn fsr-str script/deploy/DeployWithMsgSender.s.sol "$chainName" "$walletName" ExecutionFees "$@"
 # Ping-Pong App
-yarn fsr-str script/deploy/DeployWithMsgSender.s.sol "$chainName" "$walletName" "PingPongApp" "$@"
+yarn fsr-str script/deploy/DeployWithMsgSender.s.sol "$chainName" "$walletName" PingPongApp "$@"

--- a/packages/contracts-communication/test/harnesses/MessageBusHarness.sol
+++ b/packages/contracts-communication/test/harnesses/MessageBusHarness.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {MessageBus} from "../../contracts/legacy/MessageBus.sol";
+
+/// @notice Harness for TESTS ONLY
+contract MessageBusHarness is MessageBus {
+    constructor(address admin) MessageBus(admin) {}
+
+    function setNonce(uint64 nonce_) external {
+        nonce = nonce_;
+    }
+}

--- a/packages/contracts-communication/test/integration/ICIntegration.t.sol
+++ b/packages/contracts-communication/test/integration/ICIntegration.t.sol
@@ -30,13 +30,6 @@ abstract contract ICIntegrationTest is
 {
     using TypeCasts for address;
 
-    uint256 public constant COUNTER = 42;
-
-    OptionsV1 public ppOptions = OptionsV1({gasLimit: 500_000, gasAirdrop: 0});
-
-    event PingReceived(uint256 counter, uint256 dbNonce, uint64 entryIndex);
-    event PingSent(uint256 counter, uint256 dbNonce, uint64 entryIndex);
-
     function assertEq(InterchainBatch memory batch, InterchainBatch memory expected) internal {
         assertEq(batch.srcChainId, expected.srcChainId);
         assertEq(batch.dbNonce, expected.dbNonce);
@@ -139,27 +132,37 @@ abstract contract ICIntegrationTest is
         emit BatchVerified({srcChainId: batch.srcChainId, batch: encodedBatch, ethSignedBatchHash: digest});
     }
 
-    function expectPingPongEventPingReceived(uint256 counter, InterchainTxDescriptor memory desc) internal {
-        vm.expectEmit(address(pingPongApp));
-        emit PingReceived(counter, desc.dbNonce, desc.entryIndex);
-    }
-
-    function expectPingPongEventPingSent(uint256 counter, InterchainTxDescriptor memory desc) internal {
-        vm.expectEmit(address(pingPongApp));
-        emit PingSent(counter, desc.dbNonce, desc.entryIndex);
-    }
-
-    function expectPingPongCall(InterchainTransaction memory icTx, OptionsV1 memory options) internal {
+    function expectAppCall(InterchainTransaction memory icTx, OptionsV1 memory options) internal {
         bytes memory expectedCalldata = abi.encodeCall(
             IInterchainApp.appReceive, (icTx.srcChainId, icTx.srcSender, icTx.dbNonce, icTx.entryIndex, icTx.message)
         );
         vm.expectCall({
-            callee: address(pingPongApp),
+            callee: localApp(),
             msgValue: options.gasAirdrop,
             gas: uint64(options.gasLimit),
             data: expectedCalldata,
             count: 1
         });
+    }
+
+    // ═══════════════════════════════════════════ COMPLEX SERIES CHECKS ═══════════════════════════════════════════════
+
+    function expectEventsMessageSent(
+        InterchainTransaction memory icTx,
+        InterchainEntry memory entry,
+        uint256 verificationFee,
+        uint256 executionFee
+    )
+        internal
+    {
+        InterchainBatch memory batch = getInterchainBatch(entry);
+        InterchainTxDescriptor memory desc = getInterchainTxDescriptor(entry);
+        expectDatabaseEventInterchainEntryWritten(entry);
+        expectModuleEventBatchVerificationRequested(batch);
+        expectDatabaseEventInterchainBatchVerificationRequested(batch);
+        expectFeesEventExecutionFeeAdded(desc.transactionId, executionFee);
+        expectServiceEventExecutionRequested(desc.transactionId);
+        expectClientEventInterchainTransactionSent(icTx, verificationFee, executionFee);
     }
 
     // ══════════════════════════════════════════════ EXPECT REVERTS ═══════════════════════════════════════════════════
@@ -180,34 +183,12 @@ abstract contract ICIntegrationTest is
         );
     }
 
-    // ═══════════════════════════════════════════ COMPLEX SERIES CHECKS ═══════════════════════════════════════════════
-
-    function expectEventsPingSent(
-        uint256 counter,
-        InterchainTransaction memory icTx,
-        InterchainEntry memory entry,
-        uint256 verificationFee,
-        uint256 executionFee
-    )
-        internal
-    {
-        InterchainBatch memory batch = getInterchainBatch(entry);
-        InterchainTxDescriptor memory desc = getInterchainTxDescriptor(entry);
-        expectDatabaseEventInterchainEntryWritten(entry);
-        expectModuleEventBatchVerificationRequested(batch);
-        expectDatabaseEventInterchainBatchVerificationRequested(batch);
-        expectFeesEventExecutionFeeAdded(desc.transactionId, executionFee);
-        expectServiceEventExecutionRequested(desc.transactionId);
-        expectClientEventInterchainTransactionSent(icTx, verificationFee, executionFee);
-        expectPingPongEventPingSent(counter, desc);
-    }
-
     function checkBatchLeafs(InterchainBatch memory batch, bytes32[] memory leafs) internal {
         assertEq(leafs.length, 1);
         assertEq(leafs[0], batch.batchRoot);
     }
 
-    function checkDatabaseStatePingSent(InterchainEntry memory entry, uint256 initialDBNonce) internal {
+    function checkDatabaseStateMsgSent(InterchainEntry memory entry, uint256 initialDBNonce) internal {
         InterchainBatch memory batch = getInterchainBatch(entry);
         InterchainTxDescriptor memory desc = getInterchainTxDescriptor(entry);
         assertEq(desc.dbNonce, initialDBNonce);
@@ -298,38 +279,34 @@ abstract contract ICIntegrationTest is
     function getSrcTransaction() internal view returns (InterchainTransaction memory) {
         return InterchainTransaction({
             srcChainId: SRC_CHAIN_ID,
-            srcSender: address(pingPongApp).addressToBytes32(),
+            srcSender: address(srcApp).addressToBytes32(),
             dstChainId: DST_CHAIN_ID,
-            dstReceiver: address(pingPongApp).addressToBytes32(),
+            dstReceiver: address(dstApp).addressToBytes32(),
             dbNonce: SRC_INITIAL_DB_NONCE,
             entryIndex: 0,
-            options: ppOptions.encodeOptionsV1(),
-            message: getPingPongSrcMessage()
+            options: getSrcOptions().encodeOptionsV1(),
+            message: getSrcMessage()
         });
     }
 
     function getDstTransaction() internal view returns (InterchainTransaction memory) {
         return InterchainTransaction({
             srcChainId: DST_CHAIN_ID,
-            srcSender: address(pingPongApp).addressToBytes32(),
+            srcSender: address(dstApp).addressToBytes32(),
             dstChainId: SRC_CHAIN_ID,
-            dstReceiver: address(pingPongApp).addressToBytes32(),
+            dstReceiver: address(srcApp).addressToBytes32(),
             dbNonce: DST_INITIAL_DB_NONCE,
             entryIndex: 0,
-            options: ppOptions.encodeOptionsV1(),
-            message: getPingPongDstMessage()
+            options: getDstOptions().encodeOptionsV1(),
+            message: getDstMessage()
         });
     }
 
-    /// @notice Message that source chain PingPongApp sends to destination chain.
-    function getPingPongSrcMessage() internal pure returns (bytes memory) {
-        return abi.encode(COUNTER);
-    }
+    function getSrcOptions() internal view virtual returns (OptionsV1 memory);
+    function getSrcMessage() internal view virtual returns (bytes memory);
 
-    /// @notice Message that destination chain PingPongApp sends back to source chain.
-    function getPingPongDstMessage() internal pure returns (bytes memory) {
-        return abi.encode(COUNTER - 1);
-    }
+    function getDstOptions() internal view virtual returns (OptionsV1 memory);
+    function getDstMessage() internal view virtual returns (bytes memory);
 
     function toArray(address addr) internal pure returns (address[] memory arr) {
         arr = new address[](1);

--- a/packages/contracts-communication/test/integration/ICSetup.t.sol
+++ b/packages/contracts-communication/test/integration/ICSetup.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.20;
 import {ExecutionFees} from "../../contracts/ExecutionFees.sol";
 import {InterchainClientV1} from "../../contracts/InterchainClientV1.sol";
 import {InterchainDB} from "../../contracts/InterchainDB.sol";
-import {PingPongApp} from "../../contracts/apps/examples/PingPongApp.sol";
+import {ICAppV1} from "../../contracts/apps/ICAppV1.sol";
 import {SynapseExecutionServiceV1} from "../../contracts/execution/SynapseExecutionServiceV1.sol";
 import {AppConfigV1} from "../../contracts/libs/AppConfig.sol";
 import {SynapseModule} from "../../contracts/modules/SynapseModule.sol";
@@ -30,8 +30,6 @@ abstract contract ICSetup is ProxyTest {
     uint256 public constant SRC_INITIAL_DB_NONCE = 10;
     uint256 public constant DST_INITIAL_DB_NONCE = 20;
 
-    uint256 public constant PING_PONG_BALANCE = 1000 ether;
-
     uint256 public constant APP_OPTIMISTIC_PERIOD = 10 minutes;
 
     uint256 public constant INITIAL_TS = 1_704_067_200; // 2024-01-01 00:00:00 UTC
@@ -48,7 +46,8 @@ abstract contract ICSetup is ProxyTest {
     SynapseModule public module;
     SynapseGasOracleV1 public gasOracle;
 
-    PingPongApp public pingPongApp;
+    address public srcApp;
+    address public dstApp;
 
     address public executor = makeAddr("Executor");
     address public feeCollector = makeAddr("FeeCollector");
@@ -63,9 +62,11 @@ abstract contract ICSetup is ProxyTest {
         vm.warp(INITIAL_TS);
         deployLibraryHarnesses();
         deployInterchainContracts();
+        srcApp = deployApp();
+        dstApp = deployApp();
         configureInterchainContracts();
+        configureLocalApp();
         initDBNonce();
-        dealEther();
     }
 
     function deployLibraryHarnesses() internal virtual {
@@ -81,8 +82,10 @@ abstract contract ICSetup is ProxyTest {
         icClient = new InterchainClientV1({interchainDB: address(icDB), owner_: address(this)});
         module = new SynapseModule({interchainDB: address(icDB), owner_: address(this)});
         gasOracle = new SynapseGasOracleV1(address(this));
-        pingPongApp = new PingPongApp(address(this));
     }
+
+    /// @dev Should deploy the tested app and return its address.
+    function deployApp() internal virtual returns (address);
 
     function configureInterchainContracts() internal virtual {
         configureExecutionFees();
@@ -90,7 +93,6 @@ abstract contract ICSetup is ProxyTest {
         configureInterchainClient();
         configureSynapseModule();
         configureSynapseGasOracle();
-        configurePingPongApp();
     }
 
     function configureExecutionFees() internal virtual {
@@ -128,13 +130,14 @@ abstract contract ICSetup is ProxyTest {
         gasOracle.setRemoteGasData(remoteChainId(), getGasDataFixture(remoteChainId()));
     }
 
-    function configurePingPongApp() internal virtual {
+    function configureLocalApp() internal virtual {
+        address app = localApp();
         // For simplicity, we assume that the apps are deployed to the same address on both chains.
-        pingPongApp.linkRemoteAppEVM(remoteChainId(), address(pingPongApp));
-        pingPongApp.addTrustedModule(address(module));
-        pingPongApp.setAppConfigV1(AppConfigV1({requiredResponses: 1, optimisticPeriod: APP_OPTIMISTIC_PERIOD}));
-        pingPongApp.setExecutionService(address(executionService));
-        pingPongApp.addInterchainClient({client: address(icClient), updateLatest: true});
+        ICAppV1(app).linkRemoteAppEVM(remoteChainId(), remoteApp());
+        ICAppV1(app).addTrustedModule(address(module));
+        ICAppV1(app).setAppConfigV1(AppConfigV1({requiredResponses: 1, optimisticPeriod: APP_OPTIMISTIC_PERIOD}));
+        ICAppV1(app).setExecutionService(address(executionService));
+        ICAppV1(app).addInterchainClient({client: address(icClient), updateLatest: true});
     }
 
     function initDBNonce() internal virtual {
@@ -149,10 +152,6 @@ abstract contract ICSetup is ProxyTest {
         }
         // Sanity check
         require(icDB.getDBNonce() == end, "DB nonce not increased");
-    }
-
-    function dealEther() internal virtual {
-        deal(address(pingPongApp), PING_PONG_BALANCE);
     }
 
     function getGasDataFixture(uint256 chainId)
@@ -184,6 +183,14 @@ abstract contract ICSetup is ProxyTest {
         } else {
             revert("Invalid chainId");
         }
+    }
+
+    function localApp() internal view returns (address) {
+        return isSourceChainTest() ? srcApp : dstApp;
+    }
+
+    function remoteApp() internal view returns (address) {
+        return isSourceChainTest() ? dstApp : srcApp;
     }
 
     /// @notice Should return either `SRC_CHAIN_ID` or `DST_CHAIN_ID`.

--- a/packages/contracts-communication/test/integration/ICSetup.t.sol
+++ b/packages/contracts-communication/test/integration/ICSetup.t.sol
@@ -63,7 +63,9 @@ abstract contract ICSetup is ProxyTest {
         deployLibraryHarnesses();
         deployInterchainContracts();
         srcApp = deployApp();
+        vm.label(srcApp, "Src App");
         dstApp = deployApp();
+        vm.label(dstApp, "Dst App");
         configureInterchainContracts();
         configureLocalApp();
         initDBNonce();

--- a/packages/contracts-communication/test/integration/PingPong.Src.t.sol
+++ b/packages/contracts-communication/test/integration/PingPong.Src.t.sol
@@ -2,16 +2,17 @@
 pragma solidity 0.8.20;
 
 import {
-    ICIntegrationTest,
+    PingPongIntegrationTest,
     InterchainBatch,
     InterchainEntry,
     InterchainTransaction,
-    InterchainTxDescriptor
-} from "./ICIntegration.t.sol";
+    InterchainTxDescriptor,
+    PingPongApp
+} from "./PingPong.t.sol";
 
 // solhint-disable func-name-mixedcase
 // solhint-disable ordering
-contract PingPongSrcIntegrationTest is ICIntegrationTest {
+contract PingPongSrcIntegrationTest is PingPongIntegrationTest {
     InterchainBatch public batch;
     InterchainEntry public entry;
     InterchainTransaction public icTx;
@@ -27,7 +28,7 @@ contract PingPongSrcIntegrationTest is ICIntegrationTest {
         entry = getSrcInterchainEntry();
         desc = getInterchainTxDescriptor(entry);
         batch = getInterchainBatch(entry);
-        pingFee = pingPongApp.getPingFee(DST_CHAIN_ID);
+        pingFee = srcPingPongApp().getPingFee(DST_CHAIN_ID);
         verificationFee = icDB.getInterchainFee(DST_CHAIN_ID, toArray(address(module)));
         executionFee = executionService.getExecutionFee({
             dstChainId: DST_CHAIN_ID,
@@ -38,27 +39,27 @@ contract PingPongSrcIntegrationTest is ICIntegrationTest {
 
     function test_startPingPong_events() public {
         expectEventsPingSent(COUNTER, icTx, entry, verificationFee, executionFee);
-        pingPongApp.startPingPong(DST_CHAIN_ID, COUNTER);
+        srcPingPongApp().startPingPong(DST_CHAIN_ID, COUNTER);
     }
 
     function test_startPingPong_state_db() public {
-        pingPongApp.startPingPong(DST_CHAIN_ID, COUNTER);
-        checkDatabaseStatePingSent(entry, SRC_INITIAL_DB_NONCE);
+        srcPingPongApp().startPingPong(DST_CHAIN_ID, COUNTER);
+        checkDatabaseStateMsgSent(entry, SRC_INITIAL_DB_NONCE);
     }
 
     function test_startPingPong_state_execFees() public {
-        pingPongApp.startPingPong(DST_CHAIN_ID, COUNTER);
+        srcPingPongApp().startPingPong(DST_CHAIN_ID, COUNTER);
         assertEq(address(executionFees).balance, executionFee);
         assertEq(executionFees.executionFee(DST_CHAIN_ID, desc.transactionId), executionFee);
     }
 
     function test_startPingPong_state_pingPongApp() public {
-        pingPongApp.startPingPong(DST_CHAIN_ID, COUNTER);
-        assertEq(address(pingPongApp).balance, PING_PONG_BALANCE - pingFee);
+        srcPingPongApp().startPingPong(DST_CHAIN_ID, COUNTER);
+        assertEq(srcApp.balance, PING_PONG_BALANCE - pingFee);
     }
 
     function test_startPingPong_state_synapseModule() public {
-        pingPongApp.startPingPong(DST_CHAIN_ID, COUNTER);
+        srcPingPongApp().startPingPong(DST_CHAIN_ID, COUNTER);
         assertEq(address(module).balance, verificationFee);
     }
 

--- a/packages/contracts-communication/test/integration/PingPong.t.sol
+++ b/packages/contracts-communication/test/integration/PingPong.t.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {PingPongApp} from "../../contracts/apps/examples/PingPongApp.sol";
+
+import {
+    ICIntegrationTest,
+    InterchainBatch,
+    InterchainEntry,
+    InterchainTransaction,
+    InterchainTxDescriptor
+} from "./ICIntegration.t.sol";
+
+import {IInterchainApp} from "../../contracts/interfaces/IInterchainApp.sol";
+import {OptionsV1} from "../../contracts/libs/Options.sol";
+
+// solhint-disable custom-errors
+// solhint-disable ordering
+abstract contract PingPongIntegrationTest is ICIntegrationTest {
+    uint256 public constant PING_PONG_BALANCE = 1000 ether;
+    uint256 public constant COUNTER = 42;
+
+    OptionsV1 public ppOptions = OptionsV1({gasLimit: 500_000, gasAirdrop: 0});
+
+    event PingReceived(uint256 counter, uint256 dbNonce, uint64 entryIndex);
+    event PingSent(uint256 counter, uint256 dbNonce, uint64 entryIndex);
+
+    /// @dev Should deploy the tested app and return its address.
+    function deployApp() internal override returns (address app) {
+        app = address(new PingPongApp(address(this)));
+        deal(app, PING_PONG_BALANCE);
+    }
+
+    function expectPingPongEventPingReceived(uint256 counter, InterchainEntry memory entry) internal {
+        vm.expectEmit(localApp());
+        emit PingReceived(counter, entry.dbNonce, entry.entryIndex);
+    }
+
+    function expectPingPongEventPingSent(uint256 counter, InterchainEntry memory entry) internal {
+        vm.expectEmit(localApp());
+        emit PingSent(counter, entry.dbNonce, entry.entryIndex);
+    }
+
+    // ═══════════════════════════════════════════ COMPLEX SERIES CHECKS ═══════════════════════════════════════════════
+
+    function expectEventsPingSent(
+        uint256 counter,
+        InterchainTransaction memory icTx,
+        InterchainEntry memory entry,
+        uint256 verificationFee,
+        uint256 executionFee
+    )
+        internal
+    {
+        expectEventsMessageSent(icTx, entry, verificationFee, executionFee);
+        expectPingPongEventPingSent(counter, entry);
+    }
+
+    // ═══════════════════════════════════════════════ DATA HELPERS ════════════════════════════════════════════════════
+
+    function srcPingPongApp() internal view returns (PingPongApp) {
+        return PingPongApp(payable(srcApp));
+    }
+
+    function dstPingPongApp() internal view returns (PingPongApp) {
+        return PingPongApp(payable(dstApp));
+    }
+
+    function getSrcOptions() internal view override returns (OptionsV1 memory) {
+        return ppOptions;
+    }
+
+    /// @notice Message that source chain PingPongApp sends to destination chain.
+    function getSrcMessage() internal pure override returns (bytes memory) {
+        return abi.encode(COUNTER);
+    }
+
+    function getDstOptions() internal view override returns (OptionsV1 memory) {
+        return ppOptions;
+    }
+
+    /// @notice Message that destination chain PingPongApp sends back to source chain.
+    function getDstMessage() internal pure override returns (bytes memory) {
+        return abi.encode(COUNTER - 1);
+    }
+}

--- a/packages/contracts-communication/test/integration/legacy/LegacyPingPong.Src.t.sol
+++ b/packages/contracts-communication/test/integration/legacy/LegacyPingPong.Src.t.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {
+    InterchainBatch,
+    InterchainEntry,
+    InterchainTransaction,
+    InterchainTxDescriptor,
+    LegacyPingPongIntegrationTest
+} from "./LegacyPingPong.t.sol";
+
+contract LegacyPingPongSrcIntegrationTest is LegacyPingPongIntegrationTest {
+    InterchainBatch public batch;
+    InterchainEntry public entry;
+    InterchainTransaction public icTx;
+    InterchainTxDescriptor public desc;
+
+    uint256 public pingFee;
+    uint256 public verificationFee;
+    uint256 public executionFee;
+
+    function setUp() public override {
+        super.setUp();
+        icTx = getSrcTransaction();
+        entry = getSrcInterchainEntry();
+        desc = getInterchainTxDescriptor(entry);
+        batch = getInterchainBatch(entry);
+        pingFee = srcLegacyPingPong().getPingFee(DST_CHAIN_ID);
+        verificationFee = icDB.getInterchainFee(DST_CHAIN_ID, toArray(address(module)));
+        executionFee = executionService.getExecutionFee({
+            dstChainId: DST_CHAIN_ID,
+            txPayloadSize: getEncodedTx(icTx).length,
+            options: icOptions.encodeOptionsV1()
+        });
+    }
+
+    function test_startPingPong_events() public {
+        expectEventsPingSent(COUNTER, icTx, entry, verificationFee, executionFee);
+        srcLegacyPingPong().startPingPong(DST_CHAIN_ID, COUNTER);
+    }
+
+    function test_startPingPong_state_db() public {
+        srcLegacyPingPong().startPingPong(DST_CHAIN_ID, COUNTER);
+        checkDatabaseStateMsgSent(entry, SRC_INITIAL_DB_NONCE);
+    }
+
+    function test_startPingPong_state_execFees() public {
+        srcLegacyPingPong().startPingPong(DST_CHAIN_ID, COUNTER);
+        assertEq(address(executionFees).balance, executionFee);
+        assertEq(executionFees.executionFee(DST_CHAIN_ID, desc.transactionId), executionFee);
+    }
+
+    function test_startPingPong_state_legacyPingPong() public {
+        srcLegacyPingPong().startPingPong(DST_CHAIN_ID, COUNTER);
+        assertEq(srcPingPong.balance, PING_PONG_BALANCE - pingFee);
+    }
+
+    function test_startPingPong_state_synapseModule() public {
+        srcLegacyPingPong().startPingPong(DST_CHAIN_ID, COUNTER);
+        assertEq(address(module).balance, verificationFee);
+    }
+
+    function localChainId() internal pure override returns (uint256) {
+        return SRC_CHAIN_ID;
+    }
+
+    function remoteChainId() internal pure override returns (uint256) {
+        return DST_CHAIN_ID;
+    }
+}

--- a/packages/contracts-communication/test/integration/legacy/LegacyPingPong.t.sol
+++ b/packages/contracts-communication/test/integration/legacy/LegacyPingPong.t.sol
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {ICAppV1} from "../../../contracts/apps/ICAppV1.sol";
+import {LegacyPingPong} from "../../../contracts/legacy/LegacyPingPong.sol";
+import {LegacyReceiver} from "../../../contracts/legacy/LegacyReceiver.sol";
+import {LegacyMessageLib} from "../../../contracts/legacy/libs/LegacyMessage.sol";
+import {LegacyOptionsLib} from "../../../contracts/legacy/libs/LegacyOptions.sol";
+import {TypeCasts} from "../../../contracts/libs/TypeCasts.sol";
+
+import {
+    ICIntegrationTest,
+    InterchainBatch,
+    InterchainEntry,
+    InterchainTransaction,
+    InterchainTxDescriptor,
+    OptionsV1
+} from "../ICIntegration.t.sol";
+import {MessageBusHarness} from "../../harnesses/MessageBusHarness.sol";
+
+// solhint-disable custom-errors
+// solhint-disable ordering
+abstract contract LegacyPingPongIntegrationTest is ICIntegrationTest {
+    uint256 public constant PING_PONG_BALANCE = 1000 ether;
+    uint256 public constant COUNTER = 42;
+    uint256 public constant GAS_LIMIT = 500_000;
+
+    uint64 public constant SRC_MSG_BUS_NONCE = 5;
+    uint64 public constant DST_MSG_BUS_NONCE = 15;
+
+    OptionsV1 public icOptions = OptionsV1({gasLimit: GAS_LIMIT, gasAirdrop: 0});
+    bytes public legacyOptions = LegacyOptionsLib.encodeLegacyOptions(GAS_LIMIT);
+
+    address public srcPingPong;
+    address public dstPingPong;
+
+    event PingReceived(uint256 counter);
+    event PingSent(uint256 counter);
+
+    function setUp() public virtual override {
+        super.setUp();
+        srcPingPong = deployLegacyPingPong();
+        vm.label(srcPingPong, "Src PingPong");
+        dstPingPong = deployLegacyPingPong();
+        vm.label(dstPingPong, "Dst PingPong");
+        configureLocalPingPong();
+        setMsgBusNonce();
+    }
+
+    /// @dev Should deploy the tested app and return its address.
+    function deployApp() internal override returns (address app) {
+        return address(new MessageBusHarness(address(this)));
+    }
+
+    function deployLegacyPingPong() internal returns (address pingPong) {
+        pingPong = address(new LegacyPingPong(address(this)));
+        deal(pingPong, PING_PONG_BALANCE);
+    }
+
+    /// @dev Local app is MessageBus, need to grant the IC_GOVERNOR_ROLE, as it's not done in the constructor.
+    function configureLocalApp() internal virtual override {
+        address app = localApp();
+        ICAppV1(app).grantRole(ICAppV1(app).IC_GOVERNOR_ROLE(), address(this));
+        super.configureLocalApp();
+    }
+
+    function configureLocalPingPong() internal {
+        address pingPong = localLegacyPingPong();
+        bytes32 remotePingPongBytes32 = TypeCasts.addressToBytes32(isSourceChainTest() ? dstPingPong : srcPingPong);
+        LegacyReceiver(pingPong).setMessageBus(localApp());
+        LegacyReceiver(pingPong).setTrustedRemote(remoteChainId(), remotePingPongBytes32);
+    }
+
+    function setMsgBusNonce() internal {
+        uint64 nonce = isSourceChainTest() ? SRC_MSG_BUS_NONCE : DST_MSG_BUS_NONCE;
+        MessageBusHarness(localApp()).setNonce(nonce);
+    }
+
+    function expectPingPongEventPingReceived(uint256 counter) internal {
+        vm.expectEmit(localLegacyPingPong());
+        emit PingReceived(counter);
+    }
+
+    function expectPingPongEventPingSent(uint256 counter) internal {
+        vm.expectEmit(localLegacyPingPong());
+        emit PingSent(counter);
+    }
+
+    function expectPingPongCall() internal {
+        bytes memory expectedCalldata = abi.encodeCall(
+            LegacyReceiver.executeMessage,
+            (TypeCasts.addressToBytes32(srcPingPong), SRC_CHAIN_ID, getSrcLegacyMessage(), address(icClient))
+        );
+        vm.expectCall({callee: dstPingPong, msgValue: 0, data: expectedCalldata, count: 1});
+    }
+
+    // ═══════════════════════════════════════════ COMPLEX SERIES CHECKS ═══════════════════════════════════════════════
+
+    function expectEventsPingSent(
+        uint256 counter,
+        InterchainTransaction memory icTx,
+        InterchainEntry memory entry,
+        uint256 verificationFee,
+        uint256 executionFee
+    )
+        internal
+    {
+        expectEventsMessageSent(icTx, entry, verificationFee, executionFee);
+        expectPingPongEventPingSent(counter);
+    }
+
+    // ═══════════════════════════════════════════════ DATA HELPERS ════════════════════════════════════════════════════
+
+    function localLegacyPingPong() internal view returns (address) {
+        return isSourceChainTest() ? srcPingPong : dstPingPong;
+    }
+
+    function srcLegacyPingPong() internal view returns (LegacyPingPong) {
+        return LegacyPingPong(payable(srcPingPong));
+    }
+
+    function dstLegacyPingPong() internal view returns (LegacyPingPong) {
+        return LegacyPingPong(payable(dstPingPong));
+    }
+
+    function getSrcOptions() internal pure override returns (OptionsV1 memory) {
+        return OptionsV1({gasLimit: GAS_LIMIT, gasAirdrop: 0});
+    }
+
+    function getSrcMessage() internal view override returns (bytes memory) {
+        return LegacyMessageLib.encodeLegacyMessage({
+            srcSender: srcPingPong,
+            dstReceiver: dstPingPong,
+            srcNonce: SRC_MSG_BUS_NONCE,
+            message: getSrcLegacyMessage()
+        });
+    }
+
+    function getSrcLegacyMessage() internal pure returns (bytes memory) {
+        return abi.encode(COUNTER);
+    }
+
+    function getDstOptions() internal pure override returns (OptionsV1 memory) {
+        return OptionsV1({gasLimit: GAS_LIMIT, gasAirdrop: 0});
+    }
+
+    function getDstMessage() internal view override returns (bytes memory) {
+        return LegacyMessageLib.encodeLegacyMessage({
+            srcSender: dstPingPong,
+            dstReceiver: srcPingPong,
+            srcNonce: DST_MSG_BUS_NONCE,
+            message: getDstLegacyMessage()
+        });
+    }
+
+    function getDstLegacyMessage() internal pure returns (bytes memory) {
+        return abi.encode(COUNTER - 1);
+    }
+}

--- a/packages/contracts-communication/test/legacy/MessageBus.Management.t.sol
+++ b/packages/contracts-communication/test/legacy/MessageBus.Management.t.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.20;
 
+import {LegacyMessageLib} from "../../contracts/legacy/libs/LegacyMessage.sol";
+
 import {MessageBusBaseTest, InterchainClientV1Mock} from "./MessageBus.Base.t.sol";
 
 // solhint-disable func-name-mixedcase
@@ -9,8 +11,10 @@ contract MessageBusManagementTest is MessageBusBaseTest {
     uint256 public constant LENGTH_ESTIMATE = 100;
 
     function mockInterchainFees(uint256 length) internal {
+        uint256 legacyMessageLen = LegacyMessageLib.payloadSize(length);
         bytes memory expectedCalldata = abi.encodeCall(
-            InterchainClientV1Mock.getInterchainFee, (REMOTE_CHAIN_ID, execService, icModules, icOptions, length)
+            InterchainClientV1Mock.getInterchainFee,
+            (REMOTE_CHAIN_ID, execService, icModules, icOptions, legacyMessageLen)
         );
         vm.mockCall(icClient, expectedCalldata, abi.encode(MOCK_FEE));
     }

--- a/packages/contracts-communication/test/legacy/harnesses/LegacyMessageLibHarness.sol
+++ b/packages/contracts-communication/test/legacy/harnesses/LegacyMessageLibHarness.sol
@@ -24,4 +24,8 @@ contract LegacyMessageLibHarness {
     {
         return LegacyMessageLib.decodeLegacyMessage(legacyMsg);
     }
+
+    function payloadSize(uint256 messageLen) public pure returns (uint256) {
+        return LegacyMessageLib.payloadSize(messageLen);
+    }
 }

--- a/packages/contracts-communication/test/legacy/libs/LegacyMessage.t.sol
+++ b/packages/contracts-communication/test/legacy/libs/LegacyMessage.t.sol
@@ -60,4 +60,18 @@ contract LegacyMessageLibTest is Test {
         assertEq(newSrcNonce, legacyMsg.srcNonce);
         assertEq(newMessage, legacyMsg.message);
     }
+
+    function test_payloadSize(LegacyMessage memory legacyMsg) public {
+        uint256 size = libHarness.payloadSize(legacyMsg.message.length);
+        uint256 expectedSize = libHarness.encodeLegacyMessage(
+            legacyMsg.srcSender, legacyMsg.dstReceiver, legacyMsg.srcNonce, legacyMsg.message
+        ).length;
+        assertEq(size, expectedSize);
+    }
+
+    function test_payloadSize_fuzzBytesOnly(bytes memory message) public {
+        LegacyMessage memory legacyMsg;
+        legacyMsg.message = message;
+        test_payloadSize(legacyMsg);
+    }
 }


### PR DESCRIPTION
**Description**
- [x] Integration tests for `MessageBus` and corresponding `LegacyPingPong`
- [x] Fixed bug in `MessageBus` fee estimation
- [x] Deployed `MessageBus` and `LegacyPingPong`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Introduced contracts for legacy ping-pong message exchange, enhancing interchain communication capabilities.
    - Added functionality for setting gas limits, accepting, and withdrawing native assets in interchain messages.
    - New events and abstract contracts for improved legacy receiver functionality and event handling.
    - Enhanced message fee calculation based on message length.
- **Refactor**
    - Significant restructuring in integration tests to align with new communication semantics and interaction flows.
    - Updated logic in `ICSetup` for configuring and linking new app structures.
- **Tests**
    - Added and restructured integration tests for ping-pong and legacy ping-pong interchain communication.
    - New tests for payload size calculation in legacy messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->