### PR TITLE
fix(solidity-devops): use `eth_maxPriorityFeePerGas`, improve logging

### DIFF
--- a/packages/solidity-devops/js/utils/cast.js
+++ b/packages/solidity-devops/js/utils/cast.js
@@ -40,9 +40,10 @@ const getAccountNonceRPC = (rpcUrl, address) => {
 }
 
 const hasCodeRPC = (rpcUrl, address) => {
-  const code = getCommandOutput(`cast code --rpc-url ${rpcUrl} ${address}`)
-  // 0x is returned for an address without code
-  return code.length > 2
+  const codeSize = getCommandOutput(
+    `cast codesize --rpc-url ${rpcUrl} ${address}`
+  )
+  return codeSize > 0
 }
 
 module.exports = {

--- a/packages/solidity-devops/js/utils/cast.js
+++ b/packages/solidity-devops/js/utils/cast.js
@@ -1,16 +1,34 @@
+const { logError } = require('./logger.js')
 const { getCommandOutput } = require('./utils.js')
 
 const getChainIdRPC = (rpcUrl) => {
   return getCommandOutput(`cast chain-id --rpc-url ${rpcUrl}`)
 }
 
-const getChainGasPricingRPC = (rpcUrl) => {
-  const baseFee = getCommandOutput(`cast base-fee --rpc-url ${rpcUrl}`)
-  const gasPrice = getCommandOutput(`cast gas-price --rpc-url ${rpcUrl}`)
-  return {
-    baseFee: Number(baseFee),
-    gasPrice: Number(gasPrice),
+const getChainGasPriceRPC = (rpcUrl) => {
+  const output = getCommandOutput(
+    `cast gas-price --rpc-url ${rpcUrl}`,
+    (exitOnError = false)
+  )
+  if (!output) {
+    logError('  Failed to get gas price from the chain')
+    process.exit(1)
   }
+  // Output is returned without quotes
+  return Number(output)
+}
+
+const getChainMaxPriorityFeeRPC = (rpcUrl) => {
+  const output = getCommandOutput(
+    `cast rpc --rpc-url ${rpcUrl} eth_maxPriorityFeePerGas`,
+    (exitOnError = false)
+  )
+  if (!output) {
+    logError('  EIP-1559 is not supported on this chain')
+    process.exit(1)
+  }
+  // Remove quotes and convert from hex into decimal
+  return Number(output.replace(/"/g, ''))
 }
 
 const getAccountBalanceRPC = (rpcUrl, address) => {
@@ -29,7 +47,8 @@ const hasCodeRPC = (rpcUrl, address) => {
 
 module.exports = {
   getChainIdRPC,
-  getChainGasPricingRPC,
+  getChainGasPriceRPC,
+  getChainMaxPriorityFeeRPC,
   getAccountBalanceRPC,
   getAccountNonceRPC,
   hasCodeRPC,

--- a/packages/solidity-devops/js/utils/forge.js
+++ b/packages/solidity-devops/js/utils/forge.js
@@ -1,11 +1,11 @@
 const { runCommand } = require('./utils.js')
 
-const forgeScript = (scriptFN, options) => {
-  return runCommand(`forge script ${scriptFN} ${options}`)
+const forgeScript = (scriptFN, options, exitOnError = false) => {
+  return runCommand(`forge script ${scriptFN} ${options}`, exitOnError)
 }
 
-const forgeVerify = (options) => {
-  return runCommand(`forge verify-contract ${options}`)
+const forgeVerify = (options, exitOnError = false) => {
+  return runCommand(`forge verify-contract ${options}`, exitOnError)
 }
 
 module.exports = {

--- a/packages/solidity-devops/js/utils/logger.js
+++ b/packages/solidity-devops/js/utils/logger.js
@@ -20,6 +20,10 @@ const logCommand = (command) => {
   console.log(chalk.blue(redactKeys(command)))
 }
 
+const logCommandError = (command, msg = 'Command failed') => {
+  logError(`${msg}: ${redactKeys(command)}`)
+}
+
 const redactKeys = (command) => {
   // Find all options that end with -key and redact the following value
   const keyRegex = /(--\S+-key) (\S+)/g
@@ -27,4 +31,11 @@ const redactKeys = (command) => {
   return redactedCommand
 }
 
-module.exports = { logSuccess, logWarning, logError, logInfo, logCommand }
+module.exports = {
+  logSuccess,
+  logWarning,
+  logError,
+  logInfo,
+  logCommand,
+  logCommandError,
+}

--- a/packages/solidity-devops/js/utils/utils.js
+++ b/packages/solidity-devops/js/utils/utils.js
@@ -1,7 +1,7 @@
 const fs = require('fs')
 const { execSync } = require('child_process')
 
-const { logCommand, logInfo, logError } = require('./logger.js')
+const { logCommand, logCommandError, logInfo } = require('./logger.js')
 
 /**
  * Asserts that a condition is true. If not, logs an error message and exits the process.
@@ -47,12 +47,16 @@ const createDir = (...dirNames) => {
  * @param {string} command - The command to run
  * @returns {string} The output of the command
  */
-const getCommandOutput = (command) => {
+const getCommandOutput = (command, exitOnError = true) => {
   try {
     const output = execSync(command)
     return output.toString().trim()
   } catch (error) {
-    process.exit(1)
+    logCommandError(command)
+    if (exitOnError) {
+      process.exit(1)
+    }
+    return null
   }
 }
 
@@ -62,13 +66,16 @@ const getCommandOutput = (command) => {
  * @param {string} command - The command to run
  * @returns {bool} Whether the command succeeded
  */
-const runCommand = (command) => {
+const runCommand = (command, exitOnError = true) => {
   try {
     logCommand(`${command}`)
     execSync(command, { stdio: 'inherit' })
     return true
   } catch (error) {
-    logError(`Command failed: ${command}`)
+    logCommandError(command)
+    if (exitOnError) {
+      process.exit(1)
+    }
     return false
   }
 }


### PR DESCRIPTION
**Description**
- Uses `eth_maxPriorityFeePerGas` for getting the suggested priority fee. The previous approach was to get base fee and suggested gas price separately, then use their difference. This turned out to be incorrect, as often these two requests were using different block numbers, causing `baseFee > gasPrice` incorrect scenario.
- Redacts the keys in command error logs
- Internal "run command tools" (`runCommand` and `getCommandOutput`) allow to silent exit on error.