### PR TITLE
feat(synapse-interface): Removes auto-toggling chain & token selects on hover, replacing with click action

### DIFF
--- a/packages/synapse-interface/components/ui/ChainSelector.tsx
+++ b/packages/synapse-interface/components/ui/ChainSelector.tsx
@@ -20,7 +20,7 @@ export function ChainSelector({
   action,
 }: ChainSelectorTypes) {
   const [searchStr, setSearchStr] = useState('')
-  const [hover, setHover] = useState(false)
+  const [open, setOpen] = useState(false)
 
   const [currentId, setCurrentId] = useState(null)
   const dispatch = useDispatch()
@@ -55,7 +55,7 @@ export function ChainSelector({
   const onClose = () => {
     setSearchStr('')
     setCurrentId(null)
-    setHover(false)
+    setOpen(false)
   }
 
   const onSearch = (str: string) => {
@@ -63,9 +63,9 @@ export function ChainSelector({
     setCurrentId(null)
   }
 
-  const arrowUp = useKeyPress('ArrowUp', hover)
-  const arrowDown = useKeyPress('ArrowDown', hover)
-  const enterPress = useKeyPress('Enter', hover)
+  const arrowUp = useKeyPress('ArrowUp', open)
+  const arrowDown = useKeyPress('ArrowDown', open)
+  const enterPress = useKeyPress('Enter', open)
 
   const arrowDownFunc = () => {
     const currentIndex = flatItemList.findIndex((item) => item.id === currentId)
@@ -102,8 +102,8 @@ export function ChainSelector({
       selectedItem={selectedItem}
       searchStr={searchStr}
       onSearch={onSearch}
-      hover={hover}
-      setHover={setHover}
+      open={open}
+      setOpen={setOpen}
       onClose={onClose}
     >
       {Object.entries(itemList).map(([key, value]: [string, Chain[]]) => {

--- a/packages/synapse-interface/components/ui/TokenSelector.tsx
+++ b/packages/synapse-interface/components/ui/TokenSelector.tsx
@@ -20,7 +20,7 @@ export function TokenSelector({
   action,
 }: TokenSelectorTypes) {
   const [searchStr, setSearchStr] = useState('')
-  const [hover, setHover] = useState(false)
+  const [open, setOpen] = useState(false)
 
   const [currentRouteSymbol, setCurrentRouteSymbol] = useState(null)
   const dispatch = useDispatch()
@@ -54,7 +54,7 @@ export function TokenSelector({
   const onClose = () => {
     setSearchStr('')
     setCurrentRouteSymbol(null)
-    setHover(false)
+    setOpen(false)
   }
 
   const onSearch = (str: string) => {
@@ -62,9 +62,9 @@ export function TokenSelector({
     setCurrentRouteSymbol(null)
   }
 
-  const arrowUp = useKeyPress('ArrowUp', hover)
-  const arrowDown = useKeyPress('ArrowDown', hover)
-  const enterPress = useKeyPress('Enter', hover)
+  const arrowUp = useKeyPress('ArrowUp', open)
+  const arrowDown = useKeyPress('ArrowDown', open)
+  const enterPress = useKeyPress('Enter', open)
 
   const arrowDownFunc = () => {
     const currentIndex = flatItemList.findIndex(
@@ -108,8 +108,8 @@ export function TokenSelector({
       searchStr={searchStr}
       onSearch={onSearch}
       onClose={onClose}
-      hover={hover}
-      setHover={setHover}
+      open={open}
+      setOpen={setOpen}
     >
       {Object.entries(itemList).map(([key, value]: [string, Token[]]) => {
         return value.length ? (


### PR DESCRIPTION
null
7889733219eaae176b6a107f244161f654190f60: [synapse-interface preview link ](https://sanguine-synapse-interface-161d1vtpg-synapsecns.vercel.app)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new hook to close the selector when clicking outside its area.

- **Enhancements**
	- Improved dropdown visibility and interaction by replacing the `hover` state with an `open` state in various selectors. This change enhances user control through keyboard and mouse actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
22cd28b1730906dffd330d76b639084e3ddd74b2: [synapse-interface preview link ](https://sanguine-synapse-interface-r6w9wlpl1-synapsecns.vercel.app)