### PR TITLE
fix: Gas buffer in `MessageBus`, pack `AppConfig` in `ICAppV1`

### DIFF
--- a/packages/contracts-communication/contracts/legacy/MessageBus.sol
+++ b/packages/contracts-communication/contracts/legacy/MessageBus.sol
@@ -13,8 +13,12 @@ import {TypeCasts} from "../libs/TypeCasts.sol";
 import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
 contract MessageBus is ICAppV1, MessageBusEvents, IMessageBus {
+    /// @notice Default message length value for backwards compatible fee estimation.
     uint256 public messageLengthEstimate;
+    /// @notice Nonce for generating unique message IDs: incremented for each message sent.
     uint64 public nonce;
+    /// @notice Gas buffer to be added to the gas limit of the cross-chain message.
+    uint64 public gasBuffer = 20_000;
 
     constructor(address admin) ICAppV1(admin) {}
 
@@ -32,7 +36,9 @@ contract MessageBus is ICAppV1, MessageBusEvents, IMessageBus {
         if (TypeCasts.addressToBytes32(dstReceiver) != receiver) {
             revert MessageBus__NotEVMReceiver(receiver);
         }
-        uint64 cachedNonce = nonce++;
+        // Read the nonce and gas buffer from the same storage slot.
+        (uint64 cachedNonce, uint64 cachedGasBuffer) = (nonce, gasBuffer);
+        ++nonce;
         // Note: we are using the internal nonce here to generate the unique message ID.
         // This is used for tracking purposes and is not used for replay protection.
         // Instead, we rely on the Interchain Client to provide replay protection.
@@ -42,10 +48,11 @@ contract MessageBus is ICAppV1, MessageBusEvents, IMessageBus {
             srcNonce: cachedNonce,
             message: message
         });
+        OptionsV1 memory icOptions = _icOptionsV1(options, cachedGasBuffer);
         _sendToLinkedApp({
             dstChainId: SafeCast.toUint64(dstChainId),
             messageFee: msg.value,
-            options: _icOptionsV1(options),
+            options: icOptions,
             message: encodedLegacyMsg
         });
         emit MessageSent({
@@ -62,18 +69,15 @@ contract MessageBus is ICAppV1, MessageBusEvents, IMessageBus {
     }
 
     /// @inheritdoc IMessageBus
-    function setGasBuffer(uint64 gasBuffer_) external {
-        // TODO: implement
+    function setGasBuffer(uint64 gasBuffer_) external onlyRole(IC_GOVERNOR_ROLE) {
+        gasBuffer = gasBuffer_;
+        emit GasBufferSet(gasBuffer_);
     }
 
     /// @inheritdoc IMessageBus
     function setMessageLengthEstimate(uint256 length) external onlyRole(IC_GOVERNOR_ROLE) {
         messageLengthEstimate = length;
         emit MessageLengthEstimateSet(length);
-    }
-
-    function gasBuffer() external view returns (uint64) {
-        // TODO: replace with actual implementation
     }
 
     /// @inheritdoc IMessageBus
@@ -94,7 +98,7 @@ contract MessageBus is ICAppV1, MessageBusEvents, IMessageBus {
         uint256 legacyMsgLen = LegacyMessageLib.payloadSize(messageLen);
         return _getMessageFee({
             dstChainId: SafeCast.toUint64(dstChainId),
-            options: _icOptionsV1(options),
+            options: _icOptionsV1(options, gasBuffer),
             messageLen: legacyMsgLen
         });
     }
@@ -128,8 +132,10 @@ contract MessageBus is ICAppV1, MessageBusEvents, IMessageBus {
         });
     }
 
-    /// @dev Convert legacy MessageBus options to Interchain OptionsV1.
-    function _icOptionsV1(bytes calldata options) internal pure returns (OptionsV1 memory) {
-        return OptionsV1({gasLimit: LegacyOptionsLib.decodeLegacyOptions(options), gasAirdrop: 0});
+    /// @dev Convert legacy MessageBus options to Interchain OptionsV1. A gas buffer is added to reserve gas for the
+    /// destination MessageBus to forward the received message and emit the event after execution. This is necessary
+    /// to ensure that the App's requested gas limit is honored.
+    function _icOptionsV1(bytes calldata options, uint64 sendGasBuffer) internal pure returns (OptionsV1 memory) {
+        return OptionsV1({gasLimit: LegacyOptionsLib.decodeLegacyOptions(options) + sendGasBuffer, gasAirdrop: 0});
     }
 }

--- a/packages/contracts-communication/contracts/legacy/MessageBus.sol
+++ b/packages/contracts-communication/contracts/legacy/MessageBus.sol
@@ -62,9 +62,18 @@ contract MessageBus is ICAppV1, MessageBusEvents, IMessageBus {
     }
 
     /// @inheritdoc IMessageBus
+    function setGasBuffer(uint64 gasBuffer_) external {
+        // TODO: implement
+    }
+
+    /// @inheritdoc IMessageBus
     function setMessageLengthEstimate(uint256 length) external onlyRole(IC_GOVERNOR_ROLE) {
         messageLengthEstimate = length;
         emit MessageLengthEstimateSet(length);
+    }
+
+    function gasBuffer() external view returns (uint64) {
+        // TODO: replace with actual implementation
     }
 
     /// @inheritdoc IMessageBus

--- a/packages/contracts-communication/contracts/legacy/events/MessageBusEvents.sol
+++ b/packages/contracts-communication/contracts/legacy/events/MessageBusEvents.sol
@@ -24,5 +24,6 @@ abstract contract MessageBusEvents {
         bytes32 indexed messageId
     );
 
+    event GasBufferSet(uint64 gasBuffer);
     event MessageLengthEstimateSet(uint256 length);
 }

--- a/packages/contracts-communication/contracts/legacy/interfaces/IMessageBus.sol
+++ b/packages/contracts-communication/contracts/legacy/interfaces/IMessageBus.sol
@@ -20,6 +20,11 @@ interface IMessageBus {
         external
         payable;
 
+    /// @notice Allows the Interchain Governor to set the gas buffer for sending the interchain messages.
+    /// Note: The gas buffer is added to the gas limit requested by the sending app to cover the gas usage
+    /// of the MessageBus contract on the destination chain.
+    function setGasBuffer(uint64 gasBuffer_) external;
+
     /// @notice Allows the Interchain Governor to set the message length in bytes to be used for fee estimation.
     /// This does not affect the sendMessage function, but only the fee estimation.
     function setMessageLengthEstimate(uint256 length) external;

--- a/packages/contracts-communication/test/integration/legacy/LegacyPingPong.t.sol
+++ b/packages/contracts-communication/test/integration/legacy/LegacyPingPong.t.sol
@@ -23,13 +23,18 @@ import {MessageBusHarness} from "../../harnesses/MessageBusHarness.sol";
 abstract contract LegacyPingPongIntegrationTest is ICIntegrationTest {
     uint256 public constant PING_PONG_BALANCE = 1000 ether;
     uint256 public constant COUNTER = 42;
-    uint256 public constant GAS_LIMIT = 500_000;
+    /// @notice Gas limit requested by a Legacy App
+    uint256 public constant APP_GAS_LIMIT = 500_000;
+    /// @notice Gas buffer that Message Bus adds to the gas limit requested by a Legacy App
+    uint256 public constant MESSAGE_BUS_GAS_BUFFER = 20_000;
+    /// @notice Total gas limit requested for the Interchain message
+    uint256 public constant GAS_LIMIT = APP_GAS_LIMIT + MESSAGE_BUS_GAS_BUFFER;
 
     uint64 public constant SRC_MSG_BUS_NONCE = 5;
     uint64 public constant DST_MSG_BUS_NONCE = 15;
 
     OptionsV1 public icOptions = OptionsV1({gasLimit: GAS_LIMIT, gasAirdrop: 0});
-    bytes public legacyOptions = LegacyOptionsLib.encodeLegacyOptions(GAS_LIMIT);
+    bytes public legacyOptions = LegacyOptionsLib.encodeLegacyOptions(APP_GAS_LIMIT);
 
     address public srcPingPong;
     address public dstPingPong;

--- a/packages/contracts-communication/test/legacy/MessageBus.Base.t.sol
+++ b/packages/contracts-communication/test/legacy/MessageBus.Base.t.sol
@@ -27,12 +27,14 @@ abstract contract MessageBusBaseTest is MessageBusEvents, Test {
     uint256 public constant BUS_OPTIMISTIC_PERIOD = 1 minutes;
     uint256 public constant MOCK_FEE = 0.001 ether;
     uint256 public constant MOCK_GAS_LIMIT = 400_000;
+    uint256 public constant GAS_BUFFER = 20_000;
+    uint256 public constant IC_GAS_LIMIT = MOCK_GAS_LIMIT + GAS_BUFFER;
 
     uint64 public constant MOCK_NONCE = 42;
     bytes public constant MESSAGE = "One small step for man, one giant leap for mankind.";
 
     bytes public legacyOptions = LegacyOptionsLib.encodeLegacyOptions(MOCK_GAS_LIMIT);
-    bytes public icOptions = OptionsV1({gasLimit: MOCK_GAS_LIMIT, gasAirdrop: 0}).encodeOptionsV1();
+    bytes public icOptions = OptionsV1({gasLimit: IC_GAS_LIMIT, gasAirdrop: 0}).encodeOptionsV1();
 
     MessageBus public messageBus;
     address public remoteMessageBus = makeAddr("RemoteMessageBus");

--- a/packages/contracts-communication/test/legacy/MessageBus.Base.t.sol
+++ b/packages/contracts-communication/test/legacy/MessageBus.Base.t.sol
@@ -114,6 +114,11 @@ abstract contract MessageBusBaseTest is MessageBusEvents, Test {
         });
     }
 
+    function expectEventGasBufferSet(uint64 gasBuffer) internal {
+        vm.expectEmit(address(messageBus));
+        emit GasBufferSet(gasBuffer);
+    }
+
     function expectEventMessageLengthEstimateSet(uint256 length) internal {
         vm.expectEmit(address(messageBus));
         emit MessageLengthEstimateSet(length);

--- a/packages/contracts-communication/test/legacy/MessageBus.Management.t.sol
+++ b/packages/contracts-communication/test/legacy/MessageBus.Management.t.sol
@@ -9,6 +9,7 @@ import {MessageBusBaseTest, InterchainClientV1Mock} from "./MessageBus.Base.t.so
 // solhint-disable ordering
 contract MessageBusManagementTest is MessageBusBaseTest {
     uint256 public constant LENGTH_ESTIMATE = 100;
+    uint64 public constant BUFFER = 12_345;
 
     function mockInterchainFees(uint256 length) internal {
         uint256 legacyMessageLen = LegacyMessageLib.payloadSize(length);
@@ -17,6 +18,25 @@ contract MessageBusManagementTest is MessageBusBaseTest {
             (REMOTE_CHAIN_ID, execService, icModules, icOptions, legacyMessageLen)
         );
         vm.mockCall(icClient, expectedCalldata, abi.encode(MOCK_FEE));
+    }
+
+    function test_setGasBuffer_emitsEvent() public {
+        expectEventGasBufferSet(BUFFER);
+        vm.prank(governor);
+        messageBus.setGasBuffer(BUFFER);
+    }
+
+    function test_setGasBuffer_setsBuffer() public {
+        vm.prank(governor);
+        messageBus.setGasBuffer(BUFFER);
+        assertEq(messageBus.gasBuffer(), BUFFER);
+    }
+
+    function test_setGasBuffer_revert_notGovernor(address caller) public {
+        vm.assume(caller != governor);
+        expectRevertUnauthorizedGovernor(caller);
+        vm.prank(caller);
+        messageBus.setGasBuffer(BUFFER);
     }
 
     function test_setMessageLengthEstimate_emitsEvent() public {


### PR DESCRIPTION
**Description**

- Adds a configurable gas buffer that `MessageBus` adds on top of gas limit requested by the legacy apps
  - Default value of `20000` is used based on this [testnet tx](https://dashboard.tenderly.co/tx/sepolia/0xfe02d272fbdc9663585281b6e00d9a7a693c98c3d280114c779e28cd469d76b7/gas-usage).
- Improves the Interchain App template by packing the app config fields in a single storage slot.