### PR TITLE
submit-ahead flag

### DIFF
--- a/services/omnirpc/cmd/commands.go
+++ b/services/omnirpc/cmd/commands.go
@@ -163,9 +163,11 @@ var latestRewrite = &cli.Command{
 	Flags: []cli.Flag{
 		rpcFlag,
 		portFlag,
+		maxSubmitAhead,
+		chainIDFlag,
 	},
 	Action: func(c *cli.Context) error {
-		simpleProxy := confirmedtofinalized.NewProxy(c.String(rpcFlag.Name), metrics.Get(), c.Int(portFlag.Name))
+		simpleProxy := confirmedtofinalized.NewProxy(c.String(rpcFlag.Name), metrics.Get(), c.Int(portFlag.Name), c.Int(maxSubmitAhead.Name), c.Int(chainIDFlag.Name))
 
 		err := simpleProxy.Run(c.Context)
 		if err != nil {

--- a/services/omnirpc/cmd/flags.go
+++ b/services/omnirpc/cmd/flags.go
@@ -17,6 +17,12 @@ var portFlag = &cli.IntFlag{
 	Usage: "port to run the omniproxy on",
 }
 
+var maxSubmitAhead = &cli.IntFlag{
+	Name:  "max-submit-ahead",
+	Usage: "max number of blocks to submit ahead",
+	Value: 0,
+}
+
 // set the default dir to the users home path/omnirpc.yaml.
 func init() {
 	// user must set manually if this errors anyway


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**

Flag to not submit too far ahead

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
    - Added `maxSubmitAhead` flag to control the number of blocks to submit ahead in the `latestRewrite` command.
    - Enhanced transaction submission control with `chainIDFlag` parameter in the `NewProxy` function call.
    - Improved transaction validation with `maxSubmitAhead` and `chainID` parameters in the `finalizedProxyImpl` module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->