### PR TITLE
feat: interchain guard modules

### DIFF
--- a/packages/contracts-communication/contracts/InterchainClientV1.sol
+++ b/packages/contracts-communication/contracts/InterchainClientV1.sol
@@ -51,6 +51,9 @@ contract InterchainClientV1 is Ownable, InterchainClientV1Events, IInterchainCli
 
     // @inheritdoc IInterchainClientV1
     function setDefaultGuard(address guard) external onlyOwner {
+        if (guard == address(0)) {
+            revert InterchainClientV1__ZeroAddress();
+        }
         defaultGuard = guard;
         emit DefaultGuardSet(guard);
     }

--- a/packages/contracts-communication/contracts/InterchainClientV1.sol
+++ b/packages/contracts-communication/contracts/InterchainClientV1.sol
@@ -160,6 +160,7 @@ contract InterchainClientV1 is Ownable, InterchainClientV1Events, IInterchainCli
     }
 
     // @inheritdoc IInterchainClientV1
+    // solhint-disable-next-line code-complexity
     function getTxReadinessV1(
         InterchainTransaction memory icTx,
         bytes32[] calldata proof
@@ -472,9 +473,11 @@ contract InterchainClientV1 is Ownable, InterchainClientV1Events, IInterchainCli
         icTx = InterchainTransactionLib.decodeTransaction(versionedTx.getPayload());
     }
 
+    // solhint-disable no-inline-assembly
     /// @dev Decodes the revert data into a selector and two arguments.
     /// Zero values are returned if the revert data is not long enough.
-    /// Note: this is only used in `getTxReadinessV1` to decode the revert data, so usage of assembly is not a security risk.
+    /// Note: this is only used in `getTxReadinessV1` to decode the revert data,
+    /// so usage of assembly is not a security risk.
     function _decodeRevertData(bytes memory revertData)
         internal
         pure

--- a/packages/contracts-communication/contracts/InterchainClientV1.sol
+++ b/packages/contracts-communication/contracts/InterchainClientV1.sol
@@ -35,6 +35,11 @@ contract InterchainClientV1 is Ownable, InterchainClientV1Events, IInterchainCli
     /// @notice Address of the InterchainDB contract, set at the time of deployment.
     address public immutable INTERCHAIN_DB;
 
+    /// @notice Address of the Guard module used to verify the validity of batches.
+    /// Note: batches marked as invalid by the Guard could not be used for message execution,
+    /// if the app opts in to use the Guard.
+    address public defaultGuard;
+
     /// @dev Address of the InterchainClient contract on the remote chain
     mapping(uint64 chainId => bytes32 remoteClient) internal _linkedClient;
     /// @dev Executor address that completed the transaction. Address(0) if not executed yet.
@@ -42,6 +47,12 @@ contract InterchainClientV1 is Ownable, InterchainClientV1Events, IInterchainCli
 
     constructor(address interchainDB, address owner_) Ownable(owner_) {
         INTERCHAIN_DB = interchainDB;
+    }
+
+    // @inheritdoc IInterchainClientV1
+    function setDefaultGuard(address guard) external onlyOwner {
+        defaultGuard = guard;
+        emit DefaultGuardSet(guard);
     }
 
     // @inheritdoc IInterchainClientV1

--- a/packages/contracts-communication/contracts/InterchainClientV1.sol
+++ b/packages/contracts-communication/contracts/InterchainClientV1.sol
@@ -157,6 +157,39 @@ contract InterchainClientV1 is Ownable, InterchainClientV1Events, IInterchainCli
     }
 
     // @inheritdoc IInterchainClientV1
+    function getTxReadinessV1(
+        InterchainTransaction memory icTx,
+        bytes32[] calldata proof
+    )
+        external
+        view
+        returns (TxReadiness status, bytes32 firstArg, bytes32 secondArg)
+    {
+        bytes memory encodedTx = encodeTransaction(icTx);
+        try this.isExecutable(encodedTx, proof) returns (bool) {
+            return (TxReadiness.Ready, 0, 0);
+        } catch (bytes memory errorData) {
+            bytes4 selector;
+            (selector, firstArg, secondArg) = _decodeRevertData(errorData);
+            if (selector == InterchainClientV1__TxAlreadyExecuted.selector) {
+                status = TxReadiness.AlreadyExecuted;
+            } else if (selector == InterchainClientV1__BatchConflict.selector) {
+                status = TxReadiness.BatchConflict;
+            } else if (selector == InterchainClientV1__IncorrectDstChainId.selector) {
+                status = TxReadiness.IncorrectDstChainId;
+            } else if (selector == InterchainClientV1__NotEnoughResponses.selector) {
+                status = TxReadiness.NotEnoughResponses;
+            } else if (selector == InterchainClientV1__ZeroRequiredResponses.selector) {
+                status = TxReadiness.ZeroRequiredResponses;
+            } else {
+                status = TxReadiness.UndeterminedRevert;
+                firstArg = 0;
+                secondArg = 0;
+            }
+        }
+    }
+
+    // @inheritdoc IInterchainClientV1
     function getExecutor(bytes calldata encodedTx) external view returns (address) {
         return _txExecutor[keccak256(encodedTx)];
     }
@@ -420,5 +453,39 @@ contract InterchainClientV1 is Ownable, InterchainClientV1Events, IInterchainCli
             revert InterchainClientV1__InvalidTransactionVersion(version);
         }
         icTx = InterchainTransactionLib.decodeTransaction(versionedTx.getPayload());
+    }
+
+    /// @dev Decodes the revert data into a selector and two arguments.
+    /// Zero values are returned if the revert data is not long enough.
+    /// Note: this is only used in `getTxReadinessV1` to decode the revert data, so usage of assembly is not a security risk.
+    function _decodeRevertData(bytes memory revertData)
+        internal
+        pure
+        returns (bytes4 selector, bytes32 firstArg, bytes32 secondArg)
+    {
+        // The easiest way to load the bytes chunks onto the stack is to use assembly.
+        // Each time we try to load a value, we check if the revert data is long enough.
+        // We add 0x20 to skip the length field of the revert data.
+        if (revertData.length >= 4) {
+            // Load the first 32 bytes, then apply the mask that has only the 4 highest bytes set.
+            // There is no need to shift, as `bytesN` variables are right-aligned.
+            // https://github.com/ProjectOpenSea/seaport/blob/2ff6ea37/contracts/helpers/SeaportRouter.sol#L161-L175
+            selector = bytes4(0xFFFFFFFF);
+            assembly {
+                selector := and(mload(add(revertData, 0x20)), selector)
+            }
+        }
+        if (revertData.length >= 36) {
+            // Skip the length field + selector to get the 32 bytes of the first argument.
+            assembly {
+                firstArg := mload(add(revertData, 0x24))
+            }
+        }
+        if (revertData.length >= 68) {
+            // Skip the length field + selector + first argument to get the 32 bytes of the second argument.
+            assembly {
+                secondArg := mload(add(revertData, 0x44))
+            }
+        }
     }
 }

--- a/packages/contracts-communication/contracts/InterchainDB.sol
+++ b/packages/contracts-communication/contracts/InterchainDB.sol
@@ -6,7 +6,9 @@ import {IInterchainDB} from "./interfaces/IInterchainDB.sol";
 import {IInterchainModule} from "./interfaces/IInterchainModule.sol";
 
 import {BatchingV1Lib} from "./libs/BatchingV1.sol";
-import {InterchainBatch, InterchainBatchLib, BatchKey} from "./libs/InterchainBatch.sol";
+import {
+    InterchainBatch, InterchainBatchLib, BatchKey, BATCH_UNVERIFIED, BATCH_CONFLICT
+} from "./libs/InterchainBatch.sol";
 import {InterchainEntry, InterchainEntryLib} from "./libs/InterchainEntry.sol";
 import {VersionedPayloadLib} from "./libs/VersionedPayload.sol";
 import {TypeCasts} from "./libs/TypeCasts.sol";
@@ -155,10 +157,10 @@ contract InterchainDB is InterchainDBEvents, IInterchainDB {
         RemoteBatch memory remoteBatch = _remoteBatches[dstModule][batchKey];
         // Check if module verified anything for this batch key first
         if (remoteBatch.verifiedAt == 0) {
-            return InterchainBatchLib.UNVERIFIED;
+            return BATCH_UNVERIFIED;
         }
         // Check if the batch root matches the one verified by the module
-        return remoteBatch.batchRoot == batch.batchRoot ? remoteBatch.verifiedAt : InterchainBatchLib.CONFLICT;
+        return remoteBatch.batchRoot == batch.batchRoot ? remoteBatch.verifiedAt : BATCH_CONFLICT;
     }
 
     /// @inheritdoc IInterchainDB

--- a/packages/contracts-communication/contracts/apps/ICAppV1.sol
+++ b/packages/contracts-communication/contracts/apps/ICAppV1.sol
@@ -5,7 +5,7 @@ import {AbstractICApp, InterchainTxDescriptor} from "./AbstractICApp.sol";
 
 import {InterchainAppV1Events} from "../events/InterchainAppV1Events.sol";
 import {IInterchainAppV1} from "../interfaces/IInterchainAppV1.sol";
-import {AppConfigV1, AppConfigLib} from "../libs/AppConfig.sol";
+import {AppConfigV1, APP_CONFIG_GUARD_DEFAULT} from "../libs/AppConfig.sol";
 import {OptionsV1} from "../libs/Options.sol";
 import {TypeCasts} from "../libs/TypeCasts.sol";
 
@@ -228,7 +228,7 @@ abstract contract ICAppV1 is AbstractICApp, AccessControlEnumerable, InterchainA
     /// @dev Returns the guard flag and address in the app config.
     /// By default, the ICApp is using the Client-provided guard, but it can be overridden in the derived contract.
     function _getGuardConfig() internal view virtual returns (uint8 guardFlag, address guard) {
-        return (AppConfigLib.GUARD_DEFAULT, address(0));
+        return (APP_CONFIG_GUARD_DEFAULT, address(0));
     }
 
     /// @dev Returns the address of the Execution Service to use for sending messages.

--- a/packages/contracts-communication/contracts/apps/ICAppV1.sol
+++ b/packages/contracts-communication/contracts/apps/ICAppV1.sol
@@ -88,14 +88,13 @@ abstract contract ICAppV1 is AbstractICApp, AccessControlEnumerable, InterchainA
     }
 
     /// @inheritdoc IInterchainAppV1
-    // TODO: this should have `requiredResponses` and `optimisticPeriod` as parameters.
-    function setAppConfigV1(AppConfigV1 memory appConfig) external onlyRole(IC_GOVERNOR_ROLE) {
-        if (appConfig.requiredResponses == 0 || appConfig.optimisticPeriod == 0) {
-            revert InterchainApp__InvalidAppConfig(appConfig.requiredResponses, appConfig.optimisticPeriod);
+    function setAppConfigV1(uint256 requiredResponses, uint256 optimisticPeriod) external onlyRole(IC_GOVERNOR_ROLE) {
+        if (requiredResponses == 0 || optimisticPeriod == 0) {
+            revert InterchainApp__InvalidAppConfig(requiredResponses, optimisticPeriod);
         }
-        _requiredResponses = SafeCast.toUint16(appConfig.requiredResponses);
-        _optimisticPeriod = SafeCast.toUint48(appConfig.optimisticPeriod);
-        emit AppConfigV1Set(appConfig.requiredResponses, appConfig.optimisticPeriod);
+        _requiredResponses = SafeCast.toUint16(requiredResponses);
+        _optimisticPeriod = SafeCast.toUint48(optimisticPeriod);
+        emit AppConfigV1Set(requiredResponses, optimisticPeriod);
     }
 
     /// @inheritdoc IInterchainAppV1

--- a/packages/contracts-communication/contracts/apps/ICAppV1.sol
+++ b/packages/contracts-communication/contracts/apps/ICAppV1.sol
@@ -108,10 +108,12 @@ abstract contract ICAppV1 is AbstractICApp, AccessControlEnumerable, InterchainA
 
     /// @inheritdoc IInterchainAppV1
     function getAppConfigV1() public view returns (AppConfigV1 memory) {
+        (uint8 guardFlag, address guard) = _getGuardConfig();
         return AppConfigV1({
             requiredResponses: _requiredResponses,
             optimisticPeriod: _optimisticPeriod,
-            guardFlag: _getGuardFlag()
+            guardFlag: guardFlag,
+            guard: guard
         });
     }
 
@@ -224,10 +226,10 @@ abstract contract ICAppV1 is AbstractICApp, AccessControlEnumerable, InterchainA
         return getAppConfigV1().encodeAppConfigV1();
     }
 
-    /// @dev Returns the guard flag in the app config. By default, the ICApp is using the Client-provided guard,
-    /// but it can be overridden in the derived contract.
-    function _getGuardFlag() internal view virtual returns (uint256) {
-        return AppConfigLib.GUARD_DEFAULT;
+    /// @dev Returns the guard flag and address in the app config.
+    /// By default, the ICApp is using the Client-provided guard, but it can be overridden in the derived contract.
+    function _getGuardConfig() internal view virtual returns (uint8 guardFlag, address guard) {
+        return (AppConfigLib.GUARD_DEFAULT, address(0));
     }
 
     /// @dev Returns the address of the Execution Service to use for sending messages.

--- a/packages/contracts-communication/contracts/events/InterchainClientV1Events.sol
+++ b/packages/contracts-communication/contracts/events/InterchainClientV1Events.sol
@@ -2,6 +2,10 @@
 pragma solidity ^0.8.0;
 
 abstract contract InterchainClientV1Events {
+    /// @notice Emitted when the Guard module is set.
+    /// @param guard    The address of the Guard module.
+    event DefaultGuardSet(address guard);
+
     /// @notice Emitted when the InterchainClientV1 deployment on a remote chain is linked.
     /// @param chainId   The chain ID of the remote chain.
     /// @param client    The address of the InterchainClientV1 deployment on the remote chain.

--- a/packages/contracts-communication/contracts/interfaces/IInterchainAppV1.sol
+++ b/packages/contracts-communication/contracts/interfaces/IInterchainAppV1.sol
@@ -53,7 +53,7 @@ interface IInterchainAppV1 is IInterchainApp {
     /// @notice Allows the owner to set the app config for the current app. App config includes:
     /// - requiredResponses: the number of module responses required for accepting the message
     /// - optimisticPeriod: the minimum time after which the module responses are considered final
-    function setAppConfigV1(AppConfigV1 memory appConfig) external;
+    function setAppConfigV1(uint256 requiredResponses, uint256 optimisticPeriod) external;
 
     /// @notice Allows the owner to set the address of the Execution Service.
     /// This address will be used to request execution of the messages sent from this chain,

--- a/packages/contracts-communication/contracts/interfaces/IInterchainClientV1.sol
+++ b/packages/contracts-communication/contracts/interfaces/IInterchainClientV1.sol
@@ -21,6 +21,12 @@ interface IInterchainClientV1 {
     error InterchainClientV1__ZeroReceiver();
     error InterchainClientV1__ZeroRequiredResponses();
 
+    /// @notice Allows the contract owner to set the address of the Guard module.
+    /// Note: batches marked as invalid by the Guard could not be used for message execution,
+    /// if the app opts in to use the Guard.
+    /// @param guard_       The address of the Guard module.
+    function setDefaultGuard(address guard_) external;
+
     /**
      * @notice Sets the linked client for a specific chain ID.
      * @dev Stores the address of the linked client in a mapping with the chain ID as the key.

--- a/packages/contracts-communication/contracts/interfaces/IInterchainClientV1.sol
+++ b/packages/contracts-communication/contracts/interfaces/IInterchainClientV1.sol
@@ -28,6 +28,7 @@ interface IInterchainClientV1 {
     error InterchainClientV1__NotRemoteChainId(uint64 chainId);
     error InterchainClientV1__TxAlreadyExecuted(bytes32 transactionId);
     error InterchainClientV1__TxNotExecuted(bytes32 transactionId);
+    error InterchainClientV1__ZeroAddress();
     error InterchainClientV1__ZeroExecutionService();
     error InterchainClientV1__ZeroReceiver();
     error InterchainClientV1__ZeroRequiredResponses();

--- a/packages/contracts-communication/contracts/interfaces/IInterchainClientV1.sol
+++ b/packages/contracts-communication/contracts/interfaces/IInterchainClientV1.sol
@@ -1,9 +1,20 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {InterchainTxDescriptor} from "../libs/InterchainTransaction.sol";
+import {InterchainTransaction, InterchainTxDescriptor} from "../libs/InterchainTransaction.sol";
 
 interface IInterchainClientV1 {
+    // TODO: recheck the explicitness of the TxReadiness enum
+    enum TxReadiness {
+        Ready,
+        AlreadyExecuted,
+        BatchConflict,
+        IncorrectDstChainId,
+        NotEnoughResponses,
+        ZeroRequiredResponses,
+        UndeterminedRevert
+    }
+
     // TODO: standardize error names across interfaces
     error InterchainClientV1__BatchConflict(address module);
     error InterchainClientV1__FeeAmountTooLow(uint256 actual, uint256 required);
@@ -114,6 +125,31 @@ interface IInterchainClientV1 {
      * @return bool Returns true if the transaction is executable, false otherwise.
      */
     function isExecutable(bytes calldata transaction, bytes32[] calldata proof) external view returns (bool);
+
+    /// @notice Returns the readiness status of a transaction to be executed.
+    /// @dev Some of the possible statuses have additional arguments that are returned:
+    /// - Ready: the transaction is ready to be executed.
+    /// - AlreadyExecuted: the transaction has already been executed.
+    ///   - `firstArg` is the transaction ID.
+    /// - BatchConflict: one of the modules have submitted a conflicting batch.
+    ///   - `firstArg` is the address of the module.
+    ///   - This is either one of the modules that the app trusts, or the Guard module used by the app.
+    /// - IncorrectDstChainId: the destination chain ID does not match the local chain ID.
+    ///   - `firstArg` is the destination chain ID.
+    /// - NotEnoughResponses: not enough responses have been received for the transaction.
+    ///   - `firstArg` is the number of responses received.
+    ///   - `secondArg` is the number of responses required.
+    /// - ZeroRequiredResponses: the app config requires zero responses for the transaction.
+    /// - UndeterminedRevert: the transaction will revert for another reason.
+    ///
+    /// Note: the arguments are abi-encoded bytes32 values (as their types could be different).
+    function getTxReadinessV1(
+        InterchainTransaction memory icTx,
+        bytes32[] calldata proof
+    )
+        external
+        view
+        returns (TxReadiness status, bytes32 firstArg, bytes32 secondArg);
 
     /// @notice Returns the fee for sending an Interchain message.
     /// @param dstChainId           The chain ID of the destination chain.

--- a/packages/contracts-communication/contracts/libs/AppConfig.sol
+++ b/packages/contracts-communication/contracts/libs/AppConfig.sol
@@ -3,10 +3,12 @@ pragma solidity ^0.8.13;
 
 import {VersionedPayloadLib} from "./VersionedPayload.sol";
 
+// TODO: all of these could fit into a single 32 bytes slot
 struct AppConfigV1 {
     uint256 requiredResponses;
     uint256 optimisticPeriod;
     uint256 guardFlag;
+    address guard;
 }
 
 using AppConfigLib for AppConfigV1 global;
@@ -16,8 +18,9 @@ library AppConfigLib {
 
     uint16 internal constant APP_CONFIG_V1 = 1;
 
-    uint256 internal constant GUARD_DISABLED = 0;
-    uint256 internal constant GUARD_DEFAULT = 1;
+    uint8 internal constant GUARD_DISABLED = 0;
+    uint8 internal constant GUARD_DEFAULT = 1;
+    uint8 internal constant GUARD_CUSTOM = 2;
 
     error AppConfigLib__IncorrectVersion(uint16 version);
 

--- a/packages/contracts-communication/contracts/libs/AppConfig.sol
+++ b/packages/contracts-communication/contracts/libs/AppConfig.sol
@@ -6,6 +6,7 @@ import {VersionedPayloadLib} from "./VersionedPayload.sol";
 struct AppConfigV1 {
     uint256 requiredResponses;
     uint256 optimisticPeriod;
+    uint256 guardFlag;
 }
 
 using AppConfigLib for AppConfigV1 global;
@@ -14,6 +15,9 @@ library AppConfigLib {
     using VersionedPayloadLib for bytes;
 
     uint16 internal constant APP_CONFIG_V1 = 1;
+
+    uint256 internal constant GUARD_DISABLED = 0;
+    uint256 internal constant GUARD_DEFAULT = 1;
 
     error AppConfigLib__IncorrectVersion(uint16 version);
 

--- a/packages/contracts-communication/contracts/libs/AppConfig.sol
+++ b/packages/contracts-communication/contracts/libs/AppConfig.sol
@@ -13,14 +13,17 @@ struct AppConfigV1 {
 
 using AppConfigLib for AppConfigV1 global;
 
+/// @dev Signals that the app opted out of using any Guard module.
+uint8 constant APP_CONFIG_GUARD_DISABLED = 0;
+/// @dev Signals that the app uses the default Guard module provided by InterchainClient contract.
+uint8 constant APP_CONFIG_GUARD_DEFAULT = 1;
+/// @dev Signals that the app uses a custom Guard module.
+uint8 constant APP_CONFIG_GUARD_CUSTOM = 2;
+
 library AppConfigLib {
     using VersionedPayloadLib for bytes;
 
     uint16 internal constant APP_CONFIG_V1 = 1;
-
-    uint8 internal constant GUARD_DISABLED = 0;
-    uint8 internal constant GUARD_DEFAULT = 1;
-    uint8 internal constant GUARD_CUSTOM = 2;
 
     error AppConfigLib__IncorrectVersion(uint16 version);
 

--- a/packages/contracts-communication/contracts/libs/InterchainBatch.sol
+++ b/packages/contracts-communication/contracts/libs/InterchainBatch.sol
@@ -21,13 +21,13 @@ struct InterchainBatch {
     bytes32 batchRoot;
 }
 
+/// @dev Signals that the module has not verified any batch with the given key.
+uint256 constant BATCH_UNVERIFIED = 0;
+/// @dev Signals that the module has verified a conflicting batch with the given key.
+uint256 constant BATCH_CONFLICT = type(uint256).max;
+
 library InterchainBatchLib {
     using VersionedPayloadLib for bytes;
-
-    /// @dev Signals that the module has not verified any batch with the given key.
-    uint256 internal constant UNVERIFIED = 0;
-    /// @dev Signals that the module has verified a conflicting batch with the given key.
-    uint256 internal constant CONFLICT = type(uint256).max;
 
     /// @notice Constructs an InterchainBatch struct to be saved on the local chain.
     /// @param dbNonce      The database nonce of the batch

--- a/packages/contracts-communication/script/config/ConfigureAppV1.s.sol
+++ b/packages/contracts-communication/script/config/ConfigureAppV1.s.sol
@@ -96,18 +96,17 @@ abstract contract ConfigureAppV1 is SynapseScript {
     function setAppConfig() internal virtual {
         printLog("Setting app config");
         increaseIndent();
-        bytes memory rawConfig = config.parseRaw(".appConfig");
-        AppConfigV1 memory appConfig = abi.decode(rawConfig, (AppConfigV1));
-        printLog(string.concat("Required responses: ", vm.toString(appConfig.requiredResponses)));
-        printLog(string.concat("Optimistic period: ", vm.toString(appConfig.optimisticPeriod)));
+        uint256 requiredResponses = config.readUint(".appConfig.requiredResponses");
+        uint256 optimisticPeriod = config.readUint(".appConfig.optimisticPeriod");
+        printLog(string.concat("Required responses: ", vm.toString(requiredResponses)));
+        printLog(string.concat("Optimistic period: ", vm.toString(optimisticPeriod)));
         AppConfigV1 memory existingConfig = app.getAppConfigV1();
         if (
-            appConfig.requiredResponses == existingConfig.requiredResponses
-                && appConfig.optimisticPeriod == existingConfig.optimisticPeriod
+            requiredResponses == existingConfig.requiredResponses && optimisticPeriod == existingConfig.optimisticPeriod
         ) {
             printSkipWithIndent("config is already set");
         } else {
-            app.setAppConfigV1(appConfig);
+            app.setAppConfigV1(requiredResponses, optimisticPeriod);
             printSuccessWithIndent("Config set");
         }
         decreaseIndent();

--- a/packages/contracts-communication/test/InterchainClientV1.Base.t.sol
+++ b/packages/contracts-communication/test/InterchainClientV1.Base.t.sol
@@ -139,6 +139,10 @@ abstract contract InterchainClientV1BaseTest is Test, InterchainClientV1Events {
         );
     }
 
+    function expectRevertZeroAddress() internal {
+        vm.expectRevert(IInterchainClientV1.InterchainClientV1__ZeroAddress.selector);
+    }
+
     function expectRevertZeroExecutionService() internal {
         vm.expectRevert(IInterchainClientV1.InterchainClientV1__ZeroExecutionService.selector);
     }

--- a/packages/contracts-communication/test/InterchainClientV1.Base.t.sol
+++ b/packages/contracts-communication/test/InterchainClientV1.Base.t.sol
@@ -38,6 +38,7 @@ abstract contract InterchainClientV1BaseTest is Test, InterchainClientV1Events {
     address public execService;
 
     address public owner = makeAddr("Owner");
+    address public guardMock = makeAddr("Guard");
 
     function setUp() public virtual {
         vm.chainId(LOCAL_CHAIN_ID);
@@ -48,6 +49,11 @@ abstract contract InterchainClientV1BaseTest is Test, InterchainClientV1Events {
         icModuleB = address(new InterchainModuleMock());
         txLibHarness = new InterchainTransactionLibHarness();
         payloadLibHarness = new VersionedPayloadLibHarness();
+    }
+
+    function setDefaultGuard(address guard) public {
+        vm.prank(owner);
+        icClient.setDefaultGuard(guard);
     }
 
     function setLinkedClient(uint64 chainId, bytes32 client) public {
@@ -154,6 +160,11 @@ abstract contract InterchainClientV1BaseTest is Test, InterchainClientV1Events {
     }
 
     // ══════════════════════════════════════════════ EXPECT (EVENTS) ══════════════════════════════════════════════════
+
+    function expectEventGuardSet(address guard) internal {
+        vm.expectEmit(address(icClient));
+        emit DefaultGuardSet(guard);
+    }
 
     function expectEventLinkedClientSet(uint64 chainId, bytes32 client) internal {
         vm.expectEmit(address(icClient));

--- a/packages/contracts-communication/test/InterchainClientV1.Base.t.sol
+++ b/packages/contracts-communication/test/InterchainClientV1.Base.t.sol
@@ -38,7 +38,7 @@ abstract contract InterchainClientV1BaseTest is Test, InterchainClientV1Events {
     address public execService;
 
     address public owner = makeAddr("Owner");
-    address public guardMock = makeAddr("Guard");
+    address public defaultGuard = makeAddr("Default Guard");
 
     function setUp() public virtual {
         vm.chainId(LOCAL_CHAIN_ID);

--- a/packages/contracts-communication/test/InterchainClientV1.Dst.NoOP.NoDrop.t.sol
+++ b/packages/contracts-communication/test/InterchainClientV1.Dst.NoOP.NoDrop.t.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {InterchainClientV1DstTest, OptionsV1} from "./InterchainClientV1.Dst.t.sol";
+
+contract InterchainClientV1DstNoOptPeriodNoGasDropTest is InterchainClientV1DstTest {
+    function getOptions() internal pure override returns (OptionsV1 memory) {
+        return OptionsV1({gasLimit: 100_000, gasAirdrop: 0});
+    }
+
+    function getOptimisticPeriod() internal pure override returns (uint256) {
+        return 0;
+    }
+}

--- a/packages/contracts-communication/test/InterchainClientV1.Dst.NoOP.WithDrop.t.sol
+++ b/packages/contracts-communication/test/InterchainClientV1.Dst.NoOP.WithDrop.t.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {InterchainClientV1DstTest, OptionsV1} from "./InterchainClientV1.Dst.t.sol";
+
+contract InterchainClientV1DstNoOptPeriodWithGasDropTest is InterchainClientV1DstTest {
+    function getOptions() internal pure override returns (OptionsV1 memory) {
+        return OptionsV1({gasLimit: 100_000, gasAirdrop: 0.1 ether});
+    }
+
+    function getOptimisticPeriod() internal pure override returns (uint256) {
+        return 0;
+    }
+}

--- a/packages/contracts-communication/test/InterchainClientV1.Dst.WithOP.NoDrop.t.sol
+++ b/packages/contracts-communication/test/InterchainClientV1.Dst.WithOP.NoDrop.t.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {InterchainClientV1DstTest, OptionsV1} from "./InterchainClientV1.Dst.t.sol";
+
+contract InterchainClientV1DstWithOptPeriodNoGasDropTest is InterchainClientV1DstTest {
+    function getOptions() internal pure override returns (OptionsV1 memory) {
+        return OptionsV1({gasLimit: 100_000, gasAirdrop: 0});
+    }
+
+    function getOptimisticPeriod() internal pure override returns (uint256) {
+        return 10 minutes;
+    }
+}

--- a/packages/contracts-communication/test/InterchainClientV1.Dst.WithOP.WithDrop.t.sol
+++ b/packages/contracts-communication/test/InterchainClientV1.Dst.WithOP.WithDrop.t.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {InterchainClientV1DstTest, OptionsV1} from "./InterchainClientV1.Dst.t.sol";
+
+contract InterchainClientV1DstWithOptPeriodWithGasDropTest is InterchainClientV1DstTest {
+    function getOptions() internal pure override returns (OptionsV1 memory) {
+        return OptionsV1({gasLimit: 100_000, gasAirdrop: 0.1 ether});
+    }
+
+    function getOptimisticPeriod() internal pure override returns (uint256) {
+        return 10 minutes;
+    }
+}

--- a/packages/contracts-communication/test/InterchainClientV1.Dst.t.sol
+++ b/packages/contracts-communication/test/InterchainClientV1.Dst.t.sol
@@ -37,7 +37,7 @@ contract InterchainClientV1DestinationTest is InterchainClientV1BaseTest {
     uint256 public constant MOCK_GAS_LIMIT = 100_000;
     uint256 public constant MOCK_GAS_AIRDROP = 1 ether;
 
-    uint256 public constant MOCK_OPTIMISTIC_PERIOD = 10 minutes;
+    uint256 public constant MOCK_OP = 10 minutes;
     uint256 public constant BIGGER_PERIOD = 7 days;
 
     bytes32 public constant MOCK_SRC_SENDER = keccak256("Sender");
@@ -49,10 +49,16 @@ contract InterchainClientV1DestinationTest is InterchainClientV1BaseTest {
     bytes public invalidOptionsV0 = VersionedPayloadLib.encodeVersionedPayload(0, abi.encode(optionsAirdrop));
     bytes public invalidOptionsV1 = VersionedPayloadLib.encodeVersionedPayload(1, abi.encode(optionsAirdrop.gasLimit));
 
-    AppConfigV1 public oneConfNoOP = AppConfigV1({requiredResponses: 1, optimisticPeriod: 0});
-    AppConfigV1 public oneConfWithOP = AppConfigV1({requiredResponses: 1, optimisticPeriod: MOCK_OPTIMISTIC_PERIOD});
-    AppConfigV1 public twoConfNoOP = AppConfigV1({requiredResponses: 2, optimisticPeriod: 0});
-    AppConfigV1 public twoConfWithOP = AppConfigV1({requiredResponses: 2, optimisticPeriod: MOCK_OPTIMISTIC_PERIOD});
+    AppConfigV1 public oneConfNoOP = AppConfigV1({requiredResponses: 1, optimisticPeriod: 0, guardFlag: 0});
+    AppConfigV1 public oneConfWithOP = AppConfigV1({requiredResponses: 1, optimisticPeriod: MOCK_OP, guardFlag: 0});
+    AppConfigV1 public twoConfNoOP = AppConfigV1({requiredResponses: 2, optimisticPeriod: 0, guardFlag: 0});
+    AppConfigV1 public twoConfWithOP = AppConfigV1({requiredResponses: 2, optimisticPeriod: MOCK_OP, guardFlag: 0});
+
+    // TODO: tests with these configs
+    AppConfigV1 public oneConfNoOpWithG = AppConfigV1({requiredResponses: 1, optimisticPeriod: 0, guardFlag: 1});
+    AppConfigV1 public oneConfWithOpWithG = AppConfigV1({requiredResponses: 1, optimisticPeriod: MOCK_OP, guardFlag: 1});
+    AppConfigV1 public twoConfNoOpWithG = AppConfigV1({requiredResponses: 2, optimisticPeriod: 0, guardFlag: 1});
+    AppConfigV1 public twoConfWithOpWithG = AppConfigV1({requiredResponses: 2, optimisticPeriod: MOCK_OP, guardFlag: 1});
 
     address public executor = makeAddr("Executor");
 
@@ -73,8 +79,8 @@ contract InterchainClientV1DestinationTest is InterchainClientV1BaseTest {
     uint256 public constant INITIAL_TS = 1_704_067_200; // 2024-01-01 00:00:00 UTC
 
     uint256 public constant NOT_VERIFIED = 0;
-    uint256 public constant ALMOST_VERIFIED = INITIAL_TS - MOCK_OPTIMISTIC_PERIOD;
-    uint256 public constant JUST_VERIFIED = INITIAL_TS - MOCK_OPTIMISTIC_PERIOD - 1;
+    uint256 public constant ALMOST_VERIFIED = INITIAL_TS - MOCK_OP;
+    uint256 public constant JUST_VERIFIED = INITIAL_TS - MOCK_OP - 1;
     uint256 public constant OVER_VERIFIED = INITIAL_TS - BIGGER_PERIOD;
 
     uint256 public constant JUST_NOW = INITIAL_TS - 1;
@@ -82,6 +88,7 @@ contract InterchainClientV1DestinationTest is InterchainClientV1BaseTest {
     function setUp() public override {
         vm.warp(INITIAL_TS);
         super.setUp();
+        setDefaultGuard(guardMock);
         setLinkedClient(REMOTE_CHAIN_ID, MOCK_REMOTE_CLIENT);
         dstReceiver = address(new InterchainAppMock());
         dstReceiverBytes32 = bytes32(uint256(uint160(dstReceiver)));

--- a/packages/contracts-communication/test/InterchainClientV1.Dst.t.sol
+++ b/packages/contracts-communication/test/InterchainClientV1.Dst.t.sol
@@ -126,11 +126,11 @@ abstract contract InterchainClientV1DstTest is InterchainClientV1BaseTest {
     function getOptimisticPeriod() internal view virtual returns (uint256);
 
     function getAppConfig(uint256 requiredResponses, uint256 guardFlag) internal view returns (AppConfigV1 memory) {
-        // TODO: add custom guard address once implemented
         return AppConfigV1({
             requiredResponses: requiredResponses,
             optimisticPeriod: getOptimisticPeriod(),
-            guardFlag: guardFlag
+            guardFlag: guardFlag,
+            guard: guardFlag == GUARD_CUSTOM ? customGuard : address(0)
         });
     }
 

--- a/packages/contracts-communication/test/InterchainClientV1.Dst.t.sol
+++ b/packages/contracts-communication/test/InterchainClientV1.Dst.t.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.20;
 
 import {AppConfigV1} from "../contracts/libs/AppConfig.sol";
 import {InterchainBatch} from "../contracts/libs/InterchainBatch.sol";
+import {InterchainEntryLib} from "../contracts/libs/InterchainEntry.sol";
 import {OptionsV1} from "../contracts/libs/Options.sol";
 import {VersionedPayloadLib} from "../contracts/libs/VersionedPayload.sol";
 
@@ -27,38 +28,17 @@ import {InterchainDBMock} from "./mocks/InterchainDBMock.sol";
 /// 3d. Check that enough responses have been received for entry constructed in step 3b.
 /// 4. Execute the transaction by passing the message to the recipient.
 /// 5. Mark transaction as executed and emit an event.
-contract InterchainClientV1DestinationTest is InterchainClientV1BaseTest {
+abstract contract InterchainClientV1DstTest is InterchainClientV1BaseTest {
     uint64 public constant MOCK_DB_NONCE = 444;
     uint64 public constant MOCK_ENTRY_INDEX = 0;
 
     uint64 public constant MOCK_LOCAL_DB_NONCE = 123;
     uint64 public constant MOCK_LOCAL_ENTRY_INDEX = 0;
 
-    uint256 public constant MOCK_GAS_LIMIT = 100_000;
-    uint256 public constant MOCK_GAS_AIRDROP = 1 ether;
-
-    uint256 public constant MOCK_OP = 10 minutes;
     uint256 public constant BIGGER_PERIOD = 7 days;
 
     bytes32 public constant MOCK_SRC_SENDER = keccak256("Sender");
     bytes public constant MOCK_MESSAGE = "Hello, World!";
-
-    OptionsV1 public optionsAirdrop = OptionsV1({gasLimit: MOCK_GAS_LIMIT, gasAirdrop: MOCK_GAS_AIRDROP});
-    OptionsV1 public optionsNoAirdrop = OptionsV1({gasLimit: MOCK_GAS_LIMIT, gasAirdrop: 0});
-
-    bytes public invalidOptionsV0 = VersionedPayloadLib.encodeVersionedPayload(0, abi.encode(optionsAirdrop));
-    bytes public invalidOptionsV1 = VersionedPayloadLib.encodeVersionedPayload(1, abi.encode(optionsAirdrop.gasLimit));
-
-    AppConfigV1 public oneConfNoOP = AppConfigV1({requiredResponses: 1, optimisticPeriod: 0, guardFlag: 0});
-    AppConfigV1 public oneConfWithOP = AppConfigV1({requiredResponses: 1, optimisticPeriod: MOCK_OP, guardFlag: 0});
-    AppConfigV1 public twoConfNoOP = AppConfigV1({requiredResponses: 2, optimisticPeriod: 0, guardFlag: 0});
-    AppConfigV1 public twoConfWithOP = AppConfigV1({requiredResponses: 2, optimisticPeriod: MOCK_OP, guardFlag: 0});
-
-    // TODO: tests with these configs
-    AppConfigV1 public oneConfNoOpWithG = AppConfigV1({requiredResponses: 1, optimisticPeriod: 0, guardFlag: 1});
-    AppConfigV1 public oneConfWithOpWithG = AppConfigV1({requiredResponses: 1, optimisticPeriod: MOCK_OP, guardFlag: 1});
-    AppConfigV1 public twoConfNoOpWithG = AppConfigV1({requiredResponses: 2, optimisticPeriod: 0, guardFlag: 1});
-    AppConfigV1 public twoConfWithOpWithG = AppConfigV1({requiredResponses: 2, optimisticPeriod: MOCK_OP, guardFlag: 1});
 
     address public executor = makeAddr("Executor");
 
@@ -75,20 +55,18 @@ contract InterchainClientV1DestinationTest is InterchainClientV1BaseTest {
     // - Almost verified: verified exactly "optimistic period" ago
     // - Just verified: verified exactly "optimistic period + 1 second" ago
     // - Over verified: verified long ago
+    // - Conflict: module verified a conflicting batch
     // Only "just verified" and "over verified" should be considered as verified.
     uint256 public constant INITIAL_TS = 1_704_067_200; // 2024-01-01 00:00:00 UTC
 
     uint256 public constant NOT_VERIFIED = 0;
-    uint256 public constant ALMOST_VERIFIED = INITIAL_TS - MOCK_OP;
-    uint256 public constant JUST_VERIFIED = INITIAL_TS - MOCK_OP - 1;
     uint256 public constant OVER_VERIFIED = INITIAL_TS - BIGGER_PERIOD;
-
-    uint256 public constant JUST_NOW = INITIAL_TS - 1;
+    uint256 public constant CONFLICT = type(uint256).max;
 
     function setUp() public override {
         vm.warp(INITIAL_TS);
         super.setUp();
-        setDefaultGuard(guardMock);
+        setDefaultGuard(defaultGuard);
         setLinkedClient(REMOTE_CHAIN_ID, MOCK_REMOTE_CLIENT);
         dstReceiver = address(new InterchainAppMock());
         dstReceiverBytes32 = bytes32(uint256(uint160(dstReceiver)));
@@ -97,11 +75,14 @@ contract InterchainClientV1DestinationTest is InterchainClientV1BaseTest {
         twoModules.push(icModuleB);
     }
 
-    /// @dev Override the InterchainApp's receiving config to return the given appConfig and modules.
-    function mockReceivingConfig(AppConfigV1 memory appConfig, address[] memory modules) internal {
+    // ════════════════════════════════════════════════ MOCK TOOLS ═════════════════════════════════════════════════════
+
+    /// @dev Override the InterchainApp's receiving config to return the given appConfig and two modules.
+    function mockReceivingConfig(uint256 requiredResponses, uint256 guardFlag) internal {
+        AppConfigV1 memory appConfig = getAppConfig(requiredResponses, guardFlag);
         bytes memory encodedConfig = appConfig.encodeAppConfigV1();
         vm.mockCall(
-            dstReceiver, abi.encodeCall(InterchainAppMock.getReceivingConfig, ()), abi.encode(encodedConfig, modules)
+            dstReceiver, abi.encodeCall(InterchainAppMock.getReceivingConfig, ()), abi.encode(encodedConfig, twoModules)
         );
     }
 
@@ -117,7 +98,7 @@ contract InterchainClientV1DestinationTest is InterchainClientV1BaseTest {
         InterchainBatch memory batch = InterchainBatch({
             srcChainId: REMOTE_CHAIN_ID,
             dbNonce: desc.dbNonce,
-            batchRoot: keccak256(abi.encode(MOCK_REMOTE_CLIENT, desc.transactionId))
+            batchRoot: InterchainEntryLib.getEntryValue({srcWriter: MOCK_REMOTE_CLIENT, dataHash: desc.transactionId})
         });
         vm.mockCall(
             icDB, abi.encodeCall(InterchainDBMock.checkBatchVerification, (dstModule, batch)), abi.encode(verifiedAt)
@@ -131,6 +112,50 @@ contract InterchainClientV1DestinationTest is InterchainClientV1BaseTest {
         vm.mockCall(icDB, abi.encodeWithSelector(InterchainDBMock.getNextEntryIndex.selector), returnData);
         vm.mockCall(icDB, abi.encodeWithSelector(InterchainDBMock.writeEntry.selector), returnData);
         vm.mockCall(icDB, abi.encodeWithSelector(InterchainDBMock.writeEntryWithVerification.selector), returnData);
+    }
+
+    // ═════════════════════════════════════════════════ TEST DATA ═════════════════════════════════════════════════════
+
+    function getOptions() internal view virtual returns (OptionsV1 memory);
+    function getOptimisticPeriod() internal view virtual returns (uint256);
+
+    function getAppConfig(uint256 requiredResponses, uint256 guardFlag) internal view returns (AppConfigV1 memory) {
+        return AppConfigV1({
+            requiredResponses: requiredResponses,
+            optimisticPeriod: getOptimisticPeriod(),
+            guardFlag: guardFlag
+        });
+    }
+
+    function almostVerTS() internal view returns (uint256) {
+        return INITIAL_TS - getOptimisticPeriod();
+    }
+
+    function justVerTS() internal view returns (uint256) {
+        return INITIAL_TS - getOptimisticPeriod() - 1;
+    }
+
+    function getTimestampFixture(uint256 index) internal view returns (uint256) {
+        index = index % 5;
+        if (index == 0) {
+            return NOT_VERIFIED;
+        } else if (index == 1) {
+            return almostVerTS();
+        } else if (index == 2) {
+            return justVerTS();
+        } else if (index == 3) {
+            return OVER_VERIFIED;
+        } else {
+            return CONFLICT;
+        }
+    }
+
+    function boundTimestamp(uint256 timestamp) internal view returns (uint256) {
+        if (timestamp == CONFLICT) {
+            return timestamp;
+        } else {
+            return timestamp % block.timestamp;
+        }
     }
 
     /// @dev Constructs an interchain transaction and its descriptor for testing.
@@ -149,14 +174,26 @@ contract InterchainClientV1DestinationTest is InterchainClientV1BaseTest {
             options: encodedOptions,
             message: MOCK_MESSAGE
         });
-        desc = InterchainTxDescriptor({
-            dbNonce: MOCK_DB_NONCE,
-            entryIndex: MOCK_ENTRY_INDEX,
+        desc = getTxDescriptor(icTx);
+    }
+
+    function constructInterchainTx()
+        internal
+        view
+        returns (InterchainTransaction memory icTx, InterchainTxDescriptor memory desc)
+    {
+        return constructInterchainTx(getOptions().encodeOptionsV1());
+    }
+
+    function getTxDescriptor(InterchainTransaction memory icTx) internal view returns (InterchainTxDescriptor memory) {
+        return InterchainTxDescriptor({
+            dbNonce: icTx.dbNonce,
+            entryIndex: icTx.entryIndex,
             transactionId: keccak256(getEncodedTx(icTx))
         });
     }
 
-    // ═══════════════════════════════════════════════ TEST HELPERS ════════════════════════════════════════════════════
+    // ══════════════════════════════════════════════ TEST ASSERTIONS ══════════════════════════════════════════════════
 
     function expectAppReceiveCall(OptionsV1 memory options) internal {
         bytes memory expectedCalldata = abi.encodeCall(
@@ -177,940 +214,297 @@ contract InterchainClientV1DestinationTest is InterchainClientV1BaseTest {
         assertEq(icClient.getExecutorById(desc.transactionId), executor, "!getExecutorById");
     }
 
-    function executeTransaction(bytes memory encodedTx, OptionsV1 memory options, bytes32[] memory proof) internal {
+    // ═══════════════════════════════════════════════ TEST HELPERS ════════════════════════════════════════════════════
+
+    function executeTransaction(bytes memory encodedTx, bytes32[] memory proof) internal {
+        OptionsV1 memory options = getOptions();
         deal(executor, options.gasAirdrop);
         vm.prank(executor);
         icClient.interchainExecute{value: options.gasAirdrop}(options.gasLimit, encodedTx, proof);
     }
 
     function prepareExecuteTest(
-        bytes memory encodedOptions,
-        AppConfigV1 memory appConfig,
-        address[] memory modules,
+        uint256 requiredResponses,
+        uint256 guardFlag,
         uint256[] memory verificationTimes
     )
         internal
         returns (InterchainTransaction memory icTx, InterchainTxDescriptor memory desc)
     {
         // Sanity check
-        assert(modules.length == verificationTimes.length);
-        (icTx, desc) = constructInterchainTx(encodedOptions);
-        mockReceivingConfig(appConfig, modules);
-        for (uint256 i = 0; i < modules.length; i++) {
-            mockCheckVerification(modules[i], desc, verificationTimes[i]);
+        assert(twoModules.length == verificationTimes.length);
+        (icTx, desc) = constructInterchainTx();
+        mockReceivingConfig(requiredResponses, guardFlag);
+        for (uint256 i = 0; i < twoModules.length; i++) {
+            mockCheckVerification(twoModules[i], desc, verificationTimes[i]);
         }
     }
 
-    function prepareAlreadyExecutedTest(OptionsV1 memory options)
+    function prepareAlreadyExecutedTest()
         internal
         returns (InterchainTransaction memory icTx, InterchainTxDescriptor memory desc)
     {
         (icTx, desc) = prepareExecuteTest({
-            encodedOptions: options.encodeOptionsV1(),
-            appConfig: oneConfWithOP,
-            modules: oneModuleA,
-            verificationTimes: toArray(JUST_VERIFIED)
+            requiredResponses: 2,
+            guardFlag: 1,
+            verificationTimes: toArr(OVER_VERIFIED, OVER_VERIFIED)
         });
         bytes memory encodedTx = getEncodedTx(icTx);
-        executeTransaction(encodedTx, options, emptyProof);
+        executeTransaction(encodedTx, emptyProof);
         skip(1 days);
     }
 
-    function checkHappyPathScenario(
-        OptionsV1 memory options,
-        InterchainTransaction memory icTx,
-        InterchainTxDescriptor memory desc,
-        bytes32[] memory proof
-    )
-        internal
-    {
+    function makeTxDescriptorExecutable(InterchainTxDescriptor memory desc) internal {
+        mockReceivingConfig({requiredResponses: 1, guardFlag: 0});
+        mockCheckVerification(icModuleA, desc, justVerTS());
+    }
+
+    function addGuardConflict(address guard) internal {
+        (, InterchainTxDescriptor memory desc) = constructInterchainTx();
+        mockCheckVerification(guard, desc, CONFLICT);
+    }
+
+    /// @dev Assuming the transaction is ready to be executed, check the happy path scenario.
+    function executeAndCheck(InterchainTransaction memory icTx, InterchainTxDescriptor memory desc) internal {
+        OptionsV1 memory options = getOptions();
         expectAppReceiveCall(options);
         expectEventInterchainTransactionReceived(icTx, desc);
         bytes memory encodedTx = getEncodedTx(icTx);
-        assertTrue(icClient.isExecutable(encodedTx, proof));
-        executeTransaction(encodedTx, options, proof);
+        assertTrue(icClient.isExecutable(encodedTx, emptyProof));
+        executeTransaction(encodedTx, emptyProof);
         assertExecutorSaved(icTx, desc);
+        assertEq(dstReceiver.balance, options.gasAirdrop);
     }
 
-    function checkSuccessA(
-        OptionsV1 memory options,
-        AppConfigV1 memory appConfig,
-        uint256[] memory verificationTimes
-    )
-        internal
-    {
-        (InterchainTransaction memory icTx, InterchainTxDescriptor memory desc) = prepareExecuteTest({
-            encodedOptions: options.encodeOptionsV1(),
-            appConfig: appConfig,
-            modules: oneModuleA,
-            verificationTimes: verificationTimes
-        });
-        checkHappyPathScenario(options, icTx, desc, emptyProof);
-    }
-
-    function checkSuccessAB(
-        OptionsV1 memory options,
-        AppConfigV1 memory appConfig,
-        uint256[] memory verificationTimes
-    )
-        internal
-    {
-        (InterchainTransaction memory icTx, InterchainTxDescriptor memory desc) = prepareExecuteTest({
-            encodedOptions: options.encodeOptionsV1(),
-            appConfig: appConfig,
-            modules: twoModules,
-            verificationTimes: verificationTimes
-        });
-        checkHappyPathScenario(options, icTx, desc, emptyProof);
-    }
-
-    function checkNotEnoughConfirmationsA(
-        OptionsV1 memory options,
-        AppConfigV1 memory appConfig,
-        uint256 actualConfirmations,
-        uint256[] memory verificationTimes
-    )
-        internal
-    {
-        (InterchainTransaction memory icTx,) = prepareExecuteTest({
-            encodedOptions: options.encodeOptionsV1(),
-            appConfig: appConfig,
-            modules: oneModuleA,
-            verificationTimes: verificationTimes
-        });
-        bytes memory encodedTx = getEncodedTx(icTx);
-        expectRevertNotEnoughResponses({actual: actualConfirmations, required: appConfig.requiredResponses});
-        icClient.isExecutable(encodedTx, emptyProof);
-        expectRevertNotEnoughResponses({actual: actualConfirmations, required: appConfig.requiredResponses});
-        executeTransaction(encodedTx, options, emptyProof);
-    }
-
-    function checkNotEnoughConfirmationsAB(
-        OptionsV1 memory options,
-        AppConfigV1 memory appConfig,
-        uint256 actualConfirmations,
-        uint256[] memory verificationTimes
-    )
-        internal
-    {
-        (InterchainTransaction memory icTx,) = prepareExecuteTest({
-            encodedOptions: options.encodeOptionsV1(),
-            appConfig: appConfig,
-            modules: twoModules,
-            verificationTimes: verificationTimes
-        });
-        bytes memory encodedTx = getEncodedTx(icTx);
-        expectRevertNotEnoughResponses({actual: actualConfirmations, required: appConfig.requiredResponses});
-        icClient.isExecutable(encodedTx, emptyProof);
-        expectRevertNotEnoughResponses({actual: actualConfirmations, required: appConfig.requiredResponses});
-        executeTransaction(encodedTx, options, emptyProof);
-    }
-
-    function checkBatchConflictAB(
-        OptionsV1 memory options,
-        AppConfigV1 memory appConfig,
-        uint256 verificationTimeHonest
-    )
-        internal
-    {
+    /// @dev Execute the happy path scenario with the given modules and verification times.
+    function checkHappyPath(uint256 required, uint256 guardFlag, uint256[] memory times) internal {
         (InterchainTransaction memory icTx, InterchainTxDescriptor memory desc) =
-            constructInterchainTx(options.encodeOptionsV1());
-        mockReceivingConfig(appConfig, twoModules);
-        mockCheckVerification(twoModules[0], desc, verificationTimeHonest);
-        mockCheckVerification(twoModules[1], desc, type(uint256).max);
+            prepareExecuteTest(required, guardFlag, times);
+        executeAndCheck(icTx, desc);
+    }
+
+    /// @dev Execute the scenario where not enough confirmations have been received.
+    /// Both `isExecutable` and `interchainExecute` should revert.
+    function checkNotEnoughConfirmations(
+        uint256 actual,
+        uint256 required,
+        uint256 guardFlag,
+        uint256[] memory times
+    )
+        internal
+    {
+        (InterchainTransaction memory icTx,) = prepareExecuteTest(required, guardFlag, times);
         bytes memory encodedTx = getEncodedTx(icTx);
-        expectRevertBatchConflict(twoModules[1]);
+        expectRevertNotEnoughResponses({actual: actual, required: required});
         icClient.isExecutable(encodedTx, emptyProof);
-        expectRevertBatchConflict(twoModules[1]);
-        executeTransaction(encodedTx, options, emptyProof);
+        expectRevertNotEnoughResponses({actual: actual, required: required});
+        executeTransaction(encodedTx, emptyProof);
     }
 
-    // ══════════════════════════════════════════ REQUIRED: 1, MODULES: A ══════════════════════════════════════════════
-
-    function test_interchainExecute_1_A_periodNonZero_notVerifiedA_revert() public {
-        checkNotEnoughConfirmationsA(optionsNoAirdrop, oneConfWithOP, 0, toArray(NOT_VERIFIED));
-    }
-
-    function test_interchainExecute_1_A_periodNonZero_almostVerifiedA_revert() public {
-        checkNotEnoughConfirmationsA(optionsNoAirdrop, oneConfWithOP, 0, toArray(ALMOST_VERIFIED));
-    }
-
-    function test_interchainExecute_1_A_periodNonZero_justVerifiedA_noAirdrop_success() public {
-        checkSuccessA(optionsNoAirdrop, oneConfWithOP, toArray(JUST_VERIFIED));
-    }
-
-    function test_interchainExecute_1_A_periodNonZero_justVerifiedA_withAirdrop_success() public {
-        checkSuccessA(optionsAirdrop, oneConfWithOP, toArray(JUST_VERIFIED));
-    }
-
-    function test_interchainExecute_1_A_periodNonZero_overVerifiedA_noAirdrop_success() public {
-        checkSuccessA(optionsNoAirdrop, oneConfWithOP, toArray(OVER_VERIFIED));
-    }
-
-    function test_interchainExecute_1_A_periodNonZero_overVerifiedA_withAirdrop_success() public {
-        checkSuccessA(optionsAirdrop, oneConfWithOP, toArray(OVER_VERIFIED));
-    }
-
-    // ═══════════════════════════════════ REQUIRED: 1, MODULES: A (PERIOD ZERO) ═══════════════════════════════════════
-
-    function test_interchainExecute_1_A_periodZero_notVerifiedA_revert() public {
-        checkNotEnoughConfirmationsA(optionsNoAirdrop, oneConfNoOP, 0, toArray(NOT_VERIFIED));
-    }
-
-    function test_interchainExecute_1_A_periodZero_almostVerifiedA_revert() public {
-        checkNotEnoughConfirmationsA(optionsNoAirdrop, oneConfNoOP, 0, toArray(INITIAL_TS));
-    }
-
-    function test_interchainExecute_1_A_periodZero_justVerifiedA_noAirdrop_success() public {
-        checkSuccessA(optionsNoAirdrop, oneConfNoOP, toArray(JUST_NOW));
-    }
-
-    function test_interchainExecute_1_A_periodZero_justVerifiedA_withAirdrop_success() public {
-        checkSuccessA(optionsAirdrop, oneConfNoOP, toArray(JUST_NOW));
-    }
-
-    function test_interchainExecute_1_A_periodZero_overVerifiedA_noAirdrop_success() public {
-        checkSuccessA(optionsNoAirdrop, oneConfNoOP, toArray(OVER_VERIFIED));
-    }
-
-    function test_interchainExecute_1_A_periodZero_overVerifiedA_withAirdrop_success() public {
-        checkSuccessA(optionsAirdrop, oneConfNoOP, toArray(OVER_VERIFIED));
-    }
-
-    // ═════════════════════════════════════════ REQUIRED: 1, MODULES: A+B ═════════════════════════════════════════════
-
-    function test_interchainExecute_1_AB_periodNonZero_notVerifiedA_notVerifiedB_revert() public {
-        checkNotEnoughConfirmationsAB(optionsNoAirdrop, oneConfWithOP, 0, toArr(NOT_VERIFIED, NOT_VERIFIED));
-    }
-
-    function test_interchainExecute_1_AB_periodNonZero_notVerifiedA_almostVerifiedB_revert() public {
-        checkNotEnoughConfirmationsAB(optionsNoAirdrop, oneConfWithOP, 0, toArr(NOT_VERIFIED, ALMOST_VERIFIED));
-    }
-
-    function test_interchainExecute_1_AB_periodNonZero_notVerifiedA_justVerifiedB_noAirdrop_success() public {
-        checkSuccessAB(optionsNoAirdrop, oneConfWithOP, toArr(NOT_VERIFIED, JUST_VERIFIED));
-    }
-
-    function test_interchainExecute_1_AB_periodNonZero_notVerifiedA_justVerifiedB_withAirdrop_success() public {
-        checkSuccessAB(optionsAirdrop, oneConfWithOP, toArr(NOT_VERIFIED, JUST_VERIFIED));
-    }
-
-    function test_interchainExecute_1_AB_periodNonZero_notVerifiedA_overVerifiedB_noAirdrop_success() public {
-        checkSuccessAB(optionsNoAirdrop, oneConfWithOP, toArr(NOT_VERIFIED, OVER_VERIFIED));
-    }
-
-    function test_interchainExecute_1_AB_periodNonZero_notVerifiedA_overVerifiedB_withAirdrop_success() public {
-        checkSuccessAB(optionsAirdrop, oneConfWithOP, toArr(NOT_VERIFIED, OVER_VERIFIED));
-    }
-
-    function test_interchainExecute_1_AB_periodNonZero_almostVerifiedA_notVerifiedB_revert() public {
-        checkNotEnoughConfirmationsAB(optionsNoAirdrop, oneConfWithOP, 0, toArr(ALMOST_VERIFIED, NOT_VERIFIED));
-    }
-
-    function test_interchainExecute_1_AB_periodNonZero_almostVerifiedA_almostVerifiedB_revert() public {
-        checkNotEnoughConfirmationsAB(optionsNoAirdrop, oneConfWithOP, 0, toArr(ALMOST_VERIFIED, ALMOST_VERIFIED));
-    }
-
-    function test_interchainExecute_1_AB_periodNonZero_almostVerifiedA_justVerifiedB_noAirdrop_success() public {
-        checkSuccessAB(optionsNoAirdrop, oneConfWithOP, toArr(ALMOST_VERIFIED, JUST_VERIFIED));
-    }
-
-    function test_interchainExecute_1_AB_periodNonZero_almostVerifiedA_justVerifiedB_withAirdrop_success() public {
-        checkSuccessAB(optionsAirdrop, oneConfWithOP, toArr(ALMOST_VERIFIED, JUST_VERIFIED));
-    }
-
-    function test_interchainExecute_1_AB_periodNonZero_almostVerifiedA_overVerifiedB_noAirdrop_success() public {
-        checkSuccessAB(optionsNoAirdrop, oneConfWithOP, toArr(ALMOST_VERIFIED, OVER_VERIFIED));
-    }
-
-    function test_interchainExecute_1_AB_periodNonZero_almostVerifiedA_overVerifiedB_withAirdrop_success() public {
-        checkSuccessAB(optionsAirdrop, oneConfWithOP, toArr(ALMOST_VERIFIED, OVER_VERIFIED));
-    }
-
-    function test_interchainExecute_1_AB_periodNonZero_justVerifiedA_notVerifiedB_noAirdrop_success() public {
-        checkSuccessAB(optionsNoAirdrop, oneConfWithOP, toArr(JUST_VERIFIED, NOT_VERIFIED));
-    }
-
-    function test_interchainExecute_1_AB_periodNonZero_justVerifiedA_notVerifiedB_withAirdrop_success() public {
-        checkSuccessAB(optionsAirdrop, oneConfWithOP, toArr(JUST_VERIFIED, NOT_VERIFIED));
-    }
-
-    function test_interchainExecute_1_AB_periodNonZero_justVerifiedA_almostVerifiedB_noAirdrop_success() public {
-        checkSuccessAB(optionsNoAirdrop, oneConfWithOP, toArr(JUST_VERIFIED, ALMOST_VERIFIED));
-    }
-
-    function test_interchainExecute_1_AB_periodNonZero_justVerifiedA_almostVerifiedB_withAirdrop_success() public {
-        checkSuccessAB(optionsAirdrop, oneConfWithOP, toArr(JUST_VERIFIED, ALMOST_VERIFIED));
-    }
-
-    function test_interchainExecute_1_AB_periodNonZero_justVerifiedA_justVerifiedB_noAirdrop_success() public {
-        checkSuccessAB(optionsNoAirdrop, oneConfWithOP, toArr(JUST_VERIFIED, JUST_VERIFIED));
-    }
-
-    function test_interchainExecute_1_AB_periodNonZero_justVerifiedA_justVerifiedB_withAirdrop_success() public {
-        checkSuccessAB(optionsAirdrop, oneConfWithOP, toArr(JUST_VERIFIED, JUST_VERIFIED));
-    }
-
-    function test_interchainExecute_1_AB_periodNonZero_justVerifiedA_overVerifiedB_noAirdrop_success() public {
-        checkSuccessAB(optionsNoAirdrop, oneConfWithOP, toArr(JUST_VERIFIED, OVER_VERIFIED));
-    }
-
-    function test_interchainExecute_1_AB_periodNonZero_justVerifiedA_overVerifiedB_withAirdrop_success() public {
-        checkSuccessAB(optionsAirdrop, oneConfWithOP, toArr(JUST_VERIFIED, OVER_VERIFIED));
-    }
-
-    function test_interchainExecute_1_AB_periodNonZero_overVerifiedA_notVerifiedB_noAirdrop_success() public {
-        checkSuccessAB(optionsNoAirdrop, oneConfWithOP, toArr(OVER_VERIFIED, NOT_VERIFIED));
-    }
-
-    function test_interchainExecute_1_AB_periodNonZero_overVerifiedA_notVerifiedB_withAirdrop_success() public {
-        checkSuccessAB(optionsAirdrop, oneConfWithOP, toArr(OVER_VERIFIED, NOT_VERIFIED));
-    }
-
-    function test_interchainExecute_1_AB_periodNonZero_overVerifiedA_almostVerifiedB_noAirdrop_success() public {
-        checkSuccessAB(optionsNoAirdrop, oneConfWithOP, toArr(OVER_VERIFIED, ALMOST_VERIFIED));
-    }
-
-    function test_interchainExecute_1_AB_periodNonZero_overVerifiedA_almostVerifiedB_withAirdrop_success() public {
-        checkSuccessAB(optionsAirdrop, oneConfWithOP, toArr(OVER_VERIFIED, ALMOST_VERIFIED));
-    }
-
-    function test_interchainExecute_1_AB_periodNonZero_overVerifiedA_justVerifiedB_noAirdrop_success() public {
-        checkSuccessAB(optionsNoAirdrop, oneConfWithOP, toArr(OVER_VERIFIED, JUST_VERIFIED));
-    }
-
-    function test_interchainExecute_1_AB_periodNonZero_overVerifiedA_justVerifiedB_withAirdrop_success() public {
-        checkSuccessAB(optionsAirdrop, oneConfWithOP, toArr(OVER_VERIFIED, JUST_VERIFIED));
-    }
-
-    function test_interchainExecute_1_AB_periodNonZero_overVerifiedA_overVerifiedB_noAirdrop_success() public {
-        checkSuccessAB(optionsNoAirdrop, oneConfWithOP, toArr(OVER_VERIFIED, OVER_VERIFIED));
-    }
-
-    function test_interchainExecute_1_AB_periodNonZero_overVerifiedA_overVerifiedB_withAirdrop_success() public {
-        checkSuccessAB(optionsAirdrop, oneConfWithOP, toArr(OVER_VERIFIED, OVER_VERIFIED));
-    }
-
-    // ═════════════════════════════════ REQUIRED: 1, MODULES: A+B, WITH CONFLICT ══════════════════════════════════════
-
-    function test_interchainExecute_1_AB_periodNonZero_conflict_almostVerifiedA_revert() public {
-        checkBatchConflictAB(optionsNoAirdrop, oneConfWithOP, ALMOST_VERIFIED);
-    }
-
-    function test_interchainExecute_1_AB_periodNonZero_conflict_justVerifiedA_revert() public {
-        checkBatchConflictAB(optionsNoAirdrop, oneConfWithOP, JUST_VERIFIED);
-    }
-
-    function test_interchainExecute_1_AB_periodNonZero_conflict_overVerifiedA_revert() public {
-        checkBatchConflictAB(optionsNoAirdrop, oneConfWithOP, OVER_VERIFIED);
-    }
-
-    // ══════════════════════════════════ REQUIRED: 1, MODULES: A+B (PERIOD ZERO) ══════════════════════════════════════
-
-    function test_interchainExecute_1_AB_periodZero_notVerifiedA_notVerifiedB_revert() public {
-        checkNotEnoughConfirmationsAB(optionsNoAirdrop, oneConfNoOP, 0, toArr(NOT_VERIFIED, NOT_VERIFIED));
-    }
-
-    function test_interchainExecute_1_AB_periodZero_notVerifiedA_almostVerifiedB_revert() public {
-        checkNotEnoughConfirmationsAB(optionsNoAirdrop, oneConfNoOP, 0, toArr(NOT_VERIFIED, INITIAL_TS));
-    }
-
-    function test_interchainExecute_1_AB_periodZero_notVerifiedA_justVerifiedB_noAirdrop_success() public {
-        checkSuccessAB(optionsNoAirdrop, oneConfNoOP, toArr(NOT_VERIFIED, JUST_NOW));
-    }
-
-    function test_interchainExecute_1_AB_periodZero_notVerifiedA_justVerifiedB_withAirdrop_success() public {
-        checkSuccessAB(optionsAirdrop, oneConfNoOP, toArr(NOT_VERIFIED, JUST_NOW));
-    }
-
-    function test_interchainExecute_1_AB_periodZero_notVerifiedA_overVerifiedB_noAirdrop_success() public {
-        checkSuccessAB(optionsNoAirdrop, oneConfNoOP, toArr(NOT_VERIFIED, OVER_VERIFIED));
-    }
-
-    function test_interchainExecute_1_AB_periodZero_notVerifiedA_overVerifiedB_withAirdrop_success() public {
-        checkSuccessAB(optionsAirdrop, oneConfNoOP, toArr(NOT_VERIFIED, OVER_VERIFIED));
-    }
-
-    function test_interchainExecute_1_AB_periodZero_almostVerifiedA_notVerifiedB_revert() public {
-        checkNotEnoughConfirmationsAB(optionsNoAirdrop, oneConfNoOP, 0, toArr(INITIAL_TS, NOT_VERIFIED));
-    }
-
-    function test_interchainExecute_1_AB_periodZero_almostVerifiedA_almostVerifiedB_revert() public {
-        checkNotEnoughConfirmationsAB(optionsNoAirdrop, oneConfNoOP, 0, toArr(INITIAL_TS, INITIAL_TS));
-    }
-
-    function test_interchainExecute_1_AB_periodZero_almostVerifiedA_justVerifiedB_noAirdrop_success() public {
-        checkSuccessAB(optionsNoAirdrop, oneConfNoOP, toArr(INITIAL_TS, JUST_NOW));
-    }
-
-    function test_interchainExecute_1_AB_periodZero_almostVerifiedA_justVerifiedB_withAirdrop_success() public {
-        checkSuccessAB(optionsAirdrop, oneConfNoOP, toArr(INITIAL_TS, JUST_NOW));
+    /// @dev Execute the scenario where a batch conflict has been detected.
+    /// Both `isExecutable` and `interchainExecute` should revert.
+    function checkBatchConflict(address module, uint256 required, uint256 guardFlag, uint256[] memory times) internal {
+        (InterchainTransaction memory icTx,) = prepareExecuteTest(required, guardFlag, times);
+        bytes memory encodedTx = getEncodedTx(icTx);
+        expectRevertBatchConflict(module);
+        icClient.isExecutable(encodedTx, emptyProof);
+        expectRevertBatchConflict(module);
+        executeTransaction(encodedTx, emptyProof);
     }
 
-    function test_interchainExecute_1_AB_periodZero_almostVerifiedA_overVerifiedB_noAirdrop_success() public {
-        checkSuccessAB(optionsNoAirdrop, oneConfNoOP, toArr(INITIAL_TS, OVER_VERIFIED));
+    function checkScenario(uint256 required, uint256 guardFlag, uint256 indexA, uint256 indexB) internal {
+        uint256 timeA = getTimestampFixture(indexA);
+        uint256 timeB = getTimestampFixture(indexB);
+        uint256[] memory times = toArr(timeA, timeB);
+        // Check for conflicts
+        if (timeA == CONFLICT) {
+            checkBatchConflict({module: icModuleA, required: required, guardFlag: guardFlag, times: times});
+            return;
+        }
+        if (timeB == CONFLICT) {
+            checkBatchConflict({module: icModuleB, required: required, guardFlag: guardFlag, times: times});
+            return;
+        }
+        uint256 actual = 0;
+        if (timeA == justVerTS() || timeA == OVER_VERIFIED) {
+            actual++;
+        }
+        if (timeB == justVerTS() || timeB == OVER_VERIFIED) {
+            actual++;
+        }
+        if (actual >= required) {
+            checkHappyPath({required: required, guardFlag: guardFlag, times: times});
+        } else {
+            checkNotEnoughConfirmations({actual: actual, required: required, guardFlag: guardFlag, times: times});
+        }
     }
 
-    function test_interchainExecute_1_AB_periodZero_almostVerifiedA_overVerifiedB_withAirdrop_success() public {
-        checkSuccessAB(optionsAirdrop, oneConfNoOP, toArr(INITIAL_TS, OVER_VERIFIED));
-    }
-
-    function test_interchainExecute_1_AB_periodZero_justVerifiedA_notVerifiedB_noAirdrop_success() public {
-        checkSuccessAB(optionsNoAirdrop, oneConfNoOP, toArr(JUST_NOW, NOT_VERIFIED));
-    }
-
-    function test_interchainExecute_1_AB_periodZero_justVerifiedA_notVerifiedB_withAirdrop_success() public {
-        checkSuccessAB(optionsAirdrop, oneConfNoOP, toArr(JUST_NOW, NOT_VERIFIED));
-    }
-
-    function test_interchainExecute_1_AB_periodZero_justVerifiedA_almostVerifiedB_noAirdrop_success() public {
-        checkSuccessAB(optionsNoAirdrop, oneConfNoOP, toArr(JUST_NOW, INITIAL_TS));
-    }
-
-    function test_interchainExecute_1_AB_periodZero_justVerifiedA_almostVerifiedB_withAirdrop_success() public {
-        checkSuccessAB(optionsAirdrop, oneConfNoOP, toArr(JUST_NOW, INITIAL_TS));
-    }
-
-    function test_interchainExecute_1_AB_periodZero_justVerifiedA_justVerifiedB_noAirdrop_success() public {
-        checkSuccessAB(optionsNoAirdrop, oneConfNoOP, toArr(JUST_NOW, JUST_NOW));
-    }
-
-    function test_interchainExecute_1_AB_periodZero_justVerifiedA_justVerifiedB_withAirdrop_success() public {
-        checkSuccessAB(optionsAirdrop, oneConfNoOP, toArr(JUST_NOW, JUST_NOW));
-    }
-
-    function test_interchainExecute_1_AB_periodZero_justVerifiedA_overVerifiedB_noAirdrop_success() public {
-        checkSuccessAB(optionsNoAirdrop, oneConfNoOP, toArr(JUST_NOW, OVER_VERIFIED));
-    }
-
-    function test_interchainExecute_1_AB_periodZero_justVerifiedA_overVerifiedB_withAirdrop_success() public {
-        checkSuccessAB(optionsAirdrop, oneConfNoOP, toArr(JUST_NOW, OVER_VERIFIED));
-    }
-
-    function test_interchainExecute_1_AB_periodZero_overVerifiedA_notVerifiedB_noAirdrop_success() public {
-        checkSuccessAB(optionsNoAirdrop, oneConfNoOP, toArr(OVER_VERIFIED, NOT_VERIFIED));
-    }
-
-    function test_interchainExecute_1_AB_periodZero_overVerifiedA_notVerifiedB_withAirdrop_success() public {
-        checkSuccessAB(optionsAirdrop, oneConfNoOP, toArr(OVER_VERIFIED, NOT_VERIFIED));
-    }
-
-    function test_interchainExecute_1_AB_periodZero_overVerifiedA_almostVerifiedB_noAirdrop_success() public {
-        checkSuccessAB(optionsNoAirdrop, oneConfNoOP, toArr(OVER_VERIFIED, INITIAL_TS));
-    }
-
-    function test_interchainExecute_1_AB_periodZero_overVerifiedA_almostVerifiedB_withAirdrop_success() public {
-        checkSuccessAB(optionsAirdrop, oneConfNoOP, toArr(OVER_VERIFIED, INITIAL_TS));
-    }
-
-    function test_interchainExecute_1_AB_periodZero_overVerifiedA_justVerifiedB_noAirdrop_success() public {
-        checkSuccessAB(optionsNoAirdrop, oneConfNoOP, toArr(OVER_VERIFIED, JUST_NOW));
-    }
-
-    function test_interchainExecute_1_AB_periodZero_overVerifiedA_justVerifiedB_withAirdrop_success() public {
-        checkSuccessAB(optionsAirdrop, oneConfNoOP, toArr(OVER_VERIFIED, JUST_NOW));
-    }
-
-    function test_interchainExecute_1_AB_periodZero_overVerifiedA_overVerifiedB_noAirdrop_success() public {
-        checkSuccessAB(optionsNoAirdrop, oneConfNoOP, toArr(OVER_VERIFIED, OVER_VERIFIED));
-    }
-
-    function test_interchainExecute_1_AB_periodZero_overVerifiedA_overVerifiedB_withAirdrop_success() public {
-        checkSuccessAB(optionsAirdrop, oneConfNoOP, toArr(OVER_VERIFIED, OVER_VERIFIED));
-    }
-
-    // ══════════════════════════ REQUIRED: 1, MODULES: A+B, WITH CONFLICT (PERIOD ZERO) ═══════════════════════════════
-
-    function test_interchainExecute_1_AB_periodZero_conflict_almostVerifiedA_revert() public {
-        checkBatchConflictAB(optionsNoAirdrop, oneConfNoOP, ALMOST_VERIFIED);
-    }
-
-    function test_interchainExecute_1_AB_periodZero_conflict_justVerifiedA_revert() public {
-        checkBatchConflictAB(optionsNoAirdrop, oneConfNoOP, JUST_VERIFIED);
-    }
-
-    function test_interchainExecute_1_AB_periodZero_conflict_overVerifiedA_revert() public {
-        checkBatchConflictAB(optionsNoAirdrop, oneConfNoOP, OVER_VERIFIED);
-    }
-
-    // ═════════════════════════════════════════ REQUIRED: 2, MODULES: A+B ═════════════════════════════════════════════
-
-    function test_interchainExecute_2_AB_periodNonZero_notVerifiedA_notVerifiedB_revert() public {
-        checkNotEnoughConfirmationsAB(optionsNoAirdrop, twoConfWithOP, 0, toArr(NOT_VERIFIED, NOT_VERIFIED));
-    }
-
-    function test_interchainExecute_2_AB_periodNonZero_notVerifiedA_almostVerifiedB_revert() public {
-        checkNotEnoughConfirmationsAB(optionsNoAirdrop, twoConfWithOP, 0, toArr(NOT_VERIFIED, ALMOST_VERIFIED));
-    }
-
-    function test_interchainExecute_2_AB_periodNonZero_notVerifiedA_justVerifiedB_revert() public {
-        checkNotEnoughConfirmationsAB(optionsNoAirdrop, twoConfWithOP, 1, toArr(NOT_VERIFIED, JUST_VERIFIED));
-    }
-
-    function test_interchainExecute_2_AB_periodNonZero_notVerifiedA_overVerifiedB_revert() public {
-        checkNotEnoughConfirmationsAB(optionsNoAirdrop, twoConfWithOP, 1, toArr(NOT_VERIFIED, OVER_VERIFIED));
-    }
-
-    function test_interchainExecute_2_AB_periodNonZero_almostVerifiedA_notVerifiedB_revert() public {
-        checkNotEnoughConfirmationsAB(optionsNoAirdrop, twoConfWithOP, 0, toArr(ALMOST_VERIFIED, NOT_VERIFIED));
-    }
-
-    function test_interchainExecute_2_AB_periodNonZero_almostVerifiedA_almostVerifiedB_revert() public {
-        checkNotEnoughConfirmationsAB(optionsNoAirdrop, twoConfWithOP, 0, toArr(ALMOST_VERIFIED, ALMOST_VERIFIED));
-    }
-
-    function test_interchainExecute_2_AB_periodNonZero_almostVerifiedA_justVerifiedB_revert() public {
-        checkNotEnoughConfirmationsAB(optionsNoAirdrop, twoConfWithOP, 1, toArr(ALMOST_VERIFIED, JUST_VERIFIED));
-    }
+    // ═════════════════════════════════════ APP CONFIG: 1 OUT OF 2 RESPONSES ══════════════════════════════════════════
 
-    function test_interchainExecute_2_AB_periodNonZero_almostVerifiedA_overVerifiedB_revert() public {
-        checkNotEnoughConfirmationsAB(optionsNoAirdrop, twoConfWithOP, 1, toArr(ALMOST_VERIFIED, OVER_VERIFIED));
+    function test_execute_1_2_noGuard(uint256 indexA, uint256 indexB) public {
+        checkScenario({required: 1, guardFlag: 0, indexA: indexA, indexB: indexB});
     }
 
-    function test_interchainExecute_2_AB_periodNonZero_justVerifiedA_notVerifiedB_revert() public {
-        checkNotEnoughConfirmationsAB(optionsNoAirdrop, twoConfWithOP, 1, toArr(JUST_VERIFIED, NOT_VERIFIED));
+    /// @dev Guard conflict should not affect the behavior if the app didn't opt-in for the guard.
+    function test_execute_1_2_noGuard_guardConflict(uint256 indexA, uint256 indexB) public {
+        addGuardConflict(defaultGuard);
+        test_execute_1_2_noGuard(indexA, indexB);
     }
 
-    function test_interchainExecute_2_AB_periodNonZero_justVerifiedA_almostVerifiedB_revert() public {
-        checkNotEnoughConfirmationsAB(optionsNoAirdrop, twoConfWithOP, 1, toArr(JUST_VERIFIED, ALMOST_VERIFIED));
+    function test_execute_1_2_defaultGuard(uint256 indexA, uint256 indexB) public {
+        checkScenario({required: 1, guardFlag: 1, indexA: indexA, indexB: indexB});
     }
 
-    function test_interchainExecute_2_AB_periodNonZero_justVerifiedA_justVerifiedB_noAirdrop_success() public {
-        checkSuccessAB(optionsNoAirdrop, twoConfWithOP, toArr(JUST_VERIFIED, JUST_VERIFIED));
+    /// @dev Guard conflict should always revert the transaction if the app opted-in for the guard.
+    function test_execute_1_2_defaultGuard_guardConflict(uint256 indexA, uint256 indexB) public {
+        addGuardConflict(defaultGuard);
+        uint256 timeA = getTimestampFixture(indexA);
+        uint256 timeB = getTimestampFixture(indexB);
+        checkBatchConflict({module: defaultGuard, required: 1, guardFlag: 1, times: toArr(timeA, timeB)});
     }
 
-    function test_interchainExecute_2_AB_periodNonZero_justVerifiedA_justVerifiedB_withAirdrop_success() public {
-        checkSuccessAB(optionsAirdrop, twoConfWithOP, toArr(JUST_VERIFIED, JUST_VERIFIED));
-    }
-
-    function test_interchainExecute_2_AB_periodNonZero_justVerifiedA_overVerifiedB_noAirdrop_success() public {
-        checkSuccessAB(optionsNoAirdrop, twoConfWithOP, toArr(JUST_VERIFIED, OVER_VERIFIED));
-    }
-
-    function test_interchainExecute_2_AB_periodNonZero_justVerifiedA_overVerifiedB_withAirdrop_success() public {
-        checkSuccessAB(optionsAirdrop, twoConfWithOP, toArr(JUST_VERIFIED, OVER_VERIFIED));
-    }
-
-    function test_interchainExecute_2_AB_periodNonZero_overVerifiedA_notVerifiedB_revert() public {
-        checkNotEnoughConfirmationsAB(optionsNoAirdrop, twoConfWithOP, 1, toArr(OVER_VERIFIED, NOT_VERIFIED));
-    }
-
-    function test_interchainExecute_2_AB_periodNonZero_overVerifiedA_almostVerifiedB_revert() public {
-        checkNotEnoughConfirmationsAB(optionsNoAirdrop, twoConfWithOP, 1, toArr(OVER_VERIFIED, ALMOST_VERIFIED));
-    }
-
-    function test_interchainExecute_2_AB_periodNonZero_overVerifiedA_justVerifiedB_noAirdrop_success() public {
-        checkSuccessAB(optionsNoAirdrop, twoConfWithOP, toArr(OVER_VERIFIED, JUST_VERIFIED));
-    }
-
-    function test_interchainExecute_2_AB_periodNonZero_overVerifiedA_justVerifiedB_withAirdrop_success() public {
-        checkSuccessAB(optionsAirdrop, twoConfWithOP, toArr(OVER_VERIFIED, JUST_VERIFIED));
-    }
-
-    function test_interchainExecute_2_AB_periodNonZero_overVerifiedA_overVerifiedB_noAirdrop_success() public {
-        checkSuccessAB(optionsNoAirdrop, twoConfWithOP, toArr(OVER_VERIFIED, OVER_VERIFIED));
-    }
-
-    function test_interchainExecute_2_AB_periodNonZero_overVerifiedA_overVerifiedB_withAirdrop_success() public {
-        checkSuccessAB(optionsAirdrop, twoConfWithOP, toArr(OVER_VERIFIED, OVER_VERIFIED));
-    }
-
-    // ══════════════════════════════════ REQUIRED: 2, MODULES: A+B (PERIOD ZERO) ══════════════════════════════════════
-
-    function test_interchainExecute_2_AB_periodZero_notVerifiedA_notVerifiedB_revert() public {
-        checkNotEnoughConfirmationsAB(optionsNoAirdrop, twoConfNoOP, 0, toArr(NOT_VERIFIED, NOT_VERIFIED));
-    }
-
-    function test_interchainExecute_2_AB_periodZero_notVerifiedA_almostVerifiedB_revert() public {
-        checkNotEnoughConfirmationsAB(optionsNoAirdrop, twoConfNoOP, 0, toArr(NOT_VERIFIED, INITIAL_TS));
-    }
-
-    function test_interchainExecute_2_AB_periodZero_notVerifiedA_justVerifiedB_revert() public {
-        checkNotEnoughConfirmationsAB(optionsNoAirdrop, twoConfNoOP, 1, toArr(NOT_VERIFIED, JUST_NOW));
-    }
-
-    function test_interchainExecute_2_AB_periodZero_notVerifiedA_overVerifiedB_revert() public {
-        checkNotEnoughConfirmationsAB(optionsNoAirdrop, twoConfNoOP, 1, toArr(NOT_VERIFIED, OVER_VERIFIED));
-    }
-
-    function test_interchainExecute_2_AB_periodZero_almostVerifiedA_notVerifiedB_revert() public {
-        checkNotEnoughConfirmationsAB(optionsNoAirdrop, twoConfNoOP, 0, toArr(INITIAL_TS, NOT_VERIFIED));
-    }
-
-    function test_interchainExecute_2_AB_periodZero_almostVerifiedA_almostVerifiedB_revert() public {
-        checkNotEnoughConfirmationsAB(optionsNoAirdrop, twoConfNoOP, 0, toArr(INITIAL_TS, INITIAL_TS));
-    }
-
-    function test_interchainExecute_2_AB_periodZero_almostVerifiedA_justVerifiedB_revert() public {
-        checkNotEnoughConfirmationsAB(optionsNoAirdrop, twoConfNoOP, 1, toArr(INITIAL_TS, JUST_NOW));
-    }
-
-    function test_interchainExecute_2_AB_periodZero_almostVerifiedA_overVerifiedB_revert() public {
-        checkNotEnoughConfirmationsAB(optionsNoAirdrop, twoConfNoOP, 1, toArr(INITIAL_TS, OVER_VERIFIED));
-    }
-
-    function test_interchainExecute_2_AB_periodZero_justVerifiedA_notVerifiedB_revert() public {
-        checkNotEnoughConfirmationsAB(optionsNoAirdrop, twoConfNoOP, 1, toArr(JUST_NOW, NOT_VERIFIED));
-    }
-
-    function test_interchainExecute_2_AB_periodZero_justVerifiedA_almostVerifiedB_revert() public {
-        checkNotEnoughConfirmationsAB(optionsNoAirdrop, twoConfNoOP, 1, toArr(JUST_NOW, INITIAL_TS));
-    }
-
-    function test_interchainExecute_2_AB_periodZero_justVerifiedA_justVerifiedB_noAirdrop_success() public {
-        checkSuccessAB(optionsNoAirdrop, twoConfNoOP, toArr(JUST_NOW, JUST_NOW));
-    }
-
-    function test_interchainExecute_2_AB_periodZero_justVerifiedA_justVerifiedB_withAirdrop_success() public {
-        checkSuccessAB(optionsAirdrop, twoConfNoOP, toArr(JUST_NOW, JUST_NOW));
-    }
-
-    function test_interchainExecute_2_AB_periodZero_justVerifiedA_overVerifiedB_noAirdrop_success() public {
-        checkSuccessAB(optionsNoAirdrop, twoConfNoOP, toArr(JUST_NOW, OVER_VERIFIED));
-    }
-
-    function test_interchainExecute_2_AB_periodZero_justVerifiedA_overVerifiedB_withAirdrop_success() public {
-        checkSuccessAB(optionsAirdrop, twoConfNoOP, toArr(JUST_NOW, OVER_VERIFIED));
-    }
-
-    function test_interchainExecute_2_AB_periodZero_overVerifiedA_notVerifiedB_revert() public {
-        checkNotEnoughConfirmationsAB(optionsNoAirdrop, twoConfNoOP, 1, toArr(OVER_VERIFIED, NOT_VERIFIED));
-    }
+    // ═════════════════════════════════════ APP CONFIG: 2 OUT OF 2 RESPONSES ══════════════════════════════════════════
 
-    function test_interchainExecute_2_AB_periodZero_overVerifiedA_almostVerifiedB_revert() public {
-        checkNotEnoughConfirmationsAB(optionsNoAirdrop, twoConfNoOP, 1, toArr(OVER_VERIFIED, INITIAL_TS));
+    function test_execute_2_2_noGuard(uint256 indexA, uint256 indexB) public {
+        checkScenario({required: 2, guardFlag: 0, indexA: indexA, indexB: indexB});
     }
 
-    function test_interchainExecute_2_AB_periodZero_overVerifiedA_justVerifiedB_noAirdrop_success() public {
-        checkSuccessAB(optionsNoAirdrop, twoConfNoOP, toArr(OVER_VERIFIED, JUST_NOW));
+    /// @dev Guard conflict should not affect the behavior if the app didn't opt-in for the guard.
+    function test_execute_2_2_noGuard_guardConflict(uint256 indexA, uint256 indexB) public {
+        addGuardConflict(defaultGuard);
+        test_execute_2_2_noGuard(indexA, indexB);
     }
-
-    function test_interchainExecute_2_AB_periodZero_overVerifiedA_justVerifiedB_withAirdrop_success() public {
-        checkSuccessAB(optionsAirdrop, twoConfNoOP, toArr(OVER_VERIFIED, JUST_NOW));
-    }
-
-    function test_interchainExecute_2_AB_periodZero_overVerifiedA_overVerifiedB_noAirdrop_success() public {
-        checkSuccessAB(optionsNoAirdrop, twoConfNoOP, toArr(OVER_VERIFIED, OVER_VERIFIED));
-    }
-
-    function test_interchainExecute_2_AB_periodZero_overVerifiedA_overVerifiedB_withAirdrop_success() public {
-        checkSuccessAB(optionsAirdrop, twoConfNoOP, toArr(OVER_VERIFIED, OVER_VERIFIED));
-    }
-
-    // ═══════════════════════════════════════════ TESTS: GET APP CONFIG ═══════════════════════════════════════════════
 
-    function test_getAppReceivingConfigV1_oneModule() public {
-        mockReceivingConfig(oneConfWithOP, oneModuleA);
-        (AppConfigV1 memory config, address[] memory modules) = icClient.getAppReceivingConfigV1(dstReceiver);
-        assertEq(config.requiredResponses, oneConfWithOP.requiredResponses);
-        assertEq(config.optimisticPeriod, oneConfWithOP.optimisticPeriod);
-        assertEq(modules, oneModuleA);
+    function test_execute_2_2_defaultGuard(uint256 indexA, uint256 indexB) public {
+        checkScenario({required: 2, guardFlag: 1, indexA: indexA, indexB: indexB});
     }
 
-    function test_getAppReceivingConfigV1_twoModules() public {
-        mockReceivingConfig(twoConfWithOP, twoModules);
-        (AppConfigV1 memory config, address[] memory modules) = icClient.getAppReceivingConfigV1(dstReceiver);
-        assertEq(config.requiredResponses, twoConfWithOP.requiredResponses);
-        assertEq(config.optimisticPeriod, twoConfWithOP.optimisticPeriod);
-        assertEq(modules, twoModules);
+    /// @dev Guard conflict should always revert the transaction if the app opted-in for the guard.
+    function test_execute_2_2_defaultGuard_guardConflict(uint256 indexA, uint256 indexB) public {
+        addGuardConflict(defaultGuard);
+        uint256 timeA = getTimestampFixture(indexA);
+        uint256 timeB = getTimestampFixture(indexB);
+        checkBatchConflict({module: defaultGuard, required: 2, guardFlag: 1, times: toArr(timeA, timeB)});
     }
 
     // ═══════════════════════════════════════════ EXECUTE: MISC REVERTS ═══════════════════════════════════════════════
 
-    function prepareExecutableTx(InterchainTransaction memory icTx) internal {
-        InterchainTxDescriptor memory desc = InterchainTxDescriptor({
-            dbNonce: icTx.dbNonce,
-            entryIndex: icTx.entryIndex,
-            transactionId: keccak256(getEncodedTx(icTx))
-        });
-        mockReceivingConfig(oneConfWithOP, oneModuleA);
-        mockCheckVerification(icModuleA, desc, JUST_VERIFIED);
+    function encodeAndMakeExecutable(InterchainTransaction memory icTx) internal returns (bytes memory) {
+        bytes memory encodedTx = getEncodedTx(icTx);
+        makeTxDescriptorExecutable(getTxDescriptor(icTx));
+        return encodedTx;
     }
 
-    function test_interchainExecute_revert_invalidTransactionVersion(uint16 version) public {
+    function test_execute_revert_invalidTransactionVersion(uint16 version) public {
         vm.assume(version != CLIENT_VERSION);
-        (InterchainTransaction memory icTx,) = constructInterchainTx(optionsNoAirdrop.encodeOptionsV1());
+        (InterchainTransaction memory icTx,) = constructInterchainTx();
         bytes memory invalidVersionTx = VersionedPayloadLib.encodeVersionedPayload(version, abi.encode(icTx));
-        InterchainTxDescriptor memory desc = InterchainTxDescriptor({
-            dbNonce: icTx.dbNonce,
-            entryIndex: icTx.entryIndex,
-            transactionId: keccak256(invalidVersionTx)
-        });
-        mockReceivingConfig(oneConfWithOP, oneModuleA);
-        mockCheckVerification(icModuleA, desc, JUST_VERIFIED);
-        expectRevertInvalidTransactionVersion(version);
-        vm.prank(executor);
-        icClient.interchainExecute(optionsNoAirdrop.gasLimit, invalidVersionTx, new bytes32[](0));
-    }
-
-    function test_interchainExecute_revert_srcChainNotRemote() public {
-        (InterchainTransaction memory icTx,) = constructInterchainTx(optionsNoAirdrop.encodeOptionsV1());
-        mockReceivingConfig(oneConfWithOP, oneModuleA);
-        icTx.srcChainId = LOCAL_CHAIN_ID;
-        bytes memory encodedTx = getEncodedTx(icTx);
-        expectRevertNotRemoteChainId(LOCAL_CHAIN_ID);
-        executeTransaction(encodedTx, optionsNoAirdrop, emptyProof);
-    }
-
-    function test_interchainExecute_revert_srcChainNotLinked() public {
-        (InterchainTransaction memory icTx,) = constructInterchainTx(optionsNoAirdrop.encodeOptionsV1());
-        mockReceivingConfig(oneConfWithOP, oneModuleA);
-        icTx.srcChainId = UNKNOWN_CHAIN_ID;
-        bytes memory encodedTx = getEncodedTx(icTx);
-        expectRevertNoLinkedClient(UNKNOWN_CHAIN_ID);
-        executeTransaction(encodedTx, optionsNoAirdrop, emptyProof);
-    }
-
-    function test_interchainExecute_revert_dstChainIncorrect() public {
-        (InterchainTransaction memory icTx,) = constructInterchainTx(optionsNoAirdrop.encodeOptionsV1());
-        mockReceivingConfig(oneConfWithOP, oneModuleA);
-        icTx.dstChainId = UNKNOWN_CHAIN_ID;
-        bytes memory encodedTx = getEncodedTx(icTx);
-        expectRevertIncorrectDstChainId(UNKNOWN_CHAIN_ID);
-        executeTransaction(encodedTx, optionsNoAirdrop, emptyProof);
-    }
-
-    function test_interchainExecute_revert_nonZeroEntryIndex() public {
-        (InterchainTransaction memory icTx,) = constructInterchainTx(optionsNoAirdrop.encodeOptionsV1());
-        icTx.entryIndex = 1;
-        bytes memory encodedTx = getEncodedTx(icTx);
-        expectRevertIncorrectEntryIndex(icTx.entryIndex);
-        executeTransaction(encodedTx, optionsNoAirdrop, emptyProof);
-    }
-
-    function test_interchainExecute_revert_nonEmptyProof() public {
-        (InterchainTransaction memory icTx,) = constructInterchainTx(optionsNoAirdrop.encodeOptionsV1());
-        bytes memory encodedTx = getEncodedTx(icTx);
-        expectRevertIncorrectProof();
-        executeTransaction(encodedTx, optionsNoAirdrop, new bytes32[](1));
-    }
-
-    function test_interchainExecute_revert_emptyOptions() public {
-        (InterchainTransaction memory icTx,) = constructInterchainTx("");
-        bytes memory encodedTx = getEncodedTx(icTx);
-        prepareExecutableTx(icTx);
-        // OptionsLib doesn't have a specific error for this case, so we expect a generic revert during decoding.
-        vm.expectRevert();
-        executeTransaction(encodedTx, optionsNoAirdrop, emptyProof);
-    }
-
-    function test_interchainExecute_revert_invalidOptionsV0() public {
-        (InterchainTransaction memory icTx,) = constructInterchainTx(invalidOptionsV0);
-        bytes memory encodedTx = getEncodedTx(icTx);
-        prepareExecutableTx(icTx);
-        expectRevertIncorrectVersion(0);
-        executeTransaction(encodedTx, optionsNoAirdrop, emptyProof);
-    }
-
-    function test_interchainExecute_revert_invalidOptionsV1() public {
-        (InterchainTransaction memory icTx,) = constructInterchainTx(invalidOptionsV1);
-        bytes memory encodedTx = getEncodedTx(icTx);
-        prepareExecutableTx(icTx);
-        // OptionsLib doesn't have a specific error for this case, so we expect a generic revert during decoding.
-        vm.expectRevert();
-        executeTransaction(encodedTx, optionsNoAirdrop, emptyProof);
-    }
-
-    function test_interchainExecute_revert_notEnoughGasSupplied() public {
-        (InterchainTransaction memory icTx,) = constructInterchainTx(optionsNoAirdrop.encodeOptionsV1());
-        bytes memory encodedTx = getEncodedTx(icTx);
-        prepareExecutableTx(icTx);
-        expectRevertNotEnoughGasSupplied();
-        vm.prank(executor);
-        // Limiting gas for the whole transaction leads to application getting as much gas as it requested.
-        icClient.interchainExecute{gas: MOCK_GAS_LIMIT}(MOCK_GAS_LIMIT, encodedTx, emptyProof);
-    }
-
-    function test_interchainExecute_revert_alreadyExecuted() public {
-        (InterchainTransaction memory icTx, InterchainTxDescriptor memory desc) =
-            prepareAlreadyExecutedTest(optionsNoAirdrop);
-        bytes memory encodedTx = getEncodedTx(icTx);
-        expectRevertTxAlreadyExecuted(desc.transactionId);
-        executeTransaction(encodedTx, optionsNoAirdrop, emptyProof);
-    }
-
-    function test_interchainExecute_revert_withAirdrop_zeroMsgValue() public {
-        (InterchainTransaction memory icTx,) = prepareExecuteTest({
-            encodedOptions: optionsAirdrop.encodeOptionsV1(),
-            appConfig: oneConfWithOP,
-            modules: oneModuleA,
-            verificationTimes: toArray(JUST_VERIFIED)
-        });
-        bytes memory encodedTx = getEncodedTx(icTx);
-        uint256 requiredValue = optionsAirdrop.gasAirdrop;
-        optionsAirdrop.gasAirdrop = 0;
-        expectRevertIncorrectMsgValue({actual: 0, required: requiredValue});
-        executeTransaction(encodedTx, optionsAirdrop, emptyProof);
-    }
-
-    function test_interchainExecute_revert_withAirdrop_lowerMsgValue() public {
-        (InterchainTransaction memory icTx,) = prepareExecuteTest({
-            encodedOptions: optionsAirdrop.encodeOptionsV1(),
-            appConfig: oneConfWithOP,
-            modules: oneModuleA,
-            verificationTimes: toArray(JUST_VERIFIED)
-        });
-        bytes memory encodedTx = getEncodedTx(icTx);
-        uint256 requiredValue = optionsAirdrop.gasAirdrop;
-        optionsAirdrop.gasAirdrop = requiredValue - 1;
-        expectRevertIncorrectMsgValue({actual: requiredValue - 1, required: requiredValue});
-        executeTransaction(encodedTx, optionsAirdrop, emptyProof);
-    }
-
-    function test_interchainExecute_revert_withAirdrop_higherMsgValue() public {
-        (InterchainTransaction memory icTx,) = prepareExecuteTest({
-            encodedOptions: optionsAirdrop.encodeOptionsV1(),
-            appConfig: oneConfWithOP,
-            modules: oneModuleA,
-            verificationTimes: toArray(JUST_VERIFIED)
-        });
-        bytes memory encodedTx = getEncodedTx(icTx);
-        uint256 requiredValue = optionsAirdrop.gasAirdrop;
-        optionsAirdrop.gasAirdrop = requiredValue + 1;
-        expectRevertIncorrectMsgValue({actual: requiredValue + 1, required: requiredValue});
-        executeTransaction(encodedTx, optionsAirdrop, emptyProof);
-    }
-
-    function test_interchainExecute_revert_noAirdrop_nonZeroMsgValue() public {
-        (InterchainTransaction memory icTx,) = prepareExecuteTest({
-            encodedOptions: optionsNoAirdrop.encodeOptionsV1(),
-            appConfig: oneConfWithOP,
-            modules: oneModuleA,
-            verificationTimes: toArray(JUST_VERIFIED)
-        });
-        bytes memory encodedTx = getEncodedTx(icTx);
-        optionsNoAirdrop.gasAirdrop = MOCK_GAS_AIRDROP;
-        expectRevertIncorrectMsgValue({actual: MOCK_GAS_AIRDROP, required: 0});
-        executeTransaction(encodedTx, optionsNoAirdrop, emptyProof);
-    }
-
-    function test_interchainExecute_revert_zeroRequiredResponses() public {
-        AppConfigV1 memory appConfig = oneConfWithOP;
-        appConfig.requiredResponses = 0;
-        (InterchainTransaction memory icTx,) = prepareExecuteTest({
-            encodedOptions: optionsNoAirdrop.encodeOptionsV1(),
-            appConfig: appConfig,
-            modules: oneModuleA,
-            verificationTimes: toArray(JUST_VERIFIED)
-        });
-        bytes memory encodedTx = getEncodedTx(icTx);
-        expectRevertZeroRequiredResponses();
-        executeTransaction(encodedTx, optionsNoAirdrop, emptyProof);
-    }
-
-    function test_isExecutable_revert_invalidTransactionVersion(uint16 version) public {
-        vm.assume(version != CLIENT_VERSION);
-        (InterchainTransaction memory icTx,) = constructInterchainTx(optionsNoAirdrop.encodeOptionsV1());
-        bytes memory invalidVersionTx = VersionedPayloadLib.encodeVersionedPayload(version, abi.encode(icTx));
+        makeTxDescriptorExecutable(getTxDescriptor(icTx));
         expectRevertInvalidTransactionVersion(version);
         icClient.isExecutable(invalidVersionTx, emptyProof);
+        expectRevertInvalidTransactionVersion(version);
+        executeTransaction(invalidVersionTx, emptyProof);
     }
 
-    function test_isExecutable_revert_srcChainNotRemote() public {
-        (InterchainTransaction memory icTx,) = constructInterchainTx(optionsNoAirdrop.encodeOptionsV1());
-        mockReceivingConfig(oneConfWithOP, oneModuleA);
+    function test_execute_revert_srcChainNotRemote() public {
+        (InterchainTransaction memory icTx,) = constructInterchainTx();
         icTx.srcChainId = LOCAL_CHAIN_ID;
-        bytes memory encodedTx = getEncodedTx(icTx);
+        bytes memory encodedTx = encodeAndMakeExecutable(icTx);
         expectRevertNotRemoteChainId(LOCAL_CHAIN_ID);
         icClient.isExecutable(encodedTx, emptyProof);
+        expectRevertNotRemoteChainId(LOCAL_CHAIN_ID);
+        executeTransaction(encodedTx, emptyProof);
     }
 
-    function test_isExecutable_revert_srcChainNotLinked() public {
-        (InterchainTransaction memory icTx,) = constructInterchainTx(optionsNoAirdrop.encodeOptionsV1());
-        mockReceivingConfig(oneConfWithOP, oneModuleA);
+    function test_execute_revert_srcChainNotLinked() public {
+        (InterchainTransaction memory icTx,) = constructInterchainTx();
         icTx.srcChainId = UNKNOWN_CHAIN_ID;
-        bytes memory encodedTx = getEncodedTx(icTx);
+        bytes memory encodedTx = encodeAndMakeExecutable(icTx);
         expectRevertNoLinkedClient(UNKNOWN_CHAIN_ID);
         icClient.isExecutable(encodedTx, emptyProof);
+        expectRevertNoLinkedClient(UNKNOWN_CHAIN_ID);
+        executeTransaction(encodedTx, emptyProof);
     }
 
-    function test_isExecutable_revert_dstChainIncorrect() public {
-        (InterchainTransaction memory icTx,) = constructInterchainTx(optionsNoAirdrop.encodeOptionsV1());
-        mockReceivingConfig(oneConfWithOP, oneModuleA);
+    function test_execute_revert_dstChainIncorrect() public {
+        (InterchainTransaction memory icTx,) = constructInterchainTx();
         icTx.dstChainId = UNKNOWN_CHAIN_ID;
-        bytes memory encodedTx = getEncodedTx(icTx);
+        bytes memory encodedTx = encodeAndMakeExecutable(icTx);
         expectRevertIncorrectDstChainId(UNKNOWN_CHAIN_ID);
         icClient.isExecutable(encodedTx, emptyProof);
+        expectRevertIncorrectDstChainId(UNKNOWN_CHAIN_ID);
+        executeTransaction(encodedTx, emptyProof);
     }
 
-    function test_isExecutable_revert_nonZeroEntryIndex() public {
-        (InterchainTransaction memory icTx,) = constructInterchainTx(optionsNoAirdrop.encodeOptionsV1());
+    function test_execute_revert_revert_nonZeroEntryIndex() public {
+        (InterchainTransaction memory icTx,) = constructInterchainTx();
         icTx.entryIndex = 1;
-        bytes memory encodedTx = getEncodedTx(icTx);
+        bytes memory encodedTx = encodeAndMakeExecutable(icTx);
         expectRevertIncorrectEntryIndex(icTx.entryIndex);
         icClient.isExecutable(encodedTx, emptyProof);
+        expectRevertIncorrectEntryIndex(icTx.entryIndex);
+        executeTransaction(encodedTx, emptyProof);
     }
 
-    function test_isExecutable_revert_nonEmptyProof() public {
-        (InterchainTransaction memory icTx,) = constructInterchainTx(optionsNoAirdrop.encodeOptionsV1());
-        bytes memory encodedTx = getEncodedTx(icTx);
+    function test_execute_revert_revert_nonEmptyProof() public {
+        (InterchainTransaction memory icTx,) = constructInterchainTx();
+        bytes memory encodedTx = encodeAndMakeExecutable(icTx);
+        bytes32[] memory proof = new bytes32[](1);
         expectRevertIncorrectProof();
-        icClient.isExecutable(encodedTx, new bytes32[](1));
+        icClient.isExecutable(encodedTx, proof);
+        expectRevertIncorrectProof();
+        executeTransaction(encodedTx, proof);
     }
 
-    function test_isExecutable_revert_emptyOptions() public {
+    function test_execute_revert_emptyOptions() public {
         (InterchainTransaction memory icTx,) = constructInterchainTx("");
-        bytes memory encodedTx = getEncodedTx(icTx);
-        prepareExecutableTx(icTx);
+        bytes memory encodedTx = encodeAndMakeExecutable(icTx);
         // OptionsLib doesn't have a specific error for this case, so we expect a generic revert during decoding.
         vm.expectRevert();
         icClient.isExecutable(encodedTx, emptyProof);
+        vm.expectRevert();
+        executeTransaction(encodedTx, emptyProof);
     }
 
-    function test_isExecutable_revert_invalidOptionsV0() public {
+    function test_execute_revert_invalidOptionsV0() public {
+        bytes memory invalidOptionsV0 = VersionedPayloadLib.encodeVersionedPayload(0, abi.encode(getOptions()));
         (InterchainTransaction memory icTx,) = constructInterchainTx(invalidOptionsV0);
-        bytes memory encodedTx = getEncodedTx(icTx);
-        prepareExecutableTx(icTx);
+        bytes memory encodedTx = encodeAndMakeExecutable(icTx);
         expectRevertIncorrectVersion(0);
         icClient.isExecutable(encodedTx, emptyProof);
+        expectRevertIncorrectVersion(0);
+        executeTransaction(encodedTx, emptyProof);
     }
 
-    function test_isExecutable_revert_invalidOptionsV1() public {
+    function test_execute_revert_invalidOptionsV1() public {
+        // Only include a single field to make the payload invalid.
+        bytes memory invalidOptionsV1 = VersionedPayloadLib.encodeVersionedPayload(1, abi.encode(getOptions().gasLimit));
         (InterchainTransaction memory icTx,) = constructInterchainTx(invalidOptionsV1);
-        bytes memory encodedTx = getEncodedTx(icTx);
-        prepareExecutableTx(icTx);
+        bytes memory encodedTx = encodeAndMakeExecutable(icTx);
         // OptionsLib doesn't have a specific error for this case, so we expect a generic revert during decoding.
         vm.expectRevert();
         icClient.isExecutable(encodedTx, emptyProof);
+        vm.expectRevert();
+        executeTransaction(encodedTx, emptyProof);
     }
 
-    function test_isExecutable_revert_alreadyExecuted() public {
-        (InterchainTransaction memory icTx, InterchainTxDescriptor memory desc) =
-            prepareAlreadyExecutedTest(optionsNoAirdrop);
+    function test_execute_revert_alreadyExecuted() public {
+        (InterchainTransaction memory icTx, InterchainTxDescriptor memory desc) = prepareAlreadyExecutedTest();
         bytes memory encodedTx = getEncodedTx(icTx);
         expectRevertTxAlreadyExecuted(desc.transactionId);
         icClient.isExecutable(encodedTx, emptyProof);
+        expectRevertTxAlreadyExecuted(desc.transactionId);
+        executeTransaction(encodedTx, emptyProof);
     }
 
-    function test_isExecutable_revert_zeroRequiredResponses() public {
-        AppConfigV1 memory appConfig = oneConfWithOP;
-        appConfig.requiredResponses = 0;
-        (InterchainTransaction memory icTx,) = prepareExecuteTest({
-            encodedOptions: optionsNoAirdrop.encodeOptionsV1(),
-            appConfig: appConfig,
-            modules: oneModuleA,
-            verificationTimes: toArray(JUST_VERIFIED)
-        });
+    function test_execute_revert_zeroRequiredResponses() public {
+        (InterchainTransaction memory icTx, InterchainTxDescriptor memory desc) = constructInterchainTx();
         bytes memory encodedTx = getEncodedTx(icTx);
+        mockReceivingConfig({requiredResponses: 0, guardFlag: 0});
+        mockCheckVerification(icModuleA, desc, justVerTS());
         expectRevertZeroRequiredResponses();
         icClient.isExecutable(encodedTx, emptyProof);
-    }
-
-    // ═══════════════════════════════════════ TESTS: WRITE EXECUTION PROOF ════════════════════════════════════════════
-
-    function test_writeExecutionProof() public {
-        (, InterchainTxDescriptor memory desc) = prepareAlreadyExecutedTest(optionsNoAirdrop);
-        bytes32 proofHash = keccak256(abi.encode(desc.transactionId, executor));
-        bytes memory expectedCalldata = abi.encodeCall(InterchainDBMock.writeEntry, (proofHash));
-        mockLocalNextEntryIndex(MOCK_LOCAL_DB_NONCE, MOCK_LOCAL_ENTRY_INDEX);
-        vm.expectCall({callee: icDB, data: expectedCalldata, count: 1});
-        expectEventExecutionProofWritten(desc.transactionId, MOCK_LOCAL_DB_NONCE, MOCK_LOCAL_ENTRY_INDEX, executor);
-        icClient.writeExecutionProof(desc.transactionId);
-    }
-
-    function test_writeExecutionProof_revert_notExecuted() public {
-        bytes32 mockTxId = keccak256("mockTxId");
-        expectRevertTxNotExecuted(mockTxId);
-        icClient.writeExecutionProof(mockTxId);
+        expectRevertZeroRequiredResponses();
+        executeTransaction(encodedTx, emptyProof);
     }
 }

--- a/packages/contracts-communication/test/InterchainClientV1.Management.t.sol
+++ b/packages/contracts-communication/test/InterchainClientV1.Management.t.sol
@@ -11,6 +11,23 @@ contract InterchainClientV1ManagementTest is InterchainClientV1BaseTest {
         assertEq(icClient.owner(), owner);
     }
 
+    function test_setDefaultGuard_emitsEvent() public {
+        expectEventGuardSet(guardMock);
+        setDefaultGuard(guardMock);
+    }
+
+    function test_setDefaultGuard_setsGuard() public {
+        setDefaultGuard(guardMock);
+        assertEq(icClient.defaultGuard(), guardMock);
+    }
+
+    function test_setDefaultGuard_revert_notOwner(address caller) public {
+        vm.assume(caller != owner);
+        expectRevertOwnableUnauthorizedAccount(caller);
+        vm.prank(caller);
+        icClient.setDefaultGuard(guardMock);
+    }
+
     function test_setLinkedClient_emitsEvent() public {
         expectEventLinkedClientSet(REMOTE_CHAIN_ID, MOCK_REMOTE_CLIENT);
         setLinkedClient(REMOTE_CHAIN_ID, MOCK_REMOTE_CLIENT);

--- a/packages/contracts-communication/test/InterchainClientV1.Management.t.sol
+++ b/packages/contracts-communication/test/InterchainClientV1.Management.t.sol
@@ -12,20 +12,20 @@ contract InterchainClientV1ManagementTest is InterchainClientV1BaseTest {
     }
 
     function test_setDefaultGuard_emitsEvent() public {
-        expectEventGuardSet(guardMock);
-        setDefaultGuard(guardMock);
+        expectEventGuardSet(defaultGuard);
+        setDefaultGuard(defaultGuard);
     }
 
     function test_setDefaultGuard_setsGuard() public {
-        setDefaultGuard(guardMock);
-        assertEq(icClient.defaultGuard(), guardMock);
+        setDefaultGuard(defaultGuard);
+        assertEq(icClient.defaultGuard(), defaultGuard);
     }
 
     function test_setDefaultGuard_revert_notOwner(address caller) public {
         vm.assume(caller != owner);
         expectRevertOwnableUnauthorizedAccount(caller);
         vm.prank(caller);
-        icClient.setDefaultGuard(guardMock);
+        icClient.setDefaultGuard(defaultGuard);
     }
 
     function test_setLinkedClient_emitsEvent() public {

--- a/packages/contracts-communication/test/InterchainClientV1.Management.t.sol
+++ b/packages/contracts-communication/test/InterchainClientV1.Management.t.sol
@@ -21,6 +21,11 @@ contract InterchainClientV1ManagementTest is InterchainClientV1BaseTest {
         assertEq(icClient.defaultGuard(), defaultGuard);
     }
 
+    function test_setDefaultGuard_zeroAddress() public {
+        expectRevertZeroAddress();
+        setDefaultGuard(address(0));
+    }
+
     function test_setDefaultGuard_revert_notOwner(address caller) public {
         vm.assume(caller != owner);
         expectRevertOwnableUnauthorizedAccount(caller);

--- a/packages/contracts-communication/test/apps/InterchainAppV1.Management.t.sol
+++ b/packages/contracts-communication/test/apps/InterchainAppV1.Management.t.sol
@@ -389,54 +389,50 @@ abstract contract InterchainAppV1ManagementTest is InterchainAppV1Test {
     }
 
     function test_setAppConfigV1_whenNotSet() public {
-        expectEventAppConfigV1Set(appConfig);
+        expectEventAppConfigV1Set(APP_REQUIRED_RESPONSES, APP_OPTIMISTIC_PERIOD);
         vm.recordLogs();
         vm.prank(governor);
-        appHarness.setAppConfigV1(appConfig);
+        appHarness.setAppConfigV1(APP_REQUIRED_RESPONSES, APP_OPTIMISTIC_PERIOD);
         assertEq(vm.getRecordedLogs().length, 1);
-        assertEq(appHarness.getAppConfigV1(), appConfig);
+        assertEq(appHarness.getAppConfigV1().requiredResponses, APP_REQUIRED_RESPONSES);
+        assertEq(appHarness.getAppConfigV1().optimisticPeriod, APP_OPTIMISTIC_PERIOD);
     }
 
     function test_setAppConfigV1_whenSet() public {
         vm.prank(governor);
-        appHarness.setAppConfigV1(appConfig);
-        appConfig.requiredResponses += 1;
-        appConfig.optimisticPeriod += 1;
-        expectEventAppConfigV1Set(appConfig);
+        appHarness.setAppConfigV1(APP_REQUIRED_RESPONSES, APP_OPTIMISTIC_PERIOD);
+        expectEventAppConfigV1Set(APP_REQUIRED_RESPONSES + 1, APP_OPTIMISTIC_PERIOD + 1);
         vm.recordLogs();
         vm.prank(governor);
-        appHarness.setAppConfigV1(appConfig);
+        appHarness.setAppConfigV1(APP_REQUIRED_RESPONSES + 1, APP_OPTIMISTIC_PERIOD + 1);
         assertEq(vm.getRecordedLogs().length, 1);
-        assertEq(appHarness.getAppConfigV1(), appConfig);
+        assertEq(appHarness.getAppConfigV1().requiredResponses, APP_REQUIRED_RESPONSES + 1);
+        assertEq(appHarness.getAppConfigV1().optimisticPeriod, APP_OPTIMISTIC_PERIOD + 1);
     }
 
     function test_setAppConfigV1_revert_notGovernor(address caller) public {
         vm.assume(caller != governor);
         expectRevertUnauthorizedGovernor(caller);
         vm.prank(caller);
-        appHarness.setAppConfigV1(appConfig);
+        appHarness.setAppConfigV1(APP_REQUIRED_RESPONSES, APP_OPTIMISTIC_PERIOD);
     }
 
     function test_setAppConfigV1_revert_zeroConfirmations() public {
-        appConfig.requiredResponses = 0;
-        expectRevertInvalidAppConfig(appConfig);
+        expectRevertInvalidAppConfig(0, APP_OPTIMISTIC_PERIOD);
         vm.prank(governor);
-        appHarness.setAppConfigV1(appConfig);
+        appHarness.setAppConfigV1(0, APP_OPTIMISTIC_PERIOD);
     }
 
     function test_setAppConfigV1_revert_zeroOptimisticPeriod() public {
-        appConfig.optimisticPeriod = 0;
-        expectRevertInvalidAppConfig(appConfig);
+        expectRevertInvalidAppConfig(APP_REQUIRED_RESPONSES, 0);
         vm.prank(governor);
-        appHarness.setAppConfigV1(appConfig);
+        appHarness.setAppConfigV1(APP_REQUIRED_RESPONSES, 0);
     }
 
     function test_setAppConfigV1_revert_zeroedAppConfig() public {
-        appConfig.requiredResponses = 0;
-        appConfig.optimisticPeriod = 0;
-        expectRevertInvalidAppConfig(appConfig);
+        expectRevertInvalidAppConfig(0, 0);
         vm.prank(governor);
-        appHarness.setAppConfigV1(appConfig);
+        appHarness.setAppConfigV1(0, 0);
     }
 
     function test_setExecutionService_whenNotSet() public {

--- a/packages/contracts-communication/test/apps/InterchainAppV1.Messaging.t.sol
+++ b/packages/contracts-communication/test/apps/InterchainAppV1.Messaging.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.20;
 import {OptionsV1} from "../../contracts/libs/Options.sol";
 import {InterchainTxDescriptor} from "../../contracts/libs/InterchainTransaction.sol";
 
-import {InterchainAppV1Test} from "./InterchainAppV1.t.sol";
+import {InterchainAppV1Test, AppConfigV1} from "./InterchainAppV1.t.sol";
 
 import {InterchainClientV1Mock} from "../mocks/InterchainClientV1Mock.sol";
 
@@ -35,7 +35,7 @@ abstract contract InterchainAppV1MessagingTest is InterchainAppV1Test {
         appHarness.addInterchainClient({client: extraClient, updateLatest: false});
         appHarness.linkRemoteApp({chainId: REMOTE_CHAIN_ID, remoteApp: linkedAppMockBytes32});
         appHarness.addTrustedModule(moduleMock);
-        appHarness.setAppConfigV1(appConfig);
+        appHarness.setAppConfigV1({requiredResponses: APP_REQUIRED_RESPONSES, optimisticPeriod: APP_OPTIMISTIC_PERIOD});
         appHarness.setExecutionService(execServiceMock);
     }
 
@@ -138,7 +138,15 @@ abstract contract InterchainAppV1MessagingTest is InterchainAppV1Test {
 
     function test_getReceivingConfig() public {
         (bytes memory encodedConfig, address[] memory modules) = appHarness.getReceivingConfig();
-        assertEq(encodedConfig, appConfig.encodeAppConfigV1());
+        assertEq(
+            encodedConfig,
+            AppConfigV1({
+                requiredResponses: APP_REQUIRED_RESPONSES,
+                optimisticPeriod: APP_OPTIMISTIC_PERIOD,
+                guardFlag: 1,
+                guard: address(0)
+            }).encodeAppConfigV1()
+        );
         assertEq(modules, toArray(moduleMock));
     }
 

--- a/packages/contracts-communication/test/apps/InterchainAppV1.t.sol
+++ b/packages/contracts-communication/test/apps/InterchainAppV1.t.sol
@@ -30,7 +30,8 @@ abstract contract InterchainAppV1Test is Test, AbstractICAppEvents, InterchainAp
     address public linkedAppMock = makeAddr("Linked App Mock");
     bytes32 public linkedAppMockBytes32 = TypeCasts.addressToBytes32(linkedAppMock);
 
-    AppConfigV1 public appConfig = AppConfigV1({requiredResponses: 1, optimisticPeriod: APP_OPTIMISTIC_PERIOD});
+    AppConfigV1 public appConfig =
+        AppConfigV1({requiredResponses: 1, optimisticPeriod: APP_OPTIMISTIC_PERIOD, guardFlag: 1});
 
     function setUp() public virtual {
         vm.chainId(LOCAL_CHAIN_ID);

--- a/packages/contracts-communication/test/apps/InterchainAppV1.t.sol
+++ b/packages/contracts-communication/test/apps/InterchainAppV1.t.sol
@@ -20,6 +20,7 @@ abstract contract InterchainAppV1Test is Test, AbstractICAppEvents, InterchainAp
     uint64 public constant REMOTE_CHAIN_ID = 7331;
     uint64 public constant UNKNOWN_CHAIN_ID = 420;
     uint256 public constant APP_OPTIMISTIC_PERIOD = 10 minutes;
+    uint256 public constant APP_REQUIRED_RESPONSES = 1;
 
     IInterchainAppV1Harness public appHarness;
     address public icClient;
@@ -29,9 +30,6 @@ abstract contract InterchainAppV1Test is Test, AbstractICAppEvents, InterchainAp
     address public execServiceMock = makeAddr("Execution Service Mock");
     address public linkedAppMock = makeAddr("Linked App Mock");
     bytes32 public linkedAppMockBytes32 = TypeCasts.addressToBytes32(linkedAppMock);
-
-    AppConfigV1 public appConfig =
-        AppConfigV1({requiredResponses: 1, optimisticPeriod: APP_OPTIMISTIC_PERIOD, guardFlag: 1, guard: address(0)});
 
     function setUp() public virtual {
         vm.chainId(LOCAL_CHAIN_ID);
@@ -68,9 +66,9 @@ abstract contract InterchainAppV1Test is Test, AbstractICAppEvents, InterchainAp
         emit LatestClientSet(client);
     }
 
-    function expectEventAppConfigV1Set(AppConfigV1 memory config) internal {
+    function expectEventAppConfigV1Set(uint256 requiredResponses, uint256 optimisticPeriod) internal {
         vm.expectEmit(address(appHarness));
-        emit AppConfigV1Set(config.requiredResponses, config.optimisticPeriod);
+        emit AppConfigV1Set(requiredResponses, optimisticPeriod);
     }
 
     function expectEventAppLinked(uint64 chainId, bytes32 remoteApp) internal {
@@ -97,12 +95,10 @@ abstract contract InterchainAppV1Test is Test, AbstractICAppEvents, InterchainAp
         vm.expectRevert(IInterchainAppV1.InterchainApp__AppZeroAddress.selector);
     }
 
-    function expectRevertInvalidAppConfig(AppConfigV1 memory config) internal {
+    function expectRevertInvalidAppConfig(uint256 requiredResponses, uint256 optimisticPeriod) internal {
         vm.expectRevert(
             abi.encodeWithSelector(
-                IInterchainAppV1.InterchainApp__InvalidAppConfig.selector,
-                config.requiredResponses,
-                config.optimisticPeriod
+                IInterchainAppV1.InterchainApp__InvalidAppConfig.selector, requiredResponses, optimisticPeriod
             )
         );
     }

--- a/packages/contracts-communication/test/apps/InterchainAppV1.t.sol
+++ b/packages/contracts-communication/test/apps/InterchainAppV1.t.sol
@@ -31,7 +31,7 @@ abstract contract InterchainAppV1Test is Test, AbstractICAppEvents, InterchainAp
     bytes32 public linkedAppMockBytes32 = TypeCasts.addressToBytes32(linkedAppMock);
 
     AppConfigV1 public appConfig =
-        AppConfigV1({requiredResponses: 1, optimisticPeriod: APP_OPTIMISTIC_PERIOD, guardFlag: 1});
+        AppConfigV1({requiredResponses: 1, optimisticPeriod: APP_OPTIMISTIC_PERIOD, guardFlag: 1, guard: address(0)});
 
     function setUp() public virtual {
         vm.chainId(LOCAL_CHAIN_ID);

--- a/packages/contracts-communication/test/integration/ICSetup.t.sol
+++ b/packages/contracts-communication/test/integration/ICSetup.t.sol
@@ -49,6 +49,7 @@ abstract contract ICSetup is ProxyTest {
     address public srcApp;
     address public dstApp;
 
+    address public guard = makeAddr("Guard");
     address public executor = makeAddr("Executor");
     address public feeCollector = makeAddr("FeeCollector");
     // Signer public keys, sorted by their address:
@@ -108,6 +109,7 @@ abstract contract ICSetup is ProxyTest {
         // For simplicity, we assume that the clients are deployed to the same address on both chains.
         bytes32 linkedClient = address(icClient).addressToBytes32();
         icClient.setLinkedClient(remoteChainId(), linkedClient);
+        icClient.setDefaultGuard(guard);
     }
 
     function configureSynapseModule() internal virtual {

--- a/packages/contracts-communication/test/integration/ICSetup.t.sol
+++ b/packages/contracts-communication/test/integration/ICSetup.t.sol
@@ -132,9 +132,7 @@ abstract contract ICSetup is ProxyTest {
         // For simplicity, we assume that the apps are deployed to the same address on both chains.
         ICAppV1(app).linkRemoteAppEVM(remoteChainId(), remoteApp());
         ICAppV1(app).addTrustedModule(address(module));
-        ICAppV1(app).setAppConfigV1(
-            AppConfigV1({requiredResponses: 1, optimisticPeriod: APP_OPTIMISTIC_PERIOD, guardFlag: 0, guard: address(0)})
-        );
+        ICAppV1(app).setAppConfigV1({requiredResponses: 1, optimisticPeriod: APP_OPTIMISTIC_PERIOD});
         ICAppV1(app).setExecutionService(address(executionService));
         ICAppV1(app).addInterchainClient({client: address(icClient), updateLatest: true});
     }

--- a/packages/contracts-communication/test/integration/ICSetup.t.sol
+++ b/packages/contracts-communication/test/integration/ICSetup.t.sol
@@ -130,7 +130,9 @@ abstract contract ICSetup is ProxyTest {
         // For simplicity, we assume that the apps are deployed to the same address on both chains.
         ICAppV1(app).linkRemoteAppEVM(remoteChainId(), remoteApp());
         ICAppV1(app).addTrustedModule(address(module));
-        ICAppV1(app).setAppConfigV1(AppConfigV1({requiredResponses: 1, optimisticPeriod: APP_OPTIMISTIC_PERIOD}));
+        ICAppV1(app).setAppConfigV1(
+            AppConfigV1({requiredResponses: 1, optimisticPeriod: APP_OPTIMISTIC_PERIOD, guardFlag: 0})
+        );
         ICAppV1(app).setExecutionService(address(executionService));
         ICAppV1(app).addInterchainClient({client: address(icClient), updateLatest: true});
     }

--- a/packages/contracts-communication/test/integration/ICSetup.t.sol
+++ b/packages/contracts-communication/test/integration/ICSetup.t.sol
@@ -133,7 +133,7 @@ abstract contract ICSetup is ProxyTest {
         ICAppV1(app).linkRemoteAppEVM(remoteChainId(), remoteApp());
         ICAppV1(app).addTrustedModule(address(module));
         ICAppV1(app).setAppConfigV1(
-            AppConfigV1({requiredResponses: 1, optimisticPeriod: APP_OPTIMISTIC_PERIOD, guardFlag: 0})
+            AppConfigV1({requiredResponses: 1, optimisticPeriod: APP_OPTIMISTIC_PERIOD, guardFlag: 0, guard: address(0)})
         );
         ICAppV1(app).setExecutionService(address(executionService));
         ICAppV1(app).addInterchainClient({client: address(icClient), updateLatest: true});

--- a/packages/contracts-communication/test/integration/PingPong.Dst.t.sol
+++ b/packages/contracts-communication/test/integration/PingPong.Dst.t.sol
@@ -173,9 +173,22 @@ contract PingPongDstIntegrationTest is PingPongIntegrationTest {
         executeTx(ppOptions);
     }
 
+    function test_interchainExecute_revert_notConfirmed_guardMarked() public {
+        markInvalidByGuard(srcBatch);
+        expectClientRevertBatchConflict(guard);
+        executeTx(ppOptions);
+    }
+
     function test_interchainExecute_revert_confirmed_sameBlock() public {
         module.verifyRemoteBatch(moduleBatch, moduleSignatures);
         expectClientRevertNotEnoughResponses({actual: 0, required: 1});
+        executeTx(ppOptions);
+    }
+
+    function test_interchainExecute_revert_confirmed_sameBlock_guardMarked() public {
+        module.verifyRemoteBatch(moduleBatch, moduleSignatures);
+        markInvalidByGuard(srcBatch);
+        expectClientRevertBatchConflict(guard);
         executeTx(ppOptions);
     }
 
@@ -183,6 +196,14 @@ contract PingPongDstIntegrationTest is PingPongIntegrationTest {
         module.verifyRemoteBatch(moduleBatch, moduleSignatures);
         skip(APP_OPTIMISTIC_PERIOD);
         expectClientRevertNotEnoughResponses({actual: 0, required: 1});
+        executeTx(ppOptions);
+    }
+
+    function test_interchainExecute_revert_confirmed_periodMinusOneSecond_guardMarked() public {
+        module.verifyRemoteBatch(moduleBatch, moduleSignatures);
+        markInvalidByGuard(srcBatch);
+        skip(APP_OPTIMISTIC_PERIOD);
+        expectClientRevertBatchConflict(guard);
         executeTx(ppOptions);
     }
 
@@ -205,9 +226,22 @@ contract PingPongDstIntegrationTest is PingPongIntegrationTest {
         icClient.isExecutable(encodedSrcTx, new bytes32[](0));
     }
 
+    function test_isExecutable_revert_notConfirmed_guardMarked() public {
+        markInvalidByGuard(srcBatch);
+        expectClientRevertBatchConflict(guard);
+        icClient.isExecutable(encodedSrcTx, new bytes32[](0));
+    }
+
     function test_isExecutable_revert_confirmed_sameBlock() public {
         module.verifyRemoteBatch(moduleBatch, moduleSignatures);
         expectClientRevertNotEnoughResponses({actual: 0, required: 1});
+        icClient.isExecutable(encodedSrcTx, new bytes32[](0));
+    }
+
+    function test_isExecutable_revert_confirmed_sameBlock_guardMarked() public {
+        module.verifyRemoteBatch(moduleBatch, moduleSignatures);
+        markInvalidByGuard(srcBatch);
+        expectClientRevertBatchConflict(guard);
         icClient.isExecutable(encodedSrcTx, new bytes32[](0));
     }
 
@@ -215,6 +249,14 @@ contract PingPongDstIntegrationTest is PingPongIntegrationTest {
         module.verifyRemoteBatch(moduleBatch, moduleSignatures);
         skip(APP_OPTIMISTIC_PERIOD);
         expectClientRevertNotEnoughResponses({actual: 0, required: 1});
+        icClient.isExecutable(encodedSrcTx, new bytes32[](0));
+    }
+
+    function test_isExecutable_revert_confirmed_periodMinusOneSecond_guardMarked() public {
+        module.verifyRemoteBatch(moduleBatch, moduleSignatures);
+        markInvalidByGuard(srcBatch);
+        skip(APP_OPTIMISTIC_PERIOD);
+        expectClientRevertBatchConflict(guard);
         icClient.isExecutable(encodedSrcTx, new bytes32[](0));
     }
 

--- a/packages/contracts-communication/test/integration/legacy/LegacyPingPong.Dst.t.sol
+++ b/packages/contracts-communication/test/integration/legacy/LegacyPingPong.Dst.t.sol
@@ -172,9 +172,22 @@ contract LegacyPingPongDstIntegrationTest is LegacyPingPongIntegrationTest {
         executeTx(icOptions);
     }
 
+    function test_interchainExecute_revert_notConfirmed_guardMarked() public {
+        markInvalidByGuard(srcBatch);
+        expectClientRevertBatchConflict(guard);
+        executeTx(icOptions);
+    }
+
     function test_interchainExecute_revert_confirmed_sameBlock() public {
         module.verifyRemoteBatch(moduleBatch, moduleSignatures);
         expectClientRevertNotEnoughResponses({actual: 0, required: 1});
+        executeTx(icOptions);
+    }
+
+    function test_interchainExecute_revert_confirmed_sameBlock_guardMarked() public {
+        module.verifyRemoteBatch(moduleBatch, moduleSignatures);
+        markInvalidByGuard(srcBatch);
+        expectClientRevertBatchConflict(guard);
         executeTx(icOptions);
     }
 
@@ -182,6 +195,14 @@ contract LegacyPingPongDstIntegrationTest is LegacyPingPongIntegrationTest {
         module.verifyRemoteBatch(moduleBatch, moduleSignatures);
         skip(APP_OPTIMISTIC_PERIOD);
         expectClientRevertNotEnoughResponses({actual: 0, required: 1});
+        executeTx(icOptions);
+    }
+
+    function test_interchainExecute_revert_confirmed_periodMinusOneSecond_guardMarked() public {
+        module.verifyRemoteBatch(moduleBatch, moduleSignatures);
+        skip(APP_OPTIMISTIC_PERIOD);
+        markInvalidByGuard(srcBatch);
+        expectClientRevertBatchConflict(guard);
         executeTx(icOptions);
     }
 
@@ -204,9 +225,22 @@ contract LegacyPingPongDstIntegrationTest is LegacyPingPongIntegrationTest {
         icClient.isExecutable(encodedSrcTx, new bytes32[](0));
     }
 
+    function test_isExecutable_revert_notConfirmed_guardMarked() public {
+        markInvalidByGuard(srcBatch);
+        expectClientRevertBatchConflict(guard);
+        icClient.isExecutable(encodedSrcTx, new bytes32[](0));
+    }
+
     function test_isExecutable_revert_confirmed_sameBlock() public {
         module.verifyRemoteBatch(moduleBatch, moduleSignatures);
         expectClientRevertNotEnoughResponses({actual: 0, required: 1});
+        icClient.isExecutable(encodedSrcTx, new bytes32[](0));
+    }
+
+    function test_isExecutable_revert_confirmed_sameBlock_guardMarked() public {
+        module.verifyRemoteBatch(moduleBatch, moduleSignatures);
+        markInvalidByGuard(srcBatch);
+        expectClientRevertBatchConflict(guard);
         icClient.isExecutable(encodedSrcTx, new bytes32[](0));
     }
 
@@ -214,6 +248,14 @@ contract LegacyPingPongDstIntegrationTest is LegacyPingPongIntegrationTest {
         module.verifyRemoteBatch(moduleBatch, moduleSignatures);
         skip(APP_OPTIMISTIC_PERIOD);
         expectClientRevertNotEnoughResponses({actual: 0, required: 1});
+        icClient.isExecutable(encodedSrcTx, new bytes32[](0));
+    }
+
+    function test_isExecutable_revert_confirmed_periodMinusOneSecond_guardMarked() public {
+        module.verifyRemoteBatch(moduleBatch, moduleSignatures);
+        skip(APP_OPTIMISTIC_PERIOD);
+        markInvalidByGuard(srcBatch);
+        expectClientRevertBatchConflict(guard);
         icClient.isExecutable(encodedSrcTx, new bytes32[](0));
     }
 

--- a/packages/contracts-communication/test/legacy/MessageBus.Base.t.sol
+++ b/packages/contracts-communication/test/legacy/MessageBus.Base.t.sol
@@ -48,7 +48,8 @@ abstract contract MessageBusBaseTest is MessageBusEvents, Test {
     address public icModule;
     address[] public icModules;
 
-    AppConfigV1 public appConfig = AppConfigV1({requiredResponses: 1, optimisticPeriod: BUS_OPTIMISTIC_PERIOD});
+    AppConfigV1 public appConfig =
+        AppConfigV1({requiredResponses: 1, optimisticPeriod: BUS_OPTIMISTIC_PERIOD, guardFlag: 0});
 
     address public admin = makeAddr("Admin");
     address public governor = makeAddr("Governor");

--- a/packages/contracts-communication/test/legacy/MessageBus.Base.t.sol
+++ b/packages/contracts-communication/test/legacy/MessageBus.Base.t.sol
@@ -48,9 +48,6 @@ abstract contract MessageBusBaseTest is MessageBusEvents, Test {
     address public icModule;
     address[] public icModules;
 
-    AppConfigV1 public appConfig =
-        AppConfigV1({requiredResponses: 1, optimisticPeriod: BUS_OPTIMISTIC_PERIOD, guardFlag: 0, guard: address(0)});
-
     address public admin = makeAddr("Admin");
     address public governor = makeAddr("Governor");
 
@@ -76,7 +73,7 @@ abstract contract MessageBusBaseTest is MessageBusEvents, Test {
         messageBus.addInterchainClient({client: icClient, updateLatest: true});
         messageBus.linkRemoteAppEVM({chainId: REMOTE_CHAIN_ID, remoteApp: remoteMessageBus});
         messageBus.addTrustedModule(icModule);
-        messageBus.setAppConfigV1(appConfig);
+        messageBus.setAppConfigV1({requiredResponses: 1, optimisticPeriod: BUS_OPTIMISTIC_PERIOD});
         messageBus.setExecutionService(execService);
         vm.stopPrank();
     }

--- a/packages/contracts-communication/test/legacy/MessageBus.Base.t.sol
+++ b/packages/contracts-communication/test/legacy/MessageBus.Base.t.sol
@@ -49,7 +49,7 @@ abstract contract MessageBusBaseTest is MessageBusEvents, Test {
     address[] public icModules;
 
     AppConfigV1 public appConfig =
-        AppConfigV1({requiredResponses: 1, optimisticPeriod: BUS_OPTIMISTIC_PERIOD, guardFlag: 0});
+        AppConfigV1({requiredResponses: 1, optimisticPeriod: BUS_OPTIMISTIC_PERIOD, guardFlag: 0, guard: address(0)});
 
     address public admin = makeAddr("Admin");
     address public governor = makeAddr("Governor");

--- a/packages/contracts-communication/test/libs/AppConfigLib.t.sol
+++ b/packages/contracts-communication/test/libs/AppConfigLib.t.sol
@@ -13,6 +13,7 @@ contract AppConfigLibTest is Test {
         uint256 requiredResponses;
         uint256 optimisticPeriod;
         uint256 guardFlag;
+        address guard;
         bytes32 newField;
     }
 
@@ -28,6 +29,7 @@ contract AppConfigLibTest is Test {
         assertEq(decoded.requiredResponses, appConfig.requiredResponses);
         assertEq(decoded.optimisticPeriod, appConfig.optimisticPeriod);
         assertEq(decoded.guardFlag, appConfig.guardFlag);
+        assertEq(decoded.guard, appConfig.guard);
     }
 
     function test_decodeAppConfigV1_decodesV2(MockAppConfigV2 memory appConfig) public {
@@ -39,7 +41,7 @@ contract AppConfigLibTest is Test {
     }
 
     function test_decodeAppConfigV1_revertLowerVersion() public {
-        AppConfigV1 memory appConfig = AppConfigV1(3, 100, 0);
+        AppConfigV1 memory appConfig = AppConfigV1(3, 100, 0, address(0));
         uint16 incorrectVersion = AppConfigLib.APP_CONFIG_V1 - 1;
         bytes memory encoded = VersionedPayloadLib.encodeVersionedPayload(incorrectVersion, abi.encode(appConfig));
         vm.expectRevert(abi.encodeWithSelector(AppConfigLib.AppConfigLib__IncorrectVersion.selector, incorrectVersion));

--- a/packages/contracts-communication/test/libs/AppConfigLib.t.sol
+++ b/packages/contracts-communication/test/libs/AppConfigLib.t.sol
@@ -12,6 +12,7 @@ contract AppConfigLibTest is Test {
     struct MockAppConfigV2 {
         uint256 requiredResponses;
         uint256 optimisticPeriod;
+        uint256 guardFlag;
         bytes32 newField;
     }
 
@@ -26,6 +27,7 @@ contract AppConfigLibTest is Test {
         AppConfigV1 memory decoded = libHarness.decodeAppConfigV1(encoded);
         assertEq(decoded.requiredResponses, appConfig.requiredResponses);
         assertEq(decoded.optimisticPeriod, appConfig.optimisticPeriod);
+        assertEq(decoded.guardFlag, appConfig.guardFlag);
     }
 
     function test_decodeAppConfigV1_decodesV2(MockAppConfigV2 memory appConfig) public {
@@ -37,7 +39,7 @@ contract AppConfigLibTest is Test {
     }
 
     function test_decodeAppConfigV1_revertLowerVersion() public {
-        AppConfigV1 memory appConfig = AppConfigV1(3, 100);
+        AppConfigV1 memory appConfig = AppConfigV1(3, 100, 0);
         uint16 incorrectVersion = AppConfigLib.APP_CONFIG_V1 - 1;
         bytes memory encoded = VersionedPayloadLib.encodeVersionedPayload(incorrectVersion, abi.encode(appConfig));
         vm.expectRevert(abi.encodeWithSelector(AppConfigLib.AppConfigLib__IncorrectVersion.selector, incorrectVersion));

--- a/packages/contracts-communication/test/mocks/InterchainClientV1Mock.sol
+++ b/packages/contracts-communication/test/mocks/InterchainClientV1Mock.sol
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.20;
 
-import {IInterchainClientV1, InterchainTxDescriptor} from "../../contracts/interfaces/IInterchainClientV1.sol";
+import {
+    IInterchainClientV1,
+    InterchainTransaction,
+    InterchainTxDescriptor
+} from "../../contracts/interfaces/IInterchainClientV1.sol";
 
 // solhint-disable no-empty-blocks
 contract InterchainClientV1Mock is IInterchainClientV1 {
@@ -47,6 +51,15 @@ contract InterchainClientV1Mock is IInterchainClientV1 {
     function writeExecutionProof(bytes32 transactionId) external returns (uint64 dbNonce, uint64 entryIndex) {}
 
     function isExecutable(bytes calldata transaction, bytes32[] calldata proof) external view returns (bool) {}
+
+    function getTxReadinessV1(
+        InterchainTransaction memory icTx,
+        bytes32[] calldata proof
+    )
+        external
+        view
+        returns (TxReadiness status, bytes32 firstArg, bytes32 secondArg)
+    {}
 
     function getInterchainFee(
         uint64 dstChainId,

--- a/packages/contracts-communication/test/mocks/InterchainClientV1Mock.sol
+++ b/packages/contracts-communication/test/mocks/InterchainClientV1Mock.sol
@@ -5,6 +5,8 @@ import {IInterchainClientV1, InterchainTxDescriptor} from "../../contracts/inter
 
 // solhint-disable no-empty-blocks
 contract InterchainClientV1Mock is IInterchainClientV1 {
+    function setDefaultGuard(address guard_) external {}
+
     function setLinkedClient(uint64 chainId, bytes32 client) external {}
 
     function interchainSend(


### PR DESCRIPTION
**Description**
Adds a Guard service option into the `ClientV1` contract. Any batch that conflicts (see #2523) with a batch previously submitted bu a Guard will be unavailable for message execution.

Currently, there are three options for the interchain apps to choose from:
- Opt out of the Guard service.
- Opt into the default Guard service provided by the `ClientV1` contract.
- Opt into the custom Guard service that app specifies.

The default interchain app template `ICAppV1` opts into the default Guard, but this could be overriden in the derived app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved security measures for interchain communication by introducing the ability to set and verify guard addresses.
  - Enhanced app configurations with specific parameters for increased flexibility and efficiency.
  - Expanded event tracking capabilities with the addition of the `DefaultGuardSet` event for better monitoring of guard settings.

- **Refactor**
  - Optimized the process of verifying finalized responses and managing guard conflicts in interchain operations.
  - Streamlined the configuration setting process in interchain apps by refining function parameters.

- **Tests**
  - Strengthened testing frameworks to encompass new functionalities and configurations, including guard settings and app configuration adjustments.
  - Added multiple new test scenarios to cover interchain execution with guard conditions and revert behaviors.

- **Bug Fixes**
  - Resolved issues related to batch conflict handling and interchain execution conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->