### PR TITLE
feat: interchain tx readiness

### DIFF
--- a/packages/contracts-communication/contracts/InterchainClientV1.sol
+++ b/packages/contracts-communication/contracts/InterchainClientV1.sol
@@ -469,9 +469,10 @@ contract InterchainClientV1 is Ownable, InterchainClientV1Events, IInterchainCli
         if (revertData.length >= 4) {
             // Load the first 32 bytes, then apply the mask that has only the 4 highest bytes set.
             // There is no need to shift, as `bytesN` variables are right-aligned.
+            // https://github.com/ProjectOpenSea/seaport/blob/2ff6ea37/contracts/helpers/SeaportRouter.sol#L161-L175
+            selector = bytes4(0xFFFFFFFF);
             assembly {
-                selector :=
-                    and(mload(add(revertData, 0x20)), 0xFFFFFFFF00000000000000000000000000000000000000000000000000000000)
+                selector := and(mload(add(revertData, 0x20)), selector)
             }
         }
         if (revertData.length >= 36) {

--- a/packages/contracts-communication/contracts/InterchainClientV1.sol
+++ b/packages/contracts-communication/contracts/InterchainClientV1.sol
@@ -157,6 +157,18 @@ contract InterchainClientV1 is Ownable, InterchainClientV1Events, IInterchainCli
     }
 
     // @inheritdoc IInterchainClientV1
+    function getTxReadinessV1(
+        InterchainTransaction memory icTx,
+        bytes32[] calldata proof
+    )
+        external
+        view
+        returns (TxReadiness status, bytes32 firstArg, bytes32 secondArg)
+    {
+        // TODO: implement
+    }
+
+    // @inheritdoc IInterchainClientV1
     function getExecutor(bytes calldata encodedTx) external view returns (address) {
         return _txExecutor[keccak256(encodedTx)];
     }

--- a/packages/contracts-communication/contracts/interfaces/IInterchainClientV1.sol
+++ b/packages/contracts-communication/contracts/interfaces/IInterchainClientV1.sol
@@ -139,7 +139,7 @@ interface IInterchainClientV1 {
     /// - NotEnoughResponses: not enough responses have been received for the transaction.
     ///   - `firstArg` is the number of responses received.
     ///   - `secondArg` is the number of responses required.
-    /// - ZeroRequiredResponses: teh app config requires zero responses for the transaction.
+    /// - ZeroRequiredResponses: the app config requires zero responses for the transaction.
     /// - UndeterminedRevert: the transaction will revert for another reason.
     ///
     /// Note: the arguments are abi-encoded bytes32 values (as their types could be different).

--- a/packages/contracts-communication/test/mocks/InterchainClientV1Mock.sol
+++ b/packages/contracts-communication/test/mocks/InterchainClientV1Mock.sol
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.20;
 
-import {IInterchainClientV1, InterchainTxDescriptor} from "../../contracts/interfaces/IInterchainClientV1.sol";
+import {
+    IInterchainClientV1,
+    InterchainTransaction,
+    InterchainTxDescriptor
+} from "../../contracts/interfaces/IInterchainClientV1.sol";
 
 // solhint-disable no-empty-blocks
 contract InterchainClientV1Mock is IInterchainClientV1 {
@@ -47,6 +51,15 @@ contract InterchainClientV1Mock is IInterchainClientV1 {
     function writeExecutionProof(bytes32 transactionId) external returns (uint64 dbNonce, uint64 entryIndex) {}
 
     function isExecutable(bytes calldata transaction, bytes32[] calldata proof) external view returns (bool) {}
+
+    function getTxReadinessV1(
+        InterchainTransaction memory icTx,
+        bytes32[] calldata proof
+    )
+        external
+        view
+        returns (TxReadiness status, bytes32 firstArg, bytes32 secondArg)
+    {}
 
     function getInterchainFee(
         uint64 dstChainId,


### PR DESCRIPTION
**Description**
Exposes an easy way to check the readiness of an Interchain transaction. Currently, following statuses could be returned:

https://github.com/synapsecns/sanguine/blob/912cb30bb25db06dcb8bc9d9ee332bf60340b4d1/packages/contracts-communication/contracts/interfaces/IInterchainClientV1.sol#L8-L16

On top of the status, up to two variables are returned that compliment it. For instance, for `NotEnoughResponses`, the current amount of module verifications and the required one is returned. As different statuses could have accompanying variables of different types, these are always casted to `bytes32` and need to be decoded off-chain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced transaction processing logic with a new function to determine transaction readiness status and decode revert data.
	- Updated interface with a new enum and function to provide clarity on transaction readiness status and arguments.
- **Tests**
	- Expanded testing suite to cover the new transaction readiness features, ensuring reliability and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->