### PR TITLE
feat: unify claiming in `SynapseModule` and `SynapseExecutionService`

### DIFF
--- a/packages/contracts-communication/configs/global/SynapseExecutionServiceV1.testnet.json
+++ b/packages/contracts-communication/configs/global/SynapseExecutionServiceV1.testnet.json
@@ -1,4 +1,5 @@
 {
+  "claimFeeBPS": 10,
   "executorEOA": "0xD0D45E468ADF3aCB8A98391ff47267783220ba6F",
   "gasOracleName": "SynapseGasOracleV1"
 }

--- a/packages/contracts-communication/contracts/events/ClaimableFeesEvents.sol
+++ b/packages/contracts-communication/contracts/events/ClaimableFeesEvents.sol
@@ -8,6 +8,10 @@ abstract contract ClaimableFeesEvents {
     /// @param claimerFraction  The fraction of the fees to be paid to the claimer (100% = 1e18)
     event ClaimerFractionSet(uint256 claimerFraction);
 
+    /// @notice Emitted when a fee recipient is set. The fee recipient receives the claimed fees.
+    /// @param feeRecipient     The address of the fee recipient.
+    event FeeRecipientSet(address feeRecipient);
+
     /// @notice Emitted when fees are claimed to the fee recipient address.
     /// @param feeRecipient     The address that receives the claimed fees.
     /// @param claimedFees      The amount of fees claimed, after the claimer reward is deducted.

--- a/packages/contracts-communication/contracts/events/ClaimableFeesEvents.sol
+++ b/packages/contracts-communication/contracts/events/ClaimableFeesEvents.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+abstract contract ClaimableFeesEvents {
+    /// @notice Emitted when the claim fee fraction is set. This fraction of the fees will be paid
+    /// to the caller of the `claimFees` function.
+    /// This encourages rational actors to call the function as soon as claim fee is higher than the gas cost.
+    /// @param claimerFraction  The fraction of the fees to be paid to the claimer (100% = 1e18)
+    event ClaimerFractionSet(uint256 claimerFraction);
+
+    /// @notice Emitted when fees are claimed to the fee recipient address.
+    /// @param feeRecipient     The address that receives the claimed fees.
+    /// @param claimedFees      The amount of fees claimed, after the claimer reward is deducted.
+    /// @param claimer          The address of the claimer (who called `claimFees`)
+    /// @param claimerReward    The reward paid to the claimer for calling the `claimFees` function.
+    event FeesClaimed(address feeRecipient, uint256 claimedFees, address claimer, uint256 claimerReward);
+}

--- a/packages/contracts-communication/contracts/events/SynapseExecutionServiceEvents.sol
+++ b/packages/contracts-communication/contracts/events/SynapseExecutionServiceEvents.sol
@@ -24,9 +24,4 @@ abstract contract SynapseExecutionServiceEvents {
     /// @param client        The address of the Interchain Client that requested the execution.
     /// @param executionFee  The fee paid for the execution.
     event ExecutionRequested(bytes32 indexed transactionId, address client, uint256 executionFee);
-
-    /// @notice Emitted when the fees accumulated in the contract are claimed.
-    /// @param executorEOA   The address of the executor EOA that received the fees.
-    /// @param amount        The amount of fees claimed.
-    event FeesClaimed(address executorEOA, uint256 amount);
 }

--- a/packages/contracts-communication/contracts/events/SynapseModuleEvents.sol
+++ b/packages/contracts-communication/contracts/events/SynapseModuleEvents.sol
@@ -15,10 +15,6 @@ abstract contract SynapseModuleEvents {
     /// @param threshold        The threshold value.
     event ThresholdSet(uint256 threshold);
 
-    /// @notice Emitted when a fee collector is set. The fee collector collects fees from the module.
-    /// @param feeCollector     The address of the fee collector.
-    event FeeCollectorSet(address feeCollector);
-
     /// @notice Emitted when a gas oracle is set. The gas oracle will be used to estimate the gas cost of
     /// verifying a batch on the remote chain.
     /// @param gasOracle        The address of the gas oracle.
@@ -28,19 +24,6 @@ abstract contract SynapseModuleEvents {
     /// @param chainId          The chain ID of the chain.
     /// @param gasLimit         The gas limit estimate for verifying a batch on the chain.
     event VerifyGasLimitSet(uint64 chainId, uint256 gasLimit);
-
-    /// @notice Emitted when the claim fee fraction is set. This fraction of the fees will be paid
-    /// to the caller of the `claimFees` function.
-    /// This encourages rational actors to call the function as soon as claim fee is higher than the gas cost.
-    /// @param claimFeeFraction The fraction of the fees to be paid to the claimer (100% = 1e18)
-    event ClaimFeeFractionSet(uint256 claimFeeFraction);
-
-    /// @notice Emitted when fees are claimed to the fee collector address.
-    /// @param feeCollector     The address of the fee collector.
-    /// @param collectedFees    The amount of fees collected.
-    /// @param claimer          The address of the claimer (who called `claimFees`)
-    /// @param claimerFee       The amount of fees claimed by the claimer.
-    event FeesClaimed(address feeCollector, uint256 collectedFees, address claimer, uint256 claimerFee);
 
     /// @notice Emitted when the gas data from the gas oracle is sent to the remote chain.
     /// @param dstChainId       The chain ID of the destination chain.

--- a/packages/contracts-communication/contracts/execution/SynapseExecutionServiceV1.sol
+++ b/packages/contracts-communication/contracts/execution/SynapseExecutionServiceV1.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.20;
 
-import {IExecutionService, ISynapseExecutionServiceV1} from "../interfaces/ISynapseExecutionServiceV1.sol";
 import {SynapseExecutionServiceEvents} from "../events/SynapseExecutionServiceEvents.sol";
+import {ClaimableFees} from "../fees/ClaimableFees.sol";
+import {IExecutionService, ISynapseExecutionServiceV1} from "../interfaces/ISynapseExecutionServiceV1.sol";
 import {IGasOracle} from "../interfaces/IGasOracle.sol";
 import {OptionsLib, OptionsV1} from "../libs/Options.sol";
 import {VersionedPayloadLib} from "../libs/VersionedPayload.sol";
@@ -12,6 +13,7 @@ import {AccessControlUpgradeable} from "@openzeppelin/contracts-upgradeable/acce
 
 contract SynapseExecutionServiceV1 is
     AccessControlUpgradeable,
+    ClaimableFees,
     SynapseExecutionServiceEvents,
     ISynapseExecutionServiceV1
 {
@@ -20,6 +22,7 @@ contract SynapseExecutionServiceV1 is
         address executorEOA;
         address gasOracle;
         uint256 globalMarkup;
+        uint256 claimerFraction;
     }
 
     // keccak256(abi.encode(uint256(keccak256("Synapse.ExecutionService.V1")) - 1)) & ~bytes32(uint256(0xff));
@@ -40,18 +43,13 @@ contract SynapseExecutionServiceV1 is
     }
 
     /// @inheritdoc ISynapseExecutionServiceV1
-    function claimFees() external {
-        uint256 amount = address(this).balance;
-        if (amount == 0) {
-            revert SynapseExecutionService__ZeroAmount();
+    function setClaimerFraction(uint256 claimerFraction_) external virtual onlyRole(GOVERNOR_ROLE) {
+        if (claimerFraction_ > MAX_CLAIMER_FRACTION) {
+            revert ClaimableFees__ClaimerFractionExceedsMax(claimerFraction_);
         }
-        address executor = executorEOA();
-        if (executor == address(0)) {
-            revert SynapseExecutionService__ZeroAddress();
-        }
-        emit FeesClaimed(executor, amount);
-        // TODO: introduce incentives for the caller similar to ones in SynapseModule
-        Address.sendValue(payable(executor), amount);
+        SynapseExecutionServiceV1Storage storage $ = _getSynapseExecutionServiceV1Storage();
+        $.claimerFraction = claimerFraction_;
+        emit ClaimerFractionSet(claimerFraction_);
     }
 
     /// @inheritdoc ISynapseExecutionServiceV1
@@ -152,6 +150,30 @@ contract SynapseExecutionServiceV1 is
     function globalMarkup() public view virtual returns (uint256) {
         SynapseExecutionServiceV1Storage storage $ = _getSynapseExecutionServiceV1Storage();
         return $.globalMarkup;
+    }
+
+    /// @notice Returns the amount of fees that can be claimed.
+    function getClaimableAmount() public view virtual override returns (uint256) {
+        return address(this).balance;
+    }
+
+    /// @notice Returns the fraction of the fees that the claimer will receive.
+    /// The result is in the range [0, 1e18], where 1e18 is 100%.
+    function getClaimerFraction() public view virtual override returns (uint256) {
+        SynapseExecutionServiceV1Storage storage $ = _getSynapseExecutionServiceV1Storage();
+        return $.claimerFraction;
+    }
+
+    /// @notice Returns the address that will receive the claimed fees.
+    function getFeeRecipient() public view virtual override returns (address) {
+        return executorEOA();
+    }
+
+    /// @dev Hook that is called before the fees are claimed.
+    /// Useful if the inheriting contract needs to manage the state when the fees are claimed.
+    // solhint-disable-next-line no-empty-blocks
+    function _beforeFeesClaimed(uint256, uint256) internal override {
+        // No op, as the claimable amount is tracked as the contract balance
     }
 
     /// @dev ERC-7201 slot accessor

--- a/packages/contracts-communication/contracts/fees/ClaimableFees.sol
+++ b/packages/contracts-communication/contracts/fees/ClaimableFees.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {ClaimableFeesEvents} from "../events/ClaimableFeesEvents.sol";
+import {IClaimableFees} from "../interfaces/IClaimableFees.sol";
+
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+/// @notice A simple abstraction for a contract that is collecting fees in native chain token.
+/// The claim process could be performed by anyone, but the fees will be sent to
+/// the predefined address. The claimer will receive a fraction of the fees to offset
+/// the gas costs.
+/// @dev The contract is implemented in a stateless way to allow the inheriting
+/// contract to be immutable or upgradeable.
+abstract contract ClaimableFees is ClaimableFeesEvents, IClaimableFees {
+    uint256 private constant FEE_PRECISION = 1e18;
+    /// @dev The maximum fraction that the claimer can receive is 1%.
+    uint256 internal constant MAX_CLAIMER_FRACTION = 1e16;
+
+    /// @notice Transfers the accumulated fees to the fee recipient.
+    /// Message caller receives a fraction of the fees as a reward to offset the gas costs.
+    /// The reward amount could be obtained by calling the `getClaimerReward` function beforehand.
+    /// @dev Will revert if the claimable amount is zero or the fee recipient is not set.
+    function claimFees() external {
+        uint256 amount = getClaimableAmount();
+        if (amount == 0) {
+            revert ClaimableFees__ZeroAmount();
+        }
+        address recipient = getFeeRecipient();
+        if (recipient == address(0)) {
+            revert ClaimableFees__FeeRecipientNotSet();
+        }
+        // Subtract the claimer reward from the total amount
+        uint256 reward = getClaimerReward();
+        _beforeFeesClaimed(amount, reward);
+        // We can do unchecked subtraction because `getClaimerReward` ensures that `reward <= amount * 0.01`
+        unchecked {
+            amount -= reward;
+        }
+        // Emit the event before transferring the fees
+        emit FeesClaimed(recipient, amount, msg.sender, reward);
+        Address.sendValue(payable(recipient), amount);
+        Address.sendValue(payable(msg.sender), reward);
+    }
+
+    /// @notice Returns the amount of native chain token that the claimer will receive
+    /// after calling the `claimFees` function.
+    function getClaimerReward() public view returns (uint256) {
+        uint256 fraction = getClaimerFraction();
+        if (fraction > MAX_CLAIMER_FRACTION) {
+            revert ClaimableFees__ClaimerFractionExceedsMax(fraction);
+        }
+        // The returned value is in the range [0, _getClaimableAmount() * 0.01]
+        return (getClaimableAmount() * fraction) / FEE_PRECISION;
+    }
+
+    /// @notice Returns the amount of fees that can be claimed.
+    function getClaimableAmount() public view virtual returns (uint256);
+
+    /// @notice Returns the fraction of the fees that the claimer will receive.
+    /// The result is in the range [0, 1e18], where 1e18 is 100%.
+    function getClaimerFraction() public view virtual returns (uint256);
+
+    /// @notice Returns the address that will receive the claimed fees.
+    function getFeeRecipient() public view virtual returns (address);
+
+    /// @dev Hook that is called before the fees are claimed.
+    /// Useful if the inheriting contract needs to manage the state when the fees are claimed.
+    function _beforeFeesClaimed(uint256 fullAmount, uint256 reward) internal virtual;
+}

--- a/packages/contracts-communication/contracts/interfaces/IClaimableFees.sol
+++ b/packages/contracts-communication/contracts/interfaces/IClaimableFees.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IClaimableFees {
+    error ClaimableFees__ClaimerFractionExceedsMax(uint256 claimerFraction);
+    error ClaimableFees__FeeRecipientNotSet();
+    error ClaimableFees__ZeroAmount();
+
+    function claimFees() external;
+
+    function getClaimableAmount() external view returns (uint256);
+    function getClaimerFraction() external view returns (uint256);
+    function getClaimerReward() external view returns (uint256);
+    function getFeeRecipient() external view returns (address);
+}

--- a/packages/contracts-communication/contracts/interfaces/ISynapseExecutionServiceV1.sol
+++ b/packages/contracts-communication/contracts/interfaces/ISynapseExecutionServiceV1.sol
@@ -8,12 +8,12 @@ interface ISynapseExecutionServiceV1 is IExecutionService {
     error SynapseExecutionService__FeeAmountTooLow(uint256 actual, uint256 required);
     error SynapseExecutionService__OptionsVersionNotSupported(uint16 version);
     error SynapseExecutionService__ZeroAddress();
-    error SynapseExecutionService__ZeroAmount();
 
-    /// @notice Allows anyone to claim the fees accumulated in the contract. The claimed fees are
-    /// transferred to the executor EOA account.
-    /// @dev Will revert if there are no fees to claim, or if executor EOA address is not set.
-    function claimFees() external;
+    /// @notice Sets the fraction of the accumulated fees to be paid to caller of `claimFees`.
+    /// This encourages rational actors to call the function as soon as claim fee is higher than the gas cost.
+    /// @dev Could be only called by the owner. Could not exceed 1%.
+    /// @param claimerFraction  The fraction of the fees to be paid to the claimer (100% = 1e18)
+    function setClaimerFraction(uint256 claimerFraction) external;
 
     /// @notice Allows the contract governor to set the address of the EOA account that will be used
     /// to execute transactions on the remote chains.

--- a/packages/contracts-communication/contracts/interfaces/ISynapseModule.sol
+++ b/packages/contracts-communication/contracts/interfaces/ISynapseModule.sol
@@ -4,11 +4,8 @@ pragma solidity ^0.8.0;
 import {IInterchainModule} from "./IInterchainModule.sol";
 
 interface ISynapseModule is IInterchainModule {
-    error SynapseModule__ClaimFeeFractionExceedsMax(uint256 claimFeeFraction);
-    error SynapseModule__FeeCollectorNotSet();
     error SynapseModule__GasOracleNotContract(address gasOracle);
     error SynapseModule__GasOracleNotSet();
-    error SynapseModule__NoFeesToClaim();
 
     // ═══════════════════════════════════════════════ PERMISSIONED ════════════════════════════════════════════════════
 
@@ -39,14 +36,14 @@ interface ISynapseModule is IInterchainModule {
 
     /// @notice Sets the address of the fee collector, which will have the verification fees forwarded to it.
     /// @dev Could be only called by the owner.
-    /// @param feeCollector_   The address of the fee collector
-    function setFeeCollector(address feeCollector_) external;
+    /// @param feeRecipient_   The address of the fee collector
+    function setFeeRecipient(address feeRecipient_) external;
 
     /// @notice Sets the fraction of the accumulated fees to be paid to caller of `claimFees`.
     /// This encourages rational actors to call the function as soon as claim fee is higher than the gas cost.
     /// @dev Could be only called by the owner. Could not exceed 1%.
-    /// @param claimFeeFraction The fraction of the fees to be paid to the claimer (100% = 1e18)
-    function setClaimFeeFraction(uint256 claimFeeFraction) external;
+    /// @param claimerFraction  The fraction of the fees to be paid to the claimer (100% = 1e18)
+    function setClaimerFraction(uint256 claimerFraction) external;
 
     /// @notice Sets the address of the gas oracle to be used for estimating the verification fees.
     /// @dev Could be only called by the owner. Will revert if the gas oracle is not a contract.
@@ -61,13 +58,6 @@ interface ISynapseModule is IInterchainModule {
 
     // ══════════════════════════════════════════════ PERMISSIONLESS ═══════════════════════════════════════════════════
 
-    /// @notice Transfers the accumulated fees to the fee collector.
-    /// Message caller receives a percentage of the fees, this ensures that the module is self-sustainable.
-    /// The claim fee amount could be retrieved using `getClaimFeeAmount`. The rest of the fees
-    /// will be transferred to the fee collector.
-    /// @dev Will revert if the fee collector is not set.
-    function claimFees() external;
-
     /// @notice Verifies a batch from the remote chain using a set of verifier signatures.
     /// If the threshold is met, the batch will be marked as verified in the Interchain DataBase.
     /// @dev List of recovered signers from the signatures must be sorted in the ascending order.
@@ -76,16 +66,6 @@ interface ISynapseModule is IInterchainModule {
     function verifyRemoteBatch(bytes calldata encodedBatch, bytes calldata signatures) external;
 
     // ═══════════════════════════════════════════════════ VIEWS ═══════════════════════════════════════════════════════
-
-    /// @notice Returns the address of the fee collector for the module.
-    function feeCollector() external view returns (address);
-
-    /// @notice Returns the current claim fee to be paid to the caller of `claimFees`.
-    function getClaimFeeAmount() external view returns (uint256);
-
-    /// @notice Returns the fraction of the fees to be paid to the caller of `claimFees`.
-    /// The returned value is in the range [0, 1e18], where 1e18 corresponds to 100% of the fees.
-    function getClaimFeeFraction() external view returns (uint256);
 
     /// @notice Returns the address of the gas oracle used for estimating the verification fees.
     function gasOracle() external view returns (address);

--- a/packages/contracts-communication/contracts/modules/SynapseModule.sol
+++ b/packages/contracts-communication/contracts/modules/SynapseModule.sol
@@ -6,24 +6,21 @@ import {InterchainModule} from "./InterchainModule.sol";
 import {SynapseModuleEvents} from "../events/SynapseModuleEvents.sol";
 import {ISynapseGasOracle} from "../interfaces/ISynapseGasOracle.sol";
 import {ISynapseModule} from "../interfaces/ISynapseModule.sol";
-
 import {ThresholdECDSA} from "../libs/ThresholdECDSA.sol";
+
+import {ClaimableFees} from "../fees/ClaimableFees.sol";
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
-contract SynapseModule is InterchainModule, Ownable, SynapseModuleEvents, ISynapseModule {
+contract SynapseModule is InterchainModule, ClaimableFees, Ownable, SynapseModuleEvents, ISynapseModule {
     // TODO: make sure this is a good enough default value
     uint256 public constant DEFAULT_VERIFY_GAS_LIMIT = 100_000;
 
-    uint256 internal constant MAX_CLAIM_FEE_FRACTION = 0.01e18; // 1%
-    uint256 internal constant FEE_PRECISION = 1e18;
-
     /// @dev Struct to hold the verifiers and the threshold for the module.
     ThresholdECDSA internal _verifiers;
-    /// @dev Claim fee fraction, 100% = 1e18
-    uint256 internal _claimFeeFraction;
+
     /// @dev Gas limit for the verifyBatch function on the remote chain.
     mapping(uint64 chainId => uint256 gasLimit) internal _verifyGasLimit;
     /// @dev Hash of the last gas data sent to the remote chain.
@@ -31,8 +28,11 @@ contract SynapseModule is InterchainModule, Ownable, SynapseModuleEvents, ISynap
     /// @dev Nonce of the last gas data received from the remote chain.
     mapping(uint64 chainId => uint64 gasDataNonce) internal _lastGasDataNonce;
 
-    /// @inheritdoc ISynapseModule
-    address public feeCollector;
+    /// @dev Fraction of the fees to be paid to the claimer (100% = 1e18).
+    uint256 internal _claimerFraction;
+    /// @dev Recipient of the fees collected by the module.
+    address internal _feeRecipient;
+
     /// @inheritdoc ISynapseModule
     address public gasOracle;
 
@@ -75,18 +75,18 @@ contract SynapseModule is InterchainModule, Ownable, SynapseModuleEvents, ISynap
     }
 
     /// @inheritdoc ISynapseModule
-    function setFeeCollector(address feeCollector_) external onlyOwner {
-        feeCollector = feeCollector_;
-        emit FeeCollectorSet(feeCollector_);
+    function setFeeRecipient(address feeRecipient) external onlyOwner {
+        _feeRecipient = feeRecipient;
+        emit FeeRecipientSet(feeRecipient);
     }
 
     /// @inheritdoc ISynapseModule
-    function setClaimFeeFraction(uint256 claimFeeFraction) external onlyOwner {
-        if (claimFeeFraction > MAX_CLAIM_FEE_FRACTION) {
-            revert SynapseModule__ClaimFeeFractionExceedsMax(claimFeeFraction);
+    function setClaimerFraction(uint256 claimerFraction) external onlyOwner {
+        if (claimerFraction > MAX_CLAIMER_FRACTION) {
+            revert ClaimableFees__ClaimerFractionExceedsMax(claimerFraction);
         }
-        _claimFeeFraction = claimFeeFraction;
-        emit ClaimFeeFractionSet(claimFeeFraction);
+        _claimerFraction = claimerFraction;
+        emit ClaimerFractionSet(claimerFraction);
     }
 
     /// @inheritdoc ISynapseModule
@@ -107,21 +107,6 @@ contract SynapseModule is InterchainModule, Ownable, SynapseModuleEvents, ISynap
     // ══════════════════════════════════════════════ PERMISSIONLESS ═══════════════════════════════════════════════════
 
     /// @inheritdoc ISynapseModule
-    function claimFees() external {
-        if (feeCollector == address(0)) {
-            revert SynapseModule__FeeCollectorNotSet();
-        }
-        if (address(this).balance == 0) {
-            revert SynapseModule__NoFeesToClaim();
-        }
-        uint256 claimFee = getClaimFeeAmount();
-        uint256 collectedFee = address(this).balance - claimFee;
-        emit FeesClaimed(feeCollector, collectedFee, msg.sender, claimFee);
-        Address.sendValue(payable(feeCollector), collectedFee);
-        Address.sendValue(payable(msg.sender), claimFee);
-    }
-
-    /// @inheritdoc ISynapseModule
     function verifyRemoteBatch(bytes calldata encodedBatch, bytes calldata signatures) external {
         bytes32 ethSignedHash = MessageHashUtils.toEthSignedMessageHash(keccak256(encodedBatch));
         _verifiers.verifySignedHash(ethSignedHash, signatures);
@@ -131,11 +116,6 @@ contract SynapseModule is InterchainModule, Ownable, SynapseModuleEvents, ISynap
     // ═══════════════════════════════════════════════════ VIEWS ═══════════════════════════════════════════════════════
 
     /// @inheritdoc ISynapseModule
-    function getClaimFeeFraction() external view returns (uint256) {
-        return _claimFeeFraction;
-    }
-
-    /// @inheritdoc ISynapseModule
     function getVerifiers() external view returns (address[] memory) {
         return _verifiers.getSigners();
     }
@@ -143,11 +123,6 @@ contract SynapseModule is InterchainModule, Ownable, SynapseModuleEvents, ISynap
     /// @inheritdoc ISynapseModule
     function isVerifier(address account) external view returns (bool) {
         return _verifiers.isSigner(account);
-    }
-
-    /// @inheritdoc ISynapseModule
-    function getClaimFeeAmount() public view returns (uint256) {
-        return address(this).balance * _claimFeeFraction / FEE_PRECISION;
     }
 
     /// @inheritdoc ISynapseModule
@@ -163,6 +138,22 @@ contract SynapseModule is InterchainModule, Ownable, SynapseModuleEvents, ISynap
         }
     }
 
+    /// @notice Returns the amount of fees that can be claimed.
+    function getClaimableAmount() public view override returns (uint256) {
+        return address(this).balance;
+    }
+
+    /// @notice Returns the fraction of the fees that the claimer will receive.
+    /// The result is in the range [0, 1e18], where 1e18 is 100%.
+    function getClaimerFraction() public view override returns (uint256) {
+        return _claimerFraction;
+    }
+
+    /// @notice Returns the address that will receive the claimed fees.
+    function getFeeRecipient() public view override returns (address) {
+        return _feeRecipient;
+    }
+
     // ══════════════════════════════════════════════ INTERNAL LOGIC ═══════════════════════════════════════════════════
 
     /// @dev Adds a verifier to the module. Permissions should be checked in the calling function.
@@ -175,6 +166,13 @@ contract SynapseModule is InterchainModule, Ownable, SynapseModuleEvents, ISynap
     function _removeVerifier(address verifier) internal {
         _verifiers.removeSigner(verifier);
         emit VerifierRemoved(verifier);
+    }
+
+    /// @dev Hook that is called before the fees are claimed.
+    /// Useful if the inheriting contract needs to manage the state when the fees are claimed.
+    // solhint-disable-next-line no-empty-blocks
+    function _beforeFeesClaimed(uint256, uint256) internal override {
+        // No op, as the claimable amount is tracked as the contract balance
     }
 
     /// @dev Internal logic to fill the module data for the specified destination chain.

--- a/packages/contracts-communication/script/config/ConfigureSynapseExecutionServiceV1.s.sol
+++ b/packages/contracts-communication/script/config/ConfigureSynapseExecutionServiceV1.s.sol
@@ -16,6 +16,7 @@ contract ConfigureSynapseExecutionServiceV1 is SynapseScript {
     function run(string memory environment) external broadcastWithHooks {
         loadConfig(environment);
         setGovernor();
+        setClaimerFraction();
         setExecutorEOA();
         setGasOracle();
         setInterchainClient();
@@ -34,6 +35,20 @@ contract ConfigureSynapseExecutionServiceV1 is SynapseScript {
             printSuccessWithIndent(string.concat("Granted Governor role to ", vm.toString(msg.sender)));
         } else {
             printSkipWithIndent(string.concat("governor role already granted to ", vm.toString(msg.sender)));
+        }
+    }
+
+    function setClaimerFraction() internal {
+        printLog("Setting claimerFraction");
+        uint256 claimFeeBPS = config.readUint(".claimFeeBPS");
+        // Convert from basis points to wei
+        uint256 claimerFraction = claimFeeBPS * 1e18 / 10_000;
+        string memory desc = string.concat(vm.toString(claimerFraction), " [", vm.toString(claimFeeBPS), " BPS]");
+        if (service.getClaimerFraction() != claimerFraction) {
+            service.setClaimerFraction(claimerFraction);
+            printSuccessWithIndent(string.concat("Set claimerFraction to ", desc));
+        } else {
+            printSkipWithIndent(string.concat("already set to ", desc));
         }
     }
 

--- a/packages/contracts-communication/script/config/ConfigureSynapseModule.s.sol
+++ b/packages/contracts-communication/script/config/ConfigureSynapseModule.s.sol
@@ -19,8 +19,8 @@ contract ConfigureSynapseModule is SynapseScript {
 
     function run(string memory environment) external broadcastWithHooks {
         loadConfig(environment);
-        setClaimFeeFraction();
-        setFeeCollector();
+        setClaimerFraction();
+        setFeeRecipient();
         setGasOracle();
         setThreshold();
         syncVerifiers();
@@ -31,28 +31,28 @@ contract ConfigureSynapseModule is SynapseScript {
         module = SynapseModule(getDeploymentAddress({contractName: NAME, revertIfNotFound: true}));
     }
 
-    function setClaimFeeFraction() internal {
-        printLog("Setting claimFeeFraction");
+    function setClaimerFraction() internal {
+        printLog("Setting claimerFraction");
         uint256 claimFeeBPS = config.readUint(".claimFeeBPS");
         // Convert from basis points to wei
-        uint256 claimFeeFraction = claimFeeBPS * 1e18 / 10_000;
-        string memory desc = string.concat(vm.toString(claimFeeFraction), " [", vm.toString(claimFeeBPS), " BPS]");
-        if (module.getClaimFeeFraction() != claimFeeFraction) {
-            module.setClaimFeeFraction(claimFeeFraction);
-            printSuccessWithIndent(string.concat("Set claimFeeFraction to ", desc));
+        uint256 claimerFraction = claimFeeBPS * 1e18 / 10_000;
+        string memory desc = string.concat(vm.toString(claimerFraction), " [", vm.toString(claimFeeBPS), " BPS]");
+        if (module.getClaimerFraction() != claimerFraction) {
+            module.setClaimerFraction(claimerFraction);
+            printSuccessWithIndent(string.concat("Set claimerFraction to ", desc));
         } else {
             printSkipWithIndent(string.concat("already set to ", desc));
         }
     }
 
-    function setFeeCollector() internal {
-        printLog("Setting feeCollector");
-        address feeCollector = config.readAddress(".feeCollector");
-        if (module.feeCollector() != feeCollector) {
-            module.setFeeCollector(feeCollector);
-            printSuccessWithIndent(string.concat("Set feeCollector to ", vm.toString(feeCollector)));
+    function setFeeRecipient() internal {
+        printLog("Setting feeRecipient");
+        address feeRecipient = config.readAddress(".feeRecipient");
+        if (module.getFeeRecipient() != feeRecipient) {
+            module.setFeeRecipient(feeRecipient);
+            printSuccessWithIndent(string.concat("Set feeRecipient to ", vm.toString(feeRecipient)));
         } else {
-            printSkipWithIndent(string.concat("already set to ", vm.toString(feeCollector)));
+            printSkipWithIndent(string.concat("already set to ", vm.toString(feeRecipient)));
         }
     }
 

--- a/packages/contracts-communication/test/execution/SynapseExecutionServiceV1.Management.t.sol
+++ b/packages/contracts-communication/test/execution/SynapseExecutionServiceV1.Management.t.sol
@@ -80,6 +80,14 @@ contract SynapseExecutionServiceV1ManagementTest is SynapseExecutionServiceV1Tes
         assertEq(service.globalMarkup(), globalMarkup);
     }
 
+    function test_setGlobalMarkup_correctSlotERC7201() public {
+        uint256 globalMarkup = 100;
+        bytes32 slot = getExpectedLocationERC7201({namespaceId: "Synapse.ExecutionService.V1", stolOffset: 2});
+        vm.prank(governor);
+        service.setGlobalMarkup(globalMarkup);
+        assertStorageUint(address(service), slot, globalMarkup);
+    }
+
     function test_setGlobalMarkup_toZero() public {
         test_setGlobalMarkup();
         expectEventGlobalMarkupSet(0);
@@ -94,6 +102,36 @@ contract SynapseExecutionServiceV1ManagementTest is SynapseExecutionServiceV1Tes
         expectRevertNotGovernor(caller);
         vm.prank(caller);
         service.setGlobalMarkup(100);
+    }
+
+    function test_setClaimerFraction() public {
+        uint256 claimerFraction = 1e16;
+        expectEventClaimerFractionSet(claimerFraction);
+        vm.prank(governor);
+        service.setClaimerFraction(claimerFraction);
+        assertEq(service.getClaimerFraction(), claimerFraction);
+    }
+
+    function test_setClaimerFraction_correctSlotERC7201() public {
+        uint256 claimerFraction = 1e16;
+        bytes32 slot = getExpectedLocationERC7201({namespaceId: "Synapse.ExecutionService.V1", stolOffset: 3});
+        vm.prank(governor);
+        service.setClaimerFraction(claimerFraction);
+        assertStorageUint(address(service), slot, claimerFraction);
+    }
+
+    function test_setClaimerFraction_revert_overOnePercent() public {
+        expectRevertClaimerFractionExceedsMax(1e16 + 1);
+        vm.prank(governor);
+        service.setClaimerFraction(1e16 + 1);
+    }
+
+    function test_setClaimerFraction_revert_notGovernor(address caller) public {
+        assumeNotProxyAdmin({target: address(service), caller: caller});
+        vm.assume(caller != governor);
+        expectRevertNotGovernor(caller);
+        vm.prank(caller);
+        service.setClaimerFraction(1e16);
     }
 
     function test_getExecutionFee_revert_gasOracleNotSet() public {

--- a/packages/contracts-communication/test/execution/SynapseExecutionServiceV1.t.sol
+++ b/packages/contracts-communication/test/execution/SynapseExecutionServiceV1.t.sol
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.20;
 
+import {ClaimableFeesEvents} from "../../contracts/events/ClaimableFeesEvents.sol";
 import {SynapseExecutionServiceEvents} from "../../contracts/events/SynapseExecutionServiceEvents.sol";
 import {SynapseExecutionServiceV1} from "../../contracts/execution/SynapseExecutionServiceV1.sol";
+import {IClaimableFees} from "../../contracts/interfaces/IClaimableFees.sol";
 import {ISynapseExecutionServiceV1} from "../../contracts/interfaces/ISynapseExecutionServiceV1.sol";
 
 import {ProxyTest} from "../proxy/ProxyTest.t.sol";
@@ -11,7 +13,7 @@ import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol"
 
 // solhint-disable func-name-mixedcase
 // solhint-disable ordering
-contract SynapseExecutionServiceV1Test is ProxyTest, SynapseExecutionServiceEvents {
+contract SynapseExecutionServiceV1Test is ProxyTest, ClaimableFeesEvents, SynapseExecutionServiceEvents {
     bytes32 public constant GOVERNOR_ROLE = keccak256("GOVERNOR_ROLE");
     bytes32 public constant IC_CLIENT_ROLE = keccak256("IC_CLIENT_ROLE");
 
@@ -24,6 +26,11 @@ contract SynapseExecutionServiceV1Test is ProxyTest, SynapseExecutionServiceEven
     function setUp() public virtual {
         implementation = new SynapseExecutionServiceV1();
         service = SynapseExecutionServiceV1(deployProxy(address(implementation)));
+    }
+
+    function expectEventClaimerFractionSet(uint256 claimerFraction) internal {
+        vm.expectEmit(address(service));
+        emit ClaimerFractionSet(claimerFraction);
     }
 
     function expectEventExecutorEOASet(address executor) internal {
@@ -46,6 +53,12 @@ contract SynapseExecutionServiceV1Test is ProxyTest, SynapseExecutionServiceEven
         emit ExecutionRequested(transactionId, client, executionFee);
     }
 
+    function expectRevertClaimerFractionExceedsMax(uint256 claimerFraction) internal {
+        vm.expectRevert(
+            abi.encodeWithSelector(IClaimableFees.ClaimableFees__ClaimerFractionExceedsMax.selector, claimerFraction)
+        );
+    }
+
     function expectRevertGasOracleNotSet() internal {
         vm.expectRevert(ISynapseExecutionServiceV1.SynapseExecutionService__GasOracleNotSet.selector);
     }
@@ -56,6 +69,10 @@ contract SynapseExecutionServiceV1Test is ProxyTest, SynapseExecutionServiceEven
                 ISynapseExecutionServiceV1.SynapseExecutionService__FeeAmountTooLow.selector, actual, required
             )
         );
+    }
+
+    function expectRevertFeeRecipientNotSet() internal {
+        vm.expectRevert(IClaimableFees.ClaimableFees__FeeRecipientNotSet.selector);
     }
 
     function expectRevertOptionsVersionNotSupported(uint256 version) internal {
@@ -71,7 +88,7 @@ contract SynapseExecutionServiceV1Test is ProxyTest, SynapseExecutionServiceEven
     }
 
     function expectRevertZeroAmount() internal {
-        vm.expectRevert(ISynapseExecutionServiceV1.SynapseExecutionService__ZeroAmount.selector);
+        vm.expectRevert(IClaimableFees.ClaimableFees__ZeroAmount.selector);
     }
 
     function expectRevertNotGovernor(address caller) internal {

--- a/packages/contracts-communication/test/fees/ClaimableFees.t.sol
+++ b/packages/contracts-communication/test/fees/ClaimableFees.t.sol
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {ClaimableFeesEvents} from "../../contracts/events/ClaimableFeesEvents.sol";
+import {IClaimableFees} from "../../contracts/interfaces/IClaimableFees.sol";
+
+import {ClaimableFeesHarness} from "../harnesses/ClaimableFeesHarness.sol";
+
+import {Test} from "forge-std/Test.sol";
+
+// solhint-disable func-name-mixedcase
+contract ClaimableFeesTest is ClaimableFeesEvents, Test {
+    uint256 public constant INITIAL_BALANCE = 10 ether;
+    uint256 public constant CLAIMABLE_AMOUNT = 5 ether;
+
+    uint256 public constant ONE_PERCENT = 0.01e18;
+
+    ClaimableFeesHarness public harness;
+
+    address public claimer = makeAddr("Claimer");
+    address public recipient = makeAddr("Recipient");
+
+    event BeforeFeesClaimed(uint256 amount, uint256 reward);
+
+    function setUp() public {
+        harness = new ClaimableFeesHarness();
+        deal(address(harness), INITIAL_BALANCE);
+    }
+
+    function expectEvents(uint256 claimerReward) public {
+        vm.expectEmit(address(harness));
+        emit BeforeFeesClaimed(CLAIMABLE_AMOUNT, claimerReward);
+        vm.expectEmit(address(harness));
+        emit FeesClaimed(recipient, CLAIMABLE_AMOUNT - claimerReward, claimer, claimerReward);
+    }
+
+    function test_claimFees_zeroFraction_events() public {
+        harness.setup({claimableAmount: CLAIMABLE_AMOUNT, feeRecipient: recipient, claimerFraction: 0});
+        expectEvents({claimerReward: 0});
+        vm.prank(claimer);
+        harness.claimFees();
+    }
+
+    function test_claimFees_zeroFraction_balances() public {
+        harness.setup({claimableAmount: CLAIMABLE_AMOUNT, feeRecipient: recipient, claimerFraction: 0});
+        vm.prank(claimer);
+        harness.claimFees();
+        assertEq(address(harness).balance, INITIAL_BALANCE - CLAIMABLE_AMOUNT);
+        assertEq(claimer.balance, 0);
+        assertEq(recipient.balance, CLAIMABLE_AMOUNT);
+    }
+
+    function test_claimFees_zeroFraction_state() public {
+        harness.setup({claimableAmount: CLAIMABLE_AMOUNT, feeRecipient: recipient, claimerFraction: 0});
+        vm.prank(claimer);
+        harness.claimFees();
+        assertEq(harness.getClaimableAmount(), 0);
+        assertEq(harness.getClaimerReward(), 0);
+        assertEq(harness.getClaimerFraction(), 0);
+        assertEq(harness.getFeeRecipient(), recipient);
+    }
+
+    function test_claimFees_nonZeroFraction_events() public {
+        harness.setup({claimableAmount: CLAIMABLE_AMOUNT, feeRecipient: recipient, claimerFraction: ONE_PERCENT});
+        expectEvents({claimerReward: 5e16});
+        vm.prank(claimer);
+        harness.claimFees();
+    }
+
+    function test_claimFees_nonZeroFraction_balances() public {
+        harness.setup({claimableAmount: CLAIMABLE_AMOUNT, feeRecipient: recipient, claimerFraction: ONE_PERCENT});
+        vm.prank(claimer);
+        harness.claimFees();
+        assertEq(address(harness).balance, INITIAL_BALANCE - CLAIMABLE_AMOUNT);
+        assertEq(claimer.balance, 5e16);
+        assertEq(recipient.balance, CLAIMABLE_AMOUNT - 5e16);
+    }
+
+    function test_claimFees_nonZeroFraction_state() public {
+        harness.setup({claimableAmount: CLAIMABLE_AMOUNT, feeRecipient: recipient, claimerFraction: ONE_PERCENT});
+        vm.prank(claimer);
+        harness.claimFees();
+        assertEq(harness.getClaimableAmount(), 0);
+        assertEq(harness.getClaimerReward(), 0);
+        assertEq(harness.getClaimerFraction(), ONE_PERCENT);
+        assertEq(harness.getFeeRecipient(), recipient);
+    }
+
+    function test_claimFees_revert_zeroAmount() public {
+        harness.setup({claimableAmount: 0, feeRecipient: recipient, claimerFraction: ONE_PERCENT});
+        vm.expectRevert(IClaimableFees.ClaimableFees__ZeroAmount.selector);
+        vm.prank(claimer);
+        harness.claimFees();
+    }
+
+    function test_claimFees_revert_zeroFeeRecipient() public {
+        harness.setup({claimableAmount: CLAIMABLE_AMOUNT, feeRecipient: address(0), claimerFraction: ONE_PERCENT});
+        vm.expectRevert(IClaimableFees.ClaimableFees__FeeRecipientNotSet.selector);
+        vm.prank(claimer);
+        harness.claimFees();
+    }
+
+    function test_claimFees_revert_claimerFractionExceedsOnePercent() public {
+        uint256 tooBigFraction = ONE_PERCENT + 1;
+        harness.setup({claimableAmount: CLAIMABLE_AMOUNT, feeRecipient: recipient, claimerFraction: tooBigFraction});
+        vm.expectRevert(
+            abi.encodeWithSelector(IClaimableFees.ClaimableFees__ClaimerFractionExceedsMax.selector, tooBigFraction)
+        );
+        vm.prank(claimer);
+        harness.claimFees();
+    }
+}

--- a/packages/contracts-communication/test/harnesses/ClaimableFeesHarness.sol
+++ b/packages/contracts-communication/test/harnesses/ClaimableFeesHarness.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {ClaimableFees} from "../../contracts/fees/ClaimableFees.sol";
+
+contract ClaimableFeesHarness is ClaimableFees {
+    uint256 internal _claimableAmount;
+    address internal _feeRecipient;
+    uint256 internal _claimerFraction;
+
+    event BeforeFeesClaimed(uint256 amount, uint256 reward);
+
+    function setup(uint256 claimableAmount, address feeRecipient, uint256 claimerFraction) external {
+        _claimableAmount = claimableAmount;
+        _feeRecipient = feeRecipient;
+        _claimerFraction = claimerFraction;
+    }
+
+    function getClaimerFraction() public view override returns (uint256) {
+        return _claimerFraction;
+    }
+
+    function getClaimableAmount() public view override returns (uint256) {
+        return _claimableAmount;
+    }
+
+    function getFeeRecipient() public view override returns (address) {
+        return _feeRecipient;
+    }
+
+    function _beforeFeesClaimed(uint256 fullAmount, uint256 reward) internal override {
+        _claimableAmount -= fullAmount;
+        emit BeforeFeesClaimed(fullAmount, reward);
+    }
+}

--- a/packages/contracts-communication/test/integration/ICSetup.t.sol
+++ b/packages/contracts-communication/test/integration/ICSetup.t.sol
@@ -50,7 +50,7 @@ abstract contract ICSetup is ProxyTest {
     address public dstApp;
 
     address public executor = makeAddr("Executor");
-    address public feeCollector = makeAddr("FeeCollector");
+    address public feeRecipient = makeAddr("FeeRecipient");
     // Signer public keys, sorted by their address:
     // 2000 -> 0x5793e629c061e7FD642ab6A1b4d552CeC0e2D606
     // 1000 -> 0x7F1d642DbfD62aD4A8fA9810eA619707d09825D0
@@ -111,8 +111,8 @@ abstract contract ICSetup is ProxyTest {
     }
 
     function configureSynapseModule() internal virtual {
-        module.setClaimFeeFraction(0.01e18); // 1%
-        module.setFeeCollector(feeCollector);
+        module.setClaimerFraction(0.01e18); // 1%
+        module.setFeeRecipient(feeRecipient);
         module.setGasOracle(address(gasOracle));
         module.setThreshold(signerPKs.length);
         for (uint256 i = 0; i < signerPKs.length; i++) {

--- a/packages/contracts-communication/test/modules/SynapseModule.Destination.t.sol
+++ b/packages/contracts-communication/test/modules/SynapseModule.Destination.t.sol
@@ -26,7 +26,7 @@ contract SynapseModuleDestinationTest is Test, InterchainModuleEvents, SynapseMo
     SynapseGasOracleMock public gasOracle;
     InterchainDBMock public interchainDB;
 
-    address public feeCollector = makeAddr("FeeCollector");
+    address public feeRecipient = makeAddr("FeeRecipient");
     address public owner = makeAddr("Owner");
 
     uint64 public constant SRC_CHAIN_ID = 1337;
@@ -61,7 +61,7 @@ contract SynapseModuleDestinationTest is Test, InterchainModuleEvents, SynapseMo
         mockVersionedBatch = getVersionedBatch(mockBatch);
         vm.startPrank(owner);
         module.setGasOracle(address(gasOracle));
-        module.setFeeCollector(feeCollector);
+        module.setFeeRecipient(feeRecipient);
         module.addVerifier(SIGNER_0);
         module.addVerifier(SIGNER_1);
         module.addVerifier(SIGNER_2);

--- a/packages/contracts-communication/test/modules/SynapseModule.Management.t.sol
+++ b/packages/contracts-communication/test/modules/SynapseModule.Management.t.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.20;
 
+import {ClaimableFeesEvents} from "../../contracts/events/ClaimableFeesEvents.sol";
 import {SynapseModuleEvents} from "../../contracts/events/SynapseModuleEvents.sol";
+import {IClaimableFees} from "../../contracts/interfaces/IClaimableFees.sol";
 import {SynapseModule, ISynapseModule} from "../../contracts/modules/SynapseModule.sol";
 import {ThresholdECDSALib} from "../../contracts/libs/ThresholdECDSA.sol";
 
@@ -13,13 +15,13 @@ import {Test} from "forge-std/Test.sol";
 
 // solhint-disable func-name-mixedcase
 // solhint-disable ordering
-contract SynapseModuleManagementTest is Test, SynapseModuleEvents {
+contract SynapseModuleManagementTest is Test, ClaimableFeesEvents, SynapseModuleEvents {
     SynapseModule public module;
     SynapseGasOracleMock public gasOracle;
 
     address public interchainDB = makeAddr("InterchainDB");
     address public owner = makeAddr("Owner");
-    address public feeCollector = makeAddr("FeeCollector");
+    address public feeRecipient = makeAddr("FeeRecipient");
 
     address public constant VERIFIER_1 = address(1);
     address public constant VERIFIER_2 = address(2);
@@ -220,62 +222,62 @@ contract SynapseModuleManagementTest is Test, SynapseModuleEvents {
         module.setThreshold(3);
     }
 
-    function test_setFeeCollector_setsFeeCollector() public {
+    function test_setFeeRecipient_setsFeeRecipient() public {
         vm.prank(owner);
-        module.setFeeCollector(feeCollector);
-        assertEq(module.feeCollector(), feeCollector);
+        module.setFeeRecipient(feeRecipient);
+        assertEq(module.getFeeRecipient(), feeRecipient);
     }
 
-    function test_setFeeCollector_emitsEvent() public {
+    function test_setFeeRecipient_emitsEvent() public {
         vm.expectEmit(address(module));
-        emit FeeCollectorSet(feeCollector);
+        emit FeeRecipientSet(feeRecipient);
         vm.prank(owner);
-        module.setFeeCollector(feeCollector);
+        module.setFeeRecipient(feeRecipient);
     }
 
-    function test_setFeeCollector_revert_notOwner(address notOwner) public {
+    function test_setFeeRecipient_revert_notOwner(address notOwner) public {
         vm.assume(notOwner != owner);
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, notOwner));
         vm.prank(notOwner);
-        module.setFeeCollector(feeCollector);
+        module.setFeeRecipient(feeRecipient);
     }
 
     function test_setFeeFraction_setsFeeFraction() public {
         vm.prank(owner);
-        module.setClaimFeeFraction(0.001e18);
-        assertEq(module.getClaimFeeFraction(), 0.001e18);
+        module.setClaimerFraction(0.001e18);
+        assertEq(module.getClaimerFraction(), 0.001e18);
     }
 
     function test_setFeeFraction_emitsEvent() public {
         vm.expectEmit(address(module));
-        emit ClaimFeeFractionSet(0.001e18);
+        emit ClaimerFractionSet(0.001e18);
         vm.prank(owner);
-        module.setClaimFeeFraction(0.001e18);
+        module.setClaimerFraction(0.001e18);
     }
 
     function test_setFeeFraction_exactlyMax() public {
         uint256 maxFeeFraction = 0.01e18;
         vm.expectEmit(address(module));
-        emit ClaimFeeFractionSet(maxFeeFraction);
+        emit ClaimerFractionSet(maxFeeFraction);
         vm.prank(owner);
-        module.setClaimFeeFraction(maxFeeFraction);
-        assertEq(module.getClaimFeeFraction(), maxFeeFraction);
+        module.setClaimerFraction(maxFeeFraction);
+        assertEq(module.getClaimerFraction(), maxFeeFraction);
     }
 
     function test_setFeeFraction_revert_exceedsMax() public {
         uint256 fractionTooBig = 0.01e18 + 1;
         vm.expectRevert(
-            abi.encodeWithSelector(ISynapseModule.SynapseModule__ClaimFeeFractionExceedsMax.selector, fractionTooBig)
+            abi.encodeWithSelector(IClaimableFees.ClaimableFees__ClaimerFractionExceedsMax.selector, fractionTooBig)
         );
         vm.prank(owner);
-        module.setClaimFeeFraction(fractionTooBig);
+        module.setClaimerFraction(fractionTooBig);
     }
 
     function test_setFeeFraction_revert_notOwner(address notOwner) public {
         vm.assume(notOwner != owner);
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, notOwner));
         vm.prank(notOwner);
-        module.setClaimFeeFraction(0.001e18);
+        module.setClaimerFraction(0.001e18);
     }
 
     function test_setGasOracle_setsGasOracle() public {

--- a/packages/contracts-communication/test/modules/SynapseModule.Source.t.sol
+++ b/packages/contracts-communication/test/modules/SynapseModule.Source.t.sol
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.20;
 
+import {ClaimableFeesEvents} from "../../contracts/events/ClaimableFeesEvents.sol";
 import {InterchainModuleEvents} from "../../contracts/events/InterchainModuleEvents.sol";
 import {SynapseModuleEvents} from "../../contracts/events/SynapseModuleEvents.sol";
+import {IClaimableFees} from "../../contracts/interfaces/IClaimableFees.sol";
 import {IInterchainModule} from "../../contracts/interfaces/IInterchainModule.sol";
 import {InterchainBatch} from "../../contracts/libs/InterchainBatch.sol";
 import {SynapseModule, ISynapseModule} from "../../contracts/modules/SynapseModule.sol";
@@ -15,7 +17,7 @@ import {Test} from "forge-std/Test.sol";
 
 // solhint-disable func-name-mixedcase
 // solhint-disable ordering
-contract SynapseModuleSourceTest is Test, InterchainModuleEvents, SynapseModuleEvents {
+contract SynapseModuleSourceTest is Test, ClaimableFeesEvents, InterchainModuleEvents, SynapseModuleEvents {
     InterchainBatchLibHarness public batchLibHarness;
     VersionedPayloadLibHarness public payloadLibHarness;
 
@@ -23,7 +25,7 @@ contract SynapseModuleSourceTest is Test, InterchainModuleEvents, SynapseModuleE
     SynapseGasOracleMock public gasOracle;
 
     address public interchainDB = makeAddr("InterchainDB");
-    address public feeCollector = makeAddr("FeeCollector");
+    address public feeRecipient = makeAddr("FeeRecipient");
     address public owner = makeAddr("Owner");
     address public claimer = makeAddr("Claimer");
 
@@ -48,7 +50,7 @@ contract SynapseModuleSourceTest is Test, InterchainModuleEvents, SynapseModuleE
         payloadLibHarness = new VersionedPayloadLibHarness();
         vm.startPrank(owner);
         module.setGasOracle(address(gasOracle));
-        module.setFeeCollector(feeCollector);
+        module.setFeeRecipient(feeRecipient);
         module.addVerifier(address(1));
         module.addVerifier(address(2));
         module.setThreshold(2);
@@ -131,7 +133,7 @@ contract SynapseModuleSourceTest is Test, InterchainModuleEvents, SynapseModuleE
     function test_claimFees_zeroClaimFee_emitsEvent() public {
         deal(address(module), 5 ether);
         vm.expectEmit(address(module));
-        emit FeesClaimed(feeCollector, 5 ether, claimer, 0);
+        emit FeesClaimed(feeRecipient, 5 ether, claimer, 0);
         vm.prank(claimer);
         module.claimFees();
     }
@@ -140,20 +142,35 @@ contract SynapseModuleSourceTest is Test, InterchainModuleEvents, SynapseModuleE
         deal(address(module), 5 ether);
         vm.prank(claimer);
         module.claimFees();
-        assertEq(feeCollector.balance, 5 ether);
+        assertEq(feeRecipient.balance, 5 ether);
         assertEq(claimer.balance, 0);
     }
 
-    function test_claimFees_zeroClaimFee_revert_feeCollectorNotSet() public {
+    function test_claimFees_zeroClaimFee_stateChanges() public {
+        deal(address(module), 5 ether);
+        assertEq(module.getClaimableAmount(), 5 ether);
+        assertEq(module.getClaimerFraction(), 0);
+        assertEq(module.getClaimerReward(), 0);
+        assertEq(module.getFeeRecipient(), feeRecipient);
+        vm.prank(claimer);
+        module.claimFees();
+        assertEq(module.getClaimableAmount(), 0);
+        assertEq(module.getClaimerFraction(), 0);
+        assertEq(module.getClaimerReward(), 0);
+        assertEq(module.getFeeRecipient(), feeRecipient);
+    }
+
+    function test_claimFees_zeroClaimFee_revert_feeRecipientNotSet() public {
+        deal(address(module), 5 ether);
         vm.prank(owner);
-        module.setFeeCollector(address(0));
-        vm.expectRevert(abi.encodeWithSelector(ISynapseModule.SynapseModule__FeeCollectorNotSet.selector));
+        module.setFeeRecipient(address(0));
+        vm.expectRevert(abi.encodeWithSelector(IClaimableFees.ClaimableFees__FeeRecipientNotSet.selector));
         vm.prank(claimer);
         module.claimFees();
     }
 
     function test_claimFees_zeroClaimFee_revert_noFeesToClaim() public {
-        vm.expectRevert(abi.encodeWithSelector(ISynapseModule.SynapseModule__NoFeesToClaim.selector));
+        vm.expectRevert(abi.encodeWithSelector(IClaimableFees.ClaimableFees__ZeroAmount.selector));
         vm.prank(claimer);
         module.claimFees();
     }
@@ -161,10 +178,10 @@ contract SynapseModuleSourceTest is Test, InterchainModuleEvents, SynapseModuleE
     function test_claimFees_nonZeroClaimFee_emitsEvent() public {
         // Set claim fee to 0.1%
         vm.prank(owner);
-        module.setClaimFeeFraction(0.001e18);
+        module.setClaimerFraction(0.001e18);
         deal(address(module), 5 ether);
         vm.expectEmit(address(module));
-        emit FeesClaimed(feeCollector, 4.995 ether, claimer, 0.005 ether);
+        emit FeesClaimed(feeRecipient, 4.995 ether, claimer, 0.005 ether);
         vm.prank(claimer);
         module.claimFees();
     }
@@ -172,22 +189,39 @@ contract SynapseModuleSourceTest is Test, InterchainModuleEvents, SynapseModuleE
     function test_claimFees_nonZeroClaimFee_distributesFees() public {
         // Set claim fee to 0.1%
         vm.prank(owner);
-        module.setClaimFeeFraction(0.001e18);
+        module.setClaimerFraction(0.001e18);
         deal(address(module), 5 ether);
         vm.prank(claimer);
         module.claimFees();
-        assertEq(feeCollector.balance, 4.995 ether);
+        assertEq(feeRecipient.balance, 4.995 ether);
         assertEq(claimer.balance, 0.005 ether);
     }
 
-    function test_claimFees_nonZeroClaimFee_revert_feeCollectorNotSet() public {
+    function test_claimFees_nonZeroClaimFee_stateChanges() public {
+        // Set claim fee to 0.1%
+        vm.prank(owner);
+        module.setClaimerFraction(0.001e18);
+        deal(address(module), 5 ether);
+        assertEq(module.getClaimableAmount(), 5 ether);
+        assertEq(module.getClaimerFraction(), 0.001e18);
+        assertEq(module.getClaimerReward(), 0.005 ether);
+        assertEq(module.getFeeRecipient(), feeRecipient);
+        vm.prank(claimer);
+        module.claimFees();
+        assertEq(module.getClaimableAmount(), 0);
+        assertEq(module.getClaimerFraction(), 0.001e18);
+        assertEq(module.getClaimerReward(), 0);
+        assertEq(module.getFeeRecipient(), feeRecipient);
+    }
+
+    function test_claimFees_nonZeroClaimFee_revert_feeRecipientNotSet() public {
         // Set claim fee to 0.1%
         vm.startPrank(owner);
-        module.setFeeCollector(address(0));
-        module.setClaimFeeFraction(0.001e18);
+        module.setFeeRecipient(address(0));
+        module.setClaimerFraction(0.001e18);
         vm.stopPrank();
         deal(address(module), 5 ether);
-        vm.expectRevert(abi.encodeWithSelector(ISynapseModule.SynapseModule__FeeCollectorNotSet.selector));
+        vm.expectRevert(abi.encodeWithSelector(IClaimableFees.ClaimableFees__FeeRecipientNotSet.selector));
         vm.prank(claimer);
         module.claimFees();
     }
@@ -195,34 +229,10 @@ contract SynapseModuleSourceTest is Test, InterchainModuleEvents, SynapseModuleE
     function test_claimFees_nonZeroClaimFee_revert_noFeesToClaim() public {
         // Set claim fee to 0.1%
         vm.prank(owner);
-        module.setClaimFeeFraction(0.001e18);
-        vm.expectRevert(abi.encodeWithSelector(ISynapseModule.SynapseModule__NoFeesToClaim.selector));
+        module.setClaimerFraction(0.001e18);
+        vm.expectRevert(abi.encodeWithSelector(IClaimableFees.ClaimableFees__ZeroAmount.selector));
         vm.prank(claimer);
         module.claimFees();
-    }
-
-    function test_getClaimFeeAmount_zeroFees_zeroClaimFee() public {
-        assertEq(module.getClaimFeeAmount(), 0);
-    }
-
-    function test_getClaimFeeAmount_zeroFees_nonZeroClaimFee() public {
-        // Set claim fee to 0.1%
-        vm.prank(owner);
-        module.setClaimFeeFraction(0.001e18);
-        assertEq(module.getClaimFeeAmount(), 0);
-    }
-
-    function test_getClaimFeeAmount_zeroClaimFee() public {
-        deal(address(module), 5 ether);
-        assertEq(module.getClaimFeeAmount(), 0);
-    }
-
-    function test_getClaimFeeAmount_nonZeroClaimFee() public {
-        // Set claim fee to 0.1%
-        vm.prank(owner);
-        module.setClaimFeeFraction(0.001e18);
-        deal(address(module), 5 ether);
-        assertEq(module.getClaimFeeAmount(), 0.005 ether);
     }
 
     function test_getModuleFee_thresholdTwo() public {

--- a/packages/contracts-communication/test/proxy/ProxyTest.t.sol
+++ b/packages/contracts-communication/test/proxy/ProxyTest.t.sol
@@ -27,6 +27,11 @@ abstract contract ProxyTest is Test {
         assertEq(actual, expectedBytes32);
     }
 
+    function assertStorageUint(address target, bytes32 slot, uint256 expected) internal {
+        bytes32 actual = vm.load(target, slot);
+        assertEq(uint256(actual), expected);
+    }
+
     /// @dev Function to use in the fuzz tests to assume that the caller is not the proxy admin
     /// Calls from the proxy admin are not directed to the implementation contract, so they should be
     /// treated differently in the tests.


### PR DESCRIPTION
**Description**
Since #2524 `SynapseExecutionService` is accumulating the paid execution fees. This PR introduces the claiming structure similar to one existing in `SynapseModule`, and does a step further to abstract it away from both contracts.

The claiming structure is:
- All native token balance is considered "accumulated fees" and is claimable to a governor-defined fee recipient address (which is the same as executor EOA for the service).
- Anyone can claim the fees, which will transfer the accumulated fees to the fee recipient.
- The governor could set up a fraction of fees that will go to the claimer (whoever triggered the claim).

This structure allows anyone to integrate a keeper bot that will periodically claim the fees, making both module and execution service self-sustainable, without having to transfer the collected gas fees per every occasion.  