### PR TITLE
feat: allow modules to signal non-existing batches and verify their value later

### DIFF
--- a/packages/contracts-communication/contracts/InterchainDB.sol
+++ b/packages/contracts-communication/contracts/InterchainDB.sol
@@ -91,9 +91,7 @@ contract InterchainDB is InterchainDBEvents, IInterchainDB {
         RemoteBatch memory existingBatch = _remoteBatches[msg.sender][batchKey];
         // Check if that's the first time module verifies the batch
         if (existingBatch.verifiedAt == 0) {
-            _remoteBatches[msg.sender][batchKey] =
-                RemoteBatch({verifiedAt: block.timestamp, batchRoot: batch.batchRoot});
-            emit InterchainBatchVerified(msg.sender, batch.srcChainId, batch.dbNonce, batch.batchRoot);
+            _saveVerifiedBatch(msg.sender, batchKey, batch);
         } else {
             // If the module has already verified the batch, check that the batch root is the same
             if (existingBatch.batchRoot != batch.batchRoot) {
@@ -253,6 +251,12 @@ contract InterchainDB is InterchainDBEvents, IInterchainDB {
             IInterchainModule(srcModules[i]).requestBatchVerification{value: fees[i]}(dstChainId, versionedBatch);
         }
         emit InterchainBatchVerificationRequested(dstChainId, batch.dbNonce, batch.batchRoot, srcModules);
+    }
+
+    /// @dev Save the verified batch to the database and emit the event.
+    function _saveVerifiedBatch(address module, BatchKey batchKey, InterchainBatch memory batch) internal {
+        _remoteBatches[module][batchKey] = RemoteBatch({verifiedAt: block.timestamp, batchRoot: batch.batchRoot});
+        emit InterchainBatchVerified(module, batch.srcChainId, batch.dbNonce, batch.batchRoot);
     }
 
     // ══════════════════════════════════════════════ INTERNAL VIEWS ═══════════════════════════════════════════════════

--- a/packages/contracts-communication/contracts/interfaces/IInterchainDB.sol
+++ b/packages/contracts-communication/contracts/interfaces/IInterchainDB.sol
@@ -60,7 +60,11 @@ interface IInterchainDB {
         returns (uint64 dbNonce, uint64 entryIndex);
 
     /// @notice Allows the Interchain Module to verify the batch coming from the remote chain.
+    /// The module SHOULD verify the exact finalized batch from the remote chain. If the batch with a given nonce
+    /// is not finalized or does not exist, module CAN verify it with an empty root value. Once the batch is
+    /// finalized, the module SHOULD re-verify the batch with the correct root value.
     /// Note: The DB will only accept the batch of the same version as the DB itself.
+    /// @dev Will revert if the batch with the same nonce but a different non-empty root is already verified.
     /// @param versionedBatch   The versioned Interchain Batch to verify
     function verifyRemoteBatch(bytes memory versionedBatch) external;
 


### PR DESCRIPTION
**Description**
This PR modifies the behavior of the remote batches verification done by the modules. A verified batch is considered either empty or non-empty, based on the `batchRoot` value being zero or not.

- A module could verify an empty batch to signal that a batch with a given nonce is not yet finalized on the remote source chain.
- A module could verify a non-empty batch to signal that a batch with a given nonce is finalized and its root matches the verified one.
  - A module could verify an empty batch first, and then re-verify a non-empty batch for the same nonce. This allows a module to signal that the batch wasn't existing at a time, and then signal that it does exist now.
- Once a module verified a non-empty batch, it's not possible for the same module to verify any different root value for the same nonce, be that empty or non-empty one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced batch verification logic in the InterchainDB contract to handle various scenarios more effectively.
  - Improved documentation in the IInterchainDB interface detailing the verification process for remote batches.

- **Refactor**
  - Streamlined internal batch verification and event emission processes in the InterchainDB contract.
  - Optimized test functions in the InterchainDBDestinationTest contract to better simulate different batch verification scenarios.

- **Documentation**
  - Added detailed comments to clarify the behavior during batch verification conflicts in the IInterchainDB interface.

- **Tests**
  - Introduced new test cases for verifying batch scenarios in the InterchainDBDestinationTest contract.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->