### PR TITLE
feat(contracts-communication): expose batch getter in `InterchainDB`

### DIFF
--- a/packages/contracts-communication/contracts/InterchainDB.sol
+++ b/packages/contracts-communication/contracts/InterchainDB.sol
@@ -161,6 +161,11 @@ contract InterchainDB is InterchainDBEvents, IInterchainDB {
     }
 
     /// @inheritdoc IInterchainDB
+    function getVersionedBatch(uint64 dbNonce) external view returns (bytes memory versionedBatch) {
+        // TODO: implement
+    }
+
+    /// @inheritdoc IInterchainDB
     function getBatchRoot(InterchainEntry memory entry, bytes32[] calldata proof) external pure returns (bytes32) {
         return BatchingV1Lib.getBatchRoot({
             srcWriter: entry.srcWriter,

--- a/packages/contracts-communication/contracts/InterchainDB.sol
+++ b/packages/contracts-communication/contracts/InterchainDB.sol
@@ -174,7 +174,11 @@ contract InterchainDB is InterchainDBEvents, IInterchainDB {
 
     /// @inheritdoc IInterchainDB
     function getVersionedBatch(uint64 dbNonce) external view returns (bytes memory versionedBatch) {
-        // TODO: implement
+        InterchainBatch memory batch = getBatch(dbNonce);
+        return VersionedPayloadLib.encodeVersionedPayload({
+            version: DB_VERSION,
+            payload: InterchainBatchLib.encodeBatch(batch)
+        });
     }
 
     /// @inheritdoc IInterchainDB

--- a/packages/contracts-communication/contracts/InterchainDB.sol
+++ b/packages/contracts-communication/contracts/InterchainDB.sol
@@ -105,6 +105,15 @@ contract InterchainDB is InterchainDBEvents, IInterchainDB {
     // ═══════════════════════════════════════════════════ VIEWS ═══════════════════════════════════════════════════════
 
     /// @inheritdoc IInterchainDB
+    function getBatchLeafs(uint64 dbNonce) external view returns (bytes32[] memory leafs) {
+        uint256 batchSize = getBatchSize(dbNonce);
+        leafs = new bytes32[](batchSize);
+        for (uint64 i = 0; i < batchSize; ++i) {
+            leafs[i] = getEntryValue(dbNonce, i);
+        }
+    }
+
+    /// @inheritdoc IInterchainDB
     function getBatchLeafsPaginated(
         uint64 dbNonce,
         uint64 start,
@@ -114,16 +123,19 @@ contract InterchainDB is InterchainDBEvents, IInterchainDB {
         view
         returns (bytes32[] memory leafs)
     {
-        if (start != 0 || end != 1) {
+        uint256 size = getBatchSize(dbNonce);
+        if (start > end || end > size) {
             revert InterchainDB__InvalidEntryRange(dbNonce, start, end);
         }
-        return getBatchLeafs(dbNonce);
+        leafs = new bytes32[](end - start);
+        for (uint64 i = start; i < end; ++i) {
+            leafs[i - start] = getEntryValue(dbNonce, i);
+        }
     }
 
     /// @inheritdoc IInterchainDB
     function getEntryProof(uint64 dbNonce, uint64 entryIndex) external view returns (bytes32[] memory proof) {
         // In "no batching" mode: the batch root is the same as the entry value, hence the proof is empty
-        _assertBatchFinalized(dbNonce);
         _assertEntryExists(dbNonce, entryIndex);
         return new bytes32[](0);
     }
@@ -176,25 +188,18 @@ contract InterchainDB is InterchainDBEvents, IInterchainDB {
     }
 
     /// @inheritdoc IInterchainDB
-    function getBatchLeafs(uint64 dbNonce) public view returns (bytes32[] memory leafs) {
-        // In "no batching" mode: the finalized batch size is 1
-        _assertBatchFinalized(dbNonce);
-        leafs = new bytes32[](1);
-        leafs[0] = getEntryValue(dbNonce, 0);
-    }
-
-    /// @inheritdoc IInterchainDB
     function getBatchSize(uint64 dbNonce) public view returns (uint64) {
         // In "no batching" mode: the finalized batch size is 1, the pending batch size is 0
-        uint64 pendingNonce = _assertBatchExists(dbNonce);
-        return dbNonce < pendingNonce ? 1 : 0;
+        // We also return 0 for non-existent batches
+        return dbNonce < getDBNonce() ? 1 : 0;
     }
 
     /// @inheritdoc IInterchainDB
     function getBatch(uint64 dbNonce) public view returns (InterchainBatch memory) {
-        _assertBatchFinalized(dbNonce);
-        // In "no batching" mode: the batch root is the same as the entry hash
-        return InterchainBatchLib.constructLocalBatch(dbNonce, getEntryValue(dbNonce, 0));
+        // In "no batching" mode: the batch root is the same as the entry hash.
+        // For non-finalized or non-existent batches, the batch root is 0.
+        bytes32 batchRoot = dbNonce < getDBNonce() ? getEntryValue(dbNonce, 0) : bytes32(0);
+        return InterchainBatchLib.constructLocalBatch(dbNonce, batchRoot);
     }
 
     /// @inheritdoc IInterchainDB
@@ -277,22 +282,6 @@ contract InterchainDB is InterchainDBEvents, IInterchainDB {
         batch = InterchainBatchLib.decodeBatch(versionedBatch.getPayload());
         if (batch.srcChainId == block.chainid) {
             revert InterchainDB__SameChainId(batch.srcChainId);
-        }
-    }
-
-    /// @dev Check that the batch with the given nonce exists and return the pending nonce.
-    function _assertBatchExists(uint64 dbNonce) internal view returns (uint64 pendingNonce) {
-        pendingNonce = getDBNonce();
-        if (dbNonce > pendingNonce) {
-            revert InterchainDB__BatchDoesNotExist(dbNonce);
-        }
-    }
-
-    /// @dev Check that the batch with the given nonce is finalized and return the pending nonce.
-    function _assertBatchFinalized(uint64 dbNonce) internal view returns (uint64 pendingNonce) {
-        pendingNonce = getDBNonce();
-        if (dbNonce >= pendingNonce) {
-            revert InterchainDB__BatchNotFinalized(dbNonce);
         }
     }
 

--- a/packages/contracts-communication/contracts/interfaces/IInterchainDB.sol
+++ b/packages/contracts-communication/contracts/interfaces/IInterchainDB.sol
@@ -5,8 +5,6 @@ import {InterchainBatch} from "../libs/InterchainBatch.sol";
 import {InterchainEntry} from "../libs/InterchainEntry.sol";
 
 interface IInterchainDB {
-    error InterchainDB__BatchDoesNotExist(uint64 dbNonce);
-    error InterchainDB__BatchNotFinalized(uint64 dbNonce);
     error InterchainDB__ConflictingBatches(address module, bytes32 existingBatchRoot, InterchainBatch newBatch);
     error InterchainDB__EntryIndexOutOfRange(uint64 dbNonce, uint64 entryIndex, uint64 batchSize);
     error InterchainDB__IncorrectFeeAmount(uint256 actualFee, uint256 expectedFee);

--- a/packages/contracts-communication/contracts/interfaces/IInterchainDB.sol
+++ b/packages/contracts-communication/contracts/interfaces/IInterchainDB.sol
@@ -112,6 +112,11 @@ interface IInterchainDB {
     /// @param dbNonce      The database nonce of the finalized batch
     function getBatch(uint64 dbNonce) external view returns (InterchainBatch memory);
 
+    /// @notice Get the versioned Interchain Batch with the given nonce.
+    /// Note: will return a batch with an empty root if the batch does not exist, or is not finalized.
+    /// @param dbNonce      The database nonce of the batch
+    function getVersionedBatch(uint64 dbNonce) external view returns (bytes memory);
+
     /// @notice Get the Interchain Entry's value written on the local chain with the given batch nonce and entry index.
     /// Entry value is calculated as the hash of the writer address and the written data hash.
     /// Note: the batch does not have to be finalized to fetch the entry value.

--- a/packages/contracts-communication/test/InterchainDB.Src.t.sol
+++ b/packages/contracts-communication/test/InterchainDB.Src.t.sol
@@ -293,8 +293,7 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
     function test_requestVerification_writerF_oneModule() public {
         uint64 dbNonce = 0;
         InterchainBatch memory batch = getExpectedBatch(getInitialEntry(dbNonce));
-        // expectCall(address callee, uint256 msgValue, bytes calldata data)
-        vm.expectCall(address(moduleA), MODULE_A_FEE, getModuleCalldata(batch));
+        vm.expectCall({callee: address(moduleA), msgValue: MODULE_A_FEE, data: getModuleCalldata(batch)});
         expectEventBatchVerificationRequested(batch, oneModule);
         requestVerification(requestCaller, MODULE_A_FEE, dbNonce, oneModule);
     }
@@ -302,8 +301,7 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
     function test_requestVerification_writerF_oneModule_higherFee() public {
         uint64 dbNonce = 0;
         InterchainBatch memory batch = getExpectedBatch(getInitialEntry(dbNonce));
-        // expectCall(address callee, uint256 msgValue, bytes calldata data)
-        vm.expectCall(address(moduleA), MODULE_A_FEE * 2, getModuleCalldata(batch));
+        vm.expectCall({callee: address(moduleA), msgValue: MODULE_A_FEE * 2, data: getModuleCalldata(batch)});
         expectEventBatchVerificationRequested(batch, oneModule);
         requestVerification(requestCaller, MODULE_A_FEE * 2, dbNonce, oneModule);
     }
@@ -311,9 +309,8 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
     function test_requestVerification_writerF_twoModules() public {
         uint64 dbNonce = 0;
         InterchainBatch memory batch = getExpectedBatch(getInitialEntry(dbNonce));
-        // expectCall(address callee, uint256 msgValue, bytes calldata data)
-        vm.expectCall(address(moduleA), MODULE_A_FEE, getModuleCalldata(batch));
-        vm.expectCall(address(moduleB), MODULE_B_FEE, getModuleCalldata(batch));
+        vm.expectCall({callee: address(moduleA), msgValue: MODULE_A_FEE, data: getModuleCalldata(batch)});
+        vm.expectCall({callee: address(moduleB), msgValue: MODULE_B_FEE, data: getModuleCalldata(batch)});
         expectEventBatchVerificationRequested(batch, twoModules);
         requestVerification(requestCaller, MODULE_A_FEE + MODULE_B_FEE, dbNonce, twoModules);
     }
@@ -322,9 +319,8 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
         // Overpaid fees should be directed to the first module
         uint64 dbNonce = 0;
         InterchainBatch memory batch = getExpectedBatch(getInitialEntry(dbNonce));
-        // expectCall(address callee, uint256 msgValue, bytes calldata data)
-        vm.expectCall(address(moduleA), MODULE_A_FEE * 2, getModuleCalldata(batch));
-        vm.expectCall(address(moduleB), MODULE_B_FEE, getModuleCalldata(batch));
+        vm.expectCall({callee: address(moduleA), msgValue: MODULE_A_FEE * 2, data: getModuleCalldata(batch)});
+        vm.expectCall({callee: address(moduleB), msgValue: MODULE_B_FEE, data: getModuleCalldata(batch)});
         expectEventBatchVerificationRequested(batch, twoModules);
         requestVerification(requestCaller, MODULE_A_FEE * 2 + MODULE_B_FEE, dbNonce, twoModules);
     }
@@ -332,8 +328,7 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
     function test_requestVerification_writerS_oneModule() public {
         uint64 dbNonce = 2;
         InterchainBatch memory batch = getExpectedBatch(getInitialEntry(dbNonce));
-        // expectCall(address callee, uint256 msgValue, bytes calldata data)
-        vm.expectCall(address(moduleA), MODULE_A_FEE, getModuleCalldata(batch));
+        vm.expectCall({callee: address(moduleA), msgValue: MODULE_A_FEE, data: getModuleCalldata(batch)});
         expectEventBatchVerificationRequested(batch, oneModule);
         requestVerification(requestCaller, MODULE_A_FEE, dbNonce, oneModule);
     }
@@ -341,8 +336,7 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
     function test_requestVerification_writerS_oneModule_higherFee() public {
         uint64 dbNonce = 2;
         InterchainBatch memory batch = getExpectedBatch(getInitialEntry(dbNonce));
-        // expectCall(address callee, uint256 msgValue, bytes calldata data)
-        vm.expectCall(address(moduleA), MODULE_A_FEE * 2, getModuleCalldata(batch));
+        vm.expectCall({callee: address(moduleA), msgValue: MODULE_A_FEE * 2, data: getModuleCalldata(batch)});
         expectEventBatchVerificationRequested(batch, oneModule);
         requestVerification(requestCaller, MODULE_A_FEE * 2, dbNonce, oneModule);
     }
@@ -350,9 +344,8 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
     function test_requestVerification_writerS_twoModules() public {
         uint64 dbNonce = 2;
         InterchainBatch memory batch = getExpectedBatch(getInitialEntry(dbNonce));
-        // expectCall(address callee, uint256 msgValue, bytes calldata data)
-        vm.expectCall(address(moduleA), MODULE_A_FEE, getModuleCalldata(batch));
-        vm.expectCall(address(moduleB), MODULE_B_FEE, getModuleCalldata(batch));
+        vm.expectCall({callee: address(moduleA), msgValue: MODULE_A_FEE, data: getModuleCalldata(batch)});
+        vm.expectCall({callee: address(moduleB), msgValue: MODULE_B_FEE, data: getModuleCalldata(batch)});
         expectEventBatchVerificationRequested(batch, twoModules);
         requestVerification(requestCaller, MODULE_A_FEE + MODULE_B_FEE, dbNonce, twoModules);
     }
@@ -361,9 +354,8 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
         // Overpaid fees should be directed to the first module
         uint64 dbNonce = 2;
         InterchainBatch memory batch = getExpectedBatch(getInitialEntry(dbNonce));
-        // expectCall(address callee, uint256 msgValue, bytes calldata data)
-        vm.expectCall(address(moduleA), MODULE_A_FEE * 2, getModuleCalldata(batch));
-        vm.expectCall(address(moduleB), MODULE_B_FEE, getModuleCalldata(batch));
+        vm.expectCall({callee: address(moduleA), msgValue: MODULE_A_FEE * 2, data: getModuleCalldata(batch)});
+        vm.expectCall({callee: address(moduleB), msgValue: MODULE_B_FEE, data: getModuleCalldata(batch)});
         expectEventBatchVerificationRequested(batch, twoModules);
         requestVerification(requestCaller, MODULE_A_FEE * 2 + MODULE_B_FEE, dbNonce, twoModules);
     }
@@ -371,8 +363,7 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
     function test_requestVerification_nextNonce_oneModule() public {
         uint64 dbNonce = INITIAL_DB_NONCE;
         InterchainBatch memory batch = InterchainBatch({srcChainId: SRC_CHAIN_ID, dbNonce: dbNonce, batchRoot: 0});
-        // expectCall(address callee, uint256 msgValue, bytes calldata data)
-        vm.expectCall(address(moduleA), MODULE_A_FEE, getModuleCalldata(batch));
+        vm.expectCall({callee: address(moduleA), msgValue: MODULE_A_FEE, data: getModuleCalldata(batch)});
         expectEventBatchVerificationRequested(batch, oneModule);
         requestVerification(requestCaller, MODULE_A_FEE, dbNonce, oneModule);
     }
@@ -380,8 +371,7 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
     function test_requestVerification_nextNonce_oneModule_higherFee() public {
         uint64 dbNonce = INITIAL_DB_NONCE;
         InterchainBatch memory batch = InterchainBatch({srcChainId: SRC_CHAIN_ID, dbNonce: dbNonce, batchRoot: 0});
-        // expectCall(address callee, uint256 msgValue, bytes calldata data)
-        vm.expectCall(address(moduleA), MODULE_A_FEE * 2, getModuleCalldata(batch));
+        vm.expectCall({callee: address(moduleA), msgValue: MODULE_A_FEE * 2, data: getModuleCalldata(batch)});
         expectEventBatchVerificationRequested(batch, oneModule);
         requestVerification(requestCaller, MODULE_A_FEE * 2, dbNonce, oneModule);
     }
@@ -389,9 +379,8 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
     function test_requestVerification_nextNonce_twoModules() public {
         uint64 dbNonce = INITIAL_DB_NONCE;
         InterchainBatch memory batch = InterchainBatch({srcChainId: SRC_CHAIN_ID, dbNonce: dbNonce, batchRoot: 0});
-        // expectCall(address callee, uint256 msgValue, bytes calldata data)
-        vm.expectCall(address(moduleA), MODULE_A_FEE, getModuleCalldata(batch));
-        vm.expectCall(address(moduleB), MODULE_B_FEE, getModuleCalldata(batch));
+        vm.expectCall({callee: address(moduleA), msgValue: MODULE_A_FEE, data: getModuleCalldata(batch)});
+        vm.expectCall({callee: address(moduleB), msgValue: MODULE_B_FEE, data: getModuleCalldata(batch)});
         expectEventBatchVerificationRequested(batch, twoModules);
         requestVerification(requestCaller, MODULE_A_FEE + MODULE_B_FEE, dbNonce, twoModules);
     }
@@ -400,9 +389,8 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
         // Overpaid fees should be directed to the first module
         uint64 dbNonce = INITIAL_DB_NONCE;
         InterchainBatch memory batch = InterchainBatch({srcChainId: SRC_CHAIN_ID, dbNonce: dbNonce, batchRoot: 0});
-        // expectCall(address callee, uint256 msgValue, bytes calldata data)
-        vm.expectCall(address(moduleA), MODULE_A_FEE * 2, getModuleCalldata(batch));
-        vm.expectCall(address(moduleB), MODULE_B_FEE, getModuleCalldata(batch));
+        vm.expectCall({callee: address(moduleA), msgValue: MODULE_A_FEE * 2, data: getModuleCalldata(batch)});
+        vm.expectCall({callee: address(moduleB), msgValue: MODULE_B_FEE, data: getModuleCalldata(batch)});
         expectEventBatchVerificationRequested(batch, twoModules);
         requestVerification(requestCaller, MODULE_A_FEE * 2 + MODULE_B_FEE, dbNonce, twoModules);
     }
@@ -410,8 +398,7 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
     function test_requestVerification_hugeNonce_oneModule() public {
         uint64 dbNonce = 2 ** 32;
         InterchainBatch memory batch = InterchainBatch({srcChainId: SRC_CHAIN_ID, dbNonce: dbNonce, batchRoot: 0});
-        // expectCall(address callee, uint256 msgValue, bytes calldata data)
-        vm.expectCall(address(moduleA), MODULE_A_FEE, getModuleCalldata(batch));
+        vm.expectCall({callee: address(moduleA), msgValue: MODULE_A_FEE, data: getModuleCalldata(batch)});
         expectEventBatchVerificationRequested(batch, oneModule);
         requestVerification(requestCaller, MODULE_A_FEE, dbNonce, oneModule);
     }
@@ -419,8 +406,7 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
     function test_requestVerification_hugeNonce_oneModule_higherFee() public {
         uint64 dbNonce = 2 ** 32;
         InterchainBatch memory batch = InterchainBatch({srcChainId: SRC_CHAIN_ID, dbNonce: dbNonce, batchRoot: 0});
-        // expectCall(address callee, uint256 msgValue, bytes calldata data)
-        vm.expectCall(address(moduleA), MODULE_A_FEE * 2, getModuleCalldata(batch));
+        vm.expectCall({callee: address(moduleA), msgValue: MODULE_A_FEE * 2, data: getModuleCalldata(batch)});
         expectEventBatchVerificationRequested(batch, oneModule);
         requestVerification(requestCaller, MODULE_A_FEE * 2, dbNonce, oneModule);
     }
@@ -428,9 +414,8 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
     function test_requestVerification_hugeNonce_twoModules() public {
         uint64 dbNonce = 2 ** 32;
         InterchainBatch memory batch = InterchainBatch({srcChainId: SRC_CHAIN_ID, dbNonce: dbNonce, batchRoot: 0});
-        // expectCall(address callee, uint256 msgValue, bytes calldata data)
-        vm.expectCall(address(moduleA), MODULE_A_FEE, getModuleCalldata(batch));
-        vm.expectCall(address(moduleB), MODULE_B_FEE, getModuleCalldata(batch));
+        vm.expectCall({callee: address(moduleA), msgValue: MODULE_A_FEE, data: getModuleCalldata(batch)});
+        vm.expectCall({callee: address(moduleB), msgValue: MODULE_B_FEE, data: getModuleCalldata(batch)});
         expectEventBatchVerificationRequested(batch, twoModules);
         requestVerification(requestCaller, MODULE_A_FEE + MODULE_B_FEE, dbNonce, twoModules);
     }
@@ -439,9 +424,8 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
         // Overpaid fees should be directed to the first module
         uint64 dbNonce = 2 ** 32;
         InterchainBatch memory batch = InterchainBatch({srcChainId: SRC_CHAIN_ID, dbNonce: dbNonce, batchRoot: 0});
-        // expectCall(address callee, uint256 msgValue, bytes calldata data)
-        vm.expectCall(address(moduleA), MODULE_A_FEE * 2, getModuleCalldata(batch));
-        vm.expectCall(address(moduleB), MODULE_B_FEE, getModuleCalldata(batch));
+        vm.expectCall({callee: address(moduleA), msgValue: MODULE_A_FEE * 2, data: getModuleCalldata(batch)});
+        vm.expectCall({callee: address(moduleB), msgValue: MODULE_B_FEE, data: getModuleCalldata(batch)});
         expectEventBatchVerificationRequested(batch, twoModules);
         requestVerification(requestCaller, MODULE_A_FEE * 2 + MODULE_B_FEE, dbNonce, twoModules);
     }
@@ -476,7 +460,7 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
     function test_writeEntryWithVerification_writerF_oneModule_callsModule() public {
         InterchainEntry memory entry = getMockEntry(INITIAL_DB_NONCE, writerF);
         InterchainBatch memory batch = getExpectedBatch(entry);
-        vm.expectCall(address(moduleA), MODULE_A_FEE, getModuleCalldata(batch));
+        vm.expectCall({callee: address(moduleA), msgValue: MODULE_A_FEE, data: getModuleCalldata(batch)});
         writeEntryWithVerification(MODULE_A_FEE, writerF, entry.dataHash, oneModule);
     }
 
@@ -509,7 +493,7 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
         bytes32 dataHash = getMockDataHash(writerF, INITIAL_DB_NONCE);
         InterchainEntry memory entry = getMockEntry(INITIAL_DB_NONCE, writerF);
         InterchainBatch memory batch = getExpectedBatch(entry);
-        vm.expectCall(address(moduleA), MODULE_A_FEE * 2, getModuleCalldata(batch));
+        vm.expectCall({callee: address(moduleA), msgValue: MODULE_A_FEE * 2, data: getModuleCalldata(batch)});
         expectEventInterchainEntryWritten(entry);
         writeEntryWithVerification(MODULE_A_FEE * 2, writerF, dataHash, oneModule);
         assertEq(icDB.getDBNonce(), INITIAL_DB_NONCE + 1);
@@ -519,8 +503,8 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
     function test_writeEntryWithVerification_writerF_twoModules_callsModules() public {
         InterchainEntry memory entry = getMockEntry(INITIAL_DB_NONCE, writerF);
         InterchainBatch memory batch = getExpectedBatch(entry);
-        vm.expectCall(address(moduleA), MODULE_A_FEE, getModuleCalldata(batch));
-        vm.expectCall(address(moduleB), MODULE_B_FEE, getModuleCalldata(batch));
+        vm.expectCall({callee: address(moduleA), msgValue: MODULE_A_FEE, data: getModuleCalldata(batch)});
+        vm.expectCall({callee: address(moduleB), msgValue: MODULE_B_FEE, data: getModuleCalldata(batch)});
         writeEntryWithVerification(MODULE_A_FEE + MODULE_B_FEE, writerF, entry.dataHash, twoModules);
     }
 
@@ -553,8 +537,8 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
         bytes32 dataHash = getMockDataHash(writerF, INITIAL_DB_NONCE);
         InterchainEntry memory entry = getMockEntry(INITIAL_DB_NONCE, writerF);
         InterchainBatch memory batch = getExpectedBatch(entry);
-        vm.expectCall(address(moduleA), MODULE_A_FEE * 2, getModuleCalldata(batch));
-        vm.expectCall(address(moduleB), MODULE_B_FEE, getModuleCalldata(batch));
+        vm.expectCall({callee: address(moduleA), msgValue: MODULE_A_FEE * 2, data: getModuleCalldata(batch)});
+        vm.expectCall({callee: address(moduleB), msgValue: MODULE_B_FEE, data: getModuleCalldata(batch)});
         expectEventInterchainEntryWritten(entry);
         writeEntryWithVerification(MODULE_A_FEE * 2 + MODULE_B_FEE, writerF, dataHash, twoModules);
         assertEq(icDB.getDBNonce(), INITIAL_DB_NONCE + 1);
@@ -564,7 +548,7 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
     function test_writeEntryWithVerification_writerS_oneModule_callsModule() public {
         InterchainEntry memory entry = getMockEntry(INITIAL_DB_NONCE, writerS);
         InterchainBatch memory batch = getExpectedBatch(entry);
-        vm.expectCall(address(moduleA), MODULE_A_FEE, getModuleCalldata(batch));
+        vm.expectCall({callee: address(moduleA), msgValue: MODULE_A_FEE, data: getModuleCalldata(batch)});
         writeEntryWithVerification(MODULE_A_FEE, writerS, entry.dataHash, oneModule);
     }
 
@@ -597,7 +581,7 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
         bytes32 dataHash = getMockDataHash(writerS, INITIAL_DB_NONCE);
         InterchainEntry memory entry = getMockEntry(INITIAL_DB_NONCE, writerS);
         InterchainBatch memory batch = getExpectedBatch(entry);
-        vm.expectCall(address(moduleA), MODULE_A_FEE * 2, getModuleCalldata(batch));
+        vm.expectCall({callee: address(moduleA), msgValue: MODULE_A_FEE * 2, data: getModuleCalldata(batch)});
         expectEventInterchainEntryWritten(entry);
         writeEntryWithVerification(MODULE_A_FEE * 2, writerS, dataHash, oneModule);
         assertEq(icDB.getDBNonce(), INITIAL_DB_NONCE + 1);
@@ -607,8 +591,8 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
     function test_writeEntryWithVerification_writerS_twoModules_callsModules() public {
         InterchainEntry memory entry = getMockEntry(INITIAL_DB_NONCE, writerS);
         InterchainBatch memory batch = getExpectedBatch(entry);
-        vm.expectCall(address(moduleA), MODULE_A_FEE, getModuleCalldata(batch));
-        vm.expectCall(address(moduleB), MODULE_B_FEE, getModuleCalldata(batch));
+        vm.expectCall({callee: address(moduleA), msgValue: MODULE_A_FEE, data: getModuleCalldata(batch)});
+        vm.expectCall({callee: address(moduleB), msgValue: MODULE_B_FEE, data: getModuleCalldata(batch)});
         writeEntryWithVerification(MODULE_A_FEE + MODULE_B_FEE, writerS, entry.dataHash, twoModules);
     }
 
@@ -641,8 +625,8 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
         bytes32 dataHash = getMockDataHash(writerS, INITIAL_DB_NONCE);
         InterchainEntry memory entry = getMockEntry(INITIAL_DB_NONCE, writerS);
         InterchainBatch memory batch = getExpectedBatch(entry);
-        vm.expectCall(address(moduleA), MODULE_A_FEE * 2, getModuleCalldata(batch));
-        vm.expectCall(address(moduleB), MODULE_B_FEE, getModuleCalldata(batch));
+        vm.expectCall({callee: address(moduleA), msgValue: MODULE_A_FEE * 2, data: getModuleCalldata(batch)});
+        vm.expectCall({callee: address(moduleB), msgValue: MODULE_B_FEE, data: getModuleCalldata(batch)});
         expectEventInterchainEntryWritten(entry);
         writeEntryWithVerification(MODULE_A_FEE * 2 + MODULE_B_FEE, writerS, dataHash, twoModules);
         assertEq(icDB.getDBNonce(), INITIAL_DB_NONCE + 1);

--- a/packages/contracts-communication/test/InterchainDB.Src.t.sol
+++ b/packages/contracts-communication/test/InterchainDB.Src.t.sol
@@ -730,6 +730,28 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
         icDB.getBatch(INITIAL_DB_NONCE + 1);
     }
 
+    function test_getVersionedBatch_finalized() public view {
+        for (uint64 nonce = 0; nonce < INITIAL_DB_NONCE; ++nonce) {
+            bytes memory versionedBatch = icDB.getVersionedBatch(nonce);
+            InterchainBatch memory expectedBatch = getExpectedBatch(getInitialEntry(nonce));
+            assertEq(versionedBatch, getVersionedBatch(expectedBatch));
+        }
+    }
+
+    function test_getVersionedBatch_nextNonce() public view {
+        bytes memory versionedBatch = icDB.getVersionedBatch(INITIAL_DB_NONCE);
+        InterchainBatch memory expectedBatch =
+            InterchainBatch({srcChainId: SRC_CHAIN_ID, dbNonce: INITIAL_DB_NONCE, batchRoot: 0});
+        assertEq(versionedBatch, getVersionedBatch(expectedBatch));
+    }
+
+    function test_getVersionedBatch_hugeNonce() public view {
+        bytes memory versionedBatch = icDB.getVersionedBatch(2 ** 32);
+        InterchainBatch memory expectedBatch =
+            InterchainBatch({srcChainId: SRC_CHAIN_ID, dbNonce: 2 ** 32, batchRoot: 0});
+        assertEq(versionedBatch, getVersionedBatch(expectedBatch));
+    }
+
     function test_getEntryValue() public view {
         for (uint64 nonce = 0; nonce < INITIAL_DB_NONCE; ++nonce) {
             InterchainEntry memory expectedEntry = getInitialEntry(nonce);

--- a/packages/contracts-communication/test/InterchainDB.Src.t.sol
+++ b/packages/contracts-communication/test/InterchainDB.Src.t.sol
@@ -228,14 +228,18 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
 
     // ═══════════════════════════════════════════════ TESTS: SET UP ═══════════════════════════════════════════════════
 
-    function test_setup_getDBNonce() public view {
-        assertEq(icDB.getDBNonce(), INITIAL_DB_NONCE);
+    function checkCorrectDBNonceEntryIndex(uint64 expectedDBNonce) internal view {
+        assertEq(icDB.getDBNonce(), expectedDBNonce);
+        (uint64 dbNonce, uint64 entryIndex) = icDB.getNextEntryIndex();
+        assertEq(dbNonce, expectedDBNonce);
+        assertEq(entryIndex, 0);
     }
 
-    function test_setup_getEntryValue() public view {
+    function test_setup_getters() public view {
         for (uint64 i = 0; i < INITIAL_DB_NONCE; ++i) {
             assertCorrectValue(icDB.getEntryValue(i, 0), getInitialEntry(i));
         }
+        checkCorrectDBNonceEntryIndex(INITIAL_DB_NONCE);
     }
 
     // ══════════════════════════════════════════ TESTS: WRITING AN ENTRY ══════════════════════════════════════════════
@@ -249,7 +253,7 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
     function test_writeEntry_writerF_increasesDBNonce() public {
         bytes32 dataHash = getMockDataHash(writerF, INITIAL_DB_NONCE);
         writeEntry(writerF, dataHash);
-        assertEq(icDB.getDBNonce(), INITIAL_DB_NONCE + 1);
+        checkCorrectDBNonceEntryIndex(INITIAL_DB_NONCE + 1);
     }
 
     function test_writeEntry_writerF_returnsCorrectNonce() public {
@@ -273,7 +277,7 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
     function test_writeEntry_writerS_increasesDBNonce() public {
         bytes32 dataHash = getMockDataHash(writerS, INITIAL_DB_NONCE);
         writeEntry(writerS, dataHash);
-        assertEq(icDB.getDBNonce(), INITIAL_DB_NONCE + 1);
+        checkCorrectDBNonceEntryIndex(INITIAL_DB_NONCE + 1);
     }
 
     function test_writeEntry_writerS_returnsCorrectNonce() public {
@@ -474,7 +478,7 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
     function test_writeEntryWithVerification_writerF_oneModule_increasesDBNonce() public {
         bytes32 dataHash = getMockDataHash(writerF, INITIAL_DB_NONCE);
         writeEntryWithVerification(MODULE_A_FEE, writerF, dataHash, oneModule);
-        assertEq(icDB.getDBNonce(), INITIAL_DB_NONCE + 1);
+        checkCorrectDBNonceEntryIndex(INITIAL_DB_NONCE + 1);
     }
 
     function test_writeEntryWithVerification_writerF_oneModule_returnsCorrectNonce() public {
@@ -496,7 +500,7 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
         vm.expectCall({callee: address(moduleA), msgValue: MODULE_A_FEE * 2, data: getModuleCalldata(batch)});
         expectEventInterchainEntryWritten(entry);
         writeEntryWithVerification(MODULE_A_FEE * 2, writerF, dataHash, oneModule);
-        assertEq(icDB.getDBNonce(), INITIAL_DB_NONCE + 1);
+        checkCorrectDBNonceEntryIndex(INITIAL_DB_NONCE + 1);
         assertCorrectValue(icDB.getEntryValue(INITIAL_DB_NONCE, 0), entry);
     }
 
@@ -518,7 +522,7 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
     function test_writeEntryWithVerification_writerF_twoModules_increasesDBNonce() public {
         bytes32 dataHash = getMockDataHash(writerF, INITIAL_DB_NONCE);
         writeEntryWithVerification(MODULE_A_FEE + MODULE_B_FEE, writerF, dataHash, twoModules);
-        assertEq(icDB.getDBNonce(), INITIAL_DB_NONCE + 1);
+        checkCorrectDBNonceEntryIndex(INITIAL_DB_NONCE + 1);
     }
 
     function test_writeEntryWithVerification_writerF_twoModules_returnsCorrectNonce() public {
@@ -541,7 +545,7 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
         vm.expectCall({callee: address(moduleB), msgValue: MODULE_B_FEE, data: getModuleCalldata(batch)});
         expectEventInterchainEntryWritten(entry);
         writeEntryWithVerification(MODULE_A_FEE * 2 + MODULE_B_FEE, writerF, dataHash, twoModules);
-        assertEq(icDB.getDBNonce(), INITIAL_DB_NONCE + 1);
+        checkCorrectDBNonceEntryIndex(INITIAL_DB_NONCE + 1);
         assertCorrectValue(icDB.getEntryValue(INITIAL_DB_NONCE, 0), entry);
     }
 
@@ -562,7 +566,7 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
     function test_writeEntryWithVerification_writerS_oneModule_increasesDBNonce() public {
         bytes32 dataHash = getMockDataHash(writerS, INITIAL_DB_NONCE);
         writeEntryWithVerification(MODULE_A_FEE, writerS, dataHash, oneModule);
-        assertEq(icDB.getDBNonce(), INITIAL_DB_NONCE + 1);
+        checkCorrectDBNonceEntryIndex(INITIAL_DB_NONCE + 1);
     }
 
     function test_writeEntryWithVerification_writerS_oneModule_returnsCorrectNonce() public {
@@ -584,7 +588,7 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
         vm.expectCall({callee: address(moduleA), msgValue: MODULE_A_FEE * 2, data: getModuleCalldata(batch)});
         expectEventInterchainEntryWritten(entry);
         writeEntryWithVerification(MODULE_A_FEE * 2, writerS, dataHash, oneModule);
-        assertEq(icDB.getDBNonce(), INITIAL_DB_NONCE + 1);
+        checkCorrectDBNonceEntryIndex(INITIAL_DB_NONCE + 1);
         assertCorrectValue(icDB.getEntryValue(INITIAL_DB_NONCE, 0), entry);
     }
 
@@ -606,7 +610,7 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
     function test_writeEntryWithVerification_writerS_twoModules_increasesDBNonce() public {
         bytes32 dataHash = getMockDataHash(writerS, INITIAL_DB_NONCE);
         writeEntryWithVerification(MODULE_A_FEE + MODULE_B_FEE, writerS, dataHash, twoModules);
-        assertEq(icDB.getDBNonce(), INITIAL_DB_NONCE + 1);
+        checkCorrectDBNonceEntryIndex(INITIAL_DB_NONCE + 1);
     }
 
     function test_writeEntryWithVerification_writerS_twoModules_returnsCorrectNonce() public {
@@ -629,7 +633,7 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
         vm.expectCall({callee: address(moduleB), msgValue: MODULE_B_FEE, data: getModuleCalldata(batch)});
         expectEventInterchainEntryWritten(entry);
         writeEntryWithVerification(MODULE_A_FEE * 2 + MODULE_B_FEE, writerS, dataHash, twoModules);
-        assertEq(icDB.getDBNonce(), INITIAL_DB_NONCE + 1);
+        checkCorrectDBNonceEntryIndex(INITIAL_DB_NONCE + 1);
         assertCorrectValue(icDB.getEntryValue(INITIAL_DB_NONCE, 0), entry);
     }
 
@@ -824,8 +828,26 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
         icDB.getEntryValue(2 ** 32, 0);
     }
 
-    function test_getDBNonce() public view {
-        assertEq(icDB.getDBNonce(), INITIAL_DB_NONCE);
+    function test_getEntryProof_finalized() public view {
+        for (uint64 nonce = 0; nonce < INITIAL_DB_NONCE; ++nonce) {
+            bytes32[] memory proof = icDB.getEntryProof(nonce, 0);
+            assertEq(proof.length, 0, "!proof.length");
+        }
+    }
+
+    function test_getEntryProof_revert_finalizedOutOfRange() public {
+        expectRevertEntryIndexOutOfRange(INITIAL_DB_NONCE - 1, 1, 1);
+        icDB.getEntryProof(INITIAL_DB_NONCE - 1, 1);
+    }
+
+    function test_getEntryProof_revert_nextNonceOutOfRange() public {
+        expectRevertEntryIndexOutOfRange(INITIAL_DB_NONCE, 0, 0);
+        icDB.getEntryProof(INITIAL_DB_NONCE, 0);
+    }
+
+    function test_getEntryProof_revert_hugeNonceOutOfRange() public {
+        expectRevertEntryIndexOutOfRange(2 ** 32, 0, 0);
+        icDB.getEntryProof(2 ** 32, 0);
     }
 
     // ═══════════════════════════════════════════ TESTS: GET BATCH ROOT ═══════════════════════════════════════════════

--- a/packages/contracts-communication/test/mocks/InterchainDBMock.sol
+++ b/packages/contracts-communication/test/mocks/InterchainDBMock.sol
@@ -48,6 +48,8 @@ contract InterchainDBMock is IInterchainDB {
 
     function getBatch(uint64 dbNonce) external view returns (InterchainBatch memory) {}
 
+    function getVersionedBatch(uint64 dbNonce) external view returns (bytes memory versionedBatch) {}
+
     function getEntryValue(uint64 dbNonce, uint64 entryIndex) external view returns (bytes32) {}
 
     function getEntryProof(uint64 dbNonce, uint64 entryIndex) external view returns (bytes32[] memory proof) {}


### PR DESCRIPTION
**Description**
This PR adds a new getter: `InterchainDB.getVersionedBatch(nonce)`. It works for both finalized and non-finalized bacthes, and returns the properly encoded versioned batch payload.

An off-chain Guard Module could use this to submit a correct batch for the given nonce to some remote chain.

To make this work, and to follow #2536 the batch getters no longer revert when the batch is not finalized, and instead return an empty batch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced functions for batch retrieval and version management in the Interchain database.
  - Enhanced pagination capabilities for batch leaf retrieval.

- **Refactor**
  - Updated existing batch retrieval functions to handle special cases like non-finalized batches.

- **Documentation**
  - Updated interface documentation to reflect new functionalities and error handling changes.

- **Bug Fixes**
  - Removed outdated errors from the interface to align with the current functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->