### PR TITLE
fix(contracts-communication): check interchain receiver interface

### DIFF
--- a/packages/contracts-communication/contracts/InterchainClientV1.sol
+++ b/packages/contracts-communication/contracts/InterchainClientV1.sol
@@ -181,11 +181,11 @@ contract InterchainClientV1 is Ownable, InterchainClientV1Events, IInterchainCli
             } else if (selector == InterchainClientV1__BatchConflict.selector) {
                 status = TxReadiness.BatchConflict;
             } else if (selector == InterchainClientV1__IncorrectDstChainId.selector) {
-                status = TxReadiness.IncorrectDstChainId;
+                status = TxReadiness.TxWrongDstChainId;
             } else if (selector == InterchainClientV1__NotEnoughResponses.selector) {
-                status = TxReadiness.NotEnoughResponses;
+                status = TxReadiness.BatchAwaitingResponses;
             } else if (selector == InterchainClientV1__ZeroRequiredResponses.selector) {
-                status = TxReadiness.ZeroRequiredResponses;
+                status = TxReadiness.ReceiverZeroRequiredResponses;
             } else {
                 status = TxReadiness.UndeterminedRevert;
                 firstArg = 0;

--- a/packages/contracts-communication/contracts/InterchainClientV1.sol
+++ b/packages/contracts-communication/contracts/InterchainClientV1.sol
@@ -184,7 +184,7 @@ contract InterchainClientV1 is Ownable, InterchainClientV1Events, IInterchainCli
                 status = TxReadiness.BatchConflict;
             } else if (selector == InterchainClientV1__ReceiverNotICApp.selector) {
                 status = TxReadiness.ReceiverNotICApp;
-            } else if (selector == InterchainClientV1__ZeroRequiredResponses.selector) {
+            } else if (selector == InterchainClientV1__ReceiverZeroRequiredResponses.selector) {
                 status = TxReadiness.ReceiverZeroRequiredResponses;
             } else if (selector == InterchainClientV1__IncorrectDstChainId.selector) {
                 status = TxReadiness.TxWrongDstChainId;
@@ -381,10 +381,10 @@ contract InterchainClientV1 is Ownable, InterchainClientV1Events, IInterchainCli
                 proof: proof
             })
         });
-        (AppConfigV1 memory appConfig, address[] memory approvedModules) =
-            getAppReceivingConfigV1(icTx.dstReceiver.bytes32ToAddress());
+        address receiver = icTx.dstReceiver.bytes32ToAddress();
+        (AppConfigV1 memory appConfig, address[] memory approvedModules) = getAppReceivingConfigV1(receiver);
         if (appConfig.requiredResponses == 0) {
-            revert InterchainClientV1__ZeroRequiredResponses();
+            revert InterchainClientV1__ReceiverZeroRequiredResponses(receiver);
         }
         // Verify against the Guard if the app opts in to use it
         _assertNoGuardConflict(_getGuard(appConfig), batch);

--- a/packages/contracts-communication/contracts/InterchainClientV1.sol
+++ b/packages/contracts-communication/contracts/InterchainClientV1.sol
@@ -182,6 +182,8 @@ contract InterchainClientV1 is Ownable, InterchainClientV1Events, IInterchainCli
                 status = TxReadiness.BatchAwaitingResponses;
             } else if (selector == InterchainClientV1__BatchConflict.selector) {
                 status = TxReadiness.BatchConflict;
+            } else if (selector == InterchainClientV1__ReceiverNotICApp.selector) {
+                status = TxReadiness.ReceiverNotICApp;
             } else if (selector == InterchainClientV1__ZeroRequiredResponses.selector) {
                 status = TxReadiness.ReceiverZeroRequiredResponses;
             } else if (selector == InterchainClientV1__IncorrectDstChainId.selector) {

--- a/packages/contracts-communication/contracts/InterchainClientV1.sol
+++ b/packages/contracts-communication/contracts/InterchainClientV1.sol
@@ -249,20 +249,20 @@ contract InterchainClientV1 is Ownable, InterchainClientV1Events, IInterchainCli
         }
     }
 
+    /// @notice Decodes the encoded options data into a OptionsV1 struct.
+    function decodeOptions(bytes memory encodedOptions) external view returns (OptionsV1 memory) {
+        return encodedOptions.decodeOptionsV1();
+    }
+
     /// @notice Gets the V1 app config and trusted modules for the receiving app.
     function getAppReceivingConfigV1(address receiver)
-        external
+        public
         view
         returns (AppConfigV1 memory config, address[] memory modules)
     {
         bytes memory encodedConfig;
         (encodedConfig, modules) = IInterchainApp(receiver).getReceivingConfig();
         config = encodedConfig.decodeAppConfigV1();
-    }
-
-    /// @notice Decodes the encoded options data into a OptionsV1 struct.
-    function decodeOptions(bytes memory encodedOptions) external view returns (OptionsV1 memory) {
-        return encodedOptions.decodeOptionsV1();
     }
 
     /// @notice Encodes the transaction data into a bytes format.
@@ -368,9 +368,8 @@ contract InterchainClientV1 is Ownable, InterchainClientV1Events, IInterchainCli
                 proof: proof
             })
         });
-        (bytes memory encodedAppConfig, address[] memory approvedModules) =
-            IInterchainApp(TypeCasts.bytes32ToAddress(icTx.dstReceiver)).getReceivingConfig();
-        AppConfigV1 memory appConfig = encodedAppConfig.decodeAppConfigV1();
+        (AppConfigV1 memory appConfig, address[] memory approvedModules) =
+            getAppReceivingConfigV1(TypeCasts.bytes32ToAddress(icTx.dstReceiver));
         if (appConfig.requiredResponses == 0) {
             revert InterchainClientV1__ZeroRequiredResponses();
         }

--- a/packages/contracts-communication/contracts/InterchainClientV1.sol
+++ b/packages/contracts-communication/contracts/InterchainClientV1.sol
@@ -178,14 +178,14 @@ contract InterchainClientV1 is Ownable, InterchainClientV1Events, IInterchainCli
             (selector, firstArg, secondArg) = _decodeRevertData(errorData);
             if (selector == InterchainClientV1__TxAlreadyExecuted.selector) {
                 status = TxReadiness.AlreadyExecuted;
-            } else if (selector == InterchainClientV1__BatchConflict.selector) {
-                status = TxReadiness.BatchConflict;
-            } else if (selector == InterchainClientV1__IncorrectDstChainId.selector) {
-                status = TxReadiness.TxWrongDstChainId;
             } else if (selector == InterchainClientV1__NotEnoughResponses.selector) {
                 status = TxReadiness.BatchAwaitingResponses;
+            } else if (selector == InterchainClientV1__BatchConflict.selector) {
+                status = TxReadiness.BatchConflict;
             } else if (selector == InterchainClientV1__ZeroRequiredResponses.selector) {
                 status = TxReadiness.ReceiverZeroRequiredResponses;
+            } else if (selector == InterchainClientV1__IncorrectDstChainId.selector) {
+                status = TxReadiness.TxWrongDstChainId;
             } else {
                 status = TxReadiness.UndeterminedRevert;
                 firstArg = 0;

--- a/packages/contracts-communication/contracts/interfaces/IInterchainClientV1.sol
+++ b/packages/contracts-communication/contracts/interfaces/IInterchainClientV1.sol
@@ -8,10 +8,10 @@ interface IInterchainClientV1 {
     enum TxReadiness {
         Ready,
         AlreadyExecuted,
+        BatchAwaitingResponses,
         BatchConflict,
-        IncorrectDstChainId,
-        NotEnoughResponses,
-        ZeroRequiredResponses,
+        ReceiverZeroRequiredResponses,
+        TxWrongDstChainId,
         UndeterminedRevert
     }
 
@@ -133,15 +133,15 @@ interface IInterchainClientV1 {
     /// - Ready: the transaction is ready to be executed.
     /// - AlreadyExecuted: the transaction has already been executed.
     ///   - `firstArg` is the transaction ID.
+    /// - BatchAwaitingResponses: not enough responses have been received for the transaction.
+    ///   - `firstArg` is the number of responses received.
+    ///   - `secondArg` is the number of responses required.
     /// - BatchConflict: one of the modules have submitted a conflicting batch.
     ///   - `firstArg` is the address of the module.
     ///   - This is either one of the modules that the app trusts, or the Guard module used by the app.
-    /// - IncorrectDstChainId: the destination chain ID does not match the local chain ID.
+    /// - ReceiverZeroRequiredResponses: the app config requires zero responses for the transaction.
+    /// - TxWrongDstChainId: the destination chain ID does not match the local chain ID.
     ///   - `firstArg` is the destination chain ID.
-    /// - NotEnoughResponses: not enough responses have been received for the transaction.
-    ///   - `firstArg` is the number of responses received.
-    ///   - `secondArg` is the number of responses required.
-    /// - ZeroRequiredResponses: the app config requires zero responses for the transaction.
     /// - UndeterminedRevert: the transaction will revert for another reason.
     ///
     /// Note: the arguments are abi-encoded bytes32 values (as their types could be different).

--- a/packages/contracts-communication/contracts/interfaces/IInterchainClientV1.sol
+++ b/packages/contracts-communication/contracts/interfaces/IInterchainClientV1.sol
@@ -10,6 +10,7 @@ interface IInterchainClientV1 {
         AlreadyExecuted,
         BatchAwaitingResponses,
         BatchConflict,
+        ReceiverNotICApp,
         ReceiverZeroRequiredResponses,
         TxWrongDstChainId,
         UndeterminedRevert

--- a/packages/contracts-communication/contracts/interfaces/IInterchainClientV1.sol
+++ b/packages/contracts-communication/contracts/interfaces/IInterchainClientV1.sol
@@ -140,6 +140,8 @@ interface IInterchainClientV1 {
     /// - BatchConflict: one of the modules have submitted a conflicting batch.
     ///   - `firstArg` is the address of the module.
     ///   - This is either one of the modules that the app trusts, or the Guard module used by the app.
+    /// - ReceiverNotICApp: the receiver is not an Interchain app.
+    ///  - `firstArg` is the receiver address.
     /// - ReceiverZeroRequiredResponses: the app config requires zero responses for the transaction.
     /// - TxWrongDstChainId: the destination chain ID does not match the local chain ID.
     ///   - `firstArg` is the destination chain ID.

--- a/packages/contracts-communication/contracts/interfaces/IInterchainClientV1.sol
+++ b/packages/contracts-communication/contracts/interfaces/IInterchainClientV1.sol
@@ -28,12 +28,12 @@ interface IInterchainClientV1 {
     error InterchainClientV1__NotEVMClient(bytes32 client);
     error InterchainClientV1__NotRemoteChainId(uint64 chainId);
     error InterchainClientV1__ReceiverNotICApp(address receiver);
+    error InterchainClientV1__ReceiverZeroRequiredResponses(address receiver);
     error InterchainClientV1__TxAlreadyExecuted(bytes32 transactionId);
     error InterchainClientV1__TxNotExecuted(bytes32 transactionId);
     error InterchainClientV1__ZeroAddress();
     error InterchainClientV1__ZeroExecutionService();
     error InterchainClientV1__ZeroReceiver();
-    error InterchainClientV1__ZeroRequiredResponses();
 
     /// @notice Allows the contract owner to set the address of the Guard module.
     /// Note: batches marked as invalid by the Guard could not be used for message execution,

--- a/packages/contracts-communication/contracts/interfaces/IInterchainClientV1.sol
+++ b/packages/contracts-communication/contracts/interfaces/IInterchainClientV1.sol
@@ -26,6 +26,7 @@ interface IInterchainClientV1 {
     error InterchainClientV1__NotEnoughResponses(uint256 actual, uint256 required);
     error InterchainClientV1__NotEVMClient(bytes32 client);
     error InterchainClientV1__NotRemoteChainId(uint64 chainId);
+    error InterchainClientV1__ReceiverNotICApp(address receiver);
     error InterchainClientV1__TxAlreadyExecuted(bytes32 transactionId);
     error InterchainClientV1__TxNotExecuted(bytes32 transactionId);
     error InterchainClientV1__ZeroAddress();

--- a/packages/contracts-communication/test/InterchainClientV1.Base.t.sol
+++ b/packages/contracts-communication/test/InterchainClientV1.Base.t.sol
@@ -2,8 +2,10 @@
 pragma solidity 0.8.20;
 
 import {InterchainClientV1, InterchainClientV1Events, IInterchainClientV1} from "../contracts/InterchainClientV1.sol";
-import {InterchainTxDescriptor, InterchainTransaction} from "../contracts/libs/InterchainTransaction.sol";
+import {IInterchainApp} from "../contracts/interfaces/IInterchainApp.sol";
+import {AppConfigV1} from "../contracts/libs/AppConfig.sol";
 import {BatchingV1Lib} from "../contracts/libs/BatchingV1.sol";
+import {InterchainTxDescriptor, InterchainTransaction} from "../contracts/libs/InterchainTransaction.sol";
 import {OptionsLib} from "../contracts/libs/Options.sol";
 
 import {InterchainTransactionLibHarness} from "./harnesses/InterchainTransactionLibHarness.sol";
@@ -59,6 +61,17 @@ abstract contract InterchainClientV1BaseTest is Test, InterchainClientV1Events {
     function setLinkedClient(uint64 chainId, bytes32 client) public {
         vm.prank(owner);
         icClient.setLinkedClient(chainId, client);
+    }
+
+    // ══════════════════════════════════════════════════ MOCKING ══════════════════════════════════════════════════════
+
+    function mockReceivingConfig(address receiver, AppConfigV1 memory appConfig, address[] memory modules) internal {
+        bytes memory encodedConfig = appConfig.encodeAppConfigV1();
+        vm.mockCall({
+            callee: receiver,
+            data: abi.encodeCall(IInterchainApp.getReceivingConfig, ()),
+            returnData: abi.encode(encodedConfig, modules)
+        });
     }
 
     // ═════════════════════════════════════════════ EXPECT (REVERTS) ══════════════════════════════════════════════════

--- a/packages/contracts-communication/test/InterchainClientV1.Base.t.sol
+++ b/packages/contracts-communication/test/InterchainClientV1.Base.t.sol
@@ -127,6 +127,12 @@ abstract contract InterchainClientV1BaseTest is Test, InterchainClientV1Events {
         );
     }
 
+    function expectRevertReceiverNotICApp(address receiver) internal {
+        vm.expectRevert(
+            abi.encodeWithSelector(IInterchainClientV1.InterchainClientV1__ReceiverNotICApp.selector, receiver)
+        );
+    }
+
     function expectRevertTxAlreadyExecuted(bytes32 transactionId) internal {
         vm.expectRevert(
             abi.encodeWithSelector(IInterchainClientV1.InterchainClientV1__TxAlreadyExecuted.selector, transactionId)

--- a/packages/contracts-communication/test/InterchainClientV1.Base.t.sol
+++ b/packages/contracts-communication/test/InterchainClientV1.Base.t.sol
@@ -146,6 +146,14 @@ abstract contract InterchainClientV1BaseTest is Test, InterchainClientV1Events {
         );
     }
 
+    function expectRevertReceiverZeroRequiredResponses(address receiver) internal {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IInterchainClientV1.InterchainClientV1__ReceiverZeroRequiredResponses.selector, receiver
+            )
+        );
+    }
+
     function expectRevertTxAlreadyExecuted(bytes32 transactionId) internal {
         vm.expectRevert(
             abi.encodeWithSelector(IInterchainClientV1.InterchainClientV1__TxAlreadyExecuted.selector, transactionId)
@@ -168,10 +176,6 @@ abstract contract InterchainClientV1BaseTest is Test, InterchainClientV1Events {
 
     function expectRevertZeroReceiver() internal {
         vm.expectRevert(IInterchainClientV1.InterchainClientV1__ZeroReceiver.selector);
-    }
-
-    function expectRevertZeroRequiredResponses() internal {
-        vm.expectRevert(IInterchainClientV1.InterchainClientV1__ZeroRequiredResponses.selector);
     }
 
     function expectRevertIncorrectVersion(uint8 version) internal {

--- a/packages/contracts-communication/test/InterchainClientV1.Dst.t.sol
+++ b/packages/contracts-communication/test/InterchainClientV1.Dst.t.sol
@@ -667,10 +667,10 @@ abstract contract InterchainClientV1DstTest is InterchainClientV1BaseTest {
         bytes memory encodedTx = getEncodedTx(icTx);
         mockReceivingConfig({requiredResponses: 0, guardFlag: 0});
         mockCheckVerification(icModuleA, desc, justVerTS());
-        assertCorrectReadiness(icTx, IInterchainClientV1.TxReadiness.ReceiverZeroRequiredResponses);
-        expectRevertZeroRequiredResponses();
+        assertCorrectReadiness(icTx, IInterchainClientV1.TxReadiness.ReceiverZeroRequiredResponses, dstReceiver);
+        expectRevertReceiverZeroRequiredResponses(dstReceiver);
         icClient.isExecutable(encodedTx, emptyProof);
-        expectRevertZeroRequiredResponses();
+        expectRevertReceiverZeroRequiredResponses(dstReceiver);
         executeTransaction(encodedTx, emptyProof);
     }
 }

--- a/packages/contracts-communication/test/InterchainClientV1.Dst.t.sol
+++ b/packages/contracts-communication/test/InterchainClientV1.Dst.t.sol
@@ -634,6 +634,7 @@ abstract contract InterchainClientV1DstTest is InterchainClientV1BaseTest {
         (InterchainTransaction memory icTx,) = constructInterchainTx();
         icTx.dstReceiver = bytes32(uint256(uint160(receiverEOA)));
         bytes memory encodedTx = encodeAndMakeExecutable(icTx);
+        assertCorrectReadiness(icTx, IInterchainClientV1.TxReadiness.ReceiverNotICApp, receiverEOA);
         expectRevertReceiverNotICApp(receiverEOA);
         icClient.isExecutable(encodedTx, emptyProof);
         expectRevertReceiverNotICApp(receiverEOA);
@@ -644,6 +645,7 @@ abstract contract InterchainClientV1DstTest is InterchainClientV1BaseTest {
         (InterchainTransaction memory icTx,) = constructInterchainTx();
         icTx.dstReceiver = bytes32(uint256(uint160(receiverNotICApp)));
         bytes memory encodedTx = encodeAndMakeExecutable(icTx);
+        assertCorrectReadiness(icTx, IInterchainClientV1.TxReadiness.ReceiverNotICApp, receiverNotICApp);
         expectRevertReceiverNotICApp(receiverNotICApp);
         icClient.isExecutable(encodedTx, emptyProof);
         expectRevertReceiverNotICApp(receiverNotICApp);

--- a/packages/contracts-communication/test/InterchainClientV1.Dst.t.sol
+++ b/packages/contracts-communication/test/InterchainClientV1.Dst.t.sol
@@ -93,10 +93,7 @@ abstract contract InterchainClientV1DstTest is InterchainClientV1BaseTest {
     /// @dev Override the InterchainApp's receiving config to return the given appConfig and two modules.
     function mockReceivingConfig(uint256 requiredResponses, uint256 guardFlag) internal {
         AppConfigV1 memory appConfig = getAppConfig(requiredResponses, guardFlag);
-        bytes memory encodedConfig = appConfig.encodeAppConfigV1();
-        vm.mockCall(
-            dstReceiver, abi.encodeCall(InterchainAppMock.getReceivingConfig, ()), abi.encode(encodedConfig, twoModules)
-        );
+        mockReceivingConfig(dstReceiver, appConfig, twoModules);
     }
 
     /// @dev Override the InterchainDB's verification check to return the given verifiedAt timestamp

--- a/packages/contracts-communication/test/InterchainClientV1.Dst.t.sol
+++ b/packages/contracts-communication/test/InterchainClientV1.Dst.t.sol
@@ -369,7 +369,7 @@ abstract contract InterchainClientV1DstTest is InterchainClientV1BaseTest {
     {
         (InterchainTransaction memory icTx,) = prepareExecuteTest(required, guardFlag, times);
         bytes memory encodedTx = getEncodedTx(icTx);
-        assertCorrectReadiness(icTx, IInterchainClientV1.TxReadiness.NotEnoughResponses, actual, required);
+        assertCorrectReadiness(icTx, IInterchainClientV1.TxReadiness.BatchAwaitingResponses, actual, required);
         expectRevertNotEnoughResponses({actual: actual, required: required});
         icClient.isExecutable(encodedTx, emptyProof);
         expectRevertNotEnoughResponses({actual: actual, required: required});
@@ -564,7 +564,7 @@ abstract contract InterchainClientV1DstTest is InterchainClientV1BaseTest {
         (InterchainTransaction memory icTx,) = constructInterchainTx();
         icTx.dstChainId = UNKNOWN_CHAIN_ID;
         bytes memory encodedTx = encodeAndMakeExecutable(icTx);
-        assertCorrectReadiness(icTx, IInterchainClientV1.TxReadiness.IncorrectDstChainId, UNKNOWN_CHAIN_ID);
+        assertCorrectReadiness(icTx, IInterchainClientV1.TxReadiness.TxWrongDstChainId, UNKNOWN_CHAIN_ID);
         expectRevertIncorrectDstChainId(UNKNOWN_CHAIN_ID);
         icClient.isExecutable(encodedTx, emptyProof);
         expectRevertIncorrectDstChainId(UNKNOWN_CHAIN_ID);
@@ -665,7 +665,7 @@ abstract contract InterchainClientV1DstTest is InterchainClientV1BaseTest {
         bytes memory encodedTx = getEncodedTx(icTx);
         mockReceivingConfig({requiredResponses: 0, guardFlag: 0});
         mockCheckVerification(icModuleA, desc, justVerTS());
-        assertCorrectReadiness(icTx, IInterchainClientV1.TxReadiness.ZeroRequiredResponses);
+        assertCorrectReadiness(icTx, IInterchainClientV1.TxReadiness.ReceiverZeroRequiredResponses);
         expectRevertZeroRequiredResponses();
         icClient.isExecutable(encodedTx, emptyProof);
         expectRevertZeroRequiredResponses();

--- a/packages/contracts-communication/test/harnesses/NoOpHarness.sol
+++ b/packages/contracts-communication/test/harnesses/NoOpHarness.sol
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+// solhint-disable no-empty-blocks
+contract NoOpHarness {}


### PR DESCRIPTION
**Description**
This PR resolves the following TODO item https://github.com/synapsecns/sanguine/blob/fd9d62385358eab2f802459f13052c155e834c86/packages/contracts-communication/contracts/InterchainClientV1.sol#L100

- `InterchainClientV1` now throws an explicit revert, if the receiver is not a contract, or does not implement `icApp.getReceivingConfig()`
- `getTxReadinessV1()` now returns a specialized terminal status `ReceiverNotICApp` for both of these cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced error handling and type casting in `InterchainClientV1` contract.
	- Expanded `TxReadiness` enum with new statuses and added corresponding errors for better transaction readiness feedback.
	- Public visibility for `getAppReceivingConfigV1` function to allow easier access to app configurations.

- **Bug Fixes**
	- Modified key functions to ensure correct processing of interchain transactions.

- **Tests**
	- Added new test cases to validate error handling and configuration retrieval in interchain communication scenarios.

- **Documentation**
	- Updated comments and documentation to reflect changes in error handling and transaction readiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->