### PR TITLE
fix(contracts-communication): gasOracle check in ExecutionService, remove batch decoding in Module

### DIFF
--- a/packages/contracts-communication/contracts/InterchainDB.sol
+++ b/packages/contracts-communication/contracts/InterchainDB.sol
@@ -263,7 +263,9 @@ contract InterchainDB is InterchainDBEvents, IInterchainDB {
             payload: InterchainBatchLib.encodeBatch(batch)
         });
         for (uint256 i = 0; i < len; ++i) {
-            IInterchainModule(srcModules[i]).requestBatchVerification{value: fees[i]}(dstChainId, versionedBatch);
+            IInterchainModule(srcModules[i]).requestBatchVerification{value: fees[i]}(
+                dstChainId, batch.dbNonce, versionedBatch
+            );
         }
         emit InterchainBatchVerificationRequested(dstChainId, batch.dbNonce, batch.batchRoot, srcModules);
     }

--- a/packages/contracts-communication/contracts/execution/SynapseExecutionServiceV1.sol
+++ b/packages/contracts-communication/contracts/execution/SynapseExecutionServiceV1.sol
@@ -64,8 +64,8 @@ contract SynapseExecutionServiceV1 is
 
     /// @inheritdoc ISynapseExecutionServiceV1
     function setGasOracle(address gasOracle_) external virtual onlyRole(GOVERNOR_ROLE) {
-        if (gasOracle_ == address(0)) {
-            revert SynapseExecutionService__GasOracleZeroAddress();
+        if (gasOracle_.code.length == 0) {
+            revert SynapseExecutionService__GasOracleNotContract(gasOracle_);
         }
         SynapseExecutionServiceV1Storage storage $ = _getSynapseExecutionServiceV1Storage();
         $.gasOracle = gasOracle_;

--- a/packages/contracts-communication/contracts/interfaces/IInterchainModule.sol
+++ b/packages/contracts-communication/contracts/interfaces/IInterchainModule.sol
@@ -6,7 +6,6 @@ pragma solidity ^0.8.0;
 interface IInterchainModule {
     error InterchainModule__CallerNotInterchainDB(address caller);
     error InterchainModule__ChainIdNotRemote(uint64 chainId);
-    error InterchainModule__IncorrectSourceChainId(uint64 chainId);
     error InterchainModule__FeeAmountBelowMin(uint256 feeAmount, uint256 minRequired);
 
     /// @notice Request the verification of a batch from the Interchain DataBase by the module.

--- a/packages/contracts-communication/contracts/interfaces/IInterchainModule.sol
+++ b/packages/contracts-communication/contracts/interfaces/IInterchainModule.sol
@@ -17,8 +17,15 @@ interface IInterchainModule {
     /// with no guarantee of ordering.
     /// @dev Could be only called by the Interchain DataBase contract.
     /// @param dstChainId       The chain id of the destination chain
+    /// @param batchNonce       The nonce of the batch on the source chain
     /// @param versionedBatch   The versioned batch to verify
-    function requestBatchVerification(uint64 dstChainId, bytes memory versionedBatch) external payable;
+    function requestBatchVerification(
+        uint64 dstChainId,
+        uint64 batchNonce,
+        bytes memory versionedBatch
+    )
+        external
+        payable;
 
     /// @notice Get the Module fee for verifying a batch on the specified destination chain.
     /// @param dstChainId   The chain id of the destination chain

--- a/packages/contracts-communication/contracts/interfaces/ISynapseExecutionServiceV1.sol
+++ b/packages/contracts-communication/contracts/interfaces/ISynapseExecutionServiceV1.sol
@@ -6,6 +6,7 @@ import {IExecutionService} from "./IExecutionService.sol";
 interface ISynapseExecutionServiceV1 is IExecutionService {
     error SynapseExecutionService__ExecutorZeroAddress();
     error SynapseExecutionService__FeeAmountBelowMin(uint256 feeAmount, uint256 minRequired);
+    error SynapseExecutionService__GasOracleNotContract(address gasOracle);
     error SynapseExecutionService__GasOracleZeroAddress();
     error SynapseExecutionService__OptionsVersionNotSupported(uint16 version);
 

--- a/packages/contracts-communication/contracts/modules/InterchainModule.sol
+++ b/packages/contracts-communication/contracts/modules/InterchainModule.sol
@@ -37,9 +37,6 @@ abstract contract InterchainModule is InterchainModuleEvents, IInterchainModule 
         if (dstChainId == block.chainid) {
             revert InterchainModule__ChainIdNotRemote(dstChainId);
         }
-        if (batch.srcChainId != block.chainid) {
-            revert InterchainModule__IncorrectSourceChainId({chainId: batch.srcChainId});
-        }
         uint256 requiredFee = _getModuleFee(dstChainId, batch.dbNonce);
         if (msg.value < requiredFee) {
             revert InterchainModule__FeeAmountBelowMin({feeAmount: msg.value, minRequired: requiredFee});

--- a/packages/contracts-communication/contracts/modules/InterchainModule.sol
+++ b/packages/contracts-communication/contracts/modules/InterchainModule.sol
@@ -22,7 +22,14 @@ abstract contract InterchainModule is InterchainModuleEvents, IInterchainModule 
     }
 
     /// @inheritdoc IInterchainModule
-    function requestBatchVerification(uint64 dstChainId, bytes calldata versionedBatch) external payable {
+    function requestBatchVerification(
+        uint64 dstChainId,
+        uint64 batchNonce,
+        bytes calldata versionedBatch
+    )
+        external
+        payable
+    {
         if (msg.sender != INTERCHAIN_DB) {
             revert InterchainModule__CallerNotInterchainDB(msg.sender);
         }

--- a/packages/contracts-communication/contracts/modules/InterchainModule.sol
+++ b/packages/contracts-communication/contracts/modules/InterchainModule.sol
@@ -33,15 +33,14 @@ abstract contract InterchainModule is InterchainModuleEvents, IInterchainModule 
         if (msg.sender != INTERCHAIN_DB) {
             revert InterchainModule__CallerNotInterchainDB(msg.sender);
         }
-        InterchainBatch memory batch = InterchainBatchLib.decodeBatch(versionedBatch.getPayload());
         if (dstChainId == block.chainid) {
             revert InterchainModule__ChainIdNotRemote(dstChainId);
         }
-        uint256 requiredFee = _getModuleFee(dstChainId, batch.dbNonce);
+        uint256 requiredFee = _getModuleFee(dstChainId, batchNonce);
         if (msg.value < requiredFee) {
             revert InterchainModule__FeeAmountBelowMin({feeAmount: msg.value, minRequired: requiredFee});
         }
-        bytes memory moduleData = _fillModuleData(dstChainId, batch.dbNonce);
+        bytes memory moduleData = _fillModuleData(dstChainId, batchNonce);
         bytes memory encodedBatch = ModuleBatchLib.encodeVersionedModuleBatch(versionedBatch, moduleData);
         bytes32 ethSignedBatchHash = MessageHashUtils.toEthSignedMessageHash(keccak256(encodedBatch));
         _requestVerification(dstChainId, encodedBatch);

--- a/packages/contracts-communication/test/InterchainDB.Src.t.sol
+++ b/packages/contracts-communication/test/InterchainDB.Src.t.sol
@@ -114,7 +114,7 @@ contract InterchainDBSourceTest is Test, InterchainDBEvents {
 
     function getModuleCalldata(InterchainBatch memory batch) internal view returns (bytes memory) {
         bytes memory versionedBatch = getVersionedBatch(batch);
-        return abi.encodeCall(IInterchainModule.requestBatchVerification, (DST_CHAIN_ID, versionedBatch));
+        return abi.encodeCall(IInterchainModule.requestBatchVerification, (DST_CHAIN_ID, batch.dbNonce, versionedBatch));
     }
 
     function addressToBytes32(address addr) internal pure returns (bytes32) {

--- a/packages/contracts-communication/test/execution/SynapseExecutionServiceV1.t.sol
+++ b/packages/contracts-communication/test/execution/SynapseExecutionServiceV1.t.sol
@@ -66,6 +66,14 @@ contract SynapseExecutionServiceV1Test is ProxyTest, ClaimableFeesEvents, Synaps
         );
     }
 
+    function expectRevertGasOracleNotContract(address gasOracle) internal {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ISynapseExecutionServiceV1.SynapseExecutionService__GasOracleNotContract.selector, gasOracle
+            )
+        );
+    }
+
     function expectRevertGasOracleZeroAddress() internal {
         vm.expectRevert(ISynapseExecutionServiceV1.SynapseExecutionService__GasOracleZeroAddress.selector);
     }

--- a/packages/contracts-communication/test/mocks/InterchainModuleMock.sol
+++ b/packages/contracts-communication/test/mocks/InterchainModuleMock.sol
@@ -9,7 +9,14 @@ import {VersionedPayloadLib} from "../../contracts/libs/VersionedPayload.sol";
 // solhint-disable ordering
 // solhint-disable no-empty-blocks
 contract InterchainModuleMock is IInterchainModule {
-    function requestBatchVerification(uint64 dstChainId, bytes calldata versionedBatch) external payable {}
+    function requestBatchVerification(
+        uint64 dstChainId,
+        uint64 batchNonce,
+        bytes calldata versionedBatch
+    )
+        external
+        payable
+    {}
 
     function getModuleFee(uint64 dstChainId, uint64 dbNonce) external view returns (uint256) {}
 

--- a/packages/contracts-communication/test/modules/SynapseModule.Management.t.sol
+++ b/packages/contracts-communication/test/modules/SynapseModule.Management.t.sol
@@ -325,6 +325,12 @@ contract SynapseModuleManagementTest is Test, ClaimableFeesEvents, SynapseModule
         module.setGasOracle(notContract);
     }
 
+    function test_setGasOracle_revert_zeroAddress() public {
+        vm.expectRevert(abi.encodeWithSelector(ISynapseModule.SynapseModule__GasOracleNotContract.selector, address(0)));
+        vm.prank(owner);
+        module.setGasOracle(address(0));
+    }
+
     function test_setVerifyGasLimit_setsVerifyGasLimit() public {
         vm.prank(owner);
         module.setVerifyGasLimit(1, 1000);


### PR DESCRIPTION
**Description**
- `SynapseExecutionServiceV1` wasn't checking if the provided GasOracle is indeed a contract - this is now fixed, and behaves the same way as SynapseModule, which also relies on the Oracle.
- `SynapseModule` no longer decodes the batch passed by the InterchainDB for remote verification purposes.
  - This is possible, as the interchain DB reference is immutable, as the contract itself. Therefore, the Interchain Module can omit the batch checks once `msg.sender ==interchainDB` has been checked.
  - This also removes an unreachable error, where the batch requested for verification would have an incorrect source chain id. This is filled by the InterchainDB contract, see above point for trusting its data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced batch verification requests across various contracts to include a `batchNonce` parameter, improving tracking and validation processes.
  - Updated gas oracle settings in contracts to ensure address validation, enhancing security by verifying contract code presence.

- **Bug Fixes**
  - Implemented more robust error handling for gas oracle settings, including specific revert messages when the gas oracle address is not a contract or is zero.

- **Documentation**
  - Added detailed error messages and conditions in contract interfaces for clarity and better developer guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->