### PR TITLE
RFQ: drop requests for unsupported chains

### DIFF
--- a/services/rfq/relayer/inventory/manager.go
+++ b/services/rfq/relayer/inventory/manager.go
@@ -2,6 +2,7 @@ package inventory
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"strconv"
@@ -82,6 +83,9 @@ type inventoryManagerImpl struct {
 	pendingHist metric.Float64Histogram
 }
 
+// ErrUnsupportedChain is the error for an unsupported chain.
+var ErrUnsupportedChain error = errors.New("could not get gas balance for unsupported chain")
+
 // GetCommittableBalance gets the committable balances.
 func (i *inventoryManagerImpl) GetCommittableBalance(ctx context.Context, chainID int, token common.Address, options ...BalanceFetchArgOption) (*big.Int, error) {
 	committableBalances, err := i.GetCommittableBalances(ctx, options...)
@@ -94,7 +98,7 @@ func (i *inventoryManagerImpl) GetCommittableBalance(ctx context.Context, chainI
 	if balance == nil && token == chain.EthAddress {
 		gasBalance, ok := i.gasBalances[chainID]
 		if !ok || gasBalance == nil {
-			return nil, fmt.Errorf("could not get gas balance for chain %d", chainID)
+			return nil, ErrUnsupportedChain
 		}
 		balance = i.gasBalances[chainID]
 	}

--- a/services/rfq/relayer/inventory/manager.go
+++ b/services/rfq/relayer/inventory/manager.go
@@ -84,7 +84,7 @@ type inventoryManagerImpl struct {
 }
 
 // ErrUnsupportedChain is the error for an unsupported chain.
-var ErrUnsupportedChain error = errors.New("could not get gas balance for unsupported chain")
+var ErrUnsupportedChain = errors.New("could not get gas balance for unsupported chain")
 
 // GetCommittableBalance gets the committable balances.
 func (i *inventoryManagerImpl) GetCommittableBalance(ctx context.Context, chainID int, token common.Address, options ...BalanceFetchArgOption) (*big.Int, error) {

--- a/services/rfq/relayer/service/handlers.go
+++ b/services/rfq/relayer/service/handlers.go
@@ -94,6 +94,8 @@ func (r *Relayer) handleBridgeRequestedLog(parentCtx context.Context, req *fastb
 //
 // This is the second step in the bridge process. It is emitted when the relayer sees the request.
 // We check if we have enough inventory to process the request and mark it as committed pending.
+//
+//nolint:cyclop
 func (q *QuoteRequestHandler) handleSeen(ctx context.Context, span trace.Span, request reldb.QuoteRequest) (err error) {
 	shouldProcess, err := q.Quoter.ShouldProcess(ctx, request)
 	if err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced error handling for unsupported blockchain networks by introducing a specific error message when gas balance retrieval fails.

- **Bug Fixes**
  - Corrected a typo in variable naming from "balancs" to "balance" to improve code clarity and prevent potential errors.

- **Improvements**
  - Updated logic to handle quote requests more effectively when dealing with unsupported chains, ensuring better user feedback and system resilience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->