### PR TITLE
fix(solidity-devops): use case insensitive check for address equality

### DIFF
--- a/packages/solidity-devops/js/utils/deployments.js
+++ b/packages/solidity-devops/js/utils/deployments.js
@@ -4,7 +4,7 @@ const path = require('path')
 const { getChainId, hasCode } = require('./chain.js')
 const { readConfigValue } = require('./config.js')
 const { logSuccess, logInfo, logError, logWarning } = require('./logger.js')
-const { createDir } = require('./utils.js')
+const { areEqualAddresses, createDir } = require('./utils.js')
 const { assertCondition } = require('./utils.js')
 
 /**
@@ -42,7 +42,9 @@ const saveNewDeployment = (chainName, contractAlias, potentialReceipts) => {
     return
   }
   // Find the matching receipt
-  const receipt = potentialReceipts.find((r) => r.address === artifact.address)
+  const receipt = potentialReceipts.find((r) =>
+    areEqualAddresses(r.address, artifact.address)
+  )
   if (!receipt) {
     logInfo(`No receipt found for ${contractAlias} at ${artifact.address}`)
     return

--- a/packages/solidity-devops/js/utils/utils.js
+++ b/packages/solidity-devops/js/utils/utils.js
@@ -4,6 +4,21 @@ const { execSync } = require('child_process')
 const { logCommand, logCommandError, logInfo } = require('./logger.js')
 
 /**
+ * Checks if two 0x addresses are equal, regardless of case.
+ * If either address is null, returns false.
+ *
+ * @param {string} addrA - The first address
+ * @param {string} addrB - The second address
+ * @returns {bool} Whether the addresses are equal
+ */
+const areEqualAddresses = (addrA, addrB) => {
+  if (!addrA || !addrB) {
+    return false
+  }
+  return addrA.toLowerCase() === addrB.toLowerCase()
+}
+
+/**
  * Asserts that a condition is true. If not, logs an error message and exits the process.
  *
  * @param {bool} condition - The condition to assert
@@ -90,6 +105,7 @@ const syncSleep = (seconds, reason) => {
 }
 
 module.exports = {
+  areEqualAddresses,
   assertCondition,
   createDir,
   exitWithError,


### PR DESCRIPTION
**Description**
See title.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved address comparison in deployment saving process to enhance accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->