### PR TITLE
Pause SPEC

### DIFF
--- a/packages/synapse-interface/components/layouts/LandingPageWrapper/index.tsx
+++ b/packages/synapse-interface/components/layouts/LandingPageWrapper/index.tsx
@@ -52,7 +52,7 @@ export function LandingPageWrapper({ children }: { children: any }) {
       <div className={wrapperClassName} style={TODO_REMOVE_wrapperStyle}>
         <AnnouncementBanner
           bannerId="2024-05-06-pause-spec"
-          bannerContents="SPEC bridging paused"
+          bannerContents="Bridging SPEC to Ethereum paused"
           startDate={new Date('2024-05-05T18:45:09+00:00')}
           endDate={new Date('2024-05-10T18:45:09+00:00')}
         />

--- a/packages/synapse-interface/components/layouts/LandingPageWrapper/index.tsx
+++ b/packages/synapse-interface/components/layouts/LandingPageWrapper/index.tsx
@@ -26,6 +26,7 @@ import { MoreButton } from './MoreButton'
 import { PageFooter } from './PageFooter'
 import { joinClassNames } from '@/utils/joinClassNames'
 import { MaintenanceBanners } from '@/components/Maintenance/Maintenance'
+import { AnnouncementBanner } from '@/components/Maintenance/components/AnnouncementBanner'
 
 const wrapperClassName = joinClassNames({
   textColor: 'text-zinc-800 dark:text-zinc-200',
@@ -49,6 +50,12 @@ export function LandingPageWrapper({ children }: { children: any }) {
   return (
     <div className="dark">
       <div className={wrapperClassName} style={TODO_REMOVE_wrapperStyle}>
+        <AnnouncementBanner
+          bannerId="2024-05-06-pause-spec"
+          bannerContents="SPEC bridging paused"
+          startDate={new Date('2024-05-05T18:45:09+00:00')}
+          endDate={new Date('2024-05-10T18:45:09+00:00')}
+        />
         <MaintenanceBanners />
         <LandingNav />
         {children}

--- a/packages/synapse-interface/constants/tokens/index.ts
+++ b/packages/synapse-interface/constants/tokens/index.ts
@@ -32,11 +32,11 @@ const sortedTokens = Object.values(all).sort(
 
 // Key value pairs here will override bridgeMap to hide particular chain-token pairs
 export const PAUSED_TOKENS_BY_CHAIN = {
-  [CHAINS.ETH.id]: ['WETH'],
+  [CHAINS.ETH.id]: ['WETH', 'SPEC'],
   [CHAINS.OPTIMISM.id]: ['WETH'],
   [CHAINS.BOBA.id]: ['WETH'],
   [CHAINS.MOONBEAM.id]: ['WETH'],
-  [CHAINS.BASE.id]: ['WETH'],
+  [CHAINS.BASE.id]: ['WETH', 'SPEC'],
   [CHAINS.ARBITRUM.id]: ['WETH'],
   [CHAINS.FANTOM.id]: [],
   [CHAINS.DOGE.id]: ['BUSD', 'WETH'],

--- a/packages/synapse-interface/constants/tokens/index.ts
+++ b/packages/synapse-interface/constants/tokens/index.ts
@@ -32,11 +32,11 @@ const sortedTokens = Object.values(all).sort(
 
 // Key value pairs here will override bridgeMap to hide particular chain-token pairs
 export const PAUSED_TOKENS_BY_CHAIN = {
-  [CHAINS.ETH.id]: ['WETH', 'SPEC'],
+  [CHAINS.ETH.id]: ['WETH'],
   [CHAINS.OPTIMISM.id]: ['WETH'],
   [CHAINS.BOBA.id]: ['WETH'],
   [CHAINS.MOONBEAM.id]: ['WETH'],
-  [CHAINS.BASE.id]: ['WETH', 'SPEC'],
+  [CHAINS.BASE.id]: ['WETH'],
   [CHAINS.ARBITRUM.id]: ['WETH'],
   [CHAINS.FANTOM.id]: [],
   [CHAINS.DOGE.id]: ['BUSD', 'WETH'],

--- a/packages/synapse-interface/pages/state-managed-bridge/index.tsx
+++ b/packages/synapse-interface/pages/state-managed-bridge/index.tsx
@@ -74,6 +74,7 @@ import {
   getBridgeModuleNames,
 } from '@/components/Maintenance/Maintenance'
 import { wagmiConfig } from '@/wagmiConfig'
+import { ETH } from '@/constants/chains/master'
 
 const StateManagedBridge = () => {
   const { address } = useAccount()
@@ -513,9 +514,12 @@ const StateManagedBridge = () => {
   const maintenanceCountdownProgressInstances =
     useMaintenanceCountdownProgresses({ type: 'Bridge' })
 
-  const isBridgePaused = maintenanceCountdownProgressInstances.some(
-    (instance) => instance.isCurrentChainDisabled
-  )
+  const isBridgePaused =
+    maintenanceCountdownProgressInstances.some(
+      (instance) => instance.isCurrentChainDisabled
+    ) ||
+    (fromToken?.routeSymbol === 'SPEC' && toChainId === ETH.id)
+  // TODO: Remove SPEC pause when available
 
   return (
     <div className="flex flex-col w-full max-w-lg mx-auto lg:mx-0">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Expanded the list of paused tokens for both the ETH and BASE chains to include the 'SPEC' token.
	- Added an `AnnouncementBanner` component to the `LandingPageWrapper` for displaying announcements with start and end dates.
	- Updated the condition for `isBridgePaused` in the `StateManagedBridge` component to include checks based on `fromToken` and `toChainId`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
cfa2e1e6deaf7c32be97b63336b27c86467012a6: [synapse-interface preview link ](https://sanguine-synapse-interface-ho2sgspjr-synapsecns.vercel.app)
34adceb4ef7fd9a6065f2d4f31e1e1253204c345: [synapse-interface preview link ](https://sanguine-synapse-interface-k4l9m2s96-synapsecns.vercel.app)
9e5a711584b83a229bac733fbfcbb1c35f2819da: [synapse-interface preview link ](https://sanguine-synapse-interface-7y028i0yx-synapsecns.vercel.app)