### PR TITLE
feat(synapse-interface): fetch prices for gas airdrop on interval

### DIFF
--- a/packages/synapse-interface/slices/gasAirdropSlice.ts
+++ b/packages/synapse-interface/slices/gasAirdropSlice.ts
@@ -1,0 +1,76 @@
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
+
+type CoingeckoData = {
+  symbol: string
+  price: number
+}
+
+export interface GasAirdropState {
+  prices: CoingeckoData[]
+  isLoadingPrices: boolean
+}
+
+const initialState: GasAirdropState = {
+  prices: [],
+  isLoadingPrices: false,
+}
+
+export const fetchGasAirdropPrices = createAsyncThunk(
+  'gasAirdrop/fetchGasAirdropPrices',
+  async () => {
+    const ids = [
+      'ethereum',
+      'avalanche-2',
+      'defi-kingdoms',
+      'moonriver',
+      'moonbeam',
+      'canto',
+      'fantom',
+      'metis-token',
+      'binancecoin',
+      'matic-network',
+      'klay-token',
+    ]
+
+    try {
+      const prices = await fetch(
+        `https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&ids=${ids.join(
+          ','
+        )}`
+      )
+      return prices.json()
+    } catch {
+      return []
+    }
+  }
+)
+
+export const gasAirdropSlice = createSlice({
+  name: 'gasAirdrop',
+  initialState,
+  reducers: {
+    resetPriceData: () => initialState,
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchGasAirdropPrices.pending, (state) => {
+        state.isLoadingPrices = true
+      })
+      .addCase(fetchGasAirdropPrices.fulfilled, (state, action) => {
+        state.isLoadingPrices = false
+
+        const prices = action.payload.map((price) => ({
+          symbol: price.symbol.toUpperCase(),
+          price: price.current_price,
+        }))
+
+        state.prices = prices
+      })
+      .addCase(fetchGasAirdropPrices.rejected, (state) => {
+        state.isLoadingPrices = false
+        console.error('Error fetching  prices')
+      })
+  },
+})
+
+export default gasAirdropSlice.reducer

--- a/packages/synapse-interface/store/reducer.ts
+++ b/packages/synapse-interface/store/reducer.ts
@@ -14,6 +14,7 @@ import poolDeposit from '@/slices/poolDepositSlice'
 import poolUserData from '@/slices/poolUserDataSlice'
 import poolWithdraw from '@/slices/poolWithdrawSlice'
 import priceData from '@/slices/priceDataSlice'
+import gasAirdrop from '@/slices/gasAirdropSlice'
 import { api } from '@/slices/api/slice'
 import { RootActions } from '@/slices/application/actions'
 
@@ -42,6 +43,7 @@ export const appReducer = combineReducers({
   poolUserData,
   poolWithdraw,
   priceData,
+  gasAirdrop,
   [api.reducerPath]: api.reducer,
   ...persistedReducers,
 })

--- a/packages/synapse-interface/utils/hooks/useCoingeckoPrice.tsx
+++ b/packages/synapse-interface/utils/hooks/useCoingeckoPrice.tsx
@@ -1,28 +1,9 @@
-import { useSwr } from '@hooks/useSwr'
-
-const ID_MAP = {
-  ETH: 'ethereum',
-  AVAX: 'avalanche-2',
-  JEWEL: 'defi-kingdoms',
-  MOVR: 'moonriver',
-  GLMR: 'moonbeam',
-  CANTO: 'canto',
-  FTM: 'fantom',
-  METIS: 'metis-token',
-  BNB: 'binancecoin',
-  MATIC: 'matic-network',
-  KLAY: 'klay-token',
-}
+import { useAppSelector } from '@/store/hooks'
 
 export const useCoingeckoPrice = (symbol: string) => {
-  const id = ID_MAP[symbol]
+  const { prices } = useAppSelector((state) => state.gasAirdrop)
 
-  const apiUrl = `https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&ids=${id}`
+  const data = prices.find((price) => price.symbol === symbol)
 
-  const { data } = useSwr(apiUrl)
-
-  if (data) {
-    const coin = data[0]
-    return coin?.current_price
-  }
+  return data?.price
 }

--- a/packages/synapse-interface/utils/hooks/useFetchPricesOnInterval.ts
+++ b/packages/synapse-interface/utils/hooks/useFetchPricesOnInterval.ts
@@ -8,6 +8,7 @@ import {
   fetchMetisPrice,
   fetchSynPrices,
 } from '@/slices/priceDataSlice'
+import { fetchGasAirdropPrices } from '@/slices/gasAirdropSlice'
 
 export const useFetchPricesOnInterval = () => {
   const dispatch = useAppDispatch()
@@ -19,6 +20,7 @@ export const useFetchPricesOnInterval = () => {
       dispatch(fetchAvaxPrice())
       dispatch(fetchMetisPrice())
       dispatch(fetchGmxPrice())
+      dispatch(fetchGasAirdropPrices())
     }
 
     // Fetch on mount


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced functionality to fetch and manage gas airdrop prices using the Coingecko API.
	- Updated price fetching in the app to utilize Redux state for improved performance and reduced API calls.

- **Refactor**
	- Modified the `useCoingeckoPrice` hook to fetch prices from Redux state instead of direct API calls.

- **Chores**
	- Integrated `gasAirdrop` slice into the main app reducer for handling related state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
468c1657a4aa05b25d4ff3f64ece06b24309f218: [synapse-interface preview link ](https://sanguine-synapse-interface-nu131d2xc-synapsecns.vercel.app)