### PR TITLE
add "and" on fe

### DIFF
--- a/packages/synapse-interface/pages/landing/sections/HeroSection.tsx
+++ b/packages/synapse-interface/pages/landing/sections/HeroSection.tsx
@@ -18,7 +18,7 @@ export default function HeroSection() {
         communication
       </h1>
       <p className="hidden text-center text-secondaryTextColor sm:block">
-        Synapse is the most widely used, extensible, secure cross-
+        Synapse is the most widely used, extensible, and secure cross-
         <br />
         chain communications network. Build truly cross-chain
         <br />


### PR DESCRIPTION
**Description**
gm kings. Noticed the first sentence of landing page of the fe has a typo/improper english (its missing an "and"). Its also different from the bridge tagline which is:
_Synapse is the most widely used, extensible, and secure cross-chain communications network._


This pr adds an "and"

> prev:
> _Synapse is the most widely used, extensible, secure cross-chain communications network._
> 

**Resources**
https://www.youtube.com/watch?v=7Uk4DqklqFg


🫡🫡🫡
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the description in the Hero Section to enhance clarity and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->