### PR TITLE
feat(contracts-communication): default values for modules/required respones

### DIFF
--- a/packages/contracts-communication/contracts/InterchainClientV1.sol
+++ b/packages/contracts-communication/contracts/InterchainClientV1.sol
@@ -41,6 +41,10 @@ contract InterchainClientV1 is Ownable, InterchainClientV1Events, IInterchainCli
     /// if the app opts in to use the Guard.
     address public defaultGuard;
 
+    /// @notice Address of the default module to use to verify the validity of entries.
+    /// Note: this module will be used for the apps that define an empty module list in their config.
+    address public defaultModule;
+
     /// @dev Address of the InterchainClient contract on the remote chain
     mapping(uint64 chainId => bytes32 remoteClient) internal _linkedClient;
     /// @dev Executor address that completed the transaction. Address(0) if not executed yet.
@@ -60,6 +64,13 @@ contract InterchainClientV1 is Ownable, InterchainClientV1Events, IInterchainCli
         }
         defaultGuard = guard;
         emit DefaultGuardSet(guard);
+    }
+
+    /// @notice Allows the contract owner to set the address of the default module.
+    /// Note: this module will be used for the apps that define an empty module list in their config.
+    /// @param module           The address of the default module.
+    function setDefaultModule(address module) external {
+        // TODO: implement
     }
 
     /// @notice Sets the linked client for a specific chain ID.

--- a/packages/contracts-communication/contracts/InterchainClientV1.sol
+++ b/packages/contracts-communication/contracts/InterchainClientV1.sol
@@ -69,8 +69,12 @@ contract InterchainClientV1 is Ownable, InterchainClientV1Events, IInterchainCli
     /// @notice Allows the contract owner to set the address of the default module.
     /// Note: this module will be used for the apps that define an empty module list in their config.
     /// @param module           The address of the default module.
-    function setDefaultModule(address module) external {
-        // TODO: implement
+    function setDefaultModule(address module) external onlyOwner {
+        if (module == address(0)) {
+            revert InterchainClientV1__ModuleZeroAddress();
+        }
+        defaultModule = module;
+        emit DefaultModuleSet(module);
     }
 
     /// @notice Sets the linked client for a specific chain ID.

--- a/packages/contracts-communication/contracts/InterchainClientV1.sol
+++ b/packages/contracts-communication/contracts/InterchainClientV1.sol
@@ -347,6 +347,15 @@ contract InterchainClientV1 is Ownable, InterchainClientV1Events, IInterchainCli
         bytes memory encodedConfig;
         (encodedConfig, modules) = abi.decode(returnData, (bytes, address[]));
         config = encodedConfig.decodeAppConfigV1();
+        // Fallback to the default module if the app has no modules
+        if (modules.length == 0) {
+            modules = new address[](1);
+            modules[0] = defaultModule;
+        }
+        // Fallback to "all responses" if the app requires zero responses
+        if (config.requiredResponses == 0) {
+            config.requiredResponses = modules.length;
+        }
     }
 
     /// @notice Encodes the transaction data into a bytes format.

--- a/packages/contracts-communication/contracts/InterchainClientV1.sol
+++ b/packages/contracts-communication/contracts/InterchainClientV1.sol
@@ -221,7 +221,6 @@ contract InterchainClientV1 is Ownable, InterchainClientV1Events, IInterchainCli
     ///   - This is either one of the modules that the app trusts, or the Guard module used by the app.
     /// - ReceiverNotICApp: the receiver is not an Interchain app.
     ///  - `firstArg` is the receiver address.
-    /// - ReceiverZeroRequiredResponses: the app config requires zero responses for the transaction.
     /// - TxWrongDstChainId: the destination chain ID does not match the local chain ID.
     ///   - `firstArg` is the destination chain ID.
     /// - UndeterminedRevert: the transaction will revert for another reason.
@@ -247,8 +246,6 @@ contract InterchainClientV1 is Ownable, InterchainClientV1Events, IInterchainCli
                 status = TxReadiness.EntryConflict;
             } else if (selector == InterchainClientV1__ReceiverNotICApp.selector) {
                 status = TxReadiness.ReceiverNotICApp;
-            } else if (selector == InterchainClientV1__ReceiverZeroRequiredResponses.selector) {
-                status = TxReadiness.ReceiverZeroRequiredResponses;
             } else if (selector == InterchainClientV1__DstChainIdNotLocal.selector) {
                 status = TxReadiness.TxWrongDstChainId;
             } else {
@@ -449,9 +446,7 @@ contract InterchainClientV1 is Ownable, InterchainClientV1Events, IInterchainCli
         });
         address receiver = icTx.dstReceiver.bytes32ToAddress();
         (AppConfigV1 memory appConfig, address[] memory approvedModules) = getAppReceivingConfigV1(receiver);
-        if (appConfig.requiredResponses == 0) {
-            revert InterchainClientV1__ReceiverZeroRequiredResponses(receiver);
-        }
+        // Note: appConfig.requiredResponses is never zero at this point, see fallbacks in `getAppReceivingConfigV1`
         // Verify against the Guard if the app opts in to use it
         address guard = _getGuard(appConfig);
         _assertNoGuardConflict(guard, entry);

--- a/packages/contracts-communication/contracts/events/InterchainClientV1Events.sol
+++ b/packages/contracts-communication/contracts/events/InterchainClientV1Events.sol
@@ -2,9 +2,13 @@
 pragma solidity ^0.8.0;
 
 abstract contract InterchainClientV1Events {
-    /// @notice Emitted when the Guard module is set.
-    /// @param guard    The address of the Guard module.
+    /// @notice Emitted when the default Guard module is set.
+    /// @param guard    The address of the Guard module that will be used by default.
     event DefaultGuardSet(address guard);
+
+    /// @notice Emitted when the default Module is set.
+    /// @param module   The address of the Module that will be used by default.
+    event DefaultModuleSet(address module);
 
     /// @notice Emitted when the InterchainClientV1 deployment on a remote chain is linked.
     /// @param chainId   The chain ID of the remote chain.

--- a/packages/contracts-communication/contracts/interfaces/IInterchainClientV1.sol
+++ b/packages/contracts-communication/contracts/interfaces/IInterchainClientV1.sol
@@ -10,7 +10,6 @@ interface IInterchainClientV1 {
         EntryAwaitingResponses,
         EntryConflict,
         ReceiverNotICApp,
-        ReceiverZeroRequiredResponses,
         TxWrongDstChainId,
         UndeterminedRevert
     }
@@ -28,7 +27,6 @@ interface IInterchainClientV1 {
     error InterchainClientV1__MsgValueMismatch(uint256 msgValue, uint256 required);
     error InterchainClientV1__ReceiverNotICApp(address receiver);
     error InterchainClientV1__ReceiverZeroAddress();
-    error InterchainClientV1__ReceiverZeroRequiredResponses(address receiver);
     error InterchainClientV1__ResponsesAmountBelowMin(uint256 responsesAmount, uint256 minRequired);
     error InterchainClientV1__TxAlreadyExecuted(bytes32 transactionId);
     error InterchainClientV1__TxNotExecuted(bytes32 transactionId);

--- a/packages/contracts-communication/contracts/interfaces/IInterchainClientV1.sol
+++ b/packages/contracts-communication/contracts/interfaces/IInterchainClientV1.sol
@@ -24,6 +24,7 @@ interface IInterchainClientV1 {
     error InterchainClientV1__GasLeftBelowMin(uint256 gasLeft, uint256 minRequired);
     error InterchainClientV1__GuardZeroAddress();
     error InterchainClientV1__LinkedClientNotEVM(bytes32 client);
+    error InterchainClientV1__ModuleZeroAddress();
     error InterchainClientV1__MsgValueMismatch(uint256 msgValue, uint256 required);
     error InterchainClientV1__ReceiverNotICApp(address receiver);
     error InterchainClientV1__ReceiverZeroAddress();
@@ -33,7 +34,8 @@ interface IInterchainClientV1 {
     error InterchainClientV1__TxNotExecuted(bytes32 transactionId);
     error InterchainClientV1__TxVersionMismatch(uint16 txVersion, uint16 required);
 
-    function setDefaultGuard(address guard_) external;
+    function setDefaultGuard(address guard) external;
+    function setDefaultModule(address module) external;
     function setLinkedClient(uint64 chainId, bytes32 client) external;
 
     function interchainSend(

--- a/packages/contracts-communication/test/InterchainClientV1.Base.t.sol
+++ b/packages/contracts-communication/test/InterchainClientV1.Base.t.sol
@@ -278,7 +278,7 @@ abstract contract InterchainClientV1BaseTest is Test, InterchainClientV1Events {
 
     // ═══════════════════════════════════════════════════ UTILS ═══════════════════════════════════════════════════════
 
-    function toArray(uint256 a) internal pure returns (uint256[] memory arr) {
+    function toArr(uint256 a) internal pure returns (uint256[] memory arr) {
         arr = new uint256[](1);
         arr[0] = a;
     }

--- a/packages/contracts-communication/test/InterchainClientV1.Base.t.sol
+++ b/packages/contracts-communication/test/InterchainClientV1.Base.t.sol
@@ -40,6 +40,7 @@ abstract contract InterchainClientV1BaseTest is Test, InterchainClientV1Events {
 
     address public owner = makeAddr("Owner");
     address public defaultGuard = makeAddr("Default Guard");
+    address public defaultModule = makeAddr("Default Module");
 
     function setUp() public virtual {
         vm.chainId(LOCAL_CHAIN_ID);
@@ -55,6 +56,11 @@ abstract contract InterchainClientV1BaseTest is Test, InterchainClientV1Events {
     function setDefaultGuard(address guard) public {
         vm.prank(owner);
         icClient.setDefaultGuard(guard);
+    }
+
+    function setDefaultModule(address module) public {
+        vm.prank(owner);
+        icClient.setDefaultModule(module);
     }
 
     function setLinkedClient(uint64 chainId, bytes32 client) public {
@@ -171,6 +177,10 @@ abstract contract InterchainClientV1BaseTest is Test, InterchainClientV1Events {
         vm.expectRevert(IInterchainClientV1.InterchainClientV1__ExecutionServiceZeroAddress.selector);
     }
 
+    function expectRevertModuleZeroAddress() internal {
+        vm.expectRevert(IInterchainClientV1.InterchainClientV1__ModuleZeroAddress.selector);
+    }
+
     function expectRevertReceiverZeroAddress() internal {
         vm.expectRevert(IInterchainClientV1.InterchainClientV1__ReceiverZeroAddress.selector);
     }
@@ -185,9 +195,14 @@ abstract contract InterchainClientV1BaseTest is Test, InterchainClientV1Events {
 
     // ══════════════════════════════════════════════ EXPECT (EVENTS) ══════════════════════════════════════════════════
 
-    function expectEventGuardSet(address guard) internal {
+    function expectEventDefaultGuardSet(address guard) internal {
         vm.expectEmit(address(icClient));
         emit DefaultGuardSet(guard);
+    }
+
+    function expectEventDefaultModuleSet(address module) internal {
+        vm.expectEmit(address(icClient));
+        emit DefaultModuleSet(module);
     }
 
     function expectEventLinkedClientSet(uint64 chainId, bytes32 client) internal {

--- a/packages/contracts-communication/test/InterchainClientV1.Base.t.sol
+++ b/packages/contracts-communication/test/InterchainClientV1.Base.t.sol
@@ -149,14 +149,6 @@ abstract contract InterchainClientV1BaseTest is Test, InterchainClientV1Events {
         );
     }
 
-    function expectRevertReceiverZeroRequiredResponses(address receiver) internal {
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IInterchainClientV1.InterchainClientV1__ReceiverZeroRequiredResponses.selector, receiver
-            )
-        );
-    }
-
     function expectRevertTxAlreadyExecuted(bytes32 transactionId) internal {
         vm.expectRevert(
             abi.encodeWithSelector(IInterchainClientV1.InterchainClientV1__TxAlreadyExecuted.selector, transactionId)

--- a/packages/contracts-communication/test/InterchainClientV1.Dst.t.sol
+++ b/packages/contracts-communication/test/InterchainClientV1.Dst.t.sol
@@ -392,6 +392,201 @@ abstract contract InterchainClientV1DstTest is InterchainClientV1BaseTest {
         }
     }
 
+    // ═════════════════════════════════════ APP CONFIG: 1 OUT OF 1 RESPONSES ══════════════════════════════════════════
+
+    function test_execute_1_1_noGuard(uint256 indexA) public {
+        checkScenario({required: 1, guardFlag: GUARD_DISABLED, modules: modulesA, timeIndices: toArr(indexA)});
+    }
+
+    /// @dev Guard conflict should not affect the behavior if the app didn't opt-in for the guard.
+    function test_execute_1_1_noGuard_guardConflict(uint256 indexA) public {
+        addGuardConflict(defaultGuard);
+        test_execute_1_1_noGuard(indexA);
+    }
+
+    function test_execute_1_1_defaultGuard(uint256 indexA) public {
+        checkScenario({required: 1, guardFlag: GUARD_DEFAULT, modules: modulesA, timeIndices: toArr(indexA)});
+    }
+
+    /// @dev Guard conflict should always revert the transaction if the app opted-in for the guard.
+    function test_execute_1_1_defaultGuard_guardConflict(uint256 indexA) public {
+        addGuardConflict(defaultGuard);
+        (InterchainTransaction memory icTx,) = prepareExecuteTest({
+            requiredResponses: 1,
+            guardFlag: GUARD_DEFAULT,
+            modules: modulesA,
+            times: toArr(getTimestampFixture(indexA))
+        });
+        checkEntryConflict({module: defaultGuard, icTx: icTx});
+    }
+
+    function test_execute_1_1_customGuard(uint256 indexA) public {
+        checkScenario({required: 1, guardFlag: GUARD_CUSTOM, modules: modulesA, timeIndices: toArr(indexA)});
+    }
+
+    /// @dev Custom guard conflict should always revert the transaction if the app opted-in for the custom guard.
+    function test_execute_1_1_customGuard_customGuardConflict(uint256 indexA) public {
+        addGuardConflict(customGuard);
+        (InterchainTransaction memory icTx,) = prepareExecuteTest({
+            requiredResponses: 1,
+            guardFlag: GUARD_CUSTOM,
+            modules: modulesA,
+            times: toArr(getTimestampFixture(indexA))
+        });
+        checkEntryConflict({module: customGuard, icTx: icTx});
+    }
+
+    /// @dev Default guard conflict should not affect the behavior if the app opted-in for a custom guard.
+    function test_execute_1_1_customGuard_defaultGuardConflict(uint256 indexA) public {
+        addGuardConflict(defaultGuard);
+        test_execute_1_1_customGuard(indexA);
+    }
+
+    /// @dev Default Guard conflict should be ignored if the app opted-in for a custom guard,
+    /// but the custom guard conflict should still revert the transaction.
+    function test_execute_1_1_customGuard_bothGuardsConflict(uint256 indexA) public {
+        addGuardConflict(defaultGuard);
+        addGuardConflict(customGuard);
+        (InterchainTransaction memory icTx,) = prepareExecuteTest({
+            requiredResponses: 1,
+            guardFlag: GUARD_CUSTOM,
+            modules: modulesA,
+            times: toArr(getTimestampFixture(indexA))
+        });
+        checkEntryConflict({module: customGuard, icTx: icTx});
+    }
+
+    // ════════════════════════════ APP CONFIG: 1 OUT OF 1 RESPONSES (WHEN SET TO ZERO) ════════════════════════════════
+
+    /// @notice If an app sets the required responses to zero, it should default to the amount of trusted modules (1).
+    function test_execute_0_1_noGuard(uint256 indexA) public {
+        checkScenario({required: 0, guardFlag: GUARD_DISABLED, modules: modulesA, timeIndices: toArr(indexA)});
+    }
+
+    /// @dev Guard conflict should not affect the behavior if the app didn't opt-in for the guard.
+    function test_execute_0_1_noGuard_guardConflict(uint256 indexA) public {
+        addGuardConflict(defaultGuard);
+        test_execute_0_1_noGuard(indexA);
+    }
+
+    function test_execute_0_1_defaultGuard(uint256 indexA) public {
+        checkScenario({required: 0, guardFlag: GUARD_DEFAULT, modules: modulesA, timeIndices: toArr(indexA)});
+    }
+
+    /// @dev Guard conflict should always revert the transaction if the app opted-in for the guard.
+    function test_execute_0_1_defaultGuard_guardConflict(uint256 indexA) public {
+        addGuardConflict(defaultGuard);
+        (InterchainTransaction memory icTx,) = prepareExecuteTest({
+            requiredResponses: 1,
+            guardFlag: GUARD_DEFAULT,
+            modules: modulesA,
+            times: toArr(getTimestampFixture(indexA))
+        });
+        checkEntryConflict({module: defaultGuard, icTx: icTx});
+    }
+
+    function test_execute_0_1_customGuard(uint256 indexA) public {
+        checkScenario({required: 0, guardFlag: GUARD_CUSTOM, modules: modulesA, timeIndices: toArr(indexA)});
+    }
+
+    /// @dev Custom guard conflict should always revert the transaction if the app opted-in for the custom guard.
+    function test_execute_0_1_customGuard_customGuardConflict(uint256 indexA) public {
+        addGuardConflict(customGuard);
+        (InterchainTransaction memory icTx,) = prepareExecuteTest({
+            requiredResponses: 1,
+            guardFlag: GUARD_CUSTOM,
+            modules: modulesA,
+            times: toArr(getTimestampFixture(indexA))
+        });
+        checkEntryConflict({module: customGuard, icTx: icTx});
+    }
+
+    /// @dev Default guard conflict should not affect the behavior if the app opted-in for a custom guard.
+    function test_execute_0_1_customGuard_defaultGuardConflict(uint256 indexA) public {
+        addGuardConflict(defaultGuard);
+        test_execute_0_1_customGuard(indexA);
+    }
+
+    /// @dev Default Guard conflict should be ignored if the app opted-in for a custom guard,
+    /// but the custom guard conflict should still revert the transaction.
+    function test_execute_0_1_customGuard_bothGuardsConflict(uint256 indexA) public {
+        addGuardConflict(defaultGuard);
+        addGuardConflict(customGuard);
+        (InterchainTransaction memory icTx,) = prepareExecuteTest({
+            requiredResponses: 1,
+            guardFlag: GUARD_CUSTOM,
+            modules: modulesA,
+            times: toArr(getTimestampFixture(indexA))
+        });
+        checkEntryConflict({module: customGuard, icTx: icTx});
+    }
+
+    // ═════════════════════════════════════ APP CONFIG: 2 OUT OF 1 RESPONSES ══════════════════════════════════════════
+
+    /// @notice If an app sets the required responses higher than the amount of trusted modules,
+    /// there will never be enough responses to execute the transaction.
+    function test_execute_2_1_noGuard(uint256 indexA) public {
+        checkScenario({required: 2, guardFlag: GUARD_DISABLED, modules: modulesA, timeIndices: toArr(indexA)});
+    }
+
+    /// @dev Guard conflict should not affect the behavior if the app didn't opt-in for the guard.
+    function test_execute_2_1_noGuard_guardConflict(uint256 indexA) public {
+        addGuardConflict(defaultGuard);
+        test_execute_2_1_noGuard(indexA);
+    }
+
+    function test_execute_2_1_defaultGuard(uint256 indexA) public {
+        checkScenario({required: 2, guardFlag: GUARD_DEFAULT, modules: modulesA, timeIndices: toArr(indexA)});
+    }
+
+    /// @dev Guard conflict should always revert the transaction if the app opted-in for the guard.
+    function test_execute_2_1_defaultGuard_guardConflict(uint256 indexA) public {
+        addGuardConflict(defaultGuard);
+        (InterchainTransaction memory icTx,) = prepareExecuteTest({
+            requiredResponses: 2,
+            guardFlag: GUARD_DEFAULT,
+            modules: modulesA,
+            times: toArr(getTimestampFixture(indexA))
+        });
+        checkEntryConflict({module: defaultGuard, icTx: icTx});
+    }
+
+    function test_execute_2_1_customGuard(uint256 indexA) public {
+        checkScenario({required: 2, guardFlag: GUARD_CUSTOM, modules: modulesA, timeIndices: toArr(indexA)});
+    }
+
+    /// @dev Custom guard conflict should always revert the transaction if the app opted-in for the custom guard.
+    function test_execute_2_1_customGuard_customGuardConflict(uint256 indexA) public {
+        addGuardConflict(customGuard);
+        (InterchainTransaction memory icTx,) = prepareExecuteTest({
+            requiredResponses: 2,
+            guardFlag: GUARD_CUSTOM,
+            modules: modulesA,
+            times: toArr(getTimestampFixture(indexA))
+        });
+        checkEntryConflict({module: customGuard, icTx: icTx});
+    }
+
+    /// @dev Default guard conflict should not affect the behavior if the app opted-in for a custom guard.
+    function test_execute_2_1_customGuard_defaultGuardConflict(uint256 indexA) public {
+        addGuardConflict(defaultGuard);
+        test_execute_2_1_customGuard(indexA);
+    }
+
+    /// @dev Default Guard conflict should be ignored if the app opted-in for a custom guard,
+    /// but the custom guard conflict should still revert the transaction.
+    function test_execute_2_1_customGuard_bothGuardsConflict(uint256 indexA) public {
+        addGuardConflict(defaultGuard);
+        addGuardConflict(customGuard);
+        (InterchainTransaction memory icTx,) = prepareExecuteTest({
+            requiredResponses: 2,
+            guardFlag: GUARD_CUSTOM,
+            modules: modulesA,
+            times: toArr(getTimestampFixture(indexA))
+        });
+        checkEntryConflict({module: customGuard, icTx: icTx});
+    }
+
     // ═════════════════════════════════════ APP CONFIG: 1 OUT OF 2 RESPONSES ══════════════════════════════════════════
 
     function test_execute_1_2_noGuard(uint256 indexA, uint256 indexB) public {
@@ -522,7 +717,7 @@ abstract contract InterchainClientV1DstTest is InterchainClientV1BaseTest {
 
     // ════════════════════════════ APP CONFIG: 2 OUT OF 2 RESPONSES (WHEN SET TO ZERO) ════════════════════════════════
 
-    /// @notice If an app sets the required responses to zero, it should default to the amount of trusted modules.
+    /// @notice If an app sets the required responses to zero, it should default to the amount of trusted modules (2).
     function test_execute_0_2_noGuard(uint256 indexA, uint256 indexB) public {
         checkScenario({required: 0, guardFlag: GUARD_DISABLED, modules: modulesAB, timeIndices: toArr(indexA, indexB)});
     }

--- a/packages/contracts-communication/test/InterchainClientV1.Management.t.sol
+++ b/packages/contracts-communication/test/InterchainClientV1.Management.t.sol
@@ -11,17 +11,13 @@ contract InterchainClientV1ManagementTest is InterchainClientV1BaseTest {
         assertEq(icClient.owner(), owner);
     }
 
-    function test_setDefaultGuard_emitsEvent() public {
-        expectEventGuardSet(defaultGuard);
-        setDefaultGuard(defaultGuard);
-    }
-
-    function test_setDefaultGuard_setsGuard() public {
+    function test_setDefaultGuard() public {
+        expectEventDefaultGuardSet(defaultGuard);
         setDefaultGuard(defaultGuard);
         assertEq(icClient.defaultGuard(), defaultGuard);
     }
 
-    function test_setDefaultGuard_zeroAddress() public {
+    function test_setDefaultGuard_revert_zeroAddress() public {
         expectRevertGuardZeroAddress();
         setDefaultGuard(address(0));
     }
@@ -33,14 +29,34 @@ contract InterchainClientV1ManagementTest is InterchainClientV1BaseTest {
         icClient.setDefaultGuard(defaultGuard);
     }
 
-    function test_setLinkedClient_emitsEvent() public {
-        expectEventLinkedClientSet(REMOTE_CHAIN_ID, MOCK_REMOTE_CLIENT);
-        setLinkedClient(REMOTE_CHAIN_ID, MOCK_REMOTE_CLIENT);
+    function test_setDefaultModule() public {
+        expectEventDefaultModuleSet(defaultModule);
+        setDefaultModule(defaultModule);
+        assertEq(icClient.defaultModule(), defaultModule);
     }
 
-    function test_setLinkedClient_setsLinkedClient() public {
+    function test_setDefaultModule_revert_zeroAddress() public {
+        expectRevertModuleZeroAddress();
+        setDefaultModule(address(0));
+    }
+
+    function test_setDefaultModule_revert_notOwner(address caller) public {
+        vm.assume(caller != owner);
+        expectRevertOwnableUnauthorizedAccount(caller);
+        vm.prank(caller);
+        icClient.setDefaultModule(defaultModule);
+    }
+
+    function test_setLinkedClient() public {
+        expectEventLinkedClientSet(REMOTE_CHAIN_ID, MOCK_REMOTE_CLIENT);
         setLinkedClient(REMOTE_CHAIN_ID, MOCK_REMOTE_CLIENT);
         assertEq(icClient.getLinkedClient(REMOTE_CHAIN_ID), MOCK_REMOTE_CLIENT);
+    }
+
+    function test_setLinkedClient_success_zeroClient() public {
+        expectEventLinkedClientSet(REMOTE_CHAIN_ID, 0);
+        setLinkedClient(REMOTE_CHAIN_ID, 0);
+        assertEq(icClient.getLinkedClient(REMOTE_CHAIN_ID), 0);
     }
 
     function test_setLinkedClient_revert_notOwner(address caller) public {

--- a/packages/contracts-communication/test/mocks/InterchainClientV1Mock.sol
+++ b/packages/contracts-communication/test/mocks/InterchainClientV1Mock.sol
@@ -9,7 +9,9 @@ import {
 
 // solhint-disable no-empty-blocks
 contract InterchainClientV1Mock is IInterchainClientV1 {
-    function setDefaultGuard(address guard_) external {}
+    function setDefaultGuard(address guard) external {}
+
+    function setDefaultModule(address module) external {}
 
     function setLinkedClient(uint64 chainId, bytes32 client) external {}
 


### PR DESCRIPTION
**Description**
Following spec is implemented:

- If the app returns an empty set of trusted modules, a set of a single “Default Module” (as defined in the Client) is used instead.
- If the app uses a zero amount of required responses, the amount of modules in the trusted set is used instead.

**Notes**

- App that doesn’t define the modules nor required responses is effectively using a 1/1 default module setup without a guard.
    - This app could set the required responses to at least `2` to avoid receiving messages.
- App that uses `N` modules but doesn’t define a required responses count (for w/e reason) is effectively using a N/N setup with this spec.
    - Likewise, app could avoid receiving messages by setting the required responses to at least `N+1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced the ability for contract owners to set a default module address, enhancing flexibility and control over contract interactions.
	- Added new test functions related to executing with 0 required responses and different guard configurations.
- **Enhancements**
	- Updated event descriptions for clearer communication regarding settings changes in the system.
	- Added a TODO comment to remind adding tests for 0 and 1 modules.
- **Bug Fixes**
	- Adjusted logic to support scenarios where no modules are required or zero responses are needed, ensuring robustness in diverse operational contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->