### PR TITLE
fix(solidity-devops): update forge-std to 1.8.2

### DIFF
--- a/packages/solidity-devops/package.json
+++ b/packages/solidity-devops/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "chalk": "^4.1.2",
     "dotenv": "^16.4.5",
-    "forge-std": "github:foundry-rs/forge-std#v1.8.1"
+    "forge-std": "github:foundry-rs/forge-std#v1.8.2"
   },
   "bin": {
     "fsr": "js/forgeScriptRun.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19272,9 +19272,9 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==
 
-"forge-std@github:foundry-rs/forge-std#v1.8.1":
-  version "1.7.6"
-  resolved "https://codeload.github.com/foundry-rs/forge-std/tar.gz/bb4ceea94d6f10eeb5b41dc2391c6c8bf8e734ef"
+"forge-std@github:foundry-rs/forge-std#v1.8.2":
+  version "1.8.2"
+  resolved "https://codeload.github.com/foundry-rs/forge-std/tar.gz/978ac6fadb62f5f0b723c996f64be52eddba6801"
 
 fork-ts-checker-webpack-plugin@^4.1.6:
   version "4.1.6"


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**
A clear and concise description of the features you're adding in this pull request.

**Additional context**
Add any other context about the problem you're solving.

**Metadata**
- Fixes #[Link to Issue]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Enhanced development tool reliability by updating the `forge-std` package to version 1.8.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->