### PR TITLE
RFQ API: add GET /ack endpoint

### DIFF
--- a/services/rfq/api/client/client.go
+++ b/services/rfq/api/client/client.go
@@ -34,7 +34,7 @@ type UnauthenticatedClient interface {
 	GetAllQuotes(ctx context.Context) ([]*model.GetQuoteResponse, error)
 	GetSpecificQuote(ctx context.Context, q *model.GetQuoteSpecificRequest) ([]*model.GetQuoteResponse, error)
 	GetQuoteByRelayerAddress(ctx context.Context, relayerAddr string) ([]*model.GetQuoteResponse, error)
-	GetRelayAck(ctx context.Context, txID string) (*model.GetRelayAckResponse, error)
+	GetRelayAck(ctx context.Context, txID string) (*model.PutRelayAckResponse, error)
 	resty() *resty.Client
 }
 
@@ -190,8 +190,8 @@ func (c *unauthenticatedClient) GetQuoteByRelayerAddress(ctx context.Context, re
 	return quotes, nil
 }
 
-func (c *unauthenticatedClient) GetRelayAck(ctx context.Context, txID string) (*model.GetRelayAckResponse, error) {
-	var ack *model.GetRelayAckResponse
+func (c *unauthenticatedClient) GetRelayAck(ctx context.Context, txID string) (*model.PutRelayAckResponse, error) {
+	var ack *model.PutRelayAckResponse
 	resp, err := c.rClient.R().
 		SetContext(ctx).
 		SetQueryParams(map[string]string{

--- a/services/rfq/api/config/config.go
+++ b/services/rfq/api/config/config.go
@@ -27,7 +27,7 @@ type Config struct {
 	RelayAckTimeout time.Duration     `yaml:"relay_ack_timeout"`
 }
 
-const defaultRelayAckTimeout = 5 * time.Second
+const defaultRelayAckTimeout = 10 * time.Second
 
 // GetRelayAckTimeout returns the relay ack timeout.
 func (c Config) GetRelayAckTimeout() time.Duration {

--- a/services/rfq/api/config/config.go
+++ b/services/rfq/api/config/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/jftuga/ellipsis"
 	"gopkg.in/yaml.v2"
@@ -21,8 +22,19 @@ type Config struct {
 	Database   DatabaseConfig `yaml:"database"`
 	OmniRPCURL string         `yaml:"omnirpc_url"`
 	// bridges is a map of chainid->address
-	Bridges map[uint32]string `yaml:"bridges"`
-	Port    string            `yaml:"port"`
+	Bridges         map[uint32]string `yaml:"bridges"`
+	Port            string            `yaml:"port"`
+	RelayAckTimeout time.Duration     `yaml:"relay_ack_timeout"`
+}
+
+const defaultRelayAckTimeout = 5 * time.Second
+
+// GetRelayAckTimeout returns the relay ack timeout.
+func (c Config) GetRelayAckTimeout() time.Duration {
+	if c.RelayAckTimeout == 0 {
+		return defaultRelayAckTimeout
+	}
+	return c.RelayAckTimeout
 }
 
 // LoadConfig loads the config from the given path.

--- a/services/rfq/api/config/config.go
+++ b/services/rfq/api/config/config.go
@@ -27,7 +27,7 @@ type Config struct {
 	RelayAckTimeout time.Duration     `yaml:"relay_ack_timeout"`
 }
 
-const defaultRelayAckTimeout = 10 * time.Second
+const defaultRelayAckTimeout = 30 * time.Second
 
 // GetRelayAckTimeout returns the relay ack timeout.
 func (c Config) GetRelayAckTimeout() time.Duration {

--- a/services/rfq/api/docs/docs.go
+++ b/services/rfq/api/docs/docs.go
@@ -15,6 +15,37 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/ack": {
+            "put": {
+                "description": "cache an ack request to synchronize relayer actions.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ack"
+                ],
+                "summary": "Relay ack",
+                "parameters": [
+                    {
+                        "description": "query params",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.PutQuoteRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
         "/quotes": {
             "get": {
                 "description": "get quotes from all relayers.",

--- a/services/rfq/api/docs/swagger.json
+++ b/services/rfq/api/docs/swagger.json
@@ -4,6 +4,37 @@
         "contact": {}
     },
     "paths": {
+        "/ack": {
+            "put": {
+                "description": "cache an ack request to synchronize relayer actions.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ack"
+                ],
+                "summary": "Relay ack",
+                "parameters": [
+                    {
+                        "description": "query params",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.PutQuoteRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
         "/quotes": {
             "get": {
                 "description": "get quotes from all relayers.",

--- a/services/rfq/api/docs/swagger.yaml
+++ b/services/rfq/api/docs/swagger.yaml
@@ -67,6 +67,26 @@ definitions:
 info:
   contact: {}
 paths:
+  /ack:
+    put:
+      consumes:
+      - application/json
+      description: cache an ack request to synchronize relayer actions.
+      parameters:
+      - description: query params
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/model.PutQuoteRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+      summary: Relay ack
+      tags:
+      - ack
   /quotes:
     get:
       consumes:

--- a/services/rfq/api/model/request.go
+++ b/services/rfq/api/model/request.go
@@ -13,6 +13,12 @@ type PutQuoteRequest struct {
 	DestFastBridgeAddress   string `json:"dest_fast_bridge_address"`
 }
 
+// PutAckRequest contains the schema for a PUT /ack request.
+type PutAckRequest struct {
+	TxID        string `json:"tx_id"`
+	DestChainID int    `json:"dest_chain_id"`
+}
+
 // GetQuoteSpecificRequest contains the schema for a GET /quote request with specific params.
 type GetQuoteSpecificRequest struct {
 	OriginChainID   int    `json:"originChainId"`

--- a/services/rfq/api/model/response.go
+++ b/services/rfq/api/model/response.go
@@ -32,4 +32,6 @@ type PutRelayAckResponse struct {
 	TransactionID string `json:"tx_id"`
 	// ShouldRelay is a boolean indicating whether the transaction should be relayed
 	ShouldRelay bool `json:"should_relay"`
+	// RelayerAddress is the address of the relayer that is currently acked
+	RelayerAddress string `json:"relayer_address"`
 }

--- a/services/rfq/api/model/response.go
+++ b/services/rfq/api/model/response.go
@@ -26,8 +26,8 @@ type GetQuoteResponse struct {
 	UpdatedAt string `json:"updated_at"`
 }
 
-// GetRelayAckResponse contains the schema for a GET /relay/ack response.
-type GetRelayAckResponse struct {
+// PutRelayAckResponse contains the schema for a PUT /relay/ack response.
+type PutRelayAckResponse struct {
 	// TxID is the transaction ID
 	TransactionID string `json:"tx_id"`
 	// ShouldRelay is a boolean indicating whether the transaction should be relayed

--- a/services/rfq/api/model/response.go
+++ b/services/rfq/api/model/response.go
@@ -25,3 +25,11 @@ type GetQuoteResponse struct {
 	// UpdatedAt is the time that the quote was last upserted
 	UpdatedAt string `json:"updated_at"`
 }
+
+// GetRelayAckResponse contains the schema for a GET /relay/ack response.
+type GetRelayAckResponse struct {
+	// TxID is the transaction ID
+	TransactionID string `json:"tx_id"`
+	// ShouldRelay is a boolean indicating whether the transaction should be relayed
+	ShouldRelay bool `json:"should_relay"`
+}

--- a/services/rfq/api/rest/server.go
+++ b/services/rfq/api/rest/server.go
@@ -165,10 +165,17 @@ func (r *QuoterAPIServer) AuthMiddleware() gin.HandlerFunc {
 		var destChainID uint32
 		var err error
 
-		fmt.Printf("PATH: %v\n", c.Request.URL.Path)
+		// Parse the dest chain id from the request
 		switch c.Request.URL.Path {
 		case QuoteRoute:
 			var req model.PutQuoteRequest
+			err = c.BindJSON(&req)
+			if err == nil {
+				destChainID = uint32(req.DestChainID)
+				loggedRequest = &req
+			}
+		case AckRoute:
+			var req model.PutAckRequest
 			err = c.BindJSON(&req)
 			if err == nil {
 				destChainID = uint32(req.DestChainID)

--- a/services/rfq/api/rest/server.go
+++ b/services/rfq/api/rest/server.go
@@ -114,6 +114,7 @@ func NewAPI(
 // QuoteRoute is the API endpoint for handling quote related requests.
 const (
 	QuoteRoute    = "/quotes"
+	AckRoute      = "/ack"
 	cacheInterval = time.Minute
 )
 
@@ -133,6 +134,7 @@ func (r *QuoterAPIServer) Run(ctx context.Context) error {
 	// GET routes without the AuthMiddleware
 	// engine.PUT("/quotes", h.ModifyQuote)
 	engine.GET(QuoteRoute, h.GetQuotes)
+	engine.GET(AckRoute, r.GetRelayAck)
 
 	r.engine = engine
 

--- a/services/rfq/api/rest/server.go
+++ b/services/rfq/api/rest/server.go
@@ -244,6 +244,10 @@ func (r *QuoterAPIServer) checkRole(c *gin.Context, destChainID uint32) (address
 }
 
 // PutRelayAck checks if a relay is pending or not.
+// Note that the ack is not binding; that is, any relayer can still relay the transaction
+// on chain if they ignore the response to this call.
+// Also, this will not work if the API is run on multiple servers, since there is no inter-server
+// communication to maintain the cache.
 //
 // PUT /ack.
 // @dev Protected Method: Authentication is handled through middleware in server.go.

--- a/services/rfq/api/rest/server.go
+++ b/services/rfq/api/rest/server.go
@@ -244,6 +244,18 @@ func (r *QuoterAPIServer) checkRole(c *gin.Context, destChainID uint32) (address
 }
 
 // PutRelayAck checks if a relay is pending or not.
+//
+// PUT /ack.
+// @dev Protected Method: Authentication is handled through middleware in server.go.
+// @Summary Relay ack
+// @Schemes
+// @Description cache an ack request to synchronize relayer actions.
+// @Param request body model.PutQuoteRequest true "query params"
+// @Tags ack
+// @Accept json
+// @Produce json
+// @Success 200
+// @Router /ack [put].
 func (r *QuoterAPIServer) PutRelayAck(c *gin.Context) {
 	req, exists := c.Get("putRequest")
 	if !exists {

--- a/services/rfq/api/rest/server.go
+++ b/services/rfq/api/rest/server.go
@@ -212,9 +212,9 @@ func (r *QuoterAPIServer) AuthMiddleware() gin.HandlerFunc {
 
 // GetRelayAck checks if a relay is pending or not.
 func (r *QuoterAPIServer) GetRelayAck(c *gin.Context) {
-	transactionID := c.Query("transaction_id")
+	transactionID := c.Query("id")
 	if transactionID == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Must specify 'txID'"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Must specify 'id'"})
 		return
 	}
 

--- a/services/rfq/api/rest/server_test.go
+++ b/services/rfq/api/rest/server_test.go
@@ -217,10 +217,10 @@ func (c *ServerSuite) TestGetAck() {
 	c.Equal(http.StatusOK, resp.StatusCode)
 
 	// Expect ack with shouldRelay=true
-	var result relapi.GetRelayAckResponse
+	var result relapi.PutRelayAckResponse
 	err = json.NewDecoder(resp.Body).Decode(&result)
 	c.Require().NoError(err)
-	expectedResult := relapi.GetRelayAckResponse{
+	expectedResult := relapi.PutRelayAckResponse{
 		TxID:        testTxID,
 		ShouldRelay: true,
 	}
@@ -238,7 +238,7 @@ func (c *ServerSuite) TestGetAck() {
 	// Expect ack with shouldRelay=false
 	err = json.NewDecoder(resp.Body).Decode(&result)
 	c.Require().NoError(err)
-	expectedResult = relapi.GetRelayAckResponse{
+	expectedResult = relapi.PutRelayAckResponse{
 		TxID:        testTxID,
 		ShouldRelay: false,
 	}

--- a/services/rfq/api/rest/server_test.go
+++ b/services/rfq/api/rest/server_test.go
@@ -220,8 +220,9 @@ func (c *ServerSuite) TestPutAck() {
 	err = json.NewDecoder(resp.Body).Decode(&result)
 	c.Require().NoError(err)
 	expectedResult := relapi.PutRelayAckResponse{
-		TxID:        testTxID,
-		ShouldRelay: true,
+		TxID:           testTxID,
+		ShouldRelay:    true,
+		RelayerAddress: c.testWallet.Address().Hex(),
 	}
 	c.Equal(expectedResult, result)
 	err = resp.Body.Close()
@@ -238,8 +239,9 @@ func (c *ServerSuite) TestPutAck() {
 	err = json.NewDecoder(resp.Body).Decode(&result)
 	c.Require().NoError(err)
 	expectedResult = relapi.PutRelayAckResponse{
-		TxID:        testTxID,
-		ShouldRelay: false,
+		TxID:           testTxID,
+		ShouldRelay:    false,
+		RelayerAddress: c.testWallet.Address().Hex(),
 	}
 	c.Equal(expectedResult, result)
 	err = resp.Body.Close()

--- a/services/rfq/relayer/quoter/quoter.go
+++ b/services/rfq/relayer/quoter/quoter.go
@@ -78,15 +78,11 @@ type Manager struct {
 }
 
 // NewQuoterManager creates a new QuoterManager.
-func NewQuoterManager(config relconfig.Config, metricsHandler metrics.Handler, inventoryManager inventory.Manager, relayerSigner signer.Signer, feePricer pricer.FeePricer) (Quoter, error) {
-	apiClient, err := rfqAPIClient.NewAuthenticatedClient(metricsHandler, config.GetRfqAPIURL(), relayerSigner)
-	if err != nil {
-		return nil, fmt.Errorf("error creating RFQ API client: %w", err)
-	}
-
+func NewQuoterManager(config relconfig.Config, metricsHandler metrics.Handler, inventoryManager inventory.Manager, relayerSigner signer.Signer, feePricer pricer.FeePricer, apiClient rfqAPIClient.AuthenticatedClient) (Quoter, error) {
 	qt := make(map[string][]string)
 
 	// fix any casing issues.
+	var err error
 	for tokenID, destTokenIDs := range config.QuotableTokens {
 		processedDestTokens := make([]string, len(destTokenIDs))
 		for i := range destTokenIDs {

--- a/services/rfq/relayer/quoter/quoter_test.go
+++ b/services/rfq/relayer/quoter/quoter_test.go
@@ -231,7 +231,7 @@ func (s *QuoterSuite) setGasSufficiency(sufficient bool) {
 	feePricer := pricer.NewFeePricer(s.config, clientFetcher, priceFetcher, metrics.NewNullHandler())
 	inventoryManager := new(inventoryMocks.Manager)
 	inventoryManager.On(testsuite.GetFunctionName(inventoryManager.HasSufficientGas), mock.Anything, mock.Anything, mock.Anything).Return(sufficient, nil)
-	mgr, err := quoter.NewQuoterManager(s.config, metrics.NewNullHandler(), inventoryManager, nil, feePricer)
+	mgr, err := quoter.NewQuoterManager(s.config, metrics.NewNullHandler(), inventoryManager, nil, feePricer, nil)
 	s.NoError(err)
 
 	var ok bool

--- a/services/rfq/relayer/quoter/suite_test.go
+++ b/services/rfq/relayer/quoter/suite_test.go
@@ -116,7 +116,7 @@ func (s *QuoterSuite) SetupTest() {
 
 	inventoryManager := new(inventoryMocks.Manager)
 	inventoryManager.On(testsuite.GetFunctionName(inventoryManager.HasSufficientGas), mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
-	mgr, err := quoter.NewQuoterManager(s.config, metrics.NewNullHandler(), inventoryManager, nil, feePricer)
+	mgr, err := quoter.NewQuoterManager(s.config, metrics.NewNullHandler(), inventoryManager, nil, feePricer, nil)
 	s.NoError(err)
 
 	var ok bool

--- a/services/rfq/relayer/relapi/handler.go
+++ b/services/rfq/relayer/relapi/handler.go
@@ -60,7 +60,7 @@ func (h *Handler) GetQuoteRequestStatusByTxHash(c *gin.Context) {
 func (h *Handler) GetQuoteRequestStatusByTxID(c *gin.Context) {
 	txIDStr := c.Query("id")
 	if txIDStr == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Must specify 'txID'"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Must specify 'id'"})
 		return
 	}
 

--- a/services/rfq/relayer/relapi/model.go
+++ b/services/rfq/relayer/relapi/model.go
@@ -18,6 +18,7 @@ type GetTxRetryResponse struct {
 
 // PutRelayAckResponse contains the schema for a POST /relay/ack response.
 type PutRelayAckResponse struct {
-	TxID        string `json:"tx_id"`
-	ShouldRelay bool   `json:"should_relay"`
+	TxID           string `json:"tx_id"`
+	ShouldRelay    bool   `json:"should_relay"`
+	RelayerAddress string `json:"relayer_address"`
 }

--- a/services/rfq/relayer/relapi/model.go
+++ b/services/rfq/relayer/relapi/model.go
@@ -15,3 +15,9 @@ type GetTxRetryResponse struct {
 	Nonce     uint64 `json:"nonce"`
 	GasAmount string `json:"gas_amount"`
 }
+
+// GetRelayAckResponse contains the schema for a POST /relay/ack response.
+type GetRelayAckResponse struct {
+	TxID        string `json:"tx_id"`
+	ShouldRelay bool   `json:"should_relay"`
+}

--- a/services/rfq/relayer/relapi/model.go
+++ b/services/rfq/relayer/relapi/model.go
@@ -16,8 +16,8 @@ type GetTxRetryResponse struct {
 	GasAmount string `json:"gas_amount"`
 }
 
-// GetRelayAckResponse contains the schema for a POST /relay/ack response.
-type GetRelayAckResponse struct {
+// PutRelayAckResponse contains the schema for a POST /relay/ack response.
+type PutRelayAckResponse struct {
 	TxID        string `json:"tx_id"`
 	ShouldRelay bool   `json:"should_relay"`
 }

--- a/services/rfq/relayer/service/handlers.go
+++ b/services/rfq/relayer/service/handlers.go
@@ -157,8 +157,13 @@ func (q *QuoteRequestHandler) handleSeen(ctx context.Context, span trace.Span, r
 	if err != nil {
 		return fmt.Errorf("could not get relay ack: %w", err)
 	}
+	span.SetAttributes(
+		attribute.String("transaction_id", hexutil.Encode(request.TransactionID[:])),
+		attribute.Bool("should_relay", resp.ShouldRelay),
+		attribute.String("relayer_address", resp.RelayerAddress),
+	)
 	if !resp.ShouldRelay {
-		span.SetAttributes(attribute.Bool("should_relay", false))
+		span.AddEvent("not relaying due to ack")
 		return nil
 	}
 

--- a/services/rfq/relayer/service/handlers.go
+++ b/services/rfq/relayer/service/handlers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/synapsecns/sanguine/core/metrics"
+	"github.com/synapsecns/sanguine/services/rfq/api/model"
 	"github.com/synapsecns/sanguine/services/rfq/contracts/fastbridge"
 	"github.com/synapsecns/sanguine/services/rfq/relayer/inventory"
 	"github.com/synapsecns/sanguine/services/rfq/relayer/reldb"
@@ -148,7 +149,11 @@ func (q *QuoteRequestHandler) handleSeen(ctx context.Context, span trace.Span, r
 	}
 
 	// get ack from API to synchronize calls with other relayers and avoid reverts
-	resp, err := q.apiClient.GetRelayAck(ctx, hexutil.Encode(request.TransactionID[:]))
+	req := model.PutAckRequest{
+		TxID:        hexutil.Encode(request.TransactionID[:]),
+		DestChainID: int(request.Transaction.DestChainId),
+	}
+	resp, err := q.apiClient.PutRelayAck(ctx, &req)
 	if err != nil {
 		return fmt.Errorf("could not get relay ack: %w", err)
 	}

--- a/services/rfq/relayer/service/relayer.go
+++ b/services/rfq/relayer/service/relayer.go
@@ -41,7 +41,7 @@ type Relayer struct {
 	client         omniClient.RPCClient
 	chainListeners map[int]listener.ContractListener
 	apiServer      *relapi.RelayerAPIServer
-	apiClient      rfqAPIClient.UnauthenticatedClient
+	apiClient      rfqAPIClient.AuthenticatedClient
 	inventory      inventory.Manager
 	quoter         quoter.Quoter
 	submitter      submitter.TransactionSubmitter
@@ -122,7 +122,7 @@ func NewRelayer(ctx context.Context, metricHandler metrics.Handler, cfg relconfi
 		return nil, fmt.Errorf("could not get api server: %w", err)
 	}
 
-	apiClient, err := rfqAPIClient.NewUnauthenticatedClient(metricHandler, cfg.GetRfqAPIURL())
+	apiClient, err := rfqAPIClient.NewAuthenticatedClient(metricHandler, cfg.GetRfqAPIURL(), sg)
 	if err != nil {
 		return nil, fmt.Errorf("error creating RFQ API client: %w", err)
 	}

--- a/services/rfq/relayer/service/relayer.go
+++ b/services/rfq/relayer/service/relayer.go
@@ -21,6 +21,7 @@ import (
 	cctpSql "github.com/synapsecns/sanguine/services/cctp-relayer/db/sql"
 	"github.com/synapsecns/sanguine/services/cctp-relayer/relayer"
 	omniClient "github.com/synapsecns/sanguine/services/omnirpc/client"
+	rfqAPIClient "github.com/synapsecns/sanguine/services/rfq/api/client"
 	"github.com/synapsecns/sanguine/services/rfq/contracts/fastbridge"
 	"github.com/synapsecns/sanguine/services/rfq/relayer/inventory"
 	"github.com/synapsecns/sanguine/services/rfq/relayer/pricer"
@@ -40,6 +41,7 @@ type Relayer struct {
 	client         omniClient.RPCClient
 	chainListeners map[int]listener.ContractListener
 	apiServer      *relapi.RelayerAPIServer
+	apiClient      rfqAPIClient.UnauthenticatedClient
 	inventory      inventory.Manager
 	quoter         quoter.Quoter
 	submitter      submitter.TransactionSubmitter
@@ -120,6 +122,11 @@ func NewRelayer(ctx context.Context, metricHandler metrics.Handler, cfg relconfi
 		return nil, fmt.Errorf("could not get api server: %w", err)
 	}
 
+	apiClient, err := rfqAPIClient.NewUnauthenticatedClient(metricHandler, cfg.GetRfqAPIURL())
+	if err != nil {
+		return nil, fmt.Errorf("error creating RFQ API client: %w", err)
+	}
+
 	cache := ttlcache.New[common.Hash, bool](ttlcache.WithTTL[common.Hash, bool](time.Second * 30))
 	rel := Relayer{
 		db:             store,
@@ -134,6 +141,7 @@ func NewRelayer(ctx context.Context, metricHandler metrics.Handler, cfg relconfi
 		signer:         sg,
 		chainListeners: chainListeners,
 		apiServer:      apiServer,
+		apiClient:      apiClient,
 	}
 	return &rel, nil
 }

--- a/services/rfq/relayer/service/statushandler.go
+++ b/services/rfq/relayer/service/statushandler.go
@@ -44,7 +44,7 @@ type QuoteRequestHandler struct {
 	// metrics is the metrics handler.
 	metrics metrics.Handler
 	// apiClient is used to get acks before submitting a relay transaction.
-	apiClient client.UnauthenticatedClient
+	apiClient client.AuthenticatedClient
 }
 
 // Handler is the handler for a quote request.

--- a/services/rfq/relayer/service/statushandler.go
+++ b/services/rfq/relayer/service/statushandler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/jellydator/ttlcache/v3"
 	"github.com/synapsecns/sanguine/core/metrics"
+	"github.com/synapsecns/sanguine/services/rfq/api/client"
 	"github.com/synapsecns/sanguine/services/rfq/relayer/chain"
 	"github.com/synapsecns/sanguine/services/rfq/relayer/inventory"
 	"github.com/synapsecns/sanguine/services/rfq/relayer/quoter"
@@ -42,6 +43,8 @@ type QuoteRequestHandler struct {
 	RelayerAddress common.Address
 	// metrics is the metrics handler.
 	metrics metrics.Handler
+	// apiClient is used to get acks before submitting a relay transaction.
+	apiClient client.UnauthenticatedClient
 }
 
 // Handler is the handler for a quote request.
@@ -68,6 +71,7 @@ func (r *Relayer) requestToHandler(ctx context.Context, req reldb.QuoteRequest) 
 		metrics:        r.metrics,
 		RelayerAddress: r.signer.Address(),
 		claimCache:     r.claimCache,
+		apiClient:      r.apiClient,
 	}
 
 	qr.handlers[reldb.Seen] = r.deadlineMiddleware(r.gasMiddleware(qr.handleSeen))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit



- **New Features**
  - Added a new endpoint `/ack` with a `PUT` method for caching acknowledgment requests in the API.
  - Added relay acknowledgment functionality to the client interfaces for handling relay synchronization.

- **Enhancements**
  - Updated the API documentation to include the new `/ack` endpoint.
  - Improved request handling by incorporating relay acknowledgment checks to prevent reverts.

- **Testing**
  - Added new test functions to verify the PUT acknowledgment requests and relay responses.

- **Internal Improvements**
  - Refactored `QuoterManager` and `Relayer` to include additional parameters for better relay handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->