### PR TITLE
Adjusts banner date

### DIFF
--- a/packages/synapse-interface/components/layouts/LandingPageWrapper/index.tsx
+++ b/packages/synapse-interface/components/layouts/LandingPageWrapper/index.tsx
@@ -54,7 +54,7 @@ export function LandingPageWrapper({ children }: { children: any }) {
           bannerId="2024-05-02-scroll-launch"
           bannerContents="Synapse Protocol now available on Scroll"
           startDate={new Date('2024-05-08T18:45:09+00:00')}
-          endDate={new Date('2024-05-27T18:45:09+00:00')}
+          endDate={new Date('2024-06-15T18:45:09+00:00')}
         />
         <MaintenanceBanners />
         <LandingNav />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Extended the display duration of the Synapse Protocol availability banner on the landing page to June 15, 2024.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
8095f7d86afb7689f9703b705677fd2f92ea4724: [synapse-interface preview link ](https://sanguine-synapse-interface-qt1pfbopz-synapsecns.vercel.app)