### PR TITLE
make poll interval a setting

### DIFF
--- a/ethergo/listener/listener.go
+++ b/ethergo/listener/listener.go
@@ -29,8 +29,6 @@ type ContractListener interface {
 	LatestBlock() uint64
 	// Address gets the address of the contract this listener is listening to
 	Address() common.Address
-	// SetPollInterval sets the poll interval for the listener.
-	SetPollInterval(duration time.Duration)
 }
 
 // HandleLog is the handler for a log event
@@ -61,12 +59,13 @@ var (
 // NewChainListener creates a new chain listener.
 func NewChainListener(omnirpcClient client.EVM, store listenerDB.ChainListenerDB, address common.Address, initialBlock uint64, handler metrics.Handler, options ...Option) (ContractListener, error) {
 	c := &chainListener{
-		handler:      handler,
-		address:      address,
-		initialBlock: initialBlock,
-		store:        store,
-		client:       omnirpcClient,
-		backoff:      newBackoffConfig(),
+		handler:             handler,
+		address:             address,
+		initialBlock:        initialBlock,
+		store:               store,
+		client:              omnirpcClient,
+		backoff:             newBackoffConfig(),
+		pollIntervalSetting: time.Millisecond * 50,
 	}
 
 	for _, option := range options {
@@ -80,10 +79,6 @@ func NewChainListener(omnirpcClient client.EVM, store listenerDB.ChainListenerDB
 const (
 	maxGetLogsRange = 2000
 )
-
-func (c *chainListener) SetPollInterval(duration time.Duration) {
-	c.pollIntervalSetting = duration
-}
 
 func (c *chainListener) Listen(ctx context.Context, handler HandleLog) (err error) {
 	c.startBlock, c.chainID, err = c.getMetadata(ctx)

--- a/ethergo/listener/options.go
+++ b/ethergo/listener/options.go
@@ -1,6 +1,9 @@
 package listener
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // Option is a functional option for chainListener.
 type Option func(*chainListener)
@@ -12,5 +15,12 @@ type NewBlockHandler func(ctx context.Context, block uint64) error
 func WithNewBlockHandler(handler NewBlockHandler) Option {
 	return func(c *chainListener) {
 		c.newBlockHandler = handler
+	}
+}
+
+// WithPollInterval sets the poll interval.
+func WithPollInterval(interval time.Duration) Option {
+	return func(c *chainListener) {
+		c.pollIntervalSetting = interval
 	}
 }


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**

Makes poll interval an optional setting rather than an ex-post facto setting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a customizable poll interval setting for contract listeners, allowing users to set their preferred polling frequency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->