### PR TITLE
FeePricer: use different multipliers for quote / relay

### DIFF
--- a/services/rfq/relayer/pricer/fee_pricer.go
+++ b/services/rfq/relayer/pricer/fee_pricer.go
@@ -21,11 +21,11 @@ type FeePricer interface {
 	// Start starts the fee pricer.
 	Start(ctx context.Context)
 	// GetOriginFee returns the total fee for a given chainID and gas limit, denominated in a given token.
-	GetOriginFee(ctx context.Context, origin, destination uint32, denomToken string, isRelay bool) (*big.Int, error)
+	GetOriginFee(ctx context.Context, origin, destination uint32, denomToken string, isQuote bool) (*big.Int, error)
 	// GetDestinationFee returns the total fee for a given chainID and gas limit, denominated in a given token.
-	GetDestinationFee(ctx context.Context, origin, destination uint32, denomToken string, isRelay bool) (*big.Int, error)
+	GetDestinationFee(ctx context.Context, origin, destination uint32, denomToken string, isQuote bool) (*big.Int, error)
 	// GetTotalFee returns the total fee for a given origin and destination chainID, denominated in a given token.
-	GetTotalFee(ctx context.Context, origin, destination uint32, denomToken string, isRelay bool) (*big.Int, error)
+	GetTotalFee(ctx context.Context, origin, destination uint32, denomToken string, isQuote bool) (*big.Int, error)
 	// GetGasPrice returns the gas price for a given chainID in native units.
 	GetGasPrice(ctx context.Context, chainID uint32) (*big.Int, error)
 }
@@ -81,13 +81,13 @@ func (f *feePricer) Start(ctx context.Context) {
 
 var nativeDecimalsFactor = new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(18)), nil)
 
-func (f *feePricer) GetOriginFee(parentCtx context.Context, origin, destination uint32, denomToken string, isRelay bool) (*big.Int, error) {
+func (f *feePricer) GetOriginFee(parentCtx context.Context, origin, destination uint32, denomToken string, isQuote bool) (*big.Int, error) {
 	var err error
 	ctx, span := f.handler.Tracer().Start(parentCtx, "getOriginFee", trace.WithAttributes(
 		attribute.Int(metrics.Origin, int(origin)),
 		attribute.Int(metrics.Destination, int(destination)),
 		attribute.String("denom_token", denomToken),
-		attribute.Bool("is_relay", isRelay),
+		attribute.Bool("is_quote", isQuote),
 	))
 	defer func() {
 		metrics.EndSpanWithErr(span, err)
@@ -98,7 +98,7 @@ func (f *feePricer) GetOriginFee(parentCtx context.Context, origin, destination 
 	if err != nil {
 		return nil, fmt.Errorf("could not get origin gas estimate: %w", err)
 	}
-	fee, err := f.getFee(ctx, origin, destination, gasEstimate, denomToken, isRelay)
+	fee, err := f.getFee(ctx, origin, destination, gasEstimate, denomToken, isQuote)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +106,7 @@ func (f *feePricer) GetOriginFee(parentCtx context.Context, origin, destination 
 	// If specified, calculate and add the L1 fee
 	l1ChainID, l1GasEstimate, useL1Fee := f.config.GetL1FeeParams(origin, true)
 	if useL1Fee {
-		l1Fee, err := f.getFee(ctx, l1ChainID, destination, l1GasEstimate, denomToken, isRelay)
+		l1Fee, err := f.getFee(ctx, l1ChainID, destination, l1GasEstimate, denomToken, isQuote)
 		if err != nil {
 			return nil, err
 		}
@@ -117,12 +117,12 @@ func (f *feePricer) GetOriginFee(parentCtx context.Context, origin, destination 
 	return fee, nil
 }
 
-func (f *feePricer) GetDestinationFee(parentCtx context.Context, _, destination uint32, denomToken string, isRelay bool) (*big.Int, error) {
+func (f *feePricer) GetDestinationFee(parentCtx context.Context, _, destination uint32, denomToken string, isQuote bool) (*big.Int, error) {
 	var err error
 	ctx, span := f.handler.Tracer().Start(parentCtx, "getDestinationFee", trace.WithAttributes(
 		attribute.Int(metrics.Destination, int(destination)),
 		attribute.String("denom_token", denomToken),
-		attribute.Bool("is_relay", isRelay),
+		attribute.Bool("is_quote", isQuote),
 	))
 	defer func() {
 		metrics.EndSpanWithErr(span, err)
@@ -133,7 +133,7 @@ func (f *feePricer) GetDestinationFee(parentCtx context.Context, _, destination 
 	if err != nil {
 		return nil, fmt.Errorf("could not get dest gas estimate: %w", err)
 	}
-	fee, err := f.getFee(ctx, destination, destination, gasEstimate, denomToken, isRelay)
+	fee, err := f.getFee(ctx, destination, destination, gasEstimate, denomToken, isQuote)
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +141,7 @@ func (f *feePricer) GetDestinationFee(parentCtx context.Context, _, destination 
 	// If specified, calculate and add the L1 fee
 	l1ChainID, l1GasEstimate, useL1Fee := f.config.GetL1FeeParams(destination, false)
 	if useL1Fee {
-		l1Fee, err := f.getFee(ctx, l1ChainID, destination, l1GasEstimate, denomToken, isRelay)
+		l1Fee, err := f.getFee(ctx, l1ChainID, destination, l1GasEstimate, denomToken, isQuote)
 		if err != nil {
 			return nil, err
 		}
@@ -152,26 +152,26 @@ func (f *feePricer) GetDestinationFee(parentCtx context.Context, _, destination 
 	return fee, nil
 }
 
-func (f *feePricer) GetTotalFee(parentCtx context.Context, origin, destination uint32, denomToken string, isRelay bool) (_ *big.Int, err error) {
+func (f *feePricer) GetTotalFee(parentCtx context.Context, origin, destination uint32, denomToken string, isQuote bool) (_ *big.Int, err error) {
 	ctx, span := f.handler.Tracer().Start(parentCtx, "getTotalFee", trace.WithAttributes(
 		attribute.Int(metrics.Origin, int(origin)),
 		attribute.Int(metrics.Destination, int(destination)),
 		attribute.String("denom_token", denomToken),
-		attribute.Bool("is_relay", isRelay),
+		attribute.Bool("is_quote", isQuote),
 	))
 
 	defer func() {
 		metrics.EndSpanWithErr(span, err)
 	}()
 
-	originFee, err := f.GetOriginFee(ctx, origin, destination, denomToken, isRelay)
+	originFee, err := f.GetOriginFee(ctx, origin, destination, denomToken, isQuote)
 	if err != nil {
 		span.AddEvent("could not get origin fee", trace.WithAttributes(
 			attribute.String("error", err.Error()),
 		))
 		return nil, err
 	}
-	destFee, err := f.GetDestinationFee(ctx, origin, destination, denomToken, isRelay)
+	destFee, err := f.GetDestinationFee(ctx, origin, destination, denomToken, isQuote)
 	if err != nil {
 		span.AddEvent("could not get destination fee", trace.WithAttributes(
 			attribute.String("error", err.Error()),
@@ -187,7 +187,7 @@ func (f *feePricer) GetTotalFee(parentCtx context.Context, origin, destination u
 	return totalFee, nil
 }
 
-func (f *feePricer) getFee(parentCtx context.Context, gasChain, denomChain uint32, gasEstimate int, denomToken string, isRelay bool) (_ *big.Int, err error) {
+func (f *feePricer) getFee(parentCtx context.Context, gasChain, denomChain uint32, gasEstimate int, denomToken string, isQuote bool) (_ *big.Int, err error) {
 	ctx, span := f.handler.Tracer().Start(parentCtx, "getFee", trace.WithAttributes(
 		attribute.Int("gas_chain", int(gasChain)),
 		attribute.Int("denom_chain", int(denomChain)),
@@ -242,15 +242,15 @@ func (f *feePricer) getFee(parentCtx context.Context, gasChain, denomChain uint3
 	}
 
 	var multiplier float64
-	if isRelay {
-		multiplier, err = f.config.GetRelayFixedFeeMultiplier(int(gasChain))
-		if err != nil {
-			return nil, fmt.Errorf("could not get relay fixed fee multiplier: %w", err)
-		}
-	} else {
+	if isQuote {
 		multiplier, err = f.config.GetQuoteFixedFeeMultiplier(int(gasChain))
 		if err != nil {
 			return nil, fmt.Errorf("could not get quote fixed fee multiplier: %w", err)
+		}
+	} else {
+		multiplier, err = f.config.GetRelayFixedFeeMultiplier(int(gasChain))
+		if err != nil {
+			return nil, fmt.Errorf("could not get relay fixed fee multiplier: %w", err)
 		}
 	}
 

--- a/services/rfq/relayer/pricer/fee_pricer.go
+++ b/services/rfq/relayer/pricer/fee_pricer.go
@@ -21,11 +21,11 @@ type FeePricer interface {
 	// Start starts the fee pricer.
 	Start(ctx context.Context)
 	// GetOriginFee returns the total fee for a given chainID and gas limit, denominated in a given token.
-	GetOriginFee(ctx context.Context, origin, destination uint32, denomToken string, useMultiplier bool) (*big.Int, error)
+	GetOriginFee(ctx context.Context, origin, destination uint32, denomToken string, isRelay bool) (*big.Int, error)
 	// GetDestinationFee returns the total fee for a given chainID and gas limit, denominated in a given token.
-	GetDestinationFee(ctx context.Context, origin, destination uint32, denomToken string, useMultiplier bool) (*big.Int, error)
+	GetDestinationFee(ctx context.Context, origin, destination uint32, denomToken string, isRelay bool) (*big.Int, error)
 	// GetTotalFee returns the total fee for a given origin and destination chainID, denominated in a given token.
-	GetTotalFee(ctx context.Context, origin, destination uint32, denomToken string, useMultiplier bool) (*big.Int, error)
+	GetTotalFee(ctx context.Context, origin, destination uint32, denomToken string, isRelay bool) (*big.Int, error)
 	// GetGasPrice returns the gas price for a given chainID in native units.
 	GetGasPrice(ctx context.Context, chainID uint32) (*big.Int, error)
 }
@@ -81,13 +81,13 @@ func (f *feePricer) Start(ctx context.Context) {
 
 var nativeDecimalsFactor = new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(18)), nil)
 
-func (f *feePricer) GetOriginFee(parentCtx context.Context, origin, destination uint32, denomToken string, useMultiplier bool) (*big.Int, error) {
+func (f *feePricer) GetOriginFee(parentCtx context.Context, origin, destination uint32, denomToken string, isRelay bool) (*big.Int, error) {
 	var err error
 	ctx, span := f.handler.Tracer().Start(parentCtx, "getOriginFee", trace.WithAttributes(
 		attribute.Int(metrics.Origin, int(origin)),
 		attribute.Int(metrics.Destination, int(destination)),
 		attribute.String("denom_token", denomToken),
-		attribute.Bool("use_multiplier", useMultiplier),
+		attribute.Bool("is_relay", isRelay),
 	))
 	defer func() {
 		metrics.EndSpanWithErr(span, err)
@@ -98,7 +98,7 @@ func (f *feePricer) GetOriginFee(parentCtx context.Context, origin, destination 
 	if err != nil {
 		return nil, fmt.Errorf("could not get origin gas estimate: %w", err)
 	}
-	fee, err := f.getFee(ctx, origin, destination, gasEstimate, denomToken, useMultiplier)
+	fee, err := f.getFee(ctx, origin, destination, gasEstimate, denomToken, isRelay)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +106,7 @@ func (f *feePricer) GetOriginFee(parentCtx context.Context, origin, destination 
 	// If specified, calculate and add the L1 fee
 	l1ChainID, l1GasEstimate, useL1Fee := f.config.GetL1FeeParams(origin, true)
 	if useL1Fee {
-		l1Fee, err := f.getFee(ctx, l1ChainID, destination, l1GasEstimate, denomToken, useMultiplier)
+		l1Fee, err := f.getFee(ctx, l1ChainID, destination, l1GasEstimate, denomToken, isRelay)
 		if err != nil {
 			return nil, err
 		}
@@ -117,12 +117,12 @@ func (f *feePricer) GetOriginFee(parentCtx context.Context, origin, destination 
 	return fee, nil
 }
 
-func (f *feePricer) GetDestinationFee(parentCtx context.Context, _, destination uint32, denomToken string, useMultiplier bool) (*big.Int, error) {
+func (f *feePricer) GetDestinationFee(parentCtx context.Context, _, destination uint32, denomToken string, isRelay bool) (*big.Int, error) {
 	var err error
 	ctx, span := f.handler.Tracer().Start(parentCtx, "getDestinationFee", trace.WithAttributes(
 		attribute.Int(metrics.Destination, int(destination)),
 		attribute.String("denom_token", denomToken),
-		attribute.Bool("use_multiplier", useMultiplier),
+		attribute.Bool("is_relay", isRelay),
 	))
 	defer func() {
 		metrics.EndSpanWithErr(span, err)
@@ -133,7 +133,7 @@ func (f *feePricer) GetDestinationFee(parentCtx context.Context, _, destination 
 	if err != nil {
 		return nil, fmt.Errorf("could not get dest gas estimate: %w", err)
 	}
-	fee, err := f.getFee(ctx, destination, destination, gasEstimate, denomToken, useMultiplier)
+	fee, err := f.getFee(ctx, destination, destination, gasEstimate, denomToken, isRelay)
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +141,7 @@ func (f *feePricer) GetDestinationFee(parentCtx context.Context, _, destination 
 	// If specified, calculate and add the L1 fee
 	l1ChainID, l1GasEstimate, useL1Fee := f.config.GetL1FeeParams(destination, false)
 	if useL1Fee {
-		l1Fee, err := f.getFee(ctx, l1ChainID, destination, l1GasEstimate, denomToken, useMultiplier)
+		l1Fee, err := f.getFee(ctx, l1ChainID, destination, l1GasEstimate, denomToken, isRelay)
 		if err != nil {
 			return nil, err
 		}
@@ -152,26 +152,26 @@ func (f *feePricer) GetDestinationFee(parentCtx context.Context, _, destination 
 	return fee, nil
 }
 
-func (f *feePricer) GetTotalFee(parentCtx context.Context, origin, destination uint32, denomToken string, useMultiplier bool) (_ *big.Int, err error) {
+func (f *feePricer) GetTotalFee(parentCtx context.Context, origin, destination uint32, denomToken string, isRelay bool) (_ *big.Int, err error) {
 	ctx, span := f.handler.Tracer().Start(parentCtx, "getTotalFee", trace.WithAttributes(
 		attribute.Int(metrics.Origin, int(origin)),
 		attribute.Int(metrics.Destination, int(destination)),
 		attribute.String("denom_token", denomToken),
-		attribute.Bool("use_multiplier", useMultiplier),
+		attribute.Bool("is_relay", isRelay),
 	))
 
 	defer func() {
 		metrics.EndSpanWithErr(span, err)
 	}()
 
-	originFee, err := f.GetOriginFee(ctx, origin, destination, denomToken, useMultiplier)
+	originFee, err := f.GetOriginFee(ctx, origin, destination, denomToken, isRelay)
 	if err != nil {
 		span.AddEvent("could not get origin fee", trace.WithAttributes(
 			attribute.String("error", err.Error()),
 		))
 		return nil, err
 	}
-	destFee, err := f.GetDestinationFee(ctx, origin, destination, denomToken, useMultiplier)
+	destFee, err := f.GetDestinationFee(ctx, origin, destination, denomToken, isRelay)
 	if err != nil {
 		span.AddEvent("could not get destination fee", trace.WithAttributes(
 			attribute.String("error", err.Error()),
@@ -187,7 +187,7 @@ func (f *feePricer) GetTotalFee(parentCtx context.Context, origin, destination u
 	return totalFee, nil
 }
 
-func (f *feePricer) getFee(parentCtx context.Context, gasChain, denomChain uint32, gasEstimate int, denomToken string, useMultiplier bool) (_ *big.Int, err error) {
+func (f *feePricer) getFee(parentCtx context.Context, gasChain, denomChain uint32, gasEstimate int, denomToken string, isRelay bool) (_ *big.Int, err error) {
 	ctx, span := f.handler.Tracer().Start(parentCtx, "getFee", trace.WithAttributes(
 		attribute.Int("gas_chain", int(gasChain)),
 		attribute.Int("denom_chain", int(denomChain)),
@@ -241,11 +241,16 @@ func (f *feePricer) getFee(parentCtx context.Context, gasChain, denomChain uint3
 		)
 	}
 
-	multiplier := 1.
-	if useMultiplier {
-		multiplier, err = f.config.GetFixedFeeMultiplier(int(gasChain))
+	var multiplier float64
+	if isRelay {
+		multiplier, err = f.config.GetRelayFixedFeeMultiplier(int(gasChain))
 		if err != nil {
-			return nil, fmt.Errorf("could not get fixed fee multiplier: %w", err)
+			return nil, fmt.Errorf("could not get relay fixed fee multiplier: %w", err)
+		}
+	} else {
+		multiplier, err = f.config.GetQuoteFixedFeeMultiplier(int(gasChain))
+		if err != nil {
+			return nil, fmt.Errorf("could not get quote fixed fee multiplier: %w", err)
 		}
 	}
 
@@ -257,6 +262,7 @@ func (f *feePricer) getFee(parentCtx context.Context, gasChain, denomChain uint3
 		attribute.String("gas_price", gasPrice.String()),
 		attribute.Float64("native_token_price", nativeTokenPrice),
 		attribute.Float64("denom_token_price", denomTokenPrice),
+		attribute.Float64("multplier", multiplier),
 		attribute.Int("denom_token_decimals", int(denomTokenDecimals)),
 		attribute.String("fee_wei", feeWei.String()),
 		attribute.String("fee_denom", feeDenom.String()),

--- a/services/rfq/relayer/pricer/fee_pricer_test.go
+++ b/services/rfq/relayer/pricer/fee_pricer_test.go
@@ -279,7 +279,7 @@ func (s *PricerSuite) TestGetTotalFeeWithMultiplier() {
 	go func() { feePricer.Start(s.GetTestContext()) }()
 
 	// Calculate the total fee [quote].
-	fee, err := feePricer.GetTotalFee(s.GetTestContext(), s.origin, s.destination, "USDC", false)
+	fee, err := feePricer.GetTotalFee(s.GetTestContext(), s.origin, s.destination, "USDC", true)
 	s.NoError(err)
 
 	// The expected fee should be the sum of the Origin and Destination fees, i.e. 200_500_000.
@@ -287,7 +287,7 @@ func (s *PricerSuite) TestGetTotalFeeWithMultiplier() {
 	s.Equal(expectedFee, fee)
 
 	// Calculate the total fee [relay].
-	fee, err = feePricer.GetTotalFee(s.GetTestContext(), s.origin, s.destination, "USDC", true)
+	fee, err = feePricer.GetTotalFee(s.GetTestContext(), s.origin, s.destination, "USDC", false)
 	s.NoError(err)
 
 	// The expected fee should be the sum of the Origin and Destination fees, i.e. 401_000_000.
@@ -306,7 +306,7 @@ func (s *PricerSuite) TestGetTotalFeeWithMultiplier() {
 	go func() { feePricer.Start(s.GetTestContext()) }()
 
 	// Calculate the total fee.
-	fee, err = feePricer.GetTotalFee(s.GetTestContext(), s.origin, s.destination, "USDC", false)
+	fee, err = feePricer.GetTotalFee(s.GetTestContext(), s.origin, s.destination, "USDC", true)
 	s.NoError(err)
 
 	// The expected fee should be the sum of the Origin and Destination fees, i.e. 100_250_000.
@@ -325,7 +325,7 @@ func (s *PricerSuite) TestGetTotalFeeWithMultiplier() {
 	go func() { feePricer.Start(s.GetTestContext()) }()
 
 	// Calculate the total fee.
-	fee, err = feePricer.GetTotalFee(s.GetTestContext(), s.origin, s.destination, "USDC", false)
+	fee, err = feePricer.GetTotalFee(s.GetTestContext(), s.origin, s.destination, "USDC", true)
 	s.NoError(err)
 
 	// The expected fee should be the sum of the Origin and Destination fees, i.e. 100_250_000.

--- a/services/rfq/relayer/relconfig/config.go
+++ b/services/rfq/relayer/relconfig/config.go
@@ -86,8 +86,10 @@ type ChainConfig struct {
 	// QuoteWidthBps is the number of basis points to deduct from the dest amount.
 	// Note that this parameter is applied on a chain level and must be positive.
 	QuoteWidthBps float64 `yaml:"quote_width_bps"`
-	// FixedFeeMultiplier is the multiplier for the fixed fee.
-	FixedFeeMultiplier float64 `yaml:"fixed_fee_multiplier"`
+	// QuoteFixedFeeMultiplier is the multiplier for the fixed fee, applied when generating quotes.
+	QuoteFixedFeeMultiplier float64 `yaml:"quote_fixed_fee_multiplier"`
+	// RelayFixedFeeMultiplier is the multiplier for the fixed fee, applied when relaying.
+	RelayFixedFeeMultiplier float64 `yaml:"relay_fixed_fee_multiplier"`
 	// CCTP start block is the block at which the chain listener will listen for CCTP events.
 	CCTPStartBlock uint64 `yaml:"cctp_start_block"`
 }

--- a/services/rfq/relayer/relconfig/config_test.go
+++ b/services/rfq/relayer/relconfig/config_test.go
@@ -18,59 +18,59 @@ func TestChainGetters(t *testing.T) {
 	cfgWithBase := relconfig.Config{
 		Chains: map[int]relconfig.ChainConfig{
 			chainID: {
-				RFQAddress:             "0x123",
-				SynapseCCTPAddress:     "0x456",
-				TokenMessengerAddress:  "0x789",
-				Confirmations:          1,
-				NativeToken:            "MATIC",
-				DeadlineBufferSeconds:  10,
-				OriginGasEstimate:      10000,
-				DestGasEstimate:        20000,
-				L1FeeChainID:           10,
-				L1FeeOriginGasEstimate: 30000,
-				L1FeeDestGasEstimate:   40000,
-				MinGasToken:            "1000",
-				QuotePct:               50,
-				QuoteWidthBps:          10,
-				FixedFeeMultiplier:     1.1,
+				RFQAddress:              "0x123",
+				SynapseCCTPAddress:      "0x456",
+				TokenMessengerAddress:   "0x789",
+				Confirmations:           1,
+				NativeToken:             "MATIC",
+				DeadlineBufferSeconds:   10,
+				OriginGasEstimate:       10000,
+				DestGasEstimate:         20000,
+				L1FeeChainID:            10,
+				L1FeeOriginGasEstimate:  30000,
+				L1FeeDestGasEstimate:    40000,
+				MinGasToken:             "1000",
+				QuotePct:                50,
+				QuoteWidthBps:           10,
+				QuoteFixedFeeMultiplier: 1.1,
 			},
 		},
 		BaseChainConfig: relconfig.ChainConfig{
-			RFQAddress:             "0x1234",
-			SynapseCCTPAddress:     "0x456",
-			TokenMessengerAddress:  "0x789",
-			Confirmations:          2,
-			NativeToken:            "ARB",
-			DeadlineBufferSeconds:  11,
-			OriginGasEstimate:      10001,
-			DestGasEstimate:        20001,
-			L1FeeChainID:           11,
-			L1FeeOriginGasEstimate: 30001,
-			L1FeeDestGasEstimate:   40001,
-			MinGasToken:            "1001",
-			QuotePct:               51,
-			QuoteWidthBps:          11,
-			FixedFeeMultiplier:     1.2,
+			RFQAddress:              "0x1234",
+			SynapseCCTPAddress:      "0x456",
+			TokenMessengerAddress:   "0x789",
+			Confirmations:           2,
+			NativeToken:             "ARB",
+			DeadlineBufferSeconds:   11,
+			OriginGasEstimate:       10001,
+			DestGasEstimate:         20001,
+			L1FeeChainID:            11,
+			L1FeeOriginGasEstimate:  30001,
+			L1FeeDestGasEstimate:    40001,
+			MinGasToken:             "1001",
+			QuotePct:                51,
+			QuoteWidthBps:           11,
+			QuoteFixedFeeMultiplier: 1.2,
 		},
 	}
 	cfg := relconfig.Config{
 		Chains: map[int]relconfig.ChainConfig{
 			chainID: {
-				RFQAddress:             "0x123",
-				SynapseCCTPAddress:     "0x456",
-				TokenMessengerAddress:  "0x789",
-				Confirmations:          1,
-				NativeToken:            "MATIC",
-				DeadlineBufferSeconds:  10,
-				OriginGasEstimate:      10000,
-				DestGasEstimate:        20000,
-				L1FeeChainID:           10,
-				L1FeeOriginGasEstimate: 30000,
-				L1FeeDestGasEstimate:   40000,
-				MinGasToken:            "1000",
-				QuotePct:               50,
-				QuoteWidthBps:          10,
-				FixedFeeMultiplier:     1.1,
+				RFQAddress:              "0x123",
+				SynapseCCTPAddress:      "0x456",
+				TokenMessengerAddress:   "0x789",
+				Confirmations:           1,
+				NativeToken:             "MATIC",
+				DeadlineBufferSeconds:   10,
+				OriginGasEstimate:       10000,
+				DestGasEstimate:         20000,
+				L1FeeChainID:            10,
+				L1FeeOriginGasEstimate:  30000,
+				L1FeeDestGasEstimate:    40000,
+				MinGasToken:             "1000",
+				QuotePct:                50,
+				QuoteWidthBps:           10,
+				QuoteFixedFeeMultiplier: 1.1,
 				Tokens: map[string]relconfig.TokenConfig{
 					"USDC": {
 						Address:            usdcAddr,
@@ -278,18 +278,18 @@ func TestChainGetters(t *testing.T) {
 		assert.Equal(t, chainVal, cfgWithBase.Chains[chainID].QuoteWidthBps)
 	})
 
-	t.Run("GetFixedFeeMultiplier", func(t *testing.T) {
-		defaultVal, err := cfg.GetFixedFeeMultiplier(badChainID)
+	t.Run("GetQuoteFixedFeeMultiplier", func(t *testing.T) {
+		defaultVal, err := cfg.GetQuoteFixedFeeMultiplier(badChainID)
 		assert.NoError(t, err)
-		assert.Equal(t, defaultVal, relconfig.DefaultChainConfig.FixedFeeMultiplier)
+		assert.Equal(t, defaultVal, relconfig.DefaultChainConfig.QuoteFixedFeeMultiplier)
 
-		baseVal, err := cfgWithBase.GetFixedFeeMultiplier(badChainID)
+		baseVal, err := cfgWithBase.GetQuoteFixedFeeMultiplier(badChainID)
 		assert.NoError(t, err)
-		assert.Equal(t, baseVal, cfgWithBase.BaseChainConfig.FixedFeeMultiplier)
+		assert.Equal(t, baseVal, cfgWithBase.BaseChainConfig.QuoteFixedFeeMultiplier)
 
-		chainVal, err := cfgWithBase.GetFixedFeeMultiplier(chainID)
+		chainVal, err := cfgWithBase.GetQuoteFixedFeeMultiplier(chainID)
 		assert.NoError(t, err)
-		assert.Equal(t, chainVal, cfgWithBase.Chains[chainID].FixedFeeMultiplier)
+		assert.Equal(t, chainVal, cfgWithBase.Chains[chainID].QuoteFixedFeeMultiplier)
 	})
 
 	t.Run("GetMaxRebalanceAmount", func(t *testing.T) {
@@ -307,21 +307,21 @@ func TestGetQuoteOffset(t *testing.T) {
 	cfg := relconfig.Config{
 		Chains: map[int]relconfig.ChainConfig{
 			chainID: {
-				RFQAddress:             "0x123",
-				SynapseCCTPAddress:     "0x456",
-				TokenMessengerAddress:  "0x789",
-				Confirmations:          1,
-				NativeToken:            "MATIC",
-				DeadlineBufferSeconds:  10,
-				OriginGasEstimate:      10000,
-				DestGasEstimate:        20000,
-				L1FeeChainID:           10,
-				L1FeeOriginGasEstimate: 30000,
-				L1FeeDestGasEstimate:   40000,
-				MinGasToken:            "1000",
-				QuotePct:               50,
-				QuoteWidthBps:          10,
-				FixedFeeMultiplier:     1.1,
+				RFQAddress:              "0x123",
+				SynapseCCTPAddress:      "0x456",
+				TokenMessengerAddress:   "0x789",
+				Confirmations:           1,
+				NativeToken:             "MATIC",
+				DeadlineBufferSeconds:   10,
+				OriginGasEstimate:       10000,
+				DestGasEstimate:         20000,
+				L1FeeChainID:            10,
+				L1FeeOriginGasEstimate:  30000,
+				L1FeeDestGasEstimate:    40000,
+				MinGasToken:             "1000",
+				QuotePct:                50,
+				QuoteWidthBps:           10,
+				QuoteFixedFeeMultiplier: 1.1,
 				Tokens: map[string]relconfig.TokenConfig{
 					"USDC": {
 						Address:            usdcAddr,

--- a/services/rfq/relayer/relconfig/getters.go
+++ b/services/rfq/relayer/relconfig/getters.go
@@ -344,7 +344,11 @@ func (c Config) GetRelayFixedFeeMultiplier(chainID int) (value float64, err erro
 		return value, fmt.Errorf("failed to cast RelayFixedFeeMultiplier to int")
 	}
 	if value <= 0 {
-		value = DefaultChainConfig.RelayFixedFeeMultiplier
+		// If the value is not set, we default to the quote fixed fee multiplier.
+		value, err = c.GetQuoteFixedFeeMultiplier(chainID)
+		if err != nil {
+			return value, err
+		}
 	}
 	return value, nil
 }

--- a/services/rfq/relayer/relconfig/getters.go
+++ b/services/rfq/relayer/relconfig/getters.go
@@ -13,13 +13,14 @@ import (
 
 // DefaultChainConfig is the default chain config.
 var DefaultChainConfig = ChainConfig{
-	DeadlineBufferSeconds: 600,
-	OriginGasEstimate:     160000,
-	DestGasEstimate:       100000,
-	MinGasToken:           "100000000000000000", // 1 ETH
-	QuotePct:              100,
-	QuoteWidthBps:         0,
-	FixedFeeMultiplier:    1,
+	DeadlineBufferSeconds:   600,
+	OriginGasEstimate:       160000,
+	DestGasEstimate:         100000,
+	MinGasToken:             "100000000000000000", // 1 ETH
+	QuotePct:                100,
+	QuoteWidthBps:           0,
+	QuoteFixedFeeMultiplier: 1,
+	RelayFixedFeeMultiplier: 1,
 }
 
 // getChainConfigValue gets the value of a field from ChainConfig.
@@ -314,19 +315,36 @@ func (c Config) GetQuoteWidthBps(chainID int) (value float64, err error) {
 	return value, nil
 }
 
-// GetFixedFeeMultiplier returns the FixedFeeMultiplier for the given chainID.
-func (c Config) GetFixedFeeMultiplier(chainID int) (value float64, err error) {
-	rawValue, err := c.getChainConfigValue(chainID, "FixedFeeMultiplier")
+// GetQuoteFixedFeeMultiplier returns the QuoteFixedFeeMultiplier for the given chainID.
+func (c Config) GetQuoteFixedFeeMultiplier(chainID int) (value float64, err error) {
+	rawValue, err := c.getChainConfigValue(chainID, "QuoteFixedFeeMultiplier")
 	if err != nil {
 		return value, err
 	}
 
 	value, ok := rawValue.(float64)
 	if !ok {
-		return value, fmt.Errorf("failed to cast FixedFeeMultiplier to int")
+		return value, fmt.Errorf("failed to cast QuoteFixedFeeMultiplier to int")
 	}
 	if value <= 0 {
-		value = DefaultChainConfig.FixedFeeMultiplier
+		value = DefaultChainConfig.QuoteFixedFeeMultiplier
+	}
+	return value, nil
+}
+
+// GetRelayFixedFeeMultiplier returns the RelayFixedFeeMultiplier for the given chainID.
+func (c Config) GetRelayFixedFeeMultiplier(chainID int) (value float64, err error) {
+	rawValue, err := c.getChainConfigValue(chainID, "RelayFixedFeeMultiplier")
+	if err != nil {
+		return value, err
+	}
+
+	value, ok := rawValue.(float64)
+	if !ok {
+		return value, fmt.Errorf("failed to cast RelayFixedFeeMultiplier to int")
+	}
+	if value <= 0 {
+		value = DefaultChainConfig.RelayFixedFeeMultiplier
 	}
 	return value, nil
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced separate fee multipliers for quotes and relays, allowing more granular control over fee calculations.

- **Refactor**
  - Updated methods to use `isQuote` parameter instead of `useMultiplier` for fee calculations.
  - Split `FixedFeeMultiplier` into `QuoteFixedFeeMultiplier` and `RelayFixedFeeMultiplier` in configuration settings.

- **Tests**
  - Adjusted test cases to reflect changes in fee multiplier logic and configuration fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->