### PR TITLE
fix(synapse-interface): rfq maps generation

### DIFF
--- a/packages/synapse-interface/constants/bridgeMap.ts
+++ b/packages/synapse-interface/constants/bridgeMap.ts
@@ -31,7 +31,15 @@ export const BRIDGE_MAP = {
     '0x1B84765dE8B7566e4cEAF4D0fD3c5aF52D3DdE4F': {
       decimals: 18,
       symbol: 'nUSD',
-      origin: ['CCTP.USDC', 'DAI', 'USDC', 'USDT', 'nUSD', 'synFRAX'],
+      origin: [
+        'CCTP.USDC',
+        'DAI',
+        'RFQ.USDC',
+        'USDC',
+        'USDT',
+        'nUSD',
+        'synFRAX',
+      ],
       destination: ['CCTP.USDC', 'nUSD'],
       swappable: [
         '0x5f98805A4E8be255a32880FDeC7F6728C6568bA0',
@@ -60,7 +68,15 @@ export const BRIDGE_MAP = {
     '0x5f98805A4E8be255a32880FDeC7F6728C6568bA0': {
       decimals: 18,
       symbol: 'LUSD',
-      origin: ['CCTP.USDC', 'DAI', 'USDC', 'USDT', 'nUSD', 'synFRAX'],
+      origin: [
+        'CCTP.USDC',
+        'DAI',
+        'RFQ.USDC',
+        'USDC',
+        'USDT',
+        'nUSD',
+        'synFRAX',
+      ],
       destination: ['CCTP.USDC'],
       swappable: [
         '0x1B84765dE8B7566e4cEAF4D0fD3c5aF52D3DdE4F',
@@ -82,7 +98,15 @@ export const BRIDGE_MAP = {
     '0x6B175474E89094C44Da98b954EedeAC495271d0F': {
       decimals: 18,
       symbol: 'DAI',
-      origin: ['CCTP.USDC', 'DAI', 'USDC', 'USDT', 'nUSD', 'synFRAX'],
+      origin: [
+        'CCTP.USDC',
+        'DAI',
+        'RFQ.USDC',
+        'USDC',
+        'USDT',
+        'nUSD',
+        'synFRAX',
+      ],
       destination: ['CCTP.USDC', 'DAI', 'nUSD'],
       swappable: [
         '0x1B84765dE8B7566e4cEAF4D0fD3c5aF52D3DdE4F',
@@ -97,7 +121,15 @@ export const BRIDGE_MAP = {
     '0x6c3ea9036406852006290770BEdFcAbA0e23A0e8': {
       decimals: 6,
       symbol: 'PYUSD',
-      origin: ['CCTP.USDC', 'DAI', 'USDC', 'USDT', 'nUSD', 'synFRAX'],
+      origin: [
+        'CCTP.USDC',
+        'DAI',
+        'RFQ.USDC',
+        'USDC',
+        'USDT',
+        'nUSD',
+        'synFRAX',
+      ],
       destination: ['CCTP.USDC'],
       swappable: [
         '0x1B84765dE8B7566e4cEAF4D0fD3c5aF52D3DdE4F',
@@ -126,7 +158,15 @@ export const BRIDGE_MAP = {
     '0x853d955aCEf822Db058eb8505911ED77F175b99e': {
       decimals: 18,
       symbol: 'FRAX',
-      origin: ['CCTP.USDC', 'DAI', 'USDC', 'USDT', 'nUSD', 'synFRAX'],
+      origin: [
+        'CCTP.USDC',
+        'DAI',
+        'RFQ.USDC',
+        'USDC',
+        'USDT',
+        'nUSD',
+        'synFRAX',
+      ],
       destination: ['CCTP.USDC', 'synFRAX'],
       swappable: [
         '0x1B84765dE8B7566e4cEAF4D0fD3c5aF52D3DdE4F',
@@ -151,11 +191,11 @@ export const BRIDGE_MAP = {
       origin: [
         'CCTP.USDC',
         'DAI',
+        'RFQ.USDC',
         'USDC',
         'USDT',
         'nUSD',
         'synFRAX',
-        'RFQ.USDC',
       ],
       destination: ['CCTP.USDC', 'USDC', 'nUSD', 'RFQ.USDC'],
       swappable: [
@@ -192,14 +232,14 @@ export const BRIDGE_MAP = {
     '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2': {
       decimals: 18,
       symbol: 'WETH',
-      origin: ['nETH'],
+      origin: ['RFQ.ETH', 'nETH'],
       destination: ['nETH'],
       swappable: [],
     },
     '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE': {
       decimals: 18,
       symbol: 'ETH',
-      origin: ['nETH', 'RFQ.ETH'],
+      origin: ['RFQ.ETH', 'nETH'],
       destination: ['nETH', 'RFQ.ETH'],
       swappable: [],
     },
@@ -213,7 +253,15 @@ export const BRIDGE_MAP = {
     '0xdAC17F958D2ee523a2206206994597C13D831ec7': {
       decimals: 6,
       symbol: 'USDT',
-      origin: ['CCTP.USDC', 'DAI', 'USDC', 'USDT', 'nUSD', 'synFRAX'],
+      origin: [
+        'CCTP.USDC',
+        'DAI',
+        'RFQ.USDC',
+        'USDC',
+        'USDT',
+        'nUSD',
+        'synFRAX',
+      ],
       destination: ['CCTP.USDC', 'USDT', 'nUSD'],
       swappable: [
         '0x1B84765dE8B7566e4cEAF4D0fD3c5aF52D3DdE4F',
@@ -235,7 +283,15 @@ export const BRIDGE_MAP = {
     '0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E': {
       decimals: 18,
       symbol: 'crvUSD',
-      origin: ['CCTP.USDC', 'DAI', 'USDC', 'USDT', 'nUSD', 'synFRAX'],
+      origin: [
+        'CCTP.USDC',
+        'DAI',
+        'RFQ.USDC',
+        'USDC',
+        'USDT',
+        'nUSD',
+        'synFRAX',
+      ],
       destination: ['CCTP.USDC'],
       swappable: [
         '0x1B84765dE8B7566e4cEAF4D0fD3c5aF52D3DdE4F',
@@ -252,7 +308,7 @@ export const BRIDGE_MAP = {
     '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85': {
       decimals: 6,
       symbol: 'USDC',
-      origin: ['CCTP.USDC', 'nUSD', 'RFQ.USDC'],
+      origin: ['CCTP.USDC', 'RFQ.USDC', 'nUSD'],
       destination: ['CCTP.USDC', 'RFQ.USDC'],
       swappable: [
         '0x67C10C397dD0Ba417329543c1a40eb48AAa7cd00',
@@ -272,7 +328,7 @@ export const BRIDGE_MAP = {
     '0x121ab82b49B2BC4c7901CA46B8277962b4350204': {
       decimals: 18,
       symbol: 'WETH',
-      origin: ['nETH'],
+      origin: ['RFQ.ETH', 'nETH'],
       destination: ['nETH'],
       swappable: [
         '0x809DC529f07651bD43A172e8dB6f4a7a0d771036',
@@ -296,7 +352,7 @@ export const BRIDGE_MAP = {
     '0x67C10C397dD0Ba417329543c1a40eb48AAa7cd00': {
       decimals: 18,
       symbol: 'nUSD',
-      origin: ['CCTP.USDC', 'nUSD'],
+      origin: ['CCTP.USDC', 'RFQ.USDC', 'nUSD'],
       destination: ['CCTP.USDC', 'nUSD'],
       swappable: [
         '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85',
@@ -309,7 +365,7 @@ export const BRIDGE_MAP = {
     '0x7F5c764cBc14f9669B88837ca1490cCa17c31607': {
       decimals: 6,
       symbol: 'USDC.e',
-      origin: ['CCTP.USDC', 'nUSD'],
+      origin: ['CCTP.USDC', 'RFQ.USDC', 'nUSD'],
       destination: ['CCTP.USDC', 'nUSD'],
       swappable: [
         '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85',
@@ -322,7 +378,7 @@ export const BRIDGE_MAP = {
     '0x809DC529f07651bD43A172e8dB6f4a7a0d771036': {
       decimals: 18,
       symbol: 'nETH',
-      origin: ['nETH'],
+      origin: ['RFQ.ETH', 'nETH'],
       destination: ['nETH'],
       swappable: [
         '0x121ab82b49B2BC4c7901CA46B8277962b4350204',
@@ -332,7 +388,7 @@ export const BRIDGE_MAP = {
     '0x8c6f28f2F1A3C87F0f938b96d27520d9751ec8d9': {
       decimals: 18,
       symbol: 'sUSD',
-      origin: ['CCTP.USDC', 'nUSD'],
+      origin: ['CCTP.USDC', 'RFQ.USDC', 'nUSD'],
       destination: ['CCTP.USDC'],
       swappable: [
         '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85',
@@ -345,7 +401,7 @@ export const BRIDGE_MAP = {
     '0x94b008aA00579c1307B0EF2c499aD98a8ce58e58': {
       decimals: 6,
       symbol: 'USDT',
-      origin: ['CCTP.USDC', 'nUSD'],
+      origin: ['CCTP.USDC', 'RFQ.USDC', 'nUSD'],
       destination: ['CCTP.USDC'],
       swappable: [
         '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85',
@@ -365,7 +421,7 @@ export const BRIDGE_MAP = {
     '0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1': {
       decimals: 18,
       symbol: 'DAI',
-      origin: ['CCTP.USDC', 'nUSD'],
+      origin: ['CCTP.USDC', 'RFQ.USDC', 'nUSD'],
       destination: ['CCTP.USDC'],
       swappable: [
         '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85',
@@ -385,7 +441,7 @@ export const BRIDGE_MAP = {
     '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE': {
       decimals: 18,
       symbol: 'ETH',
-      origin: ['nETH', 'RFQ.ETH'],
+      origin: ['RFQ.ETH', 'nETH'],
       destination: ['nETH', 'RFQ.ETH'],
       swappable: [
         '0x121ab82b49B2BC4c7901CA46B8277962b4350204',
@@ -1191,7 +1247,7 @@ export const BRIDGE_MAP = {
     '0x417Ac0e078398C154EdFadD9Ef675d30Be60Af93': {
       decimals: 18,
       symbol: 'crvUSD',
-      origin: ['CCTP.USDC'],
+      origin: ['CCTP.USDC', 'RFQ.USDC'],
       destination: ['CCTP.USDC'],
       swappable: [
         '0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb',
@@ -1203,7 +1259,7 @@ export const BRIDGE_MAP = {
     '0x4200000000000000000000000000000000000006': {
       decimals: 18,
       symbol: 'WETH',
-      origin: ['nETH'],
+      origin: ['RFQ.ETH', 'nETH'],
       destination: ['nETH'],
       swappable: [
         '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
@@ -1220,7 +1276,7 @@ export const BRIDGE_MAP = {
     '0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb': {
       decimals: 18,
       symbol: 'DAI',
-      origin: ['CCTP.USDC'],
+      origin: ['CCTP.USDC', 'RFQ.USDC'],
       destination: ['CCTP.USDC'],
       swappable: [
         '0x417Ac0e078398C154EdFadD9Ef675d30Be60Af93',
@@ -1258,7 +1314,7 @@ export const BRIDGE_MAP = {
     '0xEB466342C4d449BC9f53A865D5Cb90586f405215': {
       decimals: 6,
       symbol: 'axlUSDC',
-      origin: ['CCTP.USDC'],
+      origin: ['CCTP.USDC', 'RFQ.USDC'],
       destination: ['CCTP.USDC'],
       swappable: [
         '0x417Ac0e078398C154EdFadD9Ef675d30Be60Af93',
@@ -1270,7 +1326,7 @@ export const BRIDGE_MAP = {
     '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE': {
       decimals: 18,
       symbol: 'ETH',
-      origin: ['nETH', 'RFQ.ETH'],
+      origin: ['RFQ.ETH', 'nETH'],
       destination: ['nETH', 'RFQ.ETH'],
       swappable: [
         '0x4200000000000000000000000000000000000006',
@@ -1280,7 +1336,7 @@ export const BRIDGE_MAP = {
     '0xb554A55358fF0382Fb21F0a478C3546d1106Be8c': {
       decimals: 18,
       symbol: 'nETH',
-      origin: ['nETH'],
+      origin: ['RFQ.ETH', 'nETH'],
       destination: ['nETH'],
       swappable: [
         '0x4200000000000000000000000000000000000006',
@@ -1290,7 +1346,7 @@ export const BRIDGE_MAP = {
     '0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA': {
       decimals: 6,
       symbol: 'USDbC',
-      origin: ['CCTP.USDC'],
+      origin: ['CCTP.USDC', 'RFQ.USDC'],
       destination: ['CCTP.USDC'],
       swappable: [
         '0x417Ac0e078398C154EdFadD9Ef675d30Be60Af93',
@@ -1325,7 +1381,7 @@ export const BRIDGE_MAP = {
     '0x17FC002b466eEc40DaE837Fc4bE5c67993ddBd6F': {
       decimals: 18,
       symbol: 'FRAX',
-      origin: ['CCTP.USDC', 'nUSD'],
+      origin: ['CCTP.USDC', 'RFQ.USDC', 'nUSD'],
       destination: ['CCTP.USDC'],
       swappable: [
         '0x2913E812Cf0dcCA30FB28E6Cac3d2DCFF4497688',
@@ -1338,7 +1394,7 @@ export const BRIDGE_MAP = {
     '0x2913E812Cf0dcCA30FB28E6Cac3d2DCFF4497688': {
       decimals: 18,
       symbol: 'nUSD',
-      origin: ['CCTP.USDC', 'nUSD'],
+      origin: ['CCTP.USDC', 'RFQ.USDC', 'nUSD'],
       destination: ['CCTP.USDC', 'nUSD'],
       swappable: [
         '0x17FC002b466eEc40DaE837Fc4bE5c67993ddBd6F',
@@ -1358,7 +1414,7 @@ export const BRIDGE_MAP = {
     '0x3ea9B0ab55F34Fb188824Ee288CeaEfC63cf908e': {
       decimals: 18,
       symbol: 'nETH',
-      origin: ['nETH'],
+      origin: ['RFQ.ETH', 'nETH'],
       destination: ['nETH'],
       swappable: [
         '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1',
@@ -1382,7 +1438,7 @@ export const BRIDGE_MAP = {
     '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1': {
       decimals: 18,
       symbol: 'WETH',
-      origin: ['nETH'],
+      origin: ['RFQ.ETH', 'nETH'],
       destination: ['nETH'],
       swappable: [
         '0x3ea9B0ab55F34Fb188824Ee288CeaEfC63cf908e',
@@ -1413,7 +1469,7 @@ export const BRIDGE_MAP = {
     '0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1': {
       decimals: 18,
       symbol: 'DAI',
-      origin: ['CCTP.USDC', 'nUSD'],
+      origin: ['CCTP.USDC', 'RFQ.USDC', 'nUSD'],
       destination: ['CCTP.USDC'],
       swappable: [
         '0x17FC002b466eEc40DaE837Fc4bE5c67993ddBd6F',
@@ -1426,7 +1482,7 @@ export const BRIDGE_MAP = {
     '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE': {
       decimals: 18,
       symbol: 'ETH',
-      origin: ['nETH', 'RFQ.ETH'],
+      origin: ['RFQ.ETH', 'nETH'],
       destination: ['nETH', 'RFQ.ETH'],
       swappable: [
         '0x3ea9B0ab55F34Fb188824Ee288CeaEfC63cf908e',
@@ -1436,7 +1492,7 @@ export const BRIDGE_MAP = {
     '0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8': {
       decimals: 6,
       symbol: 'USDC.e',
-      origin: ['CCTP.USDC', 'nUSD'],
+      origin: ['CCTP.USDC', 'RFQ.USDC', 'nUSD'],
       destination: ['CCTP.USDC', 'nUSD'],
       swappable: [
         '0x17FC002b466eEc40DaE837Fc4bE5c67993ddBd6F',
@@ -1449,7 +1505,7 @@ export const BRIDGE_MAP = {
     '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9': {
       decimals: 6,
       symbol: 'USDT',
-      origin: ['CCTP.USDC', 'nUSD'],
+      origin: ['CCTP.USDC', 'RFQ.USDC', 'nUSD'],
       destination: ['CCTP.USDC', 'nUSD'],
       swappable: [
         '0x17FC002b466eEc40DaE837Fc4bE5c67993ddBd6F',
@@ -1469,7 +1525,7 @@ export const BRIDGE_MAP = {
     '0xaf88d065e77c8cC2239327C5EDb3A432268e5831': {
       decimals: 6,
       symbol: 'USDC',
-      origin: ['CCTP.USDC', 'nUSD', 'RFQ.USDC'],
+      origin: ['CCTP.USDC', 'RFQ.USDC', 'nUSD'],
       destination: ['CCTP.USDC', 'RFQ.USDC'],
       swappable: [
         '0x17FC002b466eEc40DaE837Fc4bE5c67993ddBd6F',

--- a/packages/synapse-interface/scripts/generateMaps.js
+++ b/packages/synapse-interface/scripts/generateMaps.js
@@ -285,6 +285,17 @@ const printMaps = async () => {
       Object.keys(cctpOriginMap).forEach((token) => {
         addSetToMap(originMap, token, cctpOriginMap[token])
       })
+      // Add RFQ.ETH and RFQ.USDC to origin map of tokens bridgeable into nETH or CCTP.USDC respectively
+      if (allowedChainIdsForRfq.includes(Number(chainId))) {
+        Object.keys(originMap).forEach((token) => {
+          if (originMap[token].has('nETH')) {
+            originMap[token].add('RFQ.ETH')
+          }
+          if (originMap[token].has('CCTP.USDC')) {
+            originMap[token].add('RFQ.USDC')
+          }
+        })
+      }
       const tokens = {}
       await Promise.all(
         Object.keys(originMap).map(async (token) => {
@@ -327,24 +338,27 @@ const printMaps = async () => {
                   origin: [],
                   destination: [],
                   swappable: [], // poolSets are handled during SynapseBridge portion
-                  symbol: null,
-                  decimals: null,
+                  symbol: originTokenSymbol,
+                  decimals: await getTokenDecimals(
+                    origin_chain_id,
+                    normalizedOriginAddress
+                  ),
                 }
               }
-
+              // Add RFQ symbol to origin list if not already present
               if (
-                normalizedOriginAddress in tokens &&
                 !tokens[normalizedOriginAddress].origin.includes(
                   rfqOriginSymbol
                 )
               ) {
                 tokens[normalizedOriginAddress].origin.push(rfqOriginSymbol)
-                tokens[normalizedOriginAddress].symbol = originTokenSymbol
-                tokens[normalizedOriginAddress].decimals =
-                  await getTokenDecimals(
-                    origin_chain_id,
-                    normalizedOriginAddress
-                  )
+              }
+              // Add RFQ symbol to destination list if not already present
+              if (
+                !tokens[normalizedOriginAddress].destination.includes(
+                  rfqOriginSymbol
+                )
+              ) {
                 tokens[normalizedOriginAddress].destination.push(
                   rfqOriginSymbol
                 )


### PR DESCRIPTION
**Description**
Adds `RFQ.ETH` and `RFQ.USDC` into `origin` lists of tokens that are bridgeable via "origin swap" + RFQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced support for `RFQ.USDC` and `RFQ.ETH` tokens in the bridge mapping, enhancing token compatibility for users.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->
1160d1f1fa9d1bad2b502e360a5619eeaa622e05: [synapse-interface preview link ](https://sanguine-synapse-interface-8odykkrxe-synapsecns.vercel.app)