### PR TITLE
[DO NOT MERGE] feat(widget): transaction reverts

### DIFF
--- a/packages/widget/src/components/Transactions.tsx
+++ b/packages/widget/src/components/Transactions.tsx
@@ -8,8 +8,10 @@ import { getTimeMinutesFromNow } from '@/utils/getTimeMinutesFromNow'
 
 export const Transactions = ({
   connectedAddress,
+  provider,
 }: {
   connectedAddress: string
+  provider: any
 }) => {
   const { transactions } = useTransactionsState()
 
@@ -48,6 +50,7 @@ export const Transactions = ({
         timestamp={transaction.timestamp}
         currentTime={currentTime}
         isStoredComplete={transaction.isComplete}
+        provider={provider}
       />
     ))
   }

--- a/packages/widget/src/components/Widget.tsx
+++ b/packages/widget/src/components/Widget.tsx
@@ -394,7 +394,7 @@ export const Widget = ({
         style={{ background: 'var(--synapse-root)' }}
       >
         <BridgeMaintenanceProgressBar />
-        <Transactions connectedAddress={connectedAddress} />
+        <Transactions connectedAddress={connectedAddress} provider={provider} />
         <section
           className={cardStyle}
           style={{ background: 'var(--synapse-surface)' }}

--- a/packages/widget/src/hooks/useBridgeTxUpdater.ts
+++ b/packages/widget/src/hooks/useBridgeTxUpdater.ts
@@ -1,0 +1,36 @@
+import { useEffect } from 'react'
+
+import { useAppDispatch } from '@/state/hooks'
+import { useTransactionsState } from '@/state/slices/transactions/hooks'
+import {
+  updateTransactionKappa,
+  completeTransaction,
+} from '@/state/slices/transactions/reducer'
+
+export const useBridgeTxUpdater = (
+  kappa: string,
+  originTxHash: string,
+  isTxComplete: boolean
+) => {
+  const dispatch = useAppDispatch()
+  const { transactions } = useTransactionsState()
+
+  const storedTx = transactions.find((tx) => tx.originTxHash === originTxHash)
+
+  /** Update tx kappa when available */
+  useEffect(() => {
+    if (!storedTx.kappa && kappa && originTxHash) {
+      dispatch(updateTransactionKappa({ originTxHash, kappa }))
+    }
+  }, [dispatch, kappa])
+
+  /** Update tx for completion in store */
+  useEffect(() => {
+    if (isTxComplete && originTxHash && kappa) {
+      /** Check that we have not already marked tx as complete */
+      if (!storedTx.isComplete) {
+        dispatch(completeTransaction({ originTxHash, kappa }))
+      }
+    }
+  }, [dispatch, isTxComplete, originTxHash, kappa, transactions])
+}

--- a/packages/widget/src/hooks/useTxRevertCheck.ts
+++ b/packages/widget/src/hooks/useTxRevertCheck.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react'
+
+import { getTransactionReceipt } from '@/utils/actions/getTransactionReceipt'
+import { useIntervalTimer } from './useIntervalTimer'
+
+enum TransactionStatus {
+  REVERT = 0,
+  SUCCESS = 1,
+}
+
+export const useTxRevertCheck = (
+  txHash: string,
+  chainId: number,
+  provider: any,
+  checkForRevert: boolean
+) => {
+  const [isReverted, setIsReverted] = useState<boolean>(false)
+  const currentTime = useIntervalTimer(60000)
+
+  const getTxRevertStatus = async () => {
+    try {
+      const receipt = await getTransactionReceipt(txHash, chainId, provider)
+      console.log('receipt from tx: ', receipt)
+
+      if (receipt?.status === TransactionStatus.REVERT) {
+        setIsReverted(true)
+      }
+    } catch (error) {
+      console.error('Failed to fetch transaction receipt:', error)
+    }
+  }
+
+  useEffect(() => {
+    if (checkForRevert) {
+      getTxRevertStatus()
+    }
+  }, [checkForRevert, txHash, chainId, currentTime])
+
+  return isReverted
+}

--- a/packages/widget/src/utils/actions/getTransactionReceipt.ts
+++ b/packages/widget/src/utils/actions/getTransactionReceipt.ts
@@ -1,0 +1,13 @@
+export const getTransactionReceipt = async (
+  txHash: string,
+  chainId: number,
+  provider: any
+) => {
+  try {
+    const receipt = await provider.getTransactionReceipt(txHash)
+    return receipt
+  } catch (error) {
+    console.error('[Synapse Widget] Transaction receipt error: ', error)
+    return null
+  }
+}

--- a/packages/widget/src/utils/calculateEstimatedTimeStatus.ts
+++ b/packages/widget/src/utils/calculateEstimatedTimeStatus.ts
@@ -1,0 +1,37 @@
+/**
+ * Calculates remaining time based on given initial, current, and estimated times.
+ *
+ * @param currentTime - The current time, as a unix timestamp.
+ * @param initialTime - The initial time, as a unix timestamp.
+ * @param estimatedTime - The estimated duration to calculate, in seconds.
+ */
+export const calculateEstimatedTimeStatus = (
+  currentTime: number,
+  initialTime: number,
+  estimatedTime: number
+) => {
+  const elapsedTime = currentTime - initialTime
+  const nonNegativeElapsedTime = 0 > elapsedTime ? 0 : elapsedTime
+  const remainingTime = estimatedTime - nonNegativeElapsedTime
+  const targetTime = initialTime + estimatedTime
+
+  const oneMinuteInSeconds = 60
+
+  const isEstimatedTimeReached = remainingTime < 0
+  const isCheckTxStatus = remainingTime < oneMinuteInSeconds
+  const isCheckTxForRevert = elapsedTime > 30
+
+  const delayedTime = isEstimatedTimeReached ? remainingTime : null
+  const delayedTimeInMin = remainingTime ? Math.floor(remainingTime / 60) : null
+
+  return {
+    targetTime,
+    elapsedTime: nonNegativeElapsedTime,
+    remainingTime,
+    delayedTime,
+    delayedTimeInMin,
+    isEstimatedTimeReached,
+    isCheckTxStatus,
+    isCheckTxForRevert,
+  }
+}


### PR DESCRIPTION
Implemented functions to detect when Transaction reverts. 

Currently not applicable given we `wait()` for a transaction to mine in our `executeBridgeTxn` async thunk, so we do not store/track failed transactions. 

Can revisit in future if we decide to render reverted transactions in Widget.