### PR TITLE
chore(synapse-interface): removes boilerplate

### DIFF
--- a/packages/synapse-interface/README.md
+++ b/packages/synapse-interface/README.md
@@ -12,10 +12,6 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `pages/index.tsx`. The page auto-updates as you edit the file.
 
-[API routes](https://nextjs.org/docs/api-routes/introduction) can be accessed on [http://localhost:3000/api/hello](http://localhost:3000/api/hello). This endpoint can be edited in `pages/api/hello.ts`.
-
-The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/api-routes/introduction) instead of React pages.
-
 ---
 
 # Local Development Setup Guide


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the `README.md` to remove information about accessing API routes and editing endpoints for the `synapse-interface` package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
9c105f54e0c95cd0c5fba1f71736c8fd42ad4aa9: [synapse-interface preview link ](https://sanguine-synapse-interface-nezd60v9a-synapsecns.vercel.app)