### PR TITLE
fix(synapse-interface): disable input pending wallet

### DIFF
--- a/packages/synapse-interface/components/StateManagedBridge/InputContainer.tsx
+++ b/packages/synapse-interface/components/StateManagedBridge/InputContainer.tsx
@@ -33,12 +33,18 @@ import { formatAmount } from '../../utils/formatAmount'
 
 export const inputRef = React.createRef<HTMLInputElement>()
 
-export const InputContainer = ({ isWalletPending }) => {
+export const InputContainer = () => {
   const dispatch = useAppDispatch()
   const { chain, isConnected } = useAccount()
   const { balances } = usePortfolioState()
-  const { fromChainId, toChainId, fromToken, toToken, fromValue } =
-    useBridgeState()
+  const {
+    fromChainId,
+    toChainId,
+    fromToken,
+    toToken,
+    fromValue,
+    isWalletPending,
+  } = useBridgeState()
   const [showValue, setShowValue] = useState('')
   const [hasMounted, setHasMounted] = useState(false)
 

--- a/packages/synapse-interface/components/StateManagedBridge/InputContainer.tsx
+++ b/packages/synapse-interface/components/StateManagedBridge/InputContainer.tsx
@@ -33,7 +33,7 @@ import { formatAmount } from '../../utils/formatAmount'
 
 export const inputRef = React.createRef<HTMLInputElement>()
 
-export const InputContainer = () => {
+export const InputContainer = ({ isWalletPending }) => {
   const dispatch = useAppDispatch()
   const { chain, isConnected } = useAccount()
   const { balances } = usePortfolioState()
@@ -152,6 +152,7 @@ export const InputContainer = () => {
             inputRef={inputRef}
             showValue={showValue}
             handleFromValueChange={handleFromValueChange}
+            disabled={isWalletPending}
           />
           <AvailableBalance
             balance={formattedBalance}

--- a/packages/synapse-interface/pages/state-managed-bridge/index.tsx
+++ b/packages/synapse-interface/pages/state-managed-bridge/index.tsx
@@ -577,7 +577,7 @@ const StateManagedBridge = () => {
           )}
           {!showSettingsSlideOver && (
             <>
-              <InputContainer />
+              <InputContainer isWalletPending={isWalletPending} />
               <SwitchButton
                 onClick={() => {
                   dispatch(setFromChainId(toChainId))

--- a/packages/synapse-interface/pages/state-managed-bridge/index.tsx
+++ b/packages/synapse-interface/pages/state-managed-bridge/index.tsx
@@ -326,6 +326,7 @@ const StateManagedBridge = () => {
 
   const approveTxn = async () => {
     try {
+      dispatch(setIsWalletPending(true))
       const tx = approveToken(
         bridgeQuote?.routerAddress,
         fromChainId,
@@ -337,6 +338,8 @@ const StateManagedBridge = () => {
       getAndSetBridgeQuote()
     } catch (error) {
       return txErrorHandler(error)
+    } finally {
+      dispatch(setIsWalletPending(false))
     }
   }
 

--- a/packages/synapse-interface/pages/state-managed-bridge/index.tsx
+++ b/packages/synapse-interface/pages/state-managed-bridge/index.tsx
@@ -34,11 +34,10 @@ import {
   setFromToken,
   setToChainId,
   setToToken,
-} from '@/slices/bridge/reducer'
-import {
   updateFromValue,
   setBridgeQuote,
   setIsLoading,
+  setIsWalletPending,
   setDestinationAddress,
 } from '@/slices/bridge/reducer'
 import {
@@ -94,12 +93,12 @@ const StateManagedBridge = () => {
     debouncedFromValue,
     destinationAddress,
     isLoading: isQuoteLoading,
+    isWalletPending,
   }: BridgeState = useBridgeState()
   const { showSettingsSlideOver, showDestinationAddress } = useSelector(
     (state: RootState) => state.bridgeDisplay
   )
 
-  const [isWalletPending, setIsWalletPending] = useState<boolean>(false)
   const [isApproved, setIsApproved] = useState<boolean>(false)
 
   const dispatch = useAppDispatch()
@@ -377,7 +376,7 @@ const StateManagedBridge = () => {
       })
     )
     try {
-      setIsWalletPending(true)
+      dispatch(setIsWalletPending(true))
       const wallet = await getWalletClient(wagmiConfig, {
         chainId: fromChainId,
       })
@@ -524,7 +523,7 @@ const StateManagedBridge = () => {
 
       return txErrorHandler(error)
     } finally {
-      setIsWalletPending(false)
+      dispatch(setIsWalletPending(false))
     }
   }
 
@@ -577,7 +576,7 @@ const StateManagedBridge = () => {
           )}
           {!showSettingsSlideOver && (
             <>
-              <InputContainer isWalletPending={isWalletPending} />
+              <InputContainer />
               <SwitchButton
                 onClick={() => {
                   dispatch(setFromChainId(toChainId))

--- a/packages/synapse-interface/slices/bridge/reducer.ts
+++ b/packages/synapse-interface/slices/bridge/reducer.ts
@@ -34,6 +34,7 @@ export interface BridgeState {
   toTokensBridgeQuotes: BridgeQuoteResponse[]
   toTokensBridgeQuotesStatus: FetchState
   isLoading: boolean
+  isWalletPending: boolean
   deadlineMinutes: number | null
   destinationAddress: Address | null
 }
@@ -71,6 +72,7 @@ export const initialState: BridgeState = {
   toTokensBridgeQuotes: [],
   toTokensBridgeQuotesStatus: FetchState.IDLE,
   isLoading: false,
+  isWalletPending: false,
   deadlineMinutes: null,
   destinationAddress: null,
 }
@@ -81,6 +83,9 @@ export const bridgeSlice = createSlice({
   reducers: {
     setIsLoading: (state, action: PayloadAction<boolean>) => {
       state.isLoading = action.payload
+    },
+    setIsWalletPending: (state, action: PayloadAction<boolean>) => {
+      state.isWalletPending = action.payload
     },
     setFromChainId: (state, action: PayloadAction<number>) => {
       const incomingFromChainId = action.payload
@@ -509,6 +514,7 @@ export const {
   setDeadlineMinutes,
   setDestinationAddress,
   setIsLoading,
+  setIsWalletPending,
   resetBridgeInputs,
   clearDestinationAddress,
   resetFetchedBridgeQuotes,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Input fields are now disabled when the wallet is pending, preventing user actions during this state.

- **Refactor**
	- State management for wallet pending status has been centralized using Redux, improving consistency and maintainability.

- **Bug Fixes**
	- Removed outdated `setIsLoading` state management to streamline the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
bf8aa9f78c8617d739c55f0ceedb415f151b314f: [synapse-interface preview link ](https://sanguine-synapse-interface-ipl43zv3h-synapsecns.vercel.app)
4bf20000c1c100b4dab99cf31309d65d0b602dc9: [synapse-interface preview link ](https://sanguine-synapse-interface-hczq0xgmo-synapsecns.vercel.app)