### PR TITLE
FE Release 06-18-2024

### DIFF
--- a/packages/synapse-interface/CHANGELOG.md
+++ b/packages/synapse-interface/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.26.2](https://github.com/synapsecns/sanguine/compare/@synapsecns/synapse-interface@0.26.1...@synapsecns/synapse-interface@0.26.2) (2024-06-18)
+
+
+### Bug Fixes
+
+* **synapse-interface:** disable input pending wallet ([#2738](https://github.com/synapsecns/sanguine/issues/2738)) ([667a90e](https://github.com/synapsecns/sanguine/commit/667a90e76c0f958c37b6b760af4228657df0332d))
+
+
+
+
+
 ## [0.26.1](https://github.com/synapsecns/sanguine/compare/@synapsecns/synapse-interface@0.26.0...@synapsecns/synapse-interface@0.26.1) (2024-06-18)
 
 **Note:** Version bump only for package @synapsecns/synapse-interface

--- a/packages/synapse-interface/components/StateManagedBridge/InputContainer.tsx
+++ b/packages/synapse-interface/components/StateManagedBridge/InputContainer.tsx
@@ -37,8 +37,14 @@ export const InputContainer = () => {
   const dispatch = useAppDispatch()
   const { chain, isConnected } = useAccount()
   const { balances } = usePortfolioState()
-  const { fromChainId, toChainId, fromToken, toToken, fromValue } =
-    useBridgeState()
+  const {
+    fromChainId,
+    toChainId,
+    fromToken,
+    toToken,
+    fromValue,
+    isWalletPending,
+  } = useBridgeState()
   const [showValue, setShowValue] = useState('')
   const [hasMounted, setHasMounted] = useState(false)
 
@@ -152,6 +158,7 @@ export const InputContainer = () => {
             inputRef={inputRef}
             showValue={showValue}
             handleFromValueChange={handleFromValueChange}
+            disabled={isWalletPending}
           />
           <AvailableBalance
             balance={formattedBalance}

--- a/packages/synapse-interface/package.json
+++ b/packages/synapse-interface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synapsecns/synapse-interface",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "private": true,
   "engines": {
     "node": ">=18.18.0"

--- a/packages/synapse-interface/pages/state-managed-bridge/index.tsx
+++ b/packages/synapse-interface/pages/state-managed-bridge/index.tsx
@@ -34,11 +34,10 @@ import {
   setFromToken,
   setToChainId,
   setToToken,
-} from '@/slices/bridge/reducer'
-import {
   updateFromValue,
   setBridgeQuote,
   setIsLoading,
+  setIsWalletPending,
   setDestinationAddress,
 } from '@/slices/bridge/reducer'
 import {
@@ -94,12 +93,12 @@ const StateManagedBridge = () => {
     debouncedFromValue,
     destinationAddress,
     isLoading: isQuoteLoading,
+    isWalletPending,
   }: BridgeState = useBridgeState()
   const { showSettingsSlideOver, showDestinationAddress } = useSelector(
     (state: RootState) => state.bridgeDisplay
   )
 
-  const [isWalletPending, setIsWalletPending] = useState<boolean>(false)
   const [isApproved, setIsApproved] = useState<boolean>(false)
 
   const dispatch = useAppDispatch()
@@ -327,6 +326,7 @@ const StateManagedBridge = () => {
 
   const approveTxn = async () => {
     try {
+      dispatch(setIsWalletPending(true))
       const tx = approveToken(
         bridgeQuote?.routerAddress,
         fromChainId,
@@ -338,6 +338,8 @@ const StateManagedBridge = () => {
       getAndSetBridgeQuote()
     } catch (error) {
       return txErrorHandler(error)
+    } finally {
+      dispatch(setIsWalletPending(false))
     }
   }
 
@@ -377,7 +379,7 @@ const StateManagedBridge = () => {
       })
     )
     try {
-      setIsWalletPending(true)
+      dispatch(setIsWalletPending(true))
       const wallet = await getWalletClient(wagmiConfig, {
         chainId: fromChainId,
       })
@@ -524,7 +526,7 @@ const StateManagedBridge = () => {
 
       return txErrorHandler(error)
     } finally {
-      setIsWalletPending(false)
+      dispatch(setIsWalletPending(false))
     }
   }
 

--- a/packages/synapse-interface/slices/bridge/reducer.ts
+++ b/packages/synapse-interface/slices/bridge/reducer.ts
@@ -34,6 +34,7 @@ export interface BridgeState {
   toTokensBridgeQuotes: BridgeQuoteResponse[]
   toTokensBridgeQuotesStatus: FetchState
   isLoading: boolean
+  isWalletPending: boolean
   deadlineMinutes: number | null
   destinationAddress: Address | null
 }
@@ -71,6 +72,7 @@ export const initialState: BridgeState = {
   toTokensBridgeQuotes: [],
   toTokensBridgeQuotesStatus: FetchState.IDLE,
   isLoading: false,
+  isWalletPending: false,
   deadlineMinutes: null,
   destinationAddress: null,
 }
@@ -81,6 +83,9 @@ export const bridgeSlice = createSlice({
   reducers: {
     setIsLoading: (state, action: PayloadAction<boolean>) => {
       state.isLoading = action.payload
+    },
+    setIsWalletPending: (state, action: PayloadAction<boolean>) => {
+      state.isWalletPending = action.payload
     },
     setFromChainId: (state, action: PayloadAction<number>) => {
       const incomingFromChainId = action.payload
@@ -509,6 +514,7 @@ export const {
   setDeadlineMinutes,
   setDestinationAddress,
   setIsLoading,
+  setIsWalletPending,
   resetBridgeInputs,
   clearDestinationAddress,
   resetFetchedBridgeQuotes,


### PR DESCRIPTION
* Disable input when wallet prompt pending

* Lift isWalletPending to store

* Disable input during approve wallet pending

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**
A clear and concise description of the features you're adding in this pull request.

**Additional context**
Add any other context about the problem you're solving.

**Metadata**
- Fixes #[Link to Issue]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Disabled input functionality when the wallet is pending to prevent user input errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->