### PR TITLE
add extracontainers to allow for sidecar

### DIFF
--- a/charts/cctp/Chart.yaml
+++ b/charts/cctp/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cctp/templates/deployment.yaml
+++ b/charts/cctp/templates/deployment.yaml
@@ -57,6 +57,9 @@ spec:
           volumeMounts:
             - name: configmap
               mountPath: /config
+      {{- if .extraContainers }}
+      {{- toYaml .extraContainers | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**

Using cloudsql databases authenticated via iap requires sidecar containers (alternatively) 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for extra containers in deployments based on a new parameter.

- **Chores**
  - Updated chart version from `0.2.2` to `0.3.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->