### PR TITLE
feat(synapse-interface): optimize stale quote updater

### DIFF
--- a/packages/synapse-interface/pages/state-managed-bridge/index.tsx
+++ b/packages/synapse-interface/pages/state-managed-bridge/index.tsx
@@ -72,7 +72,7 @@ import {
   getBridgeModuleNames,
 } from '@/components/Maintenance/Maintenance'
 import { wagmiConfig } from '@/wagmiConfig'
-import { useStaleQuoteRefresher } from '@/utils/hooks/useStaleQuoteRefresher'
+import { useStaleQuoteUpdater } from '@/utils/hooks/useStaleQuoteUpdater'
 
 const StateManagedBridge = () => {
   const { address } = useAccount()
@@ -317,7 +317,7 @@ const StateManagedBridge = () => {
     }
   }
 
-  useStaleQuoteRefresher(
+  useStaleQuoteUpdater(
     bridgeQuote,
     getAndSetBridgeQuote,
     isQuoteLoading,

--- a/packages/synapse-interface/utils/hooks/useStaleQuoteUpdater.ts
+++ b/packages/synapse-interface/utils/hooks/useStaleQuoteUpdater.ts
@@ -1,5 +1,5 @@
 import { isNull, isNumber } from 'lodash'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 
 import { BridgeQuote } from '@/utils/types'
 import { calculateTimeBetween } from '@/utils/time'
@@ -9,7 +9,7 @@ import { useIntervalTimer } from '@/utils/hooks/useIntervalTimer'
  * Refreshes quotes based on selected stale timeout duration.
  * Will refresh quote when browser is active and wallet prompt is not pending.
  */
-export const useStaleQuoteRefresher = (
+export const useStaleQuoteUpdater = (
   quote: BridgeQuote,
   refreshQuoteCallback: () => Promise<void>,
   isQuoteLoading: boolean,
@@ -19,15 +19,28 @@ export const useStaleQuoteRefresher = (
   const quoteTime = quote?.timestamp
   const isValidQuote = isNumber(quoteTime) && !isNull(quoteTime)
   const currentTime = useIntervalTimer(staleTimeout, !isValidQuote)
+  const eventListenerRef = useRef<null | (() => void)>(null)
 
   useEffect(() => {
     if (isValidQuote && !isQuoteLoading && !isWalletPending) {
       const timeDifference = calculateTimeBetween(currentTime, quoteTime)
       const isStaleQuote = timeDifference >= staleTimeout
+
       if (isStaleQuote) {
-        document.addEventListener('mousemove', refreshQuoteCallback, {
+        if (eventListenerRef.current) {
+          document.removeEventListener('mousemove', eventListenerRef.current)
+        }
+
+        const newEventListener = () => {
+          refreshQuoteCallback()
+          eventListenerRef.current = null
+        }
+
+        document.addEventListener('mousemove', newEventListener, {
           once: true,
         })
+
+        eventListenerRef.current = newEventListener
       }
     }
   }, [currentTime, staleTimeout])


### PR DESCRIPTION
Updater now only fires a single callback regardless of how many `staleTimeout` intervals were passed since User has not moved mouse. Prevents multiple callbacks from being fired off if User has not been active in window for an extended period of time. 
fc79d27fb8de1668ddd5d34c8ce749d994b32249: [synapse-interface preview link ](https://sanguine-synapse-interface-419b8stz6-synapsecns.vercel.app)