### PR TITLE
listener: fix listener on l2

### DIFF
--- a/ethergo/listener/listener.go
+++ b/ethergo/listener/listener.go
@@ -189,12 +189,12 @@ func (c *chainListener) doPoll(parentCtx context.Context, handler HandleLog) (er
 }
 
 func (c chainListener) getBlockNumber(ctx context.Context) (uint64, error) {
-	block, err := c.client.BlockByNumber(ctx, big.NewInt(c.finalityMode.Int64()))
+	block, err := c.client.HeaderByNumber(ctx, big.NewInt(c.finalityMode.Int64()))
 	if err != nil {
 		return 0, fmt.Errorf("could not get block by number: %w", err)
 	}
 
-	blockNumber := block.Number()
+	blockNumber := block.Number
 
 	if c.blockWait > 0 {
 		blockNumber.Sub(blockNumber, big.NewInt(int64(c.blockWait)))


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**

fixes listener when tx type is unsupported

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Optimized the block number retrieval process by fetching block headers instead of full blocks, improving performance and efficiency.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->