### PR TITLE
remove 0x prefix

### DIFF
--- a/contrib/opbot/botmd/commands.go
+++ b/contrib/opbot/botmd/commands.go
@@ -225,7 +225,7 @@ func (b *Bot) rfqLookupCommand() *slacker.CommandDefinition {
 func toExplorerSlackLink(ogHash string) string {
 	rfqHash := strings.ToUpper(ogHash)
 	// cut off 0x
-	if len(rfqHash) > 0 {
+	if strings.HasPrefix(rfqHash, "0x") {
 		rfqHash = strings.ToLower(rfqHash[2:])
 	}
 


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**

only cutoff prefix if it exists


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted `rfqHash` processing to correctly handle prefixes, ensuring more accurate and consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->