### PR TITLE
RFQ Relayer: add balance mutex

### DIFF
--- a/services/rfq/relayer/service/chainindexer.go
+++ b/services/rfq/relayer/service/chainindexer.go
@@ -79,7 +79,7 @@ func (r *Relayer) runChainIndexer(ctx context.Context, chainID int) (err error) 
 			}
 		case *fastbridge.FastBridgeBridgeRelayed:
 			// blocking lock on the txid mutex to ensure state transitions are not overrwitten
-			unlocker := r.relayMtx.Lock(hexutil.Encode(event.TransactionId[:]))
+			unlocker := r.handlerMtx.Lock(hexutil.Encode(event.TransactionId[:]))
 			defer unlocker.Unlock()
 
 			// it wasn't me
@@ -93,7 +93,7 @@ func (r *Relayer) runChainIndexer(ctx context.Context, chainID int) (err error) 
 				return fmt.Errorf("could not handle relay: %w", err)
 			}
 		case *fastbridge.FastBridgeBridgeProofProvided:
-			unlocker := r.relayMtx.Lock(hexutil.Encode(event.TransactionId[:]))
+			unlocker := r.handlerMtx.Lock(hexutil.Encode(event.TransactionId[:]))
 			defer unlocker.Unlock()
 
 			// it wasn't me
@@ -107,7 +107,7 @@ func (r *Relayer) runChainIndexer(ctx context.Context, chainID int) (err error) 
 				return fmt.Errorf("could not handle proof provided: %w", err)
 			}
 		case *fastbridge.FastBridgeBridgeDepositClaimed:
-			unlocker := r.relayMtx.Lock(hexutil.Encode(event.TransactionId[:]))
+			unlocker := r.handlerMtx.Lock(hexutil.Encode(event.TransactionId[:]))
 			defer unlocker.Unlock()
 
 			// it wasn't me

--- a/services/rfq/relayer/service/handlers.go
+++ b/services/rfq/relayer/service/handlers.go
@@ -37,7 +37,7 @@ func (r *Relayer) handleBridgeRequestedLog(parentCtx context.Context, req *fastb
 		metrics.EndSpanWithErr(span, err)
 	}()
 
-	unlocker, ok := r.relayMtx.TryLock(hexutil.Encode(req.TransactionId[:]))
+	unlocker, ok := r.handlerMtx.TryLock(hexutil.Encode(req.TransactionId[:]))
 	if !ok {
 		span.SetAttributes(attribute.Bool("locked", true))
 		// already processing this request

--- a/services/rfq/relayer/service/relayer.go
+++ b/services/rfq/relayer/service/relayer.go
@@ -58,8 +58,8 @@ type Relayer struct {
 	decimalsCache  *xsync.MapOf[string, *uint8]
 	// semaphore is used to limit the number of concurrent requests
 	semaphore *semaphore.Weighted
-	// relayMtx is used to synchronize handling of relay requests
-	relayMtx mapmutex.StringMapMutex
+	// handlerMtx is used to synchronize handling of relay requests
+	handlerMtx mapmutex.StringMapMutex
 }
 
 var logger = log.Logger("relayer")
@@ -155,7 +155,7 @@ func NewRelayer(ctx context.Context, metricHandler metrics.Handler, cfg relconfi
 		apiServer:      apiServer,
 		apiClient:      apiClient,
 		semaphore:      semaphore.NewWeighted(maxConcurrentRequests),
-		relayMtx:       mapmutex.NewStringMapMutex(),
+		handlerMtx:     mapmutex.NewStringMapMutex(),
 	}
 	return &rel, nil
 }

--- a/services/rfq/relayer/service/relayer.go
+++ b/services/rfq/relayer/service/relayer.go
@@ -60,6 +60,8 @@ type Relayer struct {
 	semaphore *semaphore.Weighted
 	// handlerMtx is used to synchronize handling of relay requests
 	handlerMtx mapmutex.StringMapMutex
+	// balanceMtx is used to synchronize access to committable balances
+	balanceMtx mapmutex.IntMapMutex
 }
 
 var logger = log.Logger("relayer")
@@ -156,6 +158,7 @@ func NewRelayer(ctx context.Context, metricHandler metrics.Handler, cfg relconfi
 		apiClient:      apiClient,
 		semaphore:      semaphore.NewWeighted(maxConcurrentRequests),
 		handlerMtx:     mapmutex.NewStringMapMutex(),
+		balanceMtx:     mapmutex.NewIntMapMutex(),
 	}
 	return &rel, nil
 }

--- a/services/rfq/relayer/service/statushandler.go
+++ b/services/rfq/relayer/service/statushandler.go
@@ -49,8 +49,8 @@ type QuoteRequestHandler struct {
 	// mutexMiddlewareFunc is used to wrap the handler in a mutex middleware.
 	// this should only be done if Handling, not forwarding.
 	mutexMiddlewareFunc func(func(ctx context.Context, span trace.Span, req reldb.QuoteRequest) error) func(ctx context.Context, span trace.Span, req reldb.QuoteRequest) error
-	// relayMtx is the mutex for relaying.
-	relayMtx mapmutex.StringMapMutex
+	// handlerMtx is the mutex for relaying.
+	handlerMtx mapmutex.StringMapMutex
 }
 
 // Handler is the handler for a quote request.
@@ -79,7 +79,7 @@ func (r *Relayer) requestToHandler(ctx context.Context, req reldb.QuoteRequest) 
 		claimCache:          r.claimCache,
 		apiClient:           r.apiClient,
 		mutexMiddlewareFunc: r.mutexMiddleware,
-		relayMtx:            r.relayMtx,
+		handlerMtx:          r.handlerMtx,
 	}
 
 	// wrap in deadline middleware since the relay has not yet happened
@@ -102,7 +102,7 @@ func (r *Relayer) requestToHandler(ctx context.Context, req reldb.QuoteRequest) 
 
 func (r *Relayer) mutexMiddleware(next func(ctx context.Context, span trace.Span, req reldb.QuoteRequest) error) func(ctx context.Context, span trace.Span, req reldb.QuoteRequest) error {
 	return func(ctx context.Context, span trace.Span, req reldb.QuoteRequest) (err error) {
-		unlocker, ok := r.relayMtx.TryLock(hexutil.Encode(req.TransactionID[:]))
+		unlocker, ok := r.handlerMtx.TryLock(hexutil.Encode(req.TransactionID[:]))
 		if !ok {
 			span.SetAttributes(attribute.Bool("locked", true))
 			return nil
@@ -248,7 +248,7 @@ func (q *QuoteRequestHandler) Forward(ctx context.Context, request reldb.QuoteRe
 	}()
 
 	// sanity check to make sure that the lock is already acquired for this tx
-	_, ok := q.relayMtx.TryLock(txID)
+	_, ok := q.handlerMtx.TryLock(txID)
 	if ok {
 		panic(fmt.Sprintf("attempted forward while lock was not acquired for tx: %s", txID))
 	}

--- a/services/rfq/relayer/service/statushandler.go
+++ b/services/rfq/relayer/service/statushandler.go
@@ -51,6 +51,8 @@ type QuoteRequestHandler struct {
 	mutexMiddlewareFunc func(func(ctx context.Context, span trace.Span, req reldb.QuoteRequest) error) func(ctx context.Context, span trace.Span, req reldb.QuoteRequest) error
 	// handlerMtx is the mutex for relaying.
 	handlerMtx mapmutex.StringMapMutex
+	// balanceMtx is the mutex for balances.
+	balanceMtx mapmutex.IntMapMutex
 }
 
 // Handler is the handler for a quote request.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Switched from `relayMtx` to `handlerMtx` for better clarity and synchronization in handling relay events and requests.
  - Introduced `safeUpdateStatus` method for secure status updates with locking mechanisms.
  - Added `balanceMtx` for synchronizing committable balances access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->