### PR TITLE
strip links from command input

### DIFF
--- a/contrib/opbot/botmd/commands.go
+++ b/contrib/opbot/botmd/commands.go
@@ -245,6 +245,8 @@ func toTXSlackLink(txHash string, chainID uint32) string {
 }
 
 func stripLinks(input string) string {
+	fmt.Println(input)
+
 	linkRegex := regexp.MustCompile(`<https?://[^|>]+\|([^>]+)>`)
 	return linkRegex.ReplaceAllString(input, "$1")
 }

--- a/contrib/opbot/botmd/commands.go
+++ b/contrib/opbot/botmd/commands.go
@@ -245,8 +245,6 @@ func toTXSlackLink(txHash string, chainID uint32) string {
 }
 
 func stripLinks(input string) string {
-	fmt.Println(input)
-
 	linkRegex := regexp.MustCompile(`<https?://[^|>]+\|([^>]+)>`)
 	return linkRegex.ReplaceAllString(input, "$1")
 }

--- a/contrib/opbot/botmd/commands_test.go
+++ b/contrib/opbot/botmd/commands_test.go
@@ -1,0 +1,15 @@
+package botmd_test
+
+import (
+	"github.com/synapsecns/sanguine/contrib/opbot/botmd"
+	"testing"
+)
+
+func TestStripLinks(t *testing.T) {
+	testLink := "<https://example.com|example>"
+	expected := "example"
+
+	if got := botmd.StripLinks(testLink); got != expected {
+		t.Errorf("StripLinks(%s) = %s; want %s", testLink, got, expected)
+	}
+}

--- a/contrib/opbot/botmd/export_test.go
+++ b/contrib/opbot/botmd/export_test.go
@@ -1,0 +1,5 @@
+package botmd
+
+func StripLinks(input string) string {
+	return stripLinks(input)
+}

--- a/contrib/screener-api/.gitignore
+++ b/contrib/screener-api/.gitignore
@@ -1,0 +1,1 @@
+config.yml


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**

addresses #2783 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a function to remove links from strings, enhancing data processing in commands by extracting tags and transaction IDs without links.

- **Tests**
  - Added tests to verify the functionality of the new link-stripping feature.

- **Chores**
  - Updated `.gitignore` to include the `config.yml` file in the `contrib/screener-api` directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->