### PR TITLE
fix ethergo goreleaser config

### DIFF
--- a/ethergo/.goreleaser.yml
+++ b/ethergo/.goreleaser.yml
@@ -7,7 +7,7 @@ monorepo:
 builds:
   # Linux AMD64
   - id: signer-example
-    binary: api
+    binary: signer-example
     ldflags:
       # We need to build a static binary because we are building in a glibc based system and running in a musl container
       - -s -w -extldflags '-static'


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**

Fixes bug introduced in  #2795


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the build configuration to rename the binary from `api` to `signer-example` for the `signer-example` build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->