### PR TITLE
RFQ API: add bulk quotes endpoint

### DIFF
--- a/docs/bridge/docs/rfq/API/upsert-quotes.api.mdx
+++ b/docs/bridge/docs/rfq/API/upsert-quotes.api.mdx
@@ -1,0 +1,244 @@
+---
+id: upsert-quotes
+title: "Upsert quotes"
+description: "upsert bulk quotes from relayer."
+sidebar_label: "Upsert quotes"
+hide_title: true
+hide_table_of_contents: true
+api: eJyNVMGOmzAQ/RXkc9pEPea4VU89tKo2p3SFBhjAG8DesdkNQvx7ZzDZ0IRFCxIy4+fx87w37lWGLiVtvTaN2qvWOiQfJW11il5a49FFOZk6IqygQ/qqNorwpUXnH0zWqX2vUtN4bLwMwdpKpyCpts9O8vXKpSXWICNLxnJujU7+QnIZaY+1uwcwLx9DbdqQ23cWmZ/zpJtCDZswn5agm1hnM4RmOgXSOyQH/iSkswJjyDJC5z7O580JmxG2iMn1GbM4R1ycreEcG9IFM1rhPSHWmU+gz3Kf4KvsGTZFTPKMqVfXABBBt4QYQl1m/mDpqYssELBmwQuakE/hqcVBAs6axgUJv+12k5KzDL9+hp2gYMzx4oMnLh/60nAmZVvPqS34kn+2YsV4Qm2U2OrP1YA/zlDbCueGOt5Y51KAO8fs1gxys2pe2evUzA7X4IILrpN34u/Wtb5buURkeOJ66iY3l3aEVKwnRdZeiqN4/SuSCwKI8NY4X8PYoA3UAjmExn8v9H+izbr8MzfE5CKPZ7+1FR9VtmypGpt8lPWo5rKy+CUTknDfJ+DwQNUwSHi0G8d5+AqkIZHjHOW8JULGvSJyn5Ah6ntg+OVRNhd41Y7evr2ThrnVfh8eGZtMV1ltMllC8CbW5u9e/eVXqj8WYjT1GO9VBU3RQiH4kFaefxaR3uo=
+sidebar_class_name: "put api-method"
+custom_edit_url: null
+---
+
+import ApiTabs from "@theme/ApiTabs";
+import DiscriminatorTabs from "@theme/DiscriminatorTabs";
+import MethodEndpoint from "@theme/ApiExplorer/MethodEndpoint";
+import SecuritySchemes from "@theme/ApiExplorer/SecuritySchemes";
+import MimeTabs from "@theme/MimeTabs";
+import ParamsItem from "@theme/ParamsItem";
+import ResponseSamples from "@theme/ResponseSamples";
+import SchemaItem from "@theme/SchemaItem";
+import SchemaTabs from "@theme/SchemaTabs";
+import Markdown from "@theme/Markdown";
+import Heading from "@theme/Heading";
+import OperationTabs from "@theme/OperationTabs";
+import TabItem from "@theme/TabItem";
+
+<Heading
+  as={"h1"}
+  className={"openapi__heading"}
+  children={"Upsert quotes"}
+>
+</Heading>
+
+<MethodEndpoint
+  method={"put"}
+  path={"/bulk_quotes"}
+>
+  
+</MethodEndpoint>
+
+
+
+upsert bulk quotes from relayer.
+
+<Heading
+  id={"request"}
+  as={"h2"}
+  className={"openapi-tabs__heading"}
+  children={"Request"}
+>
+</Heading>
+
+<MimeTabs
+  className={"openapi-tabs__mime"}
+>
+  <TabItem
+    label={"application/json"}
+    value={"application/json-schema"}
+  >
+    <details
+      style={{}}
+      className={"openapi-markdown__details mime"}
+      data-collapsed={false}
+      open={true}
+    >
+      <summary
+        style={{}}
+        className={"openapi-markdown__details-summary-mime"}
+      >
+        <h3
+          className={"openapi-markdown__details-summary-header-body"}
+        >
+          Body
+        </h3><strong
+          className={"openapi-schema__required"}
+        >
+          required
+        </strong>
+      </summary><div
+        style={{"textAlign":"left","marginLeft":"1rem"}}
+      >
+        <div
+          style={{"marginTop":"1rem","marginBottom":"1rem"}}
+        >
+          
+          
+          query params
+          
+          
+        </div>
+      </div><ul
+        style={{"marginLeft":"1rem"}}
+      >
+        <SchemaItem
+          collapsible={true}
+          className={"schemaItem"}
+        >
+          <details
+            style={{}}
+            className={"openapi-markdown__details"}
+          >
+            <summary
+              style={{}}
+            >
+              <span
+                className={"openapi-schema__container"}
+              >
+                <strong
+                  className={"openapi-schema__property"}
+                >
+                  quotes
+                </strong><span
+                  className={"openapi-schema__name"}
+                >
+                   object[]
+                </span>
+              </span>
+            </summary><div
+              style={{"marginLeft":"1rem"}}
+            >
+              <li>
+                <div
+                  style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
+                >
+                  Array [
+                </div>
+              </li><SchemaItem
+                collapsible={false}
+                name={"dest_amount"}
+                required={false}
+                schemaName={"string"}
+                qualifierMessage={undefined}
+                schema={{"type":"string"}}
+              >
+                
+              </SchemaItem><SchemaItem
+                collapsible={false}
+                name={"dest_chain_id"}
+                required={false}
+                schemaName={"integer"}
+                qualifierMessage={undefined}
+                schema={{"type":"integer"}}
+              >
+                
+              </SchemaItem><SchemaItem
+                collapsible={false}
+                name={"dest_fast_bridge_address"}
+                required={false}
+                schemaName={"string"}
+                qualifierMessage={undefined}
+                schema={{"type":"string"}}
+              >
+                
+              </SchemaItem><SchemaItem
+                collapsible={false}
+                name={"dest_token_addr"}
+                required={false}
+                schemaName={"string"}
+                qualifierMessage={undefined}
+                schema={{"type":"string"}}
+              >
+                
+              </SchemaItem><SchemaItem
+                collapsible={false}
+                name={"fixed_fee"}
+                required={false}
+                schemaName={"string"}
+                qualifierMessage={undefined}
+                schema={{"type":"string"}}
+              >
+                
+              </SchemaItem><SchemaItem
+                collapsible={false}
+                name={"max_origin_amount"}
+                required={false}
+                schemaName={"string"}
+                qualifierMessage={undefined}
+                schema={{"type":"string"}}
+              >
+                
+              </SchemaItem><SchemaItem
+                collapsible={false}
+                name={"origin_chain_id"}
+                required={false}
+                schemaName={"integer"}
+                qualifierMessage={undefined}
+                schema={{"type":"integer"}}
+              >
+                
+              </SchemaItem><SchemaItem
+                collapsible={false}
+                name={"origin_fast_bridge_address"}
+                required={false}
+                schemaName={"string"}
+                qualifierMessage={undefined}
+                schema={{"type":"string"}}
+              >
+                
+              </SchemaItem><SchemaItem
+                collapsible={false}
+                name={"origin_token_addr"}
+                required={false}
+                schemaName={"string"}
+                qualifierMessage={undefined}
+                schema={{"type":"string"}}
+              >
+                
+              </SchemaItem><li>
+                <div
+                  style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
+                >
+                  ]
+                </div>
+              </li>
+            </div>
+          </details>
+        </SchemaItem>
+      </ul>
+    </details>
+  </TabItem>
+</MimeTabs><div>
+  <div>
+    <ApiTabs
+      label={undefined}
+      id={undefined}
+    >
+      <TabItem
+        label={"200"}
+        value={"200"}
+      >
+        <div>
+          
+          
+          OK
+          
+          
+        </div><div>
+          
+        </div>
+      </TabItem>
+    </ApiTabs>
+  </div>
+</div>
+      

--- a/services/rfq/api/client/client.go
+++ b/services/rfq/api/client/client.go
@@ -26,6 +26,7 @@ import (
 // It provides methods for creating, retrieving and updating quotes.
 type AuthenticatedClient interface {
 	PutQuote(ctx context.Context, q *model.PutQuoteRequest) error
+	PutBulkQuotes(ctx context.Context, q *model.PutBulkQuotesRequest) error
 	PutRelayAck(ctx context.Context, req *model.PutAckRequest) (*model.PutRelayAckResponse, error)
 	UnauthenticatedClient
 }
@@ -118,6 +119,19 @@ func (c *clientImpl) PutQuote(ctx context.Context, q *model.PutQuoteRequest) err
 		SetContext(ctx).
 		SetBody(q).
 		Put(rest.QuoteRoute)
+
+	// TODO: Figure out if there's anything to do with the response, right now it's result: Status Code 200 OK
+	_ = res
+
+	return err
+}
+
+// PutBulkQuotes puts multiple new quotes in the RFQ quoting API.
+func (c *clientImpl) PutBulkQuotes(ctx context.Context, q *model.PutBulkQuotesRequest) error {
+	res, err := c.rClient.R().
+		SetContext(ctx).
+		SetBody(q).
+		Put(rest.BulkQuotesRoute)
 
 	// TODO: Figure out if there's anything to do with the response, right now it's result: Status Code 200 OK
 	_ = res

--- a/services/rfq/api/client/client_test.go
+++ b/services/rfq/api/client/client_test.go
@@ -38,6 +38,65 @@ func (c *ClientSuite) TestPutAndGetQuote() {
 	c.Equal(expectedResp, *quotes[0])
 }
 
+func (c *ClientSuite) TestPutAndGetBulkQuotes() {
+	req := model.PutBulkQuotesRequest{
+		Quotes: []model.PutQuoteRequest{
+			{
+				OriginChainID:   1,
+				OriginTokenAddr: "0xOriginTokenAddr",
+				DestChainID:     42161,
+				DestTokenAddr:   "0xDestTokenAddr",
+				DestAmount:      "100",
+				MaxOriginAmount: "200",
+				FixedFee:        "10",
+			},
+			{
+				OriginChainID:   42161,
+				OriginTokenAddr: "0xOriginTokenAddr",
+				DestChainID:     1,
+				DestTokenAddr:   "0xDestTokenAddr",
+				DestAmount:      "100",
+				MaxOriginAmount: "200",
+				FixedFee:        "10",
+			},
+		},
+	}
+
+	err := c.client.PutBulkQuotes(c.GetTestContext(), &req)
+	c.Require().NoError(err)
+
+	quotes, err := c.client.GetAllQuotes(c.GetTestContext())
+	c.Require().NoError(err)
+
+	expectedResp := []model.GetQuoteResponse{
+		{
+			OriginChainID:   1,
+			OriginTokenAddr: "0xOriginTokenAddr",
+			DestChainID:     42161,
+			DestTokenAddr:   "0xDestTokenAddr",
+			DestAmount:      "100",
+			MaxOriginAmount: "200",
+			FixedFee:        "10",
+			RelayerAddr:     c.testWallet.Address().String(),
+			UpdatedAt:       quotes[0].UpdatedAt,
+		},
+		{
+			OriginChainID:   42161,
+			OriginTokenAddr: "0xOriginTokenAddr",
+			DestChainID:     1,
+			DestTokenAddr:   "0xDestTokenAddr",
+			DestAmount:      "100",
+			MaxOriginAmount: "200",
+			FixedFee:        "10",
+			RelayerAddr:     c.testWallet.Address().String(),
+			UpdatedAt:       quotes[0].UpdatedAt,
+		},
+	}
+	c.Len(quotes, 2)
+	c.Equal(expectedResp[0], *quotes[0])
+	c.Equal(expectedResp[1], *quotes[1])
+}
+
 func (c *ClientSuite) TestGetSpecificQuote() {
 	req := model.PutQuoteRequest{
 		OriginChainID:   1,

--- a/services/rfq/api/db/api_db.go
+++ b/services/rfq/api/db/api_db.go
@@ -50,6 +50,8 @@ type APIDBReader interface {
 type APIDBWriter interface {
 	// UpsertQuote upserts a quote in the database.
 	UpsertQuote(ctx context.Context, quote *Quote) error
+	// UpsertQuotes upserts multiple quotes in the database.
+	UpsertQuotes(ctx context.Context, quotes []*Quote) error
 }
 
 // APIDB is the interface for the database service.

--- a/services/rfq/api/db/sql/base/store.go
+++ b/services/rfq/api/db/sql/base/store.go
@@ -3,6 +3,7 @@ package base
 import (
 	"context"
 	"fmt"
+
 	"gorm.io/gorm/clause"
 
 	"github.com/synapsecns/sanguine/services/rfq/api/db"
@@ -60,6 +61,19 @@ func (s *Store) UpsertQuote(ctx context.Context, quote *db.Quote) error {
 
 	if dbTx.Error != nil {
 		return fmt.Errorf("could not update quote: %w", dbTx.Error)
+	}
+	return nil
+}
+
+// UpsertQuotes inserts multiple quotes into the database or updates existing ones.
+func (s *Store) UpsertQuotes(ctx context.Context, quotes []*db.Quote) error {
+	dbTx := s.DB().WithContext(ctx).
+		Clauses(clause.OnConflict{
+			UpdateAll: true,
+		}).Create(quotes)
+
+	if dbTx.Error != nil {
+		return fmt.Errorf("could not update quotes: %w", dbTx.Error)
 	}
 	return nil
 }

--- a/services/rfq/api/docs/docs.go
+++ b/services/rfq/api/docs/docs.go
@@ -46,6 +46,37 @@ const docTemplate = `{
                 }
             }
         },
+        "/bulk_quotes": {
+            "put": {
+                "description": "upsert bulk quotes from relayer.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "quotes"
+                ],
+                "summary": "Upsert quotes",
+                "parameters": [
+                    {
+                        "description": "query params",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.PutBulkQuotesRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
         "/quotes": {
             "get": {
                 "description": "get quotes from all relayers.",
@@ -181,6 +212,17 @@ const docTemplate = `{
                 "updated_at": {
                     "description": "UpdatedAt is the time that the quote was last upserted",
                     "type": "string"
+                }
+            }
+        },
+        "model.PutBulkQuotesRequest": {
+            "type": "object",
+            "properties": {
+                "quotes": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.PutQuoteRequest"
+                    }
                 }
             }
         },

--- a/services/rfq/api/docs/swagger.json
+++ b/services/rfq/api/docs/swagger.json
@@ -35,6 +35,37 @@
                 }
             }
         },
+        "/bulk_quotes": {
+            "put": {
+                "description": "upsert bulk quotes from relayer.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "quotes"
+                ],
+                "summary": "Upsert quotes",
+                "parameters": [
+                    {
+                        "description": "query params",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.PutBulkQuotesRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
         "/quotes": {
             "get": {
                 "description": "get quotes from all relayers.",
@@ -170,6 +201,17 @@
                 "updated_at": {
                     "description": "UpdatedAt is the time that the quote was last upserted",
                     "type": "string"
+                }
+            }
+        },
+        "model.PutBulkQuotesRequest": {
+            "type": "object",
+            "properties": {
+                "quotes": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.PutQuoteRequest"
+                    }
                 }
             }
         },

--- a/services/rfq/api/docs/swagger.yaml
+++ b/services/rfq/api/docs/swagger.yaml
@@ -43,6 +43,13 @@ definitions:
         description: UpdatedAt is the time that the quote was last upserted
         type: string
     type: object
+  model.PutBulkQuotesRequest:
+    properties:
+      quotes:
+        items:
+          $ref: '#/definitions/model.PutQuoteRequest'
+        type: array
+    type: object
   model.PutQuoteRequest:
     properties:
       dest_amount:
@@ -87,6 +94,26 @@ paths:
       summary: Relay ack
       tags:
       - ack
+  /bulk_quotes:
+    put:
+      consumes:
+      - application/json
+      description: upsert bulk quotes from relayer.
+      parameters:
+      - description: query params
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/model.PutBulkQuotesRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+      summary: Upsert quotes
+      tags:
+      - quotes
   /quotes:
     get:
       consumes:

--- a/services/rfq/api/model/request.go
+++ b/services/rfq/api/model/request.go
@@ -13,6 +13,11 @@ type PutQuoteRequest struct {
 	DestFastBridgeAddress   string `json:"dest_fast_bridge_address"`
 }
 
+// PutBulkQuotesRequest contains the schema for a PUT /quote request.
+type PutBulkQuotesRequest struct {
+	Quotes []PutQuoteRequest `json:"quotes"`
+}
+
 // PutAckRequest contains the schema for a PUT /ack request.
 type PutAckRequest struct {
 	TxID        string `json:"tx_id"`

--- a/services/rfq/api/rest/handler.go
+++ b/services/rfq/api/rest/handler.go
@@ -55,7 +55,7 @@ func (h *Handler) ModifyQuote(c *gin.Context) {
 		return
 	}
 
-	dbQuote, err := parseDBQuote(putRequest, relayerAddr)
+	dbQuote, err := parseDBQuote(*putRequest, relayerAddr)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
@@ -102,7 +102,7 @@ func (h *Handler) ModifyBulkQuotes(c *gin.Context) {
 
 	dbQuotes := []*db.Quote{}
 	for _, quoteReq := range putRequest.Quotes {
-		dbQuote, err := parseDBQuote(&quoteReq, relayerAddr)
+		dbQuote, err := parseDBQuote(quoteReq, relayerAddr)
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid quote request"})
 			return
@@ -118,18 +118,18 @@ func (h *Handler) ModifyBulkQuotes(c *gin.Context) {
 	c.Status(http.StatusOK)
 }
 
-func parseDBQuote(putRequest *model.PutQuoteRequest, relayerAddr interface{}) (*db.Quote, error) {
+func parseDBQuote(putRequest model.PutQuoteRequest, relayerAddr interface{}) (*db.Quote, error) {
 	destAmount, err := decimal.NewFromString(putRequest.DestAmount)
 	if err != nil {
-		return nil, fmt.Errorf("Invalid DestAmount")
+		return nil, fmt.Errorf("invalid DestAmount")
 	}
 	maxOriginAmount, err := decimal.NewFromString(putRequest.MaxOriginAmount)
 	if err != nil {
-		return nil, fmt.Errorf("Invalid MaxOriginAmount")
+		return nil, fmt.Errorf("invalid MaxOriginAmount")
 	}
 	fixedFee, err := decimal.NewFromString(putRequest.FixedFee)
 	if err != nil {
-		return nil, fmt.Errorf("Invalid FixedFee")
+		return nil, fmt.Errorf("invalid FixedFee")
 	}
 	// nolint: forcetypeassert
 	return &db.Quote{

--- a/services/rfq/api/rest/handler.go
+++ b/services/rfq/api/rest/handler.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 
@@ -54,23 +55,84 @@ func (h *Handler) ModifyQuote(c *gin.Context) {
 		return
 	}
 
+	dbQuote, err := parseDBQuote(putRequest, relayerAddr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	err = h.db.UpsertQuote(c, dbQuote)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.Status(http.StatusOK)
+}
+
+// ModifyBulkQuotes upserts multiple quotes
+//
+// PUT /bulk_quotes
+// @dev Protected Method: Authentication is handled through middleware in server.go.
+// nolint: cyclop
+// @Summary Upsert quotes
+// @Schemes
+// @Description upsert bulk quotes from relayer.
+// @Param request body model.PutBulkQuotesRequest true "query params"
+// @Tags quotes
+// @Accept json
+// @Produce json
+// @Success 200
+// @Router /bulk_quotes [put].
+func (h *Handler) ModifyBulkQuotes(c *gin.Context) {
+	// Retrieve the request from context
+	req, exists := c.Get("putRequest")
+	if !exists {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Request not found"})
+		return
+	}
+	relayerAddr, exists := c.Get("relayerAddr")
+	if !exists {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "No relayer address recovered from signature"})
+		return
+	}
+	putRequest, ok := req.(*model.PutBulkQuotesRequest)
+	if !ok {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request type"})
+		return
+	}
+
+	dbQuotes := []*db.Quote{}
+	for _, quoteReq := range putRequest.Quotes {
+		dbQuote, err := parseDBQuote(&quoteReq, relayerAddr)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid quote request"})
+			return
+		}
+		dbQuotes = append(dbQuotes, dbQuote)
+	}
+
+	err := h.db.UpsertQuotes(c, dbQuotes)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.Status(http.StatusOK)
+}
+
+func parseDBQuote(putRequest *model.PutQuoteRequest, relayerAddr interface{}) (*db.Quote, error) {
 	destAmount, err := decimal.NewFromString(putRequest.DestAmount)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid DestAmount"})
-		return
+		return nil, fmt.Errorf("Invalid DestAmount")
 	}
 	maxOriginAmount, err := decimal.NewFromString(putRequest.MaxOriginAmount)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid DestAmount"})
-		return
+		return nil, fmt.Errorf("Invalid MaxOriginAmount")
 	}
 	fixedFee, err := decimal.NewFromString(putRequest.FixedFee)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid FixedFee"})
-		return
+		return nil, fmt.Errorf("Invalid FixedFee")
 	}
 	// nolint: forcetypeassert
-	quote := &db.Quote{
+	return &db.Quote{
 		OriginChainID:   uint64(putRequest.OriginChainID),
 		OriginTokenAddr: putRequest.OriginTokenAddr,
 		DestChainID:     uint64(putRequest.DestChainID),
@@ -82,13 +144,7 @@ func (h *Handler) ModifyQuote(c *gin.Context) {
 		RelayerAddr:             relayerAddr.(string),
 		OriginFastBridgeAddress: putRequest.OriginFastBridgeAddress,
 		DestFastBridgeAddress:   putRequest.DestFastBridgeAddress,
-	}
-	err = h.db.UpsertQuote(c, quote)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	c.Status(http.StatusOK)
+	}, nil
 }
 
 // GetQuotes retrieves all quotes from the database.

--- a/services/rfq/api/rest/server.go
+++ b/services/rfq/api/rest/server.go
@@ -142,6 +142,8 @@ func NewAPI(
 const (
 	// QuoteRoute is the API endpoint for handling quote related requests.
 	QuoteRoute = "/quotes"
+	// BulkQuotesRoute is the API endpoint for handling bulk quote related requests.
+	BulkQuotesRoute = "/bulk_quotes"
 	// AckRoute is the API endpoint for handling relay ack related requests.
 	AckRoute      = "/ack"
 	cacheInterval = time.Minute
@@ -160,7 +162,9 @@ func (r *QuoterAPIServer) Run(ctx context.Context) error {
 	quotesPut := engine.Group(QuoteRoute)
 	quotesPut.Use(r.AuthMiddleware())
 	quotesPut.PUT("", h.ModifyQuote)
-	quotesPut.PUT("/bulk", h.ModifyBulkQuotes)
+	bulkQuotesPut := engine.Group(BulkQuotesRoute)
+	bulkQuotesPut.Use(r.AuthMiddleware())
+	bulkQuotesPut.PUT("", h.ModifyBulkQuotes)
 	ackPut := engine.Group(AckRoute)
 	ackPut.Use(r.AuthMiddleware())
 	ackPut.PUT("", r.PutRelayAck)

--- a/services/rfq/api/rest/server.go
+++ b/services/rfq/api/rest/server.go
@@ -160,6 +160,7 @@ func (r *QuoterAPIServer) Run(ctx context.Context) error {
 	quotesPut := engine.Group(QuoteRoute)
 	quotesPut.Use(r.AuthMiddleware())
 	quotesPut.PUT("", h.ModifyQuote)
+	quotesPut.PUT("/bulk", h.ModifyBulkQuotes)
 	ackPut := engine.Group(AckRoute)
 	ackPut.Use(r.AuthMiddleware())
 	ackPut.PUT("", r.PutRelayAck)

--- a/services/rfq/api/rest/server.go
+++ b/services/rfq/api/rest/server.go
@@ -192,8 +192,8 @@ func (r *QuoterAPIServer) Run(ctx context.Context) error {
 func (r *QuoterAPIServer) AuthMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var loggedRequest interface{}
-		var destChainID uint32
 		var err error
+		destChainIDs := []uint32{}
 
 		// Parse the dest chain id from the request
 		switch c.Request.URL.Path {
@@ -201,14 +201,23 @@ func (r *QuoterAPIServer) AuthMiddleware() gin.HandlerFunc {
 			var req model.PutQuoteRequest
 			err = c.BindJSON(&req)
 			if err == nil {
-				destChainID = uint32(req.DestChainID)
+				destChainIDs = append(destChainIDs, uint32(req.DestChainID))
+				loggedRequest = &req
+			}
+		case BulkQuotesRoute:
+			var req model.PutBulkQuotesRequest
+			err = c.BindJSON(&req)
+			if err == nil {
+				for _, quote := range req.Quotes {
+					destChainIDs = append(destChainIDs, uint32(quote.DestChainID))
+				}
 				loggedRequest = &req
 			}
 		case AckRoute:
 			var req model.PutAckRequest
 			err = c.BindJSON(&req)
 			if err == nil {
-				destChainID = uint32(req.DestChainID)
+				destChainIDs = append(destChainIDs, uint32(req.DestChainID))
 				loggedRequest = &req
 			}
 		default:
@@ -221,11 +230,21 @@ func (r *QuoterAPIServer) AuthMiddleware() gin.HandlerFunc {
 		}
 
 		// Authenticate and fetch the address from the request
-		addressRecovered, err := r.checkRole(c, destChainID)
-		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"msg": err.Error()})
-			c.Abort()
-			return
+		var addressRecovered *common.Address
+		for _, destChainID := range destChainIDs {
+			addr, err := r.checkRole(c, destChainID)
+			if err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"msg": err.Error()})
+				c.Abort()
+				return
+			}
+			if addressRecovered == nil {
+				addressRecovered = &addr
+			} else if *addressRecovered != addr {
+				c.JSON(http.StatusBadRequest, gin.H{"msg": "relayer address mismatch"})
+				c.Abort()
+				return
+			}
 		}
 
 		// Log and pass to the next middleware if authentication succeeds

--- a/services/rfq/relayer/quoter/quoter.go
+++ b/services/rfq/relayer/quoter/quoter.go
@@ -611,7 +611,7 @@ func (m *Manager) submitQuote(ctx context.Context, quote model.PutQuoteRequest) 
 	return nil
 }
 
-// Submits a single quote.
+// Submits multiple quotes.
 func (m *Manager) submitBulkQuotes(ctx context.Context, quotes []model.PutQuoteRequest) error {
 	quoteCtx, quoteCancel := context.WithTimeout(ctx, m.config.GetQuoteSubmissionTimeout())
 	defer quoteCancel()

--- a/services/rfq/relayer/relconfig/config.go
+++ b/services/rfq/relayer/relconfig/config.go
@@ -55,6 +55,8 @@ type Config struct {
 	EnableAPIWithdrawals bool `yaml:"enable_api_withdrawals"`
 	// WithdrawalWhitelist is a list of addresses that are allowed to withdraw.
 	WithdrawalWhitelist []string `yaml:"withdrawal_whitelist"`
+	// SubmitSingleQuotes enables submitting single quotes.
+	SubmitSingleQuotes bool `yaml:"submit_single_quotes"`
 }
 
 // ChainConfig represents the configuration for a chain.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced bulk quoting functionality, allowing users to put multiple new quotes in a single API request.
	- Added new endpoint `/bulk_quotes` for upserting bulk quotes from a relayer.
- **Enhancements**
	- Updated API documentation to include details for bulk quote upsert requests.
	- Refactored quote modification logic to support bulk operations.
- **Configuration**
	- Added new configuration option to toggle between single and bulk quote submission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
9fbfc1672451c2517c27080bac894c19072d1a86: [docs preview link ](https://bridge-docs-oexgqzhyo-synapsecns.vercel.app)
f026953e071b02bc4a5abf66dc5f7f761c7d1775: [docs preview link ](https://bridge-docs-obux79py6-synapsecns.vercel.app)