### PR TITLE
feat(git): purge jsdelivr cdn cache workflow

### DIFF
--- a/.github/workflows/purge.yml
+++ b/.github/workflows/purge.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   purge-cache:
     runs-on: ubuntu-latest
-
+    steps:
       - name: Purge CDN Caches
         uses: gacts/purge-jsdelivr-cache@v1
         with:

--- a/.github/workflows/purge.yml
+++ b/.github/workflows/purge.yml
@@ -9,16 +9,10 @@ jobs:
   purge-cache:
     runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
       - name: Purge CDN Caches
         uses: gacts/purge-jsdelivr-cache@v1
         with:
           url: |
             https://cdn.jsdelivr.net/gh/synapsecns/sanguine@master/packages/synapse-interface/public/pauses/v1/paused-chains.json
             https://cdn.jsdelivr.net/gh/synapsecns/sanguine@master/packages/synapse-interface/public/pauses/v1/paused-bridge-modules.json
-            https://cdn.jsdelivr.net/gh/synapsecns/sanguine@test/maintenance/packages/synapse-interface/public/pauses/v1/paused-chains.json
-            https://cdn.jsdelivr.net/gh/synapsecns/sanguine@test/maintenance/packages/synapse-interface/public/pauses/v1/paused-bridge-modules.json
 

--- a/.github/workflows/purge.yml
+++ b/.github/workflows/purge.yml
@@ -1,0 +1,20 @@
+name: Purge Cache (jsDelivr)
+
+on:
+  push:
+    paths:
+      - 'packages/synapse-interface/public/pauses/v1/**'
+
+jobs:
+  purge-cache:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Purge CDN Caches
+        uses: egad13/purge-jsdelivr-cache@v1
+        with:
+          url: 'https://cdn.jsdelivr.net/gh/synapsecns/sanguine@master/packages/synapse-interface/public/pauses/v1/paused-chains.json' |
+               'https://cdn.jsdelivr.net/gh/synapsecns/sanguine@master/packages/synapse-interface/public/pauses/v1/paused-bridge-modules.json'

--- a/.github/workflows/purge.yml
+++ b/.github/workflows/purge.yml
@@ -19,3 +19,6 @@ jobs:
           url: |
             https://cdn.jsdelivr.net/gh/synapsecns/sanguine@master/packages/synapse-interface/public/pauses/v1/paused-chains.json
             https://cdn.jsdelivr.net/gh/synapsecns/sanguine@master/packages/synapse-interface/public/pauses/v1/paused-bridge-modules.json
+            https://cdn.jsdelivr.net/gh/synapsecns/sanguine@test/maintenance/packages/synapse-interface/public/pauses/v1/paused-chains.json
+            https://cdn.jsdelivr.net/gh/synapsecns/sanguine@test/maintenance/packages/synapse-interface/public/pauses/v1/paused-bridge-modules.json
+

--- a/.github/workflows/purge.yml
+++ b/.github/workflows/purge.yml
@@ -14,7 +14,8 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Purge CDN Caches
-        uses: egad13/purge-jsdelivr-cache@v1
+        uses: gacts/purge-jsdelivr-cache@v1
         with:
-          url: 'https://cdn.jsdelivr.net/gh/synapsecns/sanguine@master/packages/synapse-interface/public/pauses/v1/paused-chains.json' |
-               'https://cdn.jsdelivr.net/gh/synapsecns/sanguine@master/packages/synapse-interface/public/pauses/v1/paused-bridge-modules.json'
+          url: |
+            https://cdn.jsdelivr.net/gh/synapsecns/sanguine@master/packages/synapse-interface/public/pauses/v1/paused-chains.json
+            https://cdn.jsdelivr.net/gh/synapsecns/sanguine@master/packages/synapse-interface/public/pauses/v1/paused-bridge-modules.json


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Introduced a new workflow to purge CDN caches (jsDelivr) on specific push events, improving cache management and ensuring up-to-date content delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->