### PR TITLE
change to latest block number for default value in listener

### DIFF
--- a/ethergo/listener/options.go
+++ b/ethergo/listener/options.go
@@ -39,7 +39,7 @@ func WithFinalityMode(mode string) Option {
 		case "finalized":
 			c.finalityMode = rpc.FinalizedBlockNumber
 		default:
-			c.finalityMode = rpc.SafeBlockNumber
+			c.finalityMode = rpc.LatestBlockNumber
 		}
 	}
 }


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**
A clear and concise description of the features you're adding in this pull request.

**Additional context**
Add any other context about the problem you're solving.

**Metadata**
- Fixes #[Link to Issue]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of unrecognized finality modes, now defaulting to the latest block number instead of a safe block number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->