### PR TITLE
FE LiFi: Revoke approvals 

### DIFF
--- a/packages/synapse-interface/pages/lifi/index.tsx
+++ b/packages/synapse-interface/pages/lifi/index.tsx
@@ -87,6 +87,10 @@ const LifiPage = () => {
           >
             <div className="pb-3 place-self-center">
             <div>
+              <h3>Li.fi / Jumper is investigating an ongoing exploit, and users should revoke approvals <a className="underline" target="_blank" href="https://x.com/lifiprotocol/status/1813196697641570635">- Li.fi Tweet</a></h3>
+              <br />
+              <h3> Check to see if you have any approvals at risk below:</h3>
+              <br />
                 <div>USDC Allowance At Risk: {usdcAllowance.toString()}</div>
                 <div>USDT Allowance At Risk: {usdtAllowance.toString()}</div>
                 <div>WETH Allowance at Risk: {wethAllowance.toString()}</div>

--- a/packages/synapse-interface/pages/lifi/index.tsx
+++ b/packages/synapse-interface/pages/lifi/index.tsx
@@ -91,9 +91,13 @@ const LifiPage = () => {
               <br />
               <h3> Check to see if you have any approvals at risk below:</h3>
               <br />
-                <div>USDC Allowance At Risk: {usdcAllowance.toString()}</div>
-                <div>USDT Allowance At Risk: {usdtAllowance.toString()}</div>
-                <div>WETH Allowance at Risk: {wethAllowance.toString()}</div>
+                {isConnected && (
+                  <>
+                    <div>USDC Allowance At Risk: {usdcAllowance.toString()}</div>
+                    <div>USDT Allowance At Risk: {usdtAllowance.toString()}</div>
+                    <div>WETH Allowance at Risk: {wethAllowance.toString()}</div>
+                  </>
+                )}
               </div>
             </div>
             {!isConnected && (
@@ -105,7 +109,7 @@ const LifiPage = () => {
                     border: '1px solid #9B6DD7',
                     borderRadius: '4px',
                   }}
-                  label="Connect wallet"
+                  label="Connect wallet to check for approvals"
                   pendingLabel="Connecting"
                   onClick={() =>
                     new Promise((resolve, reject) => {

--- a/packages/synapse-interface/pages/lifi/index.tsx
+++ b/packages/synapse-interface/pages/lifi/index.tsx
@@ -1,0 +1,176 @@
+import Grid from '@tw/Grid'
+import { useEffect, useState } from 'react'
+import { useAccount } from 'wagmi'
+
+import { DEFAULT_FROM_CHAIN } from '@/constants/swap'
+import { LandingPageWrapper } from '@layouts/LandingPageWrapper'
+import StandardPageContainer from '@layouts/StandardPageContainer'
+import { getErc20TokenAllowance } from '@/actions/getErc20TokenAllowance'
+import { approveToken } from '@/utils/approveToken'
+import { TransactionButton } from '@/components/buttons/TransactionButton'
+import { useConnectModal } from '@rainbow-me/rainbowkit'
+
+const LifiPage = () => {
+  const { address: currentAddress, chain, isConnected } = useAccount()
+  const [connectedChainId, setConnectedChainId] = useState(0)
+  const [address, setAddress] = useState(undefined)
+  const { openConnectModal } = useConnectModal()
+
+  useEffect(() => {
+    setConnectedChainId(chain?.id ?? DEFAULT_FROM_CHAIN)
+  }, [chain])
+
+  useEffect(() => {
+    setAddress(currentAddress)
+  }, [currentAddress])
+
+            const usdcAddress = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
+            const usdtAddress = '0xdac17f958d2ee523a2206206994597c13d831ec7'
+            const wethAddress = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'
+
+            const [usdcAllowance, setUsdcAllowance] = useState<bigint>(0n)
+            const [usdtAllowance, setUsdtAllowance] = useState<bigint>(0n)
+            const [wethAllowance, setWethAllowance] = useState<bigint>(0n)
+
+            useEffect(() => {
+              const fetchAllowances = async () => {
+                if (address) {
+                  const usdcAllowance = await getErc20TokenAllowance({
+                    address: "0xbc6f5a4ed57f16af3db54da801aba8d1dc4ed675",
+                    chainId: connectedChainId,
+                    tokenAddress: usdcAddress,
+                    spender: "0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae",
+                  })
+                  setUsdcAllowance(usdcAllowance)
+
+                  const usdtAllowance = await getErc20TokenAllowance({
+                    address: "0xbc6f5a4ed57f16af3db54da801aba8d1dc4ed675",
+                    chainId: connectedChainId,
+                    tokenAddress: usdtAddress,
+                    spender: "0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae",
+                  })
+                  setUsdtAllowance(usdtAllowance)
+
+                  const wethAllowance = await getErc20TokenAllowance({
+                    address: "0xbc6f5a4ed57f16af3db54da801aba8d1dc4ed675",
+                    chainId: connectedChainId,
+                    tokenAddress: wethAddress,
+                    spender: "0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae",
+                  })
+                  setWethAllowance(wethAllowance)
+                }
+              }
+
+              fetchAllowances()
+            }, [address, connectedChainId])
+
+
+
+  return (
+    <LandingPageWrapper>
+      <StandardPageContainer
+        connectedChainId={connectedChainId}
+        address={address}
+      >
+        <div className="flex justify-between">
+          <div>
+            <div className="text-2xl text-white">
+              Revoke Li.fi Approvals
+            </div>
+          </div>
+        </div>
+        <div className="py-6">
+          <Grid
+            cols={{ xs: 1 }}
+            gap={6}
+            className="justify-center px-2 py-16 sm:px-6 md:px-8"
+          >
+            <div className="pb-3 place-self-center">
+            <div>
+                <div>USDC Allowance At Risk: {usdcAllowance.toString()}</div>
+                <div>USDT Allowance At Risk: {usdtAllowance.toString()}</div>
+                <div>WETH Allowance at Risk: {wethAllowance.toString()}</div>
+              </div>
+            </div>
+            {!isConnected && (
+              <div className="flex flex-col justify-center h-full p-10">
+                <TransactionButton
+                  style={{
+                    background:
+                      'linear-gradient(90deg, rgba(128, 0, 255, 0.2) 0%, rgba(255, 0, 191, 0.2) 100%)',
+                    border: '1px solid #9B6DD7',
+                    borderRadius: '4px',
+                  }}
+                  label="Connect wallet"
+                  pendingLabel="Connecting"
+                  onClick={() =>
+                    new Promise((resolve, reject) => {
+                      try {
+                        openConnectModal()
+                        resolve(true)
+                      } catch (e) {
+                        reject(e)
+                      }
+                    })
+                  }
+                />
+              </div>
+            )}
+            {usdcAllowance > 0n && (
+              <TransactionButton
+                className="btn btn-primary"
+                pendingLabel="Revoking..."
+                label="Revoke USDC Approval"
+                onClick={async () => {
+                  await approveToken(
+                    "0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae",
+                    connectedChainId,
+                    usdcAddress,
+                    0n,
+                  )
+                  setUsdcAllowance(0n)
+                }}
+              />
+            )}
+
+            {usdtAllowance > 0n && (
+              <TransactionButton
+                className="btn btn-primary"
+                pendingLabel="Revoking..."
+                label="Revoke USDT Approval"
+                onClick={async () => {
+                  await approveToken(
+                    "0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae",
+                    connectedChainId,
+                    usdtAddress,
+                    0n,
+                  )
+                  setUsdtAllowance(0n)
+                }}
+              />
+            )}
+
+          {wethAllowance > 0n && (
+              <TransactionButton
+                className="btn btn-primary"
+                pendingLabel="Revoking..."
+                label="Revoke WETH Approval"
+                onClick={async () => {
+                  await approveToken(
+                    "0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae",
+                    connectedChainId,
+                    wethAddress,
+                    0n,
+                  )
+                  setWethAllowance(0n)
+                }}
+              />
+            )}
+          </Grid>
+        </div>
+      </StandardPageContainer>
+    </LandingPageWrapper>
+  )
+}
+
+export default LifiPage

--- a/packages/synapse-interface/pages/lifi/index.tsx
+++ b/packages/synapse-interface/pages/lifi/index.tsx
@@ -36,7 +36,7 @@ const LifiPage = () => {
               const fetchAllowances = async () => {
                 if (address) {
                   const usdcAllowance = await getErc20TokenAllowance({
-                    address: "0xbc6f5a4ed57f16af3db54da801aba8d1dc4ed675",
+                    address: currentAddress,
                     chainId: connectedChainId,
                     tokenAddress: usdcAddress,
                     spender: "0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae",
@@ -44,7 +44,7 @@ const LifiPage = () => {
                   setUsdcAllowance(usdcAllowance)
 
                   const usdtAllowance = await getErc20TokenAllowance({
-                    address: "0xbc6f5a4ed57f16af3db54da801aba8d1dc4ed675",
+                    address: currentAddress,
                     chainId: connectedChainId,
                     tokenAddress: usdtAddress,
                     spender: "0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae",
@@ -52,7 +52,7 @@ const LifiPage = () => {
                   setUsdtAllowance(usdtAllowance)
 
                   const wethAllowance = await getErc20TokenAllowance({
-                    address: "0xbc6f5a4ed57f16af3db54da801aba8d1dc4ed675",
+                    address: currentAddress,
                     chainId: connectedChainId,
                     tokenAddress: wethAddress,
                     spender: "0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae",

--- a/packages/synapse-interface/pages/lifi/index.tsx
+++ b/packages/synapse-interface/pages/lifi/index.tsx
@@ -1,8 +1,8 @@
 import Grid from '@tw/Grid'
 import { useEffect, useState } from 'react'
-import { useAccount } from 'wagmi'
+import { useAccount, useAccountEffect, useSwitchChain } from 'wagmi'
 
-import { DEFAULT_FROM_CHAIN } from '@/constants/swap'
+
 import { LandingPageWrapper } from '@layouts/LandingPageWrapper'
 import StandardPageContainer from '@layouts/StandardPageContainer'
 import { getErc20TokenAllowance } from '@/actions/getErc20TokenAllowance'
@@ -10,72 +10,80 @@ import { approveToken } from '@/utils/approveToken'
 import { TransactionButton } from '@/components/buttons/TransactionButton'
 import { useConnectModal } from '@rainbow-me/rainbowkit'
 
+const CHAIN_IDS = [1, 42161, 10]
+const LIFI_SPENDER = "0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae"
+
+const TOKENS = {
+  USDC: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+  USDT: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+  WETH: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'
+} as const;
+
+interface TokenAllowances {
+  [chainId: number]: {
+    [token: string]: bigint
+  }
+}
+
 const LifiPage = () => {
-  const { address: currentAddress, chain, isConnected } = useAccount()
-  const [connectedChainId, setConnectedChainId] = useState(0)
-  const [address, setAddress] = useState(undefined)
+  const { address, isConnected, chain } = useAccount()
+  const { chains, switchChain: switchNetwork } = useSwitchChain()
   const { openConnectModal } = useConnectModal()
 
-  useEffect(() => {
-    setConnectedChainId(chain?.id ?? DEFAULT_FROM_CHAIN)
-  }, [chain])
+  const [allowances, setAllowances] = useState<TokenAllowances>({})
 
   useEffect(() => {
-    setAddress(currentAddress)
-  }, [currentAddress])
+    const fetchAllowances = async () => {
+      if (address) {
+        const newAllowances: TokenAllowances = {}
 
-            const usdcAddress = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
-            const usdtAddress = '0xdac17f958d2ee523a2206206994597c13d831ec7'
-            const wethAddress = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'
+        for (const chainId of CHAIN_IDS) {
+          newAllowances[chainId] = {}
 
-            const [usdcAllowance, setUsdcAllowance] = useState<bigint>(0n)
-            const [usdtAllowance, setUsdtAllowance] = useState<bigint>(0n)
-            const [wethAllowance, setWethAllowance] = useState<bigint>(0n)
+          for (const [tokenName, tokenAddress] of Object.entries(TOKENS)) {
+            const allowance = await getErc20TokenAllowance({
+              address,
+              chainId,
+              tokenAddress,
+              spender: LIFI_SPENDER,
+            })
+            newAllowances[chainId][tokenName] = allowance
+          }
+        }
 
-            useEffect(() => {
-              const fetchAllowances = async () => {
-                if (address) {
-                  const usdcAllowance = await getErc20TokenAllowance({
-                    address: currentAddress,
-                    chainId: connectedChainId,
-                    tokenAddress: usdcAddress,
-                    spender: "0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae",
-                  })
-                  setUsdcAllowance(usdcAllowance)
+        setAllowances(newAllowances)
+      }
+    }
 
-                  const usdtAllowance = await getErc20TokenAllowance({
-                    address: currentAddress,
-                    chainId: connectedChainId,
-                    tokenAddress: usdtAddress,
-                    spender: "0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae",
-                  })
-                  setUsdtAllowance(usdtAllowance)
+    if (isConnected) {
+      fetchAllowances()
+    }
+  }, [address, isConnected])
 
-                  const wethAllowance = await getErc20TokenAllowance({
-                    address: currentAddress,
-                    chainId: connectedChainId,
-                    tokenAddress: wethAddress,
-                    spender: "0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae",
-                  })
-                  setWethAllowance(wethAllowance)
-                }
-              }
-
-              fetchAllowances()
-            }, [address, connectedChainId])
-
-
+  const handleRevoke = async (chainId: number, tokenName: string, tokenAddress: string) => {
+    if (chain?.id !== chainId) {
+      await switchNetwork({chainId: chainId})
+    }
+    await approveToken(LIFI_SPENDER, chainId, tokenAddress, 0n)
+    setAllowances(prev => ({
+      ...prev,
+      [chainId]: {
+        ...prev[chainId],
+        [tokenName]: 0n
+      }
+    }))
+  }
 
   return (
     <LandingPageWrapper>
       <StandardPageContainer
-        connectedChainId={connectedChainId}
+        connectedChainId={chain?.id}
         address={address}
       >
         <div className="flex justify-between">
           <div>
             <div className="text-2xl text-white">
-              Revoke Li.fi Approvals
+              Revoke Li.fi Approvals (Multi-chain)
             </div>
           </div>
         </div>
@@ -86,94 +94,49 @@ const LifiPage = () => {
             className="justify-center px-2 py-16 sm:px-6 md:px-8"
           >
             <div className="pb-3 place-self-center">
-            <div>
-              <h3>Li.fi / Jumper is investigating an ongoing exploit, and users should revoke approvals <a className="underline" target="_blank" href="https://x.com/lifiprotocol/status/1813196697641570635">- Li.fi Tweet</a></h3>
-              <br />
-              <h3> Check to see if you have any approvals at risk below:</h3>
-              <br />
-                {isConnected && (
-                  <>
-                    <div>USDC Allowance At Risk: {usdcAllowance.toString()}</div>
-                    <div>USDT Allowance At Risk: {usdtAllowance.toString()}</div>
-                    <div>WETH Allowance at Risk: {wethAllowance.toString()}</div>
-                  </>
+              <div>
+                <h3>Li.fi / Jumper is investigating an ongoing exploit, and users should revoke approvals <a className="underline" target="_blank" href="https://x.com/lifiprotocol/status/1813196697641570635">- Li.fi Tweet</a></h3>
+                <br />
+                <h3>Check to see if you have any approvals at risk below:</h3>
+                <br />
+                {isConnected ? (
+                  CHAIN_IDS.map(chainId => (
+                    <div key={chainId}>
+                      <h4>Chain ID: {chainId}</h4>
+                      {Object.entries(allowances[chainId] || {}).map(([tokenName, allowance]) => (
+                        <div key={tokenName}>
+                          {tokenName} Allowance: {allowance.toString()}
+                          {allowance > 0n && (
+                            <TransactionButton
+                              className="btn btn-primary ml-2"
+                              pendingLabel="Revoking..."
+                              label={`Revoke ${tokenName} Approval`}
+                              onClick={() => handleRevoke(chainId, tokenName, TOKENS[tokenName])}
+                            />
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  ))
+                ) : (
+                  <div className="flex flex-col justify-center h-full p-10">
+                    <TransactionButton
+                      style={{
+                        background: 'linear-gradient(90deg, rgba(128, 0, 255, 0.2) 0%, rgba(255, 0, 191, 0.2) 100%)',
+                        border: '1px solid #9B6DD7',
+                        borderRadius: '4px',
+                      }}
+                      label="Connect wallet to check for approvals"
+                      pendingLabel="Connecting"
+                      onClick={() => new Promise((resolve) => {
+                        openConnectModal()
+                        resolve(true)
+                      })}
+                    />
+                  </div>
                 )}
               </div>
             </div>
-            {!isConnected && (
-              <div className="flex flex-col justify-center h-full p-10">
-                <TransactionButton
-                  style={{
-                    background:
-                      'linear-gradient(90deg, rgba(128, 0, 255, 0.2) 0%, rgba(255, 0, 191, 0.2) 100%)',
-                    border: '1px solid #9B6DD7',
-                    borderRadius: '4px',
-                  }}
-                  label="Connect wallet to check for approvals"
-                  pendingLabel="Connecting"
-                  onClick={() =>
-                    new Promise((resolve, reject) => {
-                      try {
-                        openConnectModal()
-                        resolve(true)
-                      } catch (e) {
-                        reject(e)
-                      }
-                    })
-                  }
-                />
-              </div>
-            )}
-            {usdcAllowance > 0n && (
-              <TransactionButton
-                className="btn btn-primary"
-                pendingLabel="Revoking..."
-                label="Revoke USDC Approval"
-                onClick={async () => {
-                  await approveToken(
-                    "0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae",
-                    connectedChainId,
-                    usdcAddress,
-                    0n,
-                  )
-                  setUsdcAllowance(0n)
-                }}
-              />
-            )}
-
-            {usdtAllowance > 0n && (
-              <TransactionButton
-                className="btn btn-primary"
-                pendingLabel="Revoking..."
-                label="Revoke USDT Approval"
-                onClick={async () => {
-                  await approveToken(
-                    "0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae",
-                    connectedChainId,
-                    usdtAddress,
-                    0n,
-                  )
-                  setUsdtAllowance(0n)
-                }}
-              />
-            )}
-
-          {wethAllowance > 0n && (
-              <TransactionButton
-                className="btn btn-primary"
-                pendingLabel="Revoking..."
-                label="Revoke WETH Approval"
-                onClick={async () => {
-                  await approveToken(
-                    "0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae",
-                    connectedChainId,
-                    wethAddress,
-                    0n,
-                  )
-                  setWethAllowance(0n)
-                }}
-              />
-            )}
           </Grid>
         </div>
       </StandardPageContainer>


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**
A clear and concise description of the features you're adding in this pull request.

**Additional context**
Add any other context about the problem you're solving.

**Metadata**
- Fixes #[Link to Issue]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new page for managing Li.fi approvals for USDC, USDT, and WETH tokens.
  - Allows users to fetch token allowances and revoke approvals directly from the interface.
  - Conditional rendering based on wallet connection status for a seamless user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
9db21f2ba71dc4b77a5857fb2bd3d0d63ec2b278: [synapse-interface preview link ](https://sanguine-synapse-interface-ogdhn2r1n-synapsecns.vercel.app)
2a607fcd3e08dcd6bf14ea65952e230dcdcecff4: [synapse-interface preview link ](https://sanguine-synapse-interface-3su8eyn2s-synapsecns.vercel.app)
0faff577bfdbd88877d8f64f851579456c752429: [synapse-interface preview link ](https://sanguine-synapse-interface-m1z3geis4-synapsecns.vercel.app)
19ae944b18260af885a311054a8540deb8ecfc56: [synapse-interface preview link ](https://sanguine-synapse-interface-4lt7ws9sh-synapsecns.vercel.app)