### PR TITLE
updating etherscan link in explorer-ui

### DIFF
--- a/packages/synapse-constants/constants/chains/master.ts
+++ b/packages/synapse-constants/constants/chains/master.ts
@@ -54,7 +54,7 @@ export const ETH: Chain = {
     primary: 'https://rpc.ankr.com/eth',
     fallback: 'https://1rpc.io/eth',
   },
-  explorerUrl: 'https://etherscan.com',
+  explorerUrl: 'https://etherscan.io',
   explorerName: 'Etherscan',
   explorerImg: ethExplorerImg,
   blockTime: 12000,


### PR DESCRIPTION
changes the route from etherscan.com to etherscan.io. Changes it in the constants npm package. 