### PR TITLE
fix(solidity-devops): correctly save new deployments when script entry function is not `run()`

### DIFF
--- a/packages/solidity-devops/js/forgeScriptRun.js
+++ b/packages/solidity-devops/js/forgeScriptRun.js
@@ -58,7 +58,11 @@ if (newDeployments.length === 0) {
   logInfo('No new deployments found')
   process.exit(0)
 }
-const newReceipts = getNewDeploymentReceipts(chainName, scriptFN)
+const newReceipts = getNewDeploymentReceipts(
+  chainName,
+  scriptFN,
+  currentTimestamp
+)
 newDeployments.forEach((contractAlias) =>
   saveNewDeployment(chainName, contractAlias, newReceipts)
 )

--- a/packages/solidity-devops/js/utils/deployments.js
+++ b/packages/solidity-devops/js/utils/deployments.js
@@ -181,6 +181,13 @@ const getNewDeploymentReceipts = (chainName, scriptFN, timestamp) => {
   const chainId = getChainId(chainName)
   const scriptBaseName = path.basename(scriptFN)
   const broadcastDir = path.join('broadcast', scriptBaseName, chainId)
+  // Silent exit if the broadcast directory does not exist
+  if (!fs.existsSync(broadcastDir)) {
+    logError(
+      `No broadcast directory found for ${scriptBaseName} at ${broadcastDir}`
+    )
+    return []
+  }
   // Look for "*-latest.json" files created after the given timestamp.
   // These are named after the script entry function, which is usually "run", but could be different.
   // In practice there should be only one file, but we implement a generic logic just in case.

--- a/packages/solidity-devops/js/utils/deployments.js
+++ b/packages/solidity-devops/js/utils/deployments.js
@@ -177,11 +177,23 @@ const getAllDeploymentReceipts = (chainName) => {
   })
 }
 
-const getNewDeploymentReceipts = (chainName, scriptFN) => {
+const getNewDeploymentReceipts = (chainName, scriptFN, timestamp) => {
   const chainId = getChainId(chainName)
   const scriptBaseName = path.basename(scriptFN)
-  const broadcastFN = `broadcast/${scriptBaseName}/${chainId}/run-latest.json`
-  return extractDeploymentReceipts(broadcastFN)
+  const broadcastDir = path.join('broadcast', scriptBaseName, chainId)
+  // Look for "*-latest.json" files created after the given timestamp.
+  // These are named after the script entry function, which is usually "run", but could be different.
+  // In practice there should be only one file, but we implement a generic logic just in case.
+  return fs
+    .readdirSync(broadcastDir)
+    .filter((fn) => {
+      if (!fn.endsWith('-latest.json')) {
+        return false
+      }
+      const stats = fs.statSync(path.join(broadcastDir, fn))
+      return stats.mtimeMs > timestamp
+    })
+    .flatMap((fn) => extractDeploymentReceipts(path.join(broadcastDir, fn)))
 }
 
 const extractDeploymentReceipts = (broadcastFN) => {


### PR DESCRIPTION
**Description**
See title.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced deployment receipt functionality to use current timestamps, ensuring accurate retrieval of new deployment receipts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->