### PR TITLE
fix(synapse-interface): Fixes explorer link

### DIFF
--- a/packages/synapse-interface/README.md
+++ b/packages/synapse-interface/README.md
@@ -10,7 +10,7 @@ yarn dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
-You can start editing the page by modifying `pages/index.tsx`. The page auto-updates as you edit the file.
+You can start editing the page by modifying `pages/index.tsx`. The page auto-updates as you edit and save the file.
 
 ---
 

--- a/packages/synapse-interface/constants/chains/master.tsx
+++ b/packages/synapse-interface/constants/chains/master.tsx
@@ -43,7 +43,7 @@ export const ETH: Chain = {
       'https://eth-mainnet.g.alchemy.com/v2/rJ3f0IWjZbpgEwnzrRS6yYO3WNH0jGle',
     fallback: 'https://eth.llamarpc.com',
   },
-  explorerUrl: 'https://etherscan.com',
+  explorerUrl: 'https://etherscan.io',
   explorerName: 'Etherscan',
   explorerImg: ethExplorerImg,
   blockTime: 12000,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated the instruction text in the README for the `synapse-interface` package to clarify auto-update behavior.

- **Bug Fixes**
	- Corrected the `explorerUrl` for the Ethereum (ETH) chain from `'https://etherscan.com'` to `'https://etherscan.io'`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
b5c4c93e1ed58653ed25117323cf23533d9f6576: [synapse-interface preview link ](https://sanguine-synapse-interface-oons2zwql-synapsecns.vercel.app)
8b9f6eaf948f77f10ce68dea50acce0a3115b9a8: [synapse-interface preview link ](https://sanguine-synapse-interface-j3cdrnmfe-synapsecns.vercel.app)