### PR TITLE
feat(opbot): transaction age textblock

### DIFF
--- a/contrib/opbot/botmd/commands.go
+++ b/contrib/opbot/botmd/commands.go
@@ -244,7 +244,7 @@ func (b *Bot) rfqLookupCommand() *slacker.CommandDefinition {
 					},
 					{
 						Type: slack.MarkdownType,
-						Text: fmt.Sprintf("*Estimaed Tx Age*: %d", deltaBlockNumber),
+						Text: fmt.Sprintf("*Estimated Tx Age*: %d", deltaBlockNumber),
 					},
 				}
 

--- a/contrib/opbot/go.mod
+++ b/contrib/opbot/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/charmbracelet/huh/spinner v0.0.0-20240618200428-90406d79077d
 	github.com/davidmytton/url-verifier v1.0.1
 	github.com/dubonzi/otelresty v1.3.0
+	github.com/dustin/go-humanize v1.0.1
 	github.com/ethereum/go-ethereum v1.13.8
 	github.com/go-http-utils/headers v0.0.0-20181008091004-fed159eddc2a
 	github.com/go-resty/resty/v2 v2.13.1
@@ -112,7 +113,6 @@ require (
 	github.com/deckarep/golang-set/v2 v2.6.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
 	github.com/dennwc/varint v1.0.0 // indirect
-	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/ethereum/c-kzg-4844 v0.4.0 // indirect


### PR DESCRIPTION
@trajan0x can we change `GetQuoteRequestStatusResponse` struct `CreatedAt` rather than doing this block timestamp stuff? 

**Description**
A clear and concise description of the features you're adding in this pull request.

**Additional context**
Add any other context about the problem you're solving.

**Metadata**
- Fixes #[Link to Issue]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced transaction processing in Slack messages with additional details and timestamps.
- **Chores**
  - Updated dependencies to include new formatting capabilities for improved user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->