### PR TITLE
fix(opbot): fix opbot txage for l2s

### DIFF
--- a/contrib/opbot/botmd/commands.go
+++ b/contrib/opbot/botmd/commands.go
@@ -22,10 +22,16 @@ import (
 	"github.com/slack-io/slacker"
 	"github.com/synapsecns/sanguine/contrib/opbot/signoz"
 	"github.com/synapsecns/sanguine/ethergo/chaindata"
+	"github.com/synapsecns/sanguine/ethergo/client"
 	rfqClient "github.com/synapsecns/sanguine/services/rfq/api/client"
 	"github.com/synapsecns/sanguine/services/rfq/contracts/fastbridge"
 	"github.com/synapsecns/sanguine/services/rfq/relayer/relapi"
 )
+
+type Status struct {
+	relayer string
+	*relapi.GetQuoteRequestStatusResponse
+}
 
 func (b *Bot) requiresSignoz(definition *slacker.CommandDefinition) *slacker.CommandDefinition {
 	if b.signozEnabled {
@@ -149,11 +155,6 @@ func (b *Bot) rfqLookupCommand() *slacker.CommandDefinition {
 			"rfq 0x30f96b45ba689c809f7e936c140609eb31c99b182bef54fccf49778716a7e1ca",
 		},
 		Handler: func(ctx *slacker.CommandContext) {
-			type Status struct {
-				relayer string
-				*relapi.GetQuoteRequestStatusResponse
-			}
-
 			var statuses []Status
 			var sliceMux sync.Mutex
 
@@ -209,9 +210,9 @@ func (b *Bot) rfqLookupCommand() *slacker.CommandDefinition {
 			var slackBlocks []slack.Block
 
 			for _, status := range statuses {
-				time, err := b.getTxAge(ctx, status.GetQuoteRequestStatusResponse)
+				client, err := b.rpcClient.GetChainClient(ctx.Context(), int(status.OriginChainID))
 				if err != nil {
-					log.Printf("error getting tx age: %v\n", err)
+					log.Printf("error getting chain client: %v\n", err)
 				}
 
 				objects := []*slack.TextBlockObject{
@@ -233,7 +234,7 @@ func (b *Bot) rfqLookupCommand() *slacker.CommandDefinition {
 					},
 					{
 						Type: slack.MarkdownType,
-						Text: fmt.Sprintf("*Estimated Tx Age*: %s", humanize.Time(time)),
+						Text: fmt.Sprintf("*Estimated Tx Age*: %s", getTxAge(ctx.Context(), client, status)),
 					},
 				}
 
@@ -347,23 +348,18 @@ func (b *Bot) makeFastBridge(ctx context.Context, req *relapi.GetQuoteRequestRes
 	return fastBridgeHandle, nil
 }
 
-func (b *Bot) getTxAge(ctx *slacker.CommandContext, status *relapi.GetQuoteRequestStatusResponse) (time.Time, error) {
+func getTxAge(ctx context.Context, client client.EVM, status Status) string {
 	// TODO: add CreatedAt field to GetQuoteRequestStatusResponse so we don't need to make network calls?
-	client, err := b.rpcClient.GetChainClient(ctx.Context(), int(status.OriginChainID))
+	receipt, err := client.TransactionReceipt(ctx, common.HexToHash(status.GetQuoteRequestStatusResponse.OriginTxHash))
 	if err != nil {
-		return time.Time{}, fmt.Errorf("error getting chain client: %w", err)
+		return "unknown time ago"
+	}
+	txBlock, err := client.HeaderByHash(ctx, receipt.BlockHash)
+	if err != nil {
+		return "unknown time ago"
 	}
 
-	receipt, err := client.TransactionReceipt(ctx.Context(), common.HexToHash(status.OriginTxHash))
-	if err != nil {
-		return time.Time{}, fmt.Errorf("error fetching transaction receipt: %w", err)
-	}
-	txBlock, err := client.BlockByHash(ctx.Context(), receipt.BlockHash)
-	if err != nil {
-		return time.Time{}, fmt.Errorf("error fetching block by hash: %w", err)
-	}
-
-	return time.Unix(int64(txBlock.Time()), 0), nil
+	return humanize.Time(time.Unix(int64(txBlock.Time), 0))
 }
 
 func toExplorerSlackLink(ogHash string) string {

--- a/contrib/opbot/botmd/commands.go
+++ b/contrib/opbot/botmd/commands.go
@@ -28,11 +28,6 @@ import (
 	"github.com/synapsecns/sanguine/services/rfq/relayer/relapi"
 )
 
-type Status struct {
-	relayer string
-	*relapi.GetQuoteRequestStatusResponse
-}
-
 func (b *Bot) requiresSignoz(definition *slacker.CommandDefinition) *slacker.CommandDefinition {
 	if b.signozEnabled {
 		return definition
@@ -155,6 +150,11 @@ func (b *Bot) rfqLookupCommand() *slacker.CommandDefinition {
 			"rfq 0x30f96b45ba689c809f7e936c140609eb31c99b182bef54fccf49778716a7e1ca",
 		},
 		Handler: func(ctx *slacker.CommandContext) {
+			type Status struct {
+				relayer string
+				*relapi.GetQuoteRequestStatusResponse
+			}
+
 			var statuses []Status
 			var sliceMux sync.Mutex
 
@@ -234,7 +234,7 @@ func (b *Bot) rfqLookupCommand() *slacker.CommandDefinition {
 					},
 					{
 						Type: slack.MarkdownType,
-						Text: fmt.Sprintf("*Estimated Tx Age*: %s", getTxAge(ctx.Context(), client, status)),
+						Text: fmt.Sprintf("*Estimated Tx Age*: %s", getTxAge(ctx.Context(), client, status.GetQuoteRequestStatusResponse)),
 					},
 				}
 
@@ -348,9 +348,9 @@ func (b *Bot) makeFastBridge(ctx context.Context, req *relapi.GetQuoteRequestRes
 	return fastBridgeHandle, nil
 }
 
-func getTxAge(ctx context.Context, client client.EVM, status Status) string {
+func getTxAge(ctx context.Context, client client.EVM, res *relapi.GetQuoteRequestStatusResponse) string {
 	// TODO: add CreatedAt field to GetQuoteRequestStatusResponse so we don't need to make network calls?
-	receipt, err := client.TransactionReceipt(ctx, common.HexToHash(status.GetQuoteRequestStatusResponse.OriginTxHash))
+	receipt, err := client.TransactionReceipt(ctx, common.HexToHash(res.OriginTxHash))
 	if err != nil {
 		return "unknown time ago"
 	}

--- a/contrib/opbot/botmd/commands_test.go
+++ b/contrib/opbot/botmd/commands_test.go
@@ -22,12 +22,11 @@ func TestStripLinks(t *testing.T) {
 func TestTxAge(t *testing.T) {
 	notExpected := "unknown time ago" // should be a definite time
 
-	status := botmd.Status{
-		GetQuoteRequestStatusResponse: &relapi.GetQuoteRequestStatusResponse{
-			OriginTxHash:  "0x954264d120f5f3cf50edc39ebaf88ea9dc647d9d6843b7a120ed3677e23d7890",
-			OriginChainID: 421611,
-		},
+	status := &relapi.GetQuoteRequestStatusResponse{
+		OriginTxHash:  "0x954264d120f5f3cf50edc39ebaf88ea9dc647d9d6843b7a120ed3677e23d7890",
+		OriginChainID: 421611,
 	}
+
 	ctx := context.Background()
 
 	client := omnirpcClient.NewOmnirpcClient("https://arb1.arbitrum.io/rpc", metrics.Get())

--- a/contrib/opbot/botmd/commands_test.go
+++ b/contrib/opbot/botmd/commands_test.go
@@ -1,8 +1,13 @@
 package botmd_test
 
 import (
-	"github.com/synapsecns/sanguine/contrib/opbot/botmd"
+	"context"
 	"testing"
+
+	"github.com/synapsecns/sanguine/contrib/opbot/botmd"
+	"github.com/synapsecns/sanguine/core/metrics"
+	omnirpcClient "github.com/synapsecns/sanguine/services/omnirpc/client"
+	"github.com/synapsecns/sanguine/services/rfq/relayer/relapi"
 )
 
 func TestStripLinks(t *testing.T) {
@@ -11,5 +16,27 @@ func TestStripLinks(t *testing.T) {
 
 	if got := botmd.StripLinks(testLink); got != expected {
 		t.Errorf("StripLinks(%s) = %s; want %s", testLink, got, expected)
+	}
+}
+
+func TestTxAge(t *testing.T) {
+	notExpected := "unknown time ago" // should be a definite time
+
+	status := botmd.Status{
+		GetQuoteRequestStatusResponse: &relapi.GetQuoteRequestStatusResponse{
+			OriginTxHash:  "0x954264d120f5f3cf50edc39ebaf88ea9dc647d9d6843b7a120ed3677e23d7890",
+			OriginChainID: 421611,
+		},
+	}
+	ctx := context.Background()
+
+	client := omnirpcClient.NewOmnirpcClient("https://arb1.arbitrum.io/rpc", metrics.Get())
+	cc, err := client.GetChainClient(ctx, int(status.OriginChainID))
+	if err != nil {
+		t.Fatalf("GetChainClient() failed: %v", err)
+	}
+
+	if got := botmd.GetTxAge(context.Background(), cc, status); got == notExpected {
+		t.Errorf("TxAge(%s) = %s; want not %s", status.OriginTxHash, got, notExpected)
 	}
 }

--- a/contrib/opbot/botmd/export_test.go
+++ b/contrib/opbot/botmd/export_test.go
@@ -1,5 +1,15 @@
 package botmd
 
+import (
+	"context"
+
+	"github.com/synapsecns/sanguine/ethergo/client"
+)
+
 func StripLinks(input string) string {
 	return stripLinks(input)
+}
+
+func GetTxAge(ctx context.Context, client client.EVM, res Status) string {
+	return getTxAge(ctx, client, res)
 }

--- a/contrib/opbot/botmd/export_test.go
+++ b/contrib/opbot/botmd/export_test.go
@@ -4,12 +4,13 @@ import (
 	"context"
 
 	"github.com/synapsecns/sanguine/ethergo/client"
+	"github.com/synapsecns/sanguine/services/rfq/relayer/relapi"
 )
 
 func StripLinks(input string) string {
 	return stripLinks(input)
 }
 
-func GetTxAge(ctx context.Context, client client.EVM, res Status) string {
+func GetTxAge(ctx context.Context, client client.EVM, res *relapi.GetQuoteRequestStatusResponse) string {
 	return getTxAge(ctx, client, res)
 }


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**
A clear and concise description of the features you're adding in this pull request.

**Additional context**
Add any other context about the problem you're solving.

**Metadata**
- Fixes #[Link to Issue]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced command handling for improved transaction age retrieval.
  - Introduced a new `GetTxAge` function for better transaction age management.

- **Bug Fixes**
  - Improved error handling for chain client access.

- **Tests**
  - Added a new unit test for validating transaction age retrieval functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->