### PR TITLE
RFQ Relayer: support pointers for config values

### DIFF
--- a/services/rfq/relayer/pricer/fee_pricer_test.go
+++ b/services/rfq/relayer/pricer/fee_pricer_test.go
@@ -11,6 +11,7 @@ import (
 	fetcherMocks "github.com/synapsecns/sanguine/ethergo/submitter/mocks"
 	"github.com/synapsecns/sanguine/services/rfq/relayer/pricer"
 	priceMocks "github.com/synapsecns/sanguine/services/rfq/relayer/pricer/mocks"
+	"github.com/synapsecns/sanguine/services/rfq/relayer/relconfig"
 )
 
 var defaultPrices = map[string]float64{"ETH": 2000., "USDC": 1., "MATIC": 0.5}
@@ -261,8 +262,8 @@ func (s *PricerSuite) TestGetGasPrice() {
 
 func (s *PricerSuite) TestGetTotalFeeWithMultiplier() {
 	// Override the fixed fee multiplier to greater than 1.
-	s.config.BaseChainConfig.QuoteFixedFeeMultiplier = 2
-	s.config.BaseChainConfig.RelayFixedFeeMultiplier = 4
+	s.config.BaseChainConfig.QuoteFixedFeeMultiplier = relconfig.NewFloatPtr(2)
+	s.config.BaseChainConfig.RelayFixedFeeMultiplier = relconfig.NewFloatPtr(4)
 
 	// Build a new FeePricer with a mocked client for fetching gas price.
 	clientFetcher := new(fetcherMocks.ClientFetcher)
@@ -295,7 +296,7 @@ func (s *PricerSuite) TestGetTotalFeeWithMultiplier() {
 	s.Equal(expectedFee, fee)
 
 	// Override the fixed fee multiplier to less than 1; should default to 1.
-	s.config.BaseChainConfig.QuoteFixedFeeMultiplier = -1
+	s.config.BaseChainConfig.QuoteFixedFeeMultiplier = relconfig.NewFloatPtr(-1)
 
 	// Build a new FeePricer with a mocked client for fetching gas price.
 	clientOrigin.On(testsuite.GetFunctionName(clientOrigin.SuggestGasPrice), mock.Anything).Once().Return(headerOrigin, nil)
@@ -314,7 +315,7 @@ func (s *PricerSuite) TestGetTotalFeeWithMultiplier() {
 	s.Equal(expectedFee, fee)
 
 	// Reset the fixed fee multiplier to zero; should default to 1
-	s.config.BaseChainConfig.QuoteFixedFeeMultiplier = 0
+	s.config.BaseChainConfig.QuoteFixedFeeMultiplier = relconfig.NewFloatPtr(0)
 
 	// Build a new FeePricer with a mocked client for fetching gas price.
 	clientOrigin.On(testsuite.GetFunctionName(clientOrigin.SuggestGasPrice), mock.Anything).Once().Return(headerOrigin, nil)

--- a/services/rfq/relayer/quoter/quoter_test.go
+++ b/services/rfq/relayer/quoter/quoter_test.go
@@ -165,7 +165,7 @@ func (s *QuoterSuite) TestGetOriginAmount() {
 	balance := big.NewInt(1000_000_000) // 1000 USDC
 
 	setQuoteParams := func(quotePct, quoteOffset float64, minQuoteAmount string) {
-		s.config.BaseChainConfig.QuotePct = quotePct
+		s.config.BaseChainConfig.QuotePct = &quotePct
 		destTokenCfg := s.config.Chains[dest].Tokens["USDC"]
 		destTokenCfg.MinQuoteAmount = minQuoteAmount
 		originTokenCfg := s.config.Chains[origin].Tokens["USDC"]

--- a/services/rfq/relayer/relconfig/config.go
+++ b/services/rfq/relayer/relconfig/config.go
@@ -90,7 +90,7 @@ type ChainConfig struct {
 	// MinGasToken is minimum amount of gas that should be leftover after bridging a gas token.
 	MinGasToken string `yaml:"min_gas_token"`
 	// QuotePct is the percent of balance to quote.
-	QuotePct float64 `yaml:"quote_pct"`
+	QuotePct *float64 `yaml:"quote_pct"`
 	// QuoteWidthBps is the number of basis points to deduct from the dest amount.
 	// Note that this parameter is applied on a chain level and must be positive.
 	QuoteWidthBps float64 `yaml:"quote_width_bps"`

--- a/services/rfq/relayer/relconfig/config.go
+++ b/services/rfq/relayer/relconfig/config.go
@@ -95,9 +95,9 @@ type ChainConfig struct {
 	// Note that this parameter is applied on a chain level and must be positive.
 	QuoteWidthBps float64 `yaml:"quote_width_bps"`
 	// QuoteFixedFeeMultiplier is the multiplier for the fixed fee, applied when generating quotes.
-	QuoteFixedFeeMultiplier float64 `yaml:"quote_fixed_fee_multiplier"`
+	QuoteFixedFeeMultiplier *float64 `yaml:"quote_fixed_fee_multiplier"`
 	// RelayFixedFeeMultiplier is the multiplier for the fixed fee, applied when relaying.
-	RelayFixedFeeMultiplier float64 `yaml:"relay_fixed_fee_multiplier"`
+	RelayFixedFeeMultiplier *float64 `yaml:"relay_fixed_fee_multiplier"`
 	// CCTP start block is the block at which the chain listener will listen for CCTP events.
 	CCTPStartBlock uint64 `yaml:"cctp_start_block"`
 }

--- a/services/rfq/relayer/relconfig/config_test.go
+++ b/services/rfq/relayer/relconfig/config_test.go
@@ -31,9 +31,9 @@ func TestChainGetters(t *testing.T) {
 				L1FeeOriginGasEstimate:  30000,
 				L1FeeDestGasEstimate:    40000,
 				MinGasToken:             "1000",
-				QuotePct:                relconfig.NewFloat64Pointer(0),
+				QuotePct:                relconfig.NewFloatPtr(0),
 				QuoteWidthBps:           10,
-				QuoteFixedFeeMultiplier: relconfig.NewFloat64Pointer(1.1),
+				QuoteFixedFeeMultiplier: relconfig.NewFloatPtr(1.1),
 			},
 		},
 		BaseChainConfig: relconfig.ChainConfig{
@@ -49,9 +49,9 @@ func TestChainGetters(t *testing.T) {
 			L1FeeOriginGasEstimate:  30001,
 			L1FeeDestGasEstimate:    40001,
 			MinGasToken:             "1001",
-			QuotePct:                relconfig.NewFloat64Pointer(51),
+			QuotePct:                relconfig.NewFloatPtr(51),
 			QuoteWidthBps:           11,
-			QuoteFixedFeeMultiplier: relconfig.NewFloat64Pointer(1.2),
+			QuoteFixedFeeMultiplier: relconfig.NewFloatPtr(1.2),
 		},
 	}
 	cfg := relconfig.Config{
@@ -69,9 +69,9 @@ func TestChainGetters(t *testing.T) {
 				L1FeeOriginGasEstimate:  30000,
 				L1FeeDestGasEstimate:    40000,
 				MinGasToken:             "1000",
-				QuotePct:                relconfig.NewFloat64Pointer(50),
+				QuotePct:                relconfig.NewFloatPtr(50),
 				QuoteWidthBps:           10,
-				QuoteFixedFeeMultiplier: relconfig.NewFloat64Pointer(1.1),
+				QuoteFixedFeeMultiplier: relconfig.NewFloatPtr(1.1),
 				Tokens: map[string]relconfig.TokenConfig{
 					"USDC": {
 						Address:            usdcAddr,
@@ -320,9 +320,9 @@ func TestGetQuoteOffset(t *testing.T) {
 				L1FeeOriginGasEstimate:  30000,
 				L1FeeDestGasEstimate:    40000,
 				MinGasToken:             "1000",
-				QuotePct:                relconfig.NewFloat64Pointer(50),
+				QuotePct:                relconfig.NewFloatPtr(50),
 				QuoteWidthBps:           10,
-				QuoteFixedFeeMultiplier: relconfig.NewFloat64Pointer(1.1),
+				QuoteFixedFeeMultiplier: relconfig.NewFloatPtr(1.1),
 				Tokens: map[string]relconfig.TokenConfig{
 					"USDC": {
 						Address:            usdcAddr,

--- a/services/rfq/relayer/relconfig/config_test.go
+++ b/services/rfq/relayer/relconfig/config_test.go
@@ -33,7 +33,7 @@ func TestChainGetters(t *testing.T) {
 				MinGasToken:             "1000",
 				QuotePct:                relconfig.NewFloat64Pointer(0),
 				QuoteWidthBps:           10,
-				QuoteFixedFeeMultiplier: 1.1,
+				QuoteFixedFeeMultiplier: relconfig.NewFloat64Pointer(1.1),
 			},
 		},
 		BaseChainConfig: relconfig.ChainConfig{
@@ -51,7 +51,7 @@ func TestChainGetters(t *testing.T) {
 			MinGasToken:             "1001",
 			QuotePct:                relconfig.NewFloat64Pointer(51),
 			QuoteWidthBps:           11,
-			QuoteFixedFeeMultiplier: 1.2,
+			QuoteFixedFeeMultiplier: relconfig.NewFloat64Pointer(1.2),
 		},
 	}
 	cfg := relconfig.Config{
@@ -71,7 +71,7 @@ func TestChainGetters(t *testing.T) {
 				MinGasToken:             "1000",
 				QuotePct:                relconfig.NewFloat64Pointer(50),
 				QuoteWidthBps:           10,
-				QuoteFixedFeeMultiplier: 1.1,
+				QuoteFixedFeeMultiplier: relconfig.NewFloat64Pointer(1.1),
 				Tokens: map[string]relconfig.TokenConfig{
 					"USDC": {
 						Address:            usdcAddr,
@@ -282,15 +282,15 @@ func TestChainGetters(t *testing.T) {
 	t.Run("GetQuoteFixedFeeMultiplier", func(t *testing.T) {
 		defaultVal, err := cfg.GetQuoteFixedFeeMultiplier(badChainID)
 		assert.NoError(t, err)
-		assert.Equal(t, defaultVal, relconfig.DefaultChainConfig.QuoteFixedFeeMultiplier)
+		assert.Equal(t, defaultVal, *relconfig.DefaultChainConfig.QuoteFixedFeeMultiplier)
 
 		baseVal, err := cfgWithBase.GetQuoteFixedFeeMultiplier(badChainID)
 		assert.NoError(t, err)
-		assert.Equal(t, baseVal, cfgWithBase.BaseChainConfig.QuoteFixedFeeMultiplier)
+		assert.Equal(t, baseVal, *cfgWithBase.BaseChainConfig.QuoteFixedFeeMultiplier)
 
 		chainVal, err := cfgWithBase.GetQuoteFixedFeeMultiplier(chainID)
 		assert.NoError(t, err)
-		assert.Equal(t, chainVal, cfgWithBase.Chains[chainID].QuoteFixedFeeMultiplier)
+		assert.Equal(t, chainVal, *cfgWithBase.Chains[chainID].QuoteFixedFeeMultiplier)
 	})
 
 	t.Run("GetMaxRebalanceAmount", func(t *testing.T) {
@@ -322,7 +322,7 @@ func TestGetQuoteOffset(t *testing.T) {
 				MinGasToken:             "1000",
 				QuotePct:                relconfig.NewFloat64Pointer(50),
 				QuoteWidthBps:           10,
-				QuoteFixedFeeMultiplier: 1.1,
+				QuoteFixedFeeMultiplier: relconfig.NewFloat64Pointer(1.1),
 				Tokens: map[string]relconfig.TokenConfig{
 					"USDC": {
 						Address:            usdcAddr,

--- a/services/rfq/relayer/relconfig/config_test.go
+++ b/services/rfq/relayer/relconfig/config_test.go
@@ -1,9 +1,10 @@
 package relconfig_test
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
@@ -30,7 +31,7 @@ func TestChainGetters(t *testing.T) {
 				L1FeeOriginGasEstimate:  30000,
 				L1FeeDestGasEstimate:    40000,
 				MinGasToken:             "1000",
-				QuotePct:                50,
+				QuotePct:                relconfig.NewFloat64Pointer(0),
 				QuoteWidthBps:           10,
 				QuoteFixedFeeMultiplier: 1.1,
 			},
@@ -48,7 +49,7 @@ func TestChainGetters(t *testing.T) {
 			L1FeeOriginGasEstimate:  30001,
 			L1FeeDestGasEstimate:    40001,
 			MinGasToken:             "1001",
-			QuotePct:                51,
+			QuotePct:                relconfig.NewFloat64Pointer(51),
 			QuoteWidthBps:           11,
 			QuoteFixedFeeMultiplier: 1.2,
 		},
@@ -68,7 +69,7 @@ func TestChainGetters(t *testing.T) {
 				L1FeeOriginGasEstimate:  30000,
 				L1FeeDestGasEstimate:    40000,
 				MinGasToken:             "1000",
-				QuotePct:                50,
+				QuotePct:                relconfig.NewFloat64Pointer(50),
 				QuoteWidthBps:           10,
 				QuoteFixedFeeMultiplier: 1.1,
 				Tokens: map[string]relconfig.TokenConfig{
@@ -253,15 +254,15 @@ func TestChainGetters(t *testing.T) {
 	t.Run("GetQuotePct", func(t *testing.T) {
 		defaultVal, err := cfg.GetQuotePct(badChainID)
 		assert.NoError(t, err)
-		assert.Equal(t, defaultVal, relconfig.DefaultChainConfig.QuotePct)
+		assert.Equal(t, defaultVal, 100.)
 
 		baseVal, err := cfgWithBase.GetQuotePct(badChainID)
 		assert.NoError(t, err)
-		assert.Equal(t, baseVal, cfgWithBase.BaseChainConfig.QuotePct)
+		assert.Equal(t, baseVal, 51.)
 
 		chainVal, err := cfgWithBase.GetQuotePct(chainID)
 		assert.NoError(t, err)
-		assert.Equal(t, chainVal, cfgWithBase.Chains[chainID].QuotePct)
+		assert.Equal(t, chainVal, 0.)
 	})
 
 	t.Run("GetQuoteWidthBps", func(t *testing.T) {
@@ -319,7 +320,7 @@ func TestGetQuoteOffset(t *testing.T) {
 				L1FeeOriginGasEstimate:  30000,
 				L1FeeDestGasEstimate:    40000,
 				MinGasToken:             "1000",
-				QuotePct:                50,
+				QuotePct:                relconfig.NewFloat64Pointer(50),
 				QuoteWidthBps:           10,
 				QuoteFixedFeeMultiplier: 1.1,
 				Tokens: map[string]relconfig.TokenConfig{

--- a/services/rfq/relayer/relconfig/getters.go
+++ b/services/rfq/relayer/relconfig/getters.go
@@ -19,8 +19,8 @@ var DefaultChainConfig = ChainConfig{
 	MinGasToken:             "100000000000000000", // 1 ETH
 	QuotePct:                NewFloat64Pointer(100),
 	QuoteWidthBps:           0,
-	QuoteFixedFeeMultiplier: 1,
-	RelayFixedFeeMultiplier: 1,
+	QuoteFixedFeeMultiplier: NewFloat64Pointer(1),
+	RelayFixedFeeMultiplier: NewFloat64Pointer(1),
 }
 
 // NewFloat64Pointer returns a pointer to a float64.
@@ -344,7 +344,7 @@ func (c Config) GetQuoteFixedFeeMultiplier(chainID int) (value float64, err erro
 		return value, fmt.Errorf("failed to cast QuoteFixedFeeMultiplier to int")
 	}
 	if value <= 0 {
-		value = DefaultChainConfig.QuoteFixedFeeMultiplier
+		value = *DefaultChainConfig.QuoteFixedFeeMultiplier
 	}
 	return value, nil
 }

--- a/services/rfq/relayer/relconfig/getters.go
+++ b/services/rfq/relayer/relconfig/getters.go
@@ -2,6 +2,7 @@ package relconfig
 
 import (
 	"fmt"
+	"github.com/synapsecns/sanguine/core"
 	"math/big"
 	"reflect"
 	"time"
@@ -25,7 +26,7 @@ var DefaultChainConfig = ChainConfig{
 
 // NewFloatPtr returns a pointer to a float64.
 func NewFloatPtr(val float64) *float64 {
-	return &val
+	return core.PtrTo(val)
 }
 
 // getChainConfigValue gets the value of a field from ChainConfig.

--- a/services/rfq/relayer/relconfig/getters.go
+++ b/services/rfq/relayer/relconfig/getters.go
@@ -17,14 +17,14 @@ var DefaultChainConfig = ChainConfig{
 	OriginGasEstimate:       160000,
 	DestGasEstimate:         100000,
 	MinGasToken:             "100000000000000000", // 1 ETH
-	QuotePct:                NewFloat64Pointer(100),
+	QuotePct:                NewFloatPtr(100),
 	QuoteWidthBps:           0,
-	QuoteFixedFeeMultiplier: NewFloat64Pointer(1),
-	RelayFixedFeeMultiplier: NewFloat64Pointer(1),
+	QuoteFixedFeeMultiplier: NewFloatPtr(1),
+	RelayFixedFeeMultiplier: NewFloatPtr(1),
 }
 
-// NewFloat64Pointer returns a pointer to a float64.
-func NewFloat64Pointer(val float64) *float64 {
+// NewFloatPtr returns a pointer to a float64.
+func NewFloatPtr(val float64) *float64 {
 	return &val
 }
 


### PR DESCRIPTION
If a zero value is specified in a config field, it won't be overridden as a base or default value (assuming the field is a pointer).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced configuration management by allowing certain fields to accept pointer types, enabling the representation of uninitialized states.
	- Introduced a new helper function to facilitate pointer handling for configuration values.

- **Bug Fixes**
	- Updated test cases to ensure proper validation of configuration parameters with the new pointer-based approach.

- **Refactor**
	- Streamlined logic for configuration handling by replacing outdated functions with clearer alternatives focused on pointer dereferencing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->