### PR TITLE
increase default scribe timeout

### DIFF
--- a/.github/workflows/goreleaser-actions.yml
+++ b/.github/workflows/goreleaser-actions.yml
@@ -140,7 +140,7 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ github.ref == 'refs/heads/master' && '0' || '1' }}
 
       - name: Set up cache
         if:  ${{ !contains(runner.name, 'nsc') }}

--- a/.github/workflows/goreleaser-actions.yml
+++ b/.github/workflows/goreleaser-actions.yml
@@ -178,10 +178,12 @@ jobs:
 
       -
         name: Fetch all tags
+        if: steps.branch-name.outputs.is_default == 'true'
         run: git fetch --force --tags
 
       # get the tag we just created
       - name: Git Fetch Unshallow
+        if: steps.branch-name.outputs.is_default == 'true'
         run: git fetch
 
       - name: Import GPG key

--- a/.github/workflows/goreleaser-actions.yml
+++ b/.github/workflows/goreleaser-actions.yml
@@ -141,7 +141,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          submodules: 'recursive'
 
       - name: Set up cache
         if:  ${{ !contains(runner.name, 'nsc') }}

--- a/services/scribe/service/chain.go
+++ b/services/scribe/service/chain.go
@@ -8,6 +8,7 @@ import (
 	"github.com/synapsecns/sanguine/services/scribe/service/indexer"
 	scribeTypes "github.com/synapsecns/sanguine/services/scribe/types"
 	"math/big"
+	"os"
 
 	"math"
 	"time"
@@ -398,8 +399,8 @@ func (c *ChainIndexer) livefillAtHead(parentContext context.Context) error {
 				continue
 			}
 
-			// Default refresh rate for livefill to tip is 1 second.
-			timeout = 1 * time.Second
+			// Default refresh rate for livefill to tip is 3 second.
+			timeout = defaultTimeout
 		}
 	}
 }
@@ -470,7 +471,15 @@ func (c *ChainIndexer) livefill(parentContext context.Context) error {
 
 			// Default refresh rate for livefill is 1 second.
 			// TODO add to config
-			timeout = 1 * time.Second
+			timeout = defaultTimeout
 		}
+	}
+}
+
+var defaultTimeout = 3 * time.Second
+
+func init() {
+	if os.Getenv("CI") != "" {
+		defaultTimeout = 1 * time.Second
 	}
 }


### PR DESCRIPTION
**Description**

Increases default timeout from 1 to 3 seconds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved configurability of timeout settings for livefill methods, enhancing adaptability based on execution context.

- **Bug Fixes**
	- Increased default timeout from 1 second to 3 seconds to reduce potential timeouts during operations.

- **Chores**
	- Modified GitHub Actions workflow to adjust submodule handling and optimize fetch depth based on branch context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->