### PR TITLE
fix(synapse-interface): use rfq origin pools when generating bridge maps

### DIFF
--- a/packages/synapse-interface/constants/bridgeMap.ts
+++ b/packages/synapse-interface/constants/bridgeMap.ts
@@ -1795,18 +1795,32 @@ export const BRIDGE_MAP = {
   },
   '59144': {
     '0x176211869cA2b568f2A7D4EE941E073a821EE1ff': {
+      decimals: 6,
+      symbol: 'USDC',
       origin: ['RFQ.USDC'],
       destination: ['RFQ.USDC'],
       swappable: [],
-      symbol: 'USDC',
+    },
+    '0xA219439258ca9da29E9Cc4cE5596924745e12B93': {
       decimals: 6,
+      symbol: 'USDT',
+      origin: ['RFQ.USDC'],
+      destination: [],
+      swappable: [],
     },
     '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE': {
+      decimals: 18,
+      symbol: 'ETH',
       origin: ['RFQ.ETH'],
       destination: ['RFQ.ETH'],
       swappable: [],
-      symbol: 'ETH',
+    },
+    '0xe5D7C2a44FfDDf6b295A15c148167daaAf5Cf34f': {
       decimals: 18,
+      symbol: 'WETH',
+      origin: ['RFQ.ETH'],
+      destination: [],
+      swappable: [],
     },
   },
   '81457': {
@@ -1820,8 +1834,8 @@ export const BRIDGE_MAP = {
     '0x4300000000000000000000000000000000000003': {
       decimals: 18,
       symbol: 'USDB',
-      origin: ['nUSD', 'RFQ.USDB'],
-      destination: ['nUSD', 'RFQ.USDB'],
+      origin: ['nUSD'],
+      destination: ['nUSD'],
       swappable: ['0x3194B0A295D87fDAA54DF852c248F7a6BAF6c6e0'],
     },
     '0x4300000000000000000000000000000000000004': {
@@ -1864,18 +1878,32 @@ export const BRIDGE_MAP = {
   },
   '534352': {
     '0x06eFdBFf2a14a7c8E15944D1F4A48F9F95F663A4': {
+      decimals: 6,
+      symbol: 'USDC',
       origin: ['RFQ.USDC'],
       destination: ['RFQ.USDC'],
       swappable: [],
-      symbol: 'USDC',
-      decimals: 6,
+    },
+    '0x5300000000000000000000000000000000000004': {
+      decimals: 18,
+      symbol: 'WETH',
+      origin: ['RFQ.ETH'],
+      destination: [],
+      swappable: [],
     },
     '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE': {
+      decimals: 18,
+      symbol: 'ETH',
       origin: ['RFQ.ETH'],
       destination: ['RFQ.ETH'],
       swappable: [],
-      symbol: 'ETH',
-      decimals: 18,
+    },
+    '0xf55BEC9cafDbE8730f096Aa55dad6D22d44099Df': {
+      decimals: 6,
+      symbol: 'USDT',
+      origin: ['RFQ.USDC'],
+      destination: [],
+      swappable: [],
     },
   },
   '1313161554': {

--- a/packages/synapse-interface/constants/bridgeMap.ts
+++ b/packages/synapse-interface/constants/bridgeMap.ts
@@ -1799,14 +1799,14 @@ export const BRIDGE_MAP = {
       symbol: 'USDC',
       origin: ['RFQ.USDC'],
       destination: ['RFQ.USDC'],
-      swappable: [],
+      swappable: ['0xA219439258ca9da29E9Cc4cE5596924745e12B93'],
     },
     '0xA219439258ca9da29E9Cc4cE5596924745e12B93': {
       decimals: 6,
       symbol: 'USDT',
       origin: ['RFQ.USDC'],
       destination: [],
-      swappable: [],
+      swappable: ['0x176211869cA2b568f2A7D4EE941E073a821EE1ff'],
     },
     '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE': {
       decimals: 18,
@@ -1882,7 +1882,7 @@ export const BRIDGE_MAP = {
       symbol: 'USDC',
       origin: ['RFQ.USDC'],
       destination: ['RFQ.USDC'],
-      swappable: [],
+      swappable: ['0xf55BEC9cafDbE8730f096Aa55dad6D22d44099Df'],
     },
     '0x5300000000000000000000000000000000000004': {
       decimals: 18,
@@ -1903,7 +1903,7 @@ export const BRIDGE_MAP = {
       symbol: 'USDT',
       origin: ['RFQ.USDC'],
       destination: [],
-      swappable: [],
+      swappable: ['0x06eFdBFf2a14a7c8E15944D1F4A48F9F95F663A4'],
     },
   },
   '1313161554': {

--- a/packages/synapse-interface/scripts/abi/FastBridgeRouter.json
+++ b/packages/synapse-interface/scripts/abi/FastBridgeRouter.json
@@ -1,0 +1,387 @@
+[
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "owner_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "receive",
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "GAS_REBATE_FLAG",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes1",
+        "internalType": "bytes1"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "adapterSwap",
+    "inputs": [
+      {
+        "name": "recipient",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "tokenIn",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amountIn",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "tokenOut",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "rawParams",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "amountOut",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "bridge",
+    "inputs": [
+      {
+        "name": "recipient",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "chainId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "originQuery",
+        "type": "tuple",
+        "internalType": "struct SwapQuery",
+        "components": [
+          {
+            "name": "routerAdapter",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "tokenOut",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "minAmountOut",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "deadline",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "rawParams",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      },
+      {
+        "name": "destQuery",
+        "type": "tuple",
+        "internalType": "struct SwapQuery",
+        "components": [
+          {
+            "name": "routerAdapter",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "tokenOut",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "minAmountOut",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "deadline",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "rawParams",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "fastBridge",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getOriginAmountOut",
+    "inputs": [
+      {
+        "name": "tokenIn",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "rfqTokens",
+        "type": "address[]",
+        "internalType": "address[]"
+      },
+      {
+        "name": "amountIn",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "originQueries",
+        "type": "tuple[]",
+        "internalType": "struct SwapQuery[]",
+        "components": [
+          {
+            "name": "routerAdapter",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "tokenOut",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "minAmountOut",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "deadline",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "rawParams",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "owner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "renounceOwnership",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setFastBridge",
+    "inputs": [
+      {
+        "name": "fastBridge_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setSwapQuoter",
+    "inputs": [
+      {
+        "name": "swapQuoter_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "swapQuoter",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "transferOwnership",
+    "inputs": [
+      {
+        "name": "newOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "FastBridgeSet",
+    "inputs": [
+      {
+        "name": "newFastBridge",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferred",
+    "inputs": [
+      {
+        "name": "previousOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "SwapQuoterSet",
+    "inputs": [
+      {
+        "name": "newSwapQuoter",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "DeadlineExceeded",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InsufficientOutputAmount",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MsgValueIncorrect",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "PoolNotFound",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "TokenAddressMismatch",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "TokenNotContract",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "TokenNotETH",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "TokensIdentical",
+    "inputs": []
+  }
+]

--- a/packages/synapse-interface/scripts/generateMaps.js
+++ b/packages/synapse-interface/scripts/generateMaps.js
@@ -102,7 +102,7 @@ const getSwapQuoter = async (chainId) => {
 // into SynapseBridge tokens for a given chain.
 const getBridgeOriginMap = async (chainId) => {
   const swapQuoter = await getSwapQuoter(chainId)
-  if (!SynapseRouters[chainId] || !swapQuoter) {
+  if (!swapQuoter) {
     return {
       originMap: {},
       poolSets: [],
@@ -112,8 +112,8 @@ const getBridgeOriginMap = async (chainId) => {
   // Get WETH address
   const weth = await swapQuoter.weth()
   // Get list of supported tokens
-  let bridgeTokens = await SynapseRouters[chainId].bridgeTokens()
-  const pools = await SynapseRouters[chainId].allPools()
+  let bridgeTokens = (await SynapseRouters[chainId]?.bridgeTokens()) || []
+  const pools = await swapQuoter.allPools()
 
   // Collect map from bridge token to symbols by doing tokenToSymbol for each bridge token
   const allTokenSymbols = {}

--- a/packages/synapse-interface/scripts/generateMaps.js
+++ b/packages/synapse-interface/scripts/generateMaps.js
@@ -354,7 +354,6 @@ const sortMapByKeys = (map) => {
 }
 const printMaps = async () => {
   const bridgeMap = {}
-  const bridgeSymbolsMap = {}
   console.log('Starting on chains: ', Object.keys(providers))
 
   const rfqResponse = await fetchRfqData()
@@ -395,7 +394,6 @@ const printMaps = async () => {
         })
       )
       bridgeMap[chainId] = sortMapByKeys(tokens)
-      bridgeSymbolsMap[chainId] = sortMapByKeys(extractBridgeSymbolsMap(tokens))
       console.log('Finished chain: ', chainId)
     })
   )
@@ -417,34 +415,6 @@ const extractSwappable = (poolSets, token) => {
     }
   })
   return Array.from(tokenSet).sort()
-}
-
-const extractBridgeSymbolsMap = (tokens) => {
-  const bridgeSymbolsOriginSets = {}
-  const bridgeSymbolsDestinationSets = {}
-  // Add all bridge symbols that be swapped to/from each token
-  Object.keys(tokens).forEach((token) => {
-    tokens[token].origin.forEach((symbol) => {
-      addSetToMap(bridgeSymbolsOriginSets, symbol, new Set([token]))
-    })
-    tokens[token].destination.forEach((symbol) => {
-      addSetToMap(bridgeSymbolsDestinationSets, symbol, new Set([token]))
-    })
-  })
-  // Bridge symbols are keys that are present in either map
-  const bridgeSymbols = new Set([
-    ...Object.keys(bridgeSymbolsOriginSets),
-    ...Object.keys(bridgeSymbolsDestinationSets),
-  ])
-  const bridgeSymbolsMap = {}
-
-  bridgeSymbols.forEach((symbol) => {
-    bridgeSymbolsMap[symbol] = {
-      origin: Array.from(bridgeSymbolsOriginSets[symbol]).sort(),
-      destination: Array.from(bridgeSymbolsDestinationSets[symbol]).sort(),
-    }
-  })
-  return bridgeSymbolsMap
 }
 
 const getTokenSymbol = async (chainId, token) => {

--- a/packages/synapse-interface/scripts/utils/fetchRfqData.js
+++ b/packages/synapse-interface/scripts/utils/fetchRfqData.js
@@ -7,7 +7,12 @@ const fetchRfqData = async () => {
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`)
     }
-    return await response.json()
+    quotes = await response.json()
+    // Filter out quotes older than a day ago
+    const updatedAtThreshold = Date.now() - 24 * 60 * 60 * 1000
+    return quotes.filter(
+      (quote) => new Date(quote.updated_at) > updatedAtThreshold
+    )
   } catch (error) {
     console.error('Failed to fetch RFQ data:', error)
     return []


### PR DESCRIPTION
**Description**
- Simplified the generation of the bridge maps for RFQ by making it a bit more generic. 
- Origin liquidity pools are now checked for swap+RFQ type of interactions. 
- The "swappable" lists are now filled for all chains (previously was only filled for chains with SynapseBridge).
- Quotes older than 1 day ago are no longer used to create the RFQ bridge map
c54a3d91b21a7f72f7f5828878db1ee1c56ff073: [synapse-interface preview link ](https://sanguine-synapse-interface-5z3v7h8d8-synapsecns.vercel.app)