### PR TITLE
OmniRPC: add option for caching chain clients

### DIFF
--- a/services/omnirpc/client/options.go
+++ b/services/omnirpc/client/options.go
@@ -4,6 +4,7 @@ package client
 type rpcOptions struct {
 	confirmations int
 	captureReqRes bool
+	cachedClients bool
 }
 
 // OptionsArgsOption is an option passed into the client.
@@ -20,6 +21,13 @@ func WithDefaultConfirmations(confirmations int) OptionsArgsOption {
 func WithCaptureReqRes() OptionsArgsOption {
 	return func(options *rpcOptions) {
 		options.captureReqRes = true
+	}
+}
+
+// WithCachedClients allows chain clients to be cached after first dial.
+func WithCachedClients() OptionsArgsOption {
+	return func(options *rpcOptions) {
+		options.cachedClients = true
 	}
 }
 

--- a/services/rfq/relayer/service/handlers.go
+++ b/services/rfq/relayer/service/handlers.go
@@ -59,7 +59,6 @@ func (r *Relayer) handleBridgeRequestedLog(parentCtx context.Context, req *fastb
 		return nil
 	}
 
-	// TODO: these should be premade
 	originClient, err := r.client.GetChainClient(ctx, int(chainID))
 	if err != nil {
 		return fmt.Errorf("could not get correct omnirpc client: %w", err)

--- a/services/rfq/relayer/service/relayer.go
+++ b/services/rfq/relayer/service/relayer.go
@@ -72,7 +72,7 @@ var logger = log.Logger("relayer")
 //
 // The relayer is the core of the application. It is responsible for starting the listener and quoter event loops.
 func NewRelayer(ctx context.Context, metricHandler metrics.Handler, cfg relconfig.Config) (*Relayer, error) {
-	omniClient := omniClient.NewOmnirpcClient(cfg.OmniRPCURL, metricHandler, omniClient.WithCaptureReqRes())
+	omniClient := omniClient.NewOmnirpcClient(cfg.OmniRPCURL, metricHandler, omniClient.WithCaptureReqRes(), omniClient.WithCachedClients())
 
 	// TODO: pull from config
 	dbType, err := dbcommon.DBTypeFromString(cfg.Database.Type)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced caching for EVM clients, enhancing performance by allowing quicker client retrieval.
  - Added a configuration option to enable client caching when initializing the RPC client.

- **Bug Fixes**
  - Removed obsolete comments in the relayer handling function for improved code clarity.

- **Refactor**
  - Updated the client instantiation process in the relayer to support the new caching feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->