### PR TITLE
feat(synapse-interface): use origin user address for getting bridge quotes

### DIFF
--- a/packages/synapse-interface/pages/state-managed-bridge/index.tsx
+++ b/packages/synapse-interface/pages/state-managed-bridge/index.tsx
@@ -163,7 +163,10 @@ const StateManagedBridge = () => {
         toChainId,
         fromToken.addresses[fromChainId],
         toToken.addresses[toChainId],
-        stringToBigInt(debouncedFromValue, fromToken?.decimals[fromChainId])
+        stringToBigInt(debouncedFromValue, fromToken?.decimals[fromChainId]),
+        {
+          originUserAddress: address,
+        }
       )
 
       const pausedBridgeModules = new Set(

--- a/packages/synapse-interface/utils/hooks/useGasEstimator.ts
+++ b/packages/synapse-interface/utils/hooks/useGasEstimator.ts
@@ -151,7 +151,8 @@ const getBridgeQuote = async (
   toChainId: number,
   fromToken: Token,
   toToken: Token,
-  amount: string
+  amount: string,
+  userAddress: string
 ) => {
   try {
     return await synapseSDK.bridgeQuote(
@@ -159,7 +160,10 @@ const getBridgeQuote = async (
       toChainId,
       fromToken.addresses[fromChainId],
       toToken.addresses[toChainId],
-      stringToBigInt(amount, fromToken?.decimals[fromChainId])
+      stringToBigInt(amount, fromToken?.decimals[fromChainId]),
+      {
+        originUserAddress: userAddress,
+      }
     )
   } catch (error) {
     console.error('getBridgeQuote: ', error)
@@ -248,7 +252,8 @@ const queryEstimatedBridgeGasLimit = async (
     toChainId,
     fromToken,
     toToken,
-    amount
+    amount,
+    address // userAddress
   )
 
   const bridgePayload = await getBridgePayload(


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**
A clear and concise description of the features you're adding in this pull request.

**Additional context**
Add any other context about the problem you're solving.

**Metadata**
- Fixes #[Link to Issue]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced state management in the bridge component by integrating user-specific information, improving user context in operations.
  - Updated gas estimation functionalities to consider user addresses, allowing for more personalized and accurate gas limit calculations.

- **Bug Fixes**
  - Ensured that the functionality for estimating bridge gas limits operates correctly with the user's address, enhancing reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
fd8c3bfe4f78c22ff186fcda462edc960a1b6911: [synapse-interface preview link ](https://sanguine-synapse-interface-dtf2xwoz3-synapsecns.vercel.app)
b5a648e39e0dcb4a04d8c2b66db93405e9b99bbe: [synapse-interface preview link ](https://sanguine-synapse-interface-nkxz5alvy-synapsecns.vercel.app)