### PR TITLE
[goreleaser] Explorer fix bridgewithdraw event 

### DIFF
--- a/services/explorer/consumer/parser/bridgeparser.go
+++ b/services/explorer/consumer/parser/bridgeparser.go
@@ -156,6 +156,12 @@ func eventToBridgeEvent(event bridgeTypes.EventLog, chainID uint32) model.Bridge
 	} else {
 		kappa.Valid = false
 	}
+	// For event type 2 (BridgeWithdraw), Amount is calculated as GetAmount() - GetFee()
+	// For all other event types, Amount is simply GetAmount()
+	amount := event.GetAmount()
+	if event.GetEventType().Int() == 2 { // Event Type 2 is WithdrawEvent
+		amount = new(big.Int).Sub(event.GetAmount(), event.GetFee())
+	}
 
 	return model.BridgeEvent{
 		InsertTime:         uint64(time.Now().UnixNano()),
@@ -164,7 +170,7 @@ func eventToBridgeEvent(event bridgeTypes.EventLog, chainID uint32) model.Bridge
 		EventType:          event.GetEventType().Int(),
 		BlockNumber:        event.GetBlockNumber(),
 		TxHash:             event.GetTxHash().String(),
-		Amount:             event.GetAmount(),
+		Amount:             amount,
 		EventIndex:         event.GetEventIndex(),
 		DestinationKappa:   destinationKappa,
 		Sender:             "",

--- a/services/explorer/consumer/parser/bridgeparser.go
+++ b/services/explorer/consumer/parser/bridgeparser.go
@@ -156,8 +156,8 @@ func eventToBridgeEvent(event bridgeTypes.EventLog, chainID uint32) model.Bridge
 	} else {
 		kappa.Valid = false
 	}
-	// For event type 2 (BridgeWithdraw), Amount is calculated as GetAmount() - GetFee()
-	// For all other event types, Amount is simply GetAmount()
+	// For event type 2 (TokenWithdraw), Amount is calculated as GetAmount() - GetFee()
+	// For all other event types, Amount is simply GetAmount(), which directly pulls the amount from the event
 	amount := event.GetAmount()
 	if event.GetEventType().Int() == 2 { // Event Type 2 is WithdrawEvent
 		amount = new(big.Int).Sub(event.GetAmount(), event.GetFee())


### PR DESCRIPTION
Specifically the Event TokenWithdraw from the synapse bridge contract emits the "amount" variable before the fee is subtracted, whereas all other events emit the amount variable after the fee is subtracted. To fix this, we add a small conditional that subtracts the fee from the "amount" value emitted, only if it is EventType TokenWithdraw. 

This should fix all values for this event moving forward, and we can also backfill if we reboot explorer-indexer. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved accuracy of the Amount calculation for TokenWithdraw events by accounting for transaction fees.
  
- **Bug Fixes**
  - Addressed an issue with Amount retrieval for specific event types to ensure correct fee deductions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->