### PR TITLE
feat(rfq-relayer): add mutex on committable balance consumption

### DIFF
--- a/services/rfq/relayer/service/relayer.go
+++ b/services/rfq/relayer/service/relayer.go
@@ -61,8 +61,10 @@ type Relayer struct {
 	decimalsCache  *xsync.MapOf[string, *uint8]
 	// semaphore is used to limit the number of concurrent requests
 	semaphore *semaphore.Weighted
-	// handlerMtx is used to synchronize handling of relay requests
-	handlerMtx   mapmutex.StringMapMutex
+	// handlerMtx is used to synchronize handling of relay requests, keyed on transaction ID
+	handlerMtx mapmutex.StringMapMutex
+	// balanceMtx is used to synchronize balance requests, keyed on a chainID and tokenAddress pair
+	balanceMtx   mapmutex.StringMapMutex
 	otelRecorder iOtelRecorder
 }
 
@@ -165,6 +167,7 @@ func NewRelayer(ctx context.Context, metricHandler metrics.Handler, cfg relconfi
 		apiClient:      apiClient,
 		semaphore:      semaphore.NewWeighted(maxConcurrentRequests),
 		handlerMtx:     mapmutex.NewStringMapMutex(),
+		balanceMtx:     mapmutex.NewStringMapMutex(),
 		otelRecorder:   otelRecorder,
 	}
 	return &rel, nil

--- a/services/rfq/relayer/service/statushandler.go
+++ b/services/rfq/relayer/service/statushandler.go
@@ -52,6 +52,12 @@ type QuoteRequestHandler struct {
 	mutexMiddlewareFunc func(func(ctx context.Context, span trace.Span, req reldb.QuoteRequest) error) func(ctx context.Context, span trace.Span, req reldb.QuoteRequest) error
 	// handlerMtx is the mutex for relaying.
 	handlerMtx mapmutex.StringMapMutex
+	// balanceMtx is the mutex for balances.
+	balanceMtx mapmutex.StringMapMutex
+}
+
+func getBalanceMtxKey(chainID uint32, token common.Address) string {
+	return fmt.Sprintf("%d-%s", chainID, token.Hex())
 }
 
 // Handler is the handler for a quote request.
@@ -81,6 +87,7 @@ func (r *Relayer) requestToHandler(ctx context.Context, req reldb.QuoteRequest) 
 		apiClient:           r.apiClient,
 		mutexMiddlewareFunc: r.mutexMiddleware,
 		handlerMtx:          r.handlerMtx,
+		balanceMtx:          r.balanceMtx,
 	}
 
 	// wrap in deadline middleware since the relay has not yet happened


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced a new locking mechanism for balance management to enhance concurrency control.
  - Added a mutex for balance requests in the relayer to synchronize access.

- **Improvements**
  - Enhanced the `QuoteRequestHandler` with a mutex for thread-safe balance operations.
  - Improved documentation for mutex usage in the relayer struct for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->