### PR TITLE
fix(rfq-relayer): cap rebalance amount at origin initial threshold

### DIFF
--- a/services/rfq/relayer/inventory/rebalance.go
+++ b/services/rfq/relayer/inventory/rebalance.go
@@ -260,6 +260,9 @@ func getRebalanceAmount(span trace.Span, cfg relconfig.Config, tokens map[int]ma
 		}
 		if initialDelta.Cmp(big.NewInt(0)) > 0 && amount.Cmp(initialDelta) > 0 {
 			amount = initialDelta
+			if span != nil {
+				span.SetAttributes(attribute.String("rebalance_amount_adjusted", amount.String()))
+			}
 			return amount, nil
 		}
 		return nil, nil


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced logic for calculating rebalance amounts based on maintenance thresholds, improving balance management.
	- Adjustments to prevent breaches of maintenance thresholds, ensuring better stability in token operations.
	- Added more contextual tracing attributes for improved debugging and monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->