### PR TITLE
docs(rfq): withdrawal CLI documentation

### DIFF
--- a/docs/bridge/docs/rfq/Relayer/Relayer.md
+++ b/docs/bridge/docs/rfq/Relayer/Relayer.md
@@ -64,6 +64,24 @@ The relayer can also be run with docker. To do this, you will need to pull the [
 docker run ghcr.io/synapsecns/sanguine/rfq-relayer:latest --config /path/to/config
 ```
 
+### Withdrawals
+
+The `POST /withdraw` endpoint is exposed to allow for withdrawing from the relayer wallet without having to deal with the private key directly. This can be used for manual rebalancing, if desired. To use this feature, the following config values must be set:
+
+```yaml
+enable_api_withdrawals: true
+withdrawal_whitelist:
+  - <your_address_here>
+```
+
+The relayer CLI (at `services/rfq/relayer/main.go`) exposes a withdrawal command for convenience:
+
+```bash
+go run main.go withdraw --relayer-url https://localhost:8081 --chain-id 1 --amount 1000000000000000000 --token-address 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE --to 0x0000000000000000000000000000000000000000
+```
+
+Be sure to sub in your respective `to` address!
+
 ### Configuration
 
 The relayer is configured with a yaml file. The following is an example configuration:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Introduced a `POST /withdraw` endpoint for easy fund withdrawal from the relayer wallet, eliminating the need for direct private key management.
    - Added a withdrawal command in the relayer CLI for convenient command-line access to execute withdrawals.

- **Configuration Updates**
    - New options for YAML configuration to enable API withdrawals and specify a whitelist of authorized addresses for enhanced security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
28cac9e401a1be41ad81e78a36a1dea74decf0c0: [docs preview link ](https://bridge-docs-8iu9rofj2-synapsecns.vercel.app)