### PR TITLE
maintenance(synapse-interface): canto pause 

### DIFF
--- a/packages/synapse-interface/public/pauses/v1/paused-chains.json
+++ b/packages/synapse-interface/public/pauses/v1/paused-chains.json
@@ -22,15 +22,15 @@
     "pausedToChains": [7700],
     "pauseBridge": true,
     "pauseSwap": true,
-    "startTimePauseChain": "2024-08-09T14:15:00Z",
-    "endTimePauseChain": "2024-08-09T14:45:00Z",
-    "startTimeBanner": "2024-08-09T13:00:00Z",
-    "endTimeBanner": "2024-08-09T14:45:00Z",
-    "inputWarningMessage": "Canto chain paused until network upgrade completes.",
-    "bannerMessage": "Canto will be paused 15 minutes ahead of the upgrade (August 9th, 14:30 UTC). Will be back online shortly following the network upgrade.",
-    "progressBarMessage": "Canto upgrade in progress",
+    "startTimePauseChain": "2024-08-15T17:35:00Z",
+    "endTimePauseChain": "2024-08-16T17:35:00Z",
+    "startTimeBanner": "2024-08-15T17:35:00Z",
+    "endTimeBanner": "2024-08-16T17:35:00Z",
+    "inputWarningMessage": "Canto chain paused.",
+    "bannerMessage": "Canto chain currently paused.",
+    "progressBarMessage": "Canto chain paused.",
     "disableBanner": false,
-    "disableWarning": false,
+    "disableWarning": true,
     "disableCountdown": false
   }
 ]

--- a/packages/synapse-interface/public/pauses/v1/paused-chains.json
+++ b/packages/synapse-interface/public/pauses/v1/paused-chains.json
@@ -26,9 +26,9 @@
     "endTimePauseChain": "2024-08-16T17:35:00Z",
     "startTimeBanner": "2024-08-15T17:35:00Z",
     "endTimeBanner": "2024-08-16T17:35:00Z",
-    "inputWarningMessage": "Canto chain paused.",
-    "bannerMessage": "Canto chain currently paused.",
-    "progressBarMessage": "Canto chain paused.",
+    "inputWarningMessage": "Canto chain paused due to chain instability.",
+    "bannerMessage": "Canto chain currently paused due to chain instability.",
+    "progressBarMessage": "Canto chain paused due to chain instability.",
     "disableBanner": false,
     "disableWarning": true,
     "disableCountdown": false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated timestamps for the paused state of the Canto chain to reflect new scheduling for August 15th and 16th, 2024.
	- Revamped messages related to the paused state to provide clearer and more concise information.
	- Disabled warning messages by changing the relevant configuration setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
b322b1ef71b4e60693bd1baf99f15227b13bdf42: [synapse-interface preview link ](https://sanguine-synapse-interface-27godggrw-synapsecns.vercel.app)