### PR TITLE
fix(synapse-interface): hide Blast WETH

### DIFF
--- a/packages/synapse-interface/constants/tokens/index.ts
+++ b/packages/synapse-interface/constants/tokens/index.ts
@@ -37,6 +37,7 @@ export const PAUSED_TOKENS_BY_CHAIN = {
   [CHAINS.BOBA.id]: ['WETH'],
   [CHAINS.MOONBEAM.id]: ['WETH'],
   [CHAINS.BASE.id]: ['WETH'],
+  [CHAINS.BLAST.id]: ['WETH'],
   [CHAINS.ARBITRUM.id]: ['WETH'],
   [CHAINS.FANTOM.id]: [],
   [CHAINS.DOGE.id]: ['BUSD', 'WETH'],


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**
A clear and concise description of the features you're adding in this pull request.

**Additional context**
Add any other context about the problem you're solving.

**Metadata**
- Fixes #[Link to Issue]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for the `CHAINS.BLAST` blockchain, enabling management of paused tokens for this chain with the inclusion of the `WETH` token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
ca22c03d69e569ac536afb49e871ce9bd6112c86: [synapse-interface preview link ](https://sanguine-synapse-interface-8jp4ihqh5-synapsecns.vercel.app)