### PR TITLE
refactor(relapi): deprecate `GetQuoteRequestStatusResponse` model

### DIFF
--- a/contrib/opbot/botmd/commands_test.go
+++ b/contrib/opbot/botmd/commands_test.go
@@ -22,7 +22,7 @@ func TestStripLinks(t *testing.T) {
 func TestTxAge(t *testing.T) {
 	notExpected := "unknown time ago" // should be a definite time
 
-	status := &relapi.GetQuoteRequestStatusResponse{
+	status := &relapi.GetQuoteRequestResponse{
 		OriginTxHash:  "0x954264d120f5f3cf50edc39ebaf88ea9dc647d9d6843b7a120ed3677e23d7890",
 		OriginChainID: 421611,
 	}

--- a/contrib/opbot/botmd/export_test.go
+++ b/contrib/opbot/botmd/export_test.go
@@ -11,6 +11,6 @@ func StripLinks(input string) string {
 	return stripLinks(input)
 }
 
-func GetTxAge(ctx context.Context, client client.EVM, res *relapi.GetQuoteRequestStatusResponse) string {
+func GetTxAge(ctx context.Context, client client.EVM, res *relapi.GetQuoteRequestResponse) string {
 	return getTxAge(ctx, client, res)
 }

--- a/services/rfq/relayer/relapi/client.go
+++ b/services/rfq/relayer/relapi/client.go
@@ -15,10 +15,6 @@ import (
 // RelayerClient is the interface for the relayer client.
 type RelayerClient interface {
 	Health(ctx context.Context) (ok bool, err error)
-	// Deprecated: use GetQuoteRequestByTxHash
-	GetQuoteRequestStatusByTxHash(ctx context.Context, hash string) (*GetQuoteRequestStatusResponse, error)
-	// Deprecated: use GetQuoteRequestStatusByTxID
-	GetQuoteRequestStatusByTxID(ctx context.Context, hash string) (*GetQuoteRequestStatusResponse, error)
 	RetryTransaction(ctx context.Context, txhash string) (*GetTxRetryResponse, error)
 	Withdraw(ctx context.Context, req *WithdrawRequest) (*WithdrawResponse, error)
 	GetTxHashByNonce(ctx context.Context, req *GetTxByNonceRequest) (*TxHashByNonceResponse, error)
@@ -58,8 +54,8 @@ func (r *relayerClient) Health(ctx context.Context) (ok bool, err error) {
 	return ok, nil
 }
 
-func (r *relayerClient) GetQuoteRequestStatusByTxHash(ctx context.Context, hash string) (*GetQuoteRequestStatusResponse, error) {
-	var res GetQuoteRequestStatusResponse
+func (r *relayerClient) GetQuoteRequestStatusByTxHash(ctx context.Context, hash string) (*GetQuoteRequestResponse, error) {
+	var res GetQuoteRequestResponse
 
 	resp, err := r.client.R().SetContext(ctx).
 		SetQueryParam("hash", hash).
@@ -75,8 +71,8 @@ func (r *relayerClient) GetQuoteRequestStatusByTxHash(ctx context.Context, hash 
 	return &res, nil
 }
 
-func (r *relayerClient) GetQuoteRequestStatusByTxID(ctx context.Context, txid string) (*GetQuoteRequestStatusResponse, error) {
-	var res GetQuoteRequestStatusResponse
+func (r *relayerClient) GetQuoteRequestStatusByTxID(ctx context.Context, txid string) (*GetQuoteRequestResponse, error) {
+	var res GetQuoteRequestResponse
 
 	resp, err := r.client.R().SetContext(ctx).
 		SetQueryParam("id", txid).

--- a/services/rfq/relayer/relapi/client_test.go
+++ b/services/rfq/relayer/relapi/client_test.go
@@ -26,7 +26,7 @@ func (c *RelayerClientSuite) TestGetQuoteRequestStatusByTxHash() {
 	err := c.underlying.database.StoreQuoteRequest(c.GetTestContext(), testReq)
 	c.Require().NoError(err)
 
-	resp, err := c.Client.GetQuoteRequestStatusByTxHash(c.GetTestContext(), testReq.OriginTxHash.String())
+	resp, err := c.Client.GetQuoteRequestByTxHash(c.GetTestContext(), testReq.OriginTxHash.String())
 	c.Require().NoError(err)
 
 	c.Equal(resp.Status, testReq.Status.String())
@@ -40,7 +40,7 @@ func (c *RelayerClientSuite) TestGetQuoteRequestStatusByTxID() {
 	err := c.underlying.database.StoreQuoteRequest(c.GetTestContext(), testReq)
 	c.Require().NoError(err)
 
-	resp, err := c.Client.GetQuoteRequestStatusByTxID(c.GetTestContext(), hexutil.Encode(testReq.TransactionID[:]))
+	resp, err := c.Client.GetQuoteRequestByTXID(c.GetTestContext(), hexutil.Encode(testReq.TransactionID[:]))
 	c.Require().NoError(err)
 
 	c.Equal(resp.Status, testReq.Status.String())

--- a/services/rfq/relayer/relapi/handler.go
+++ b/services/rfq/relayer/relapi/handler.go
@@ -66,13 +66,16 @@ func (h *Handler) GetQuoteRequestStatusByTxHash(c *gin.Context) {
 		return
 	}
 
-	resp := GetQuoteRequestStatusResponse{
-		Status:        quoteRequest.Status.String(),
-		TxID:          hexutil.Encode(quoteRequest.TransactionID[:]),
-		OriginTxHash:  quoteRequest.OriginTxHash.String(),
-		OriginChainID: quoteRequest.Transaction.OriginChainId,
-		DestChainID:   quoteRequest.Transaction.DestChainId,
-		DestTxHash:    quoteRequest.DestTxHash.String(),
+	resp := GetQuoteRequestResponse{
+		Status:          quoteRequest.Status.String(),
+		TxID:            hexutil.Encode(quoteRequest.TransactionID[:]),
+		QuoteRequestRaw: common.Bytes2Hex(quoteRequest.RawRequest),
+		OriginTxHash:    quoteRequest.OriginTxHash.String(),
+		DestTxHash:      quoteRequest.DestTxHash.String(),
+		OriginChainID:   quoteRequest.Transaction.OriginChainId,
+		DestChainID:     quoteRequest.Transaction.DestChainId,
+		OriginToken:     quoteRequest.Transaction.OriginToken.Hex(),
+		DestToken:       quoteRequest.Transaction.DestToken.Hex(),
 	}
 	c.JSON(http.StatusOK, resp)
 }
@@ -99,13 +102,16 @@ func (h *Handler) GetQuoteRequestStatusByTxID(c *gin.Context) {
 		return
 	}
 
-	resp := GetQuoteRequestStatusResponse{
-		Status:        quoteRequest.Status.String(),
-		TxID:          hexutil.Encode(quoteRequest.TransactionID[:]),
-		OriginTxHash:  quoteRequest.OriginTxHash.String(),
-		OriginChainID: quoteRequest.Transaction.OriginChainId,
-		DestChainID:   quoteRequest.Transaction.DestChainId,
-		DestTxHash:    quoteRequest.DestTxHash.String(),
+	resp := GetQuoteRequestResponse{
+		Status:          quoteRequest.Status.String(),
+		TxID:            hexutil.Encode(quoteRequest.TransactionID[:]),
+		QuoteRequestRaw: common.Bytes2Hex(quoteRequest.RawRequest),
+		OriginTxHash:    quoteRequest.OriginTxHash.String(),
+		DestTxHash:      quoteRequest.DestTxHash.String(),
+		OriginChainID:   quoteRequest.Transaction.OriginChainId,
+		DestChainID:     quoteRequest.Transaction.DestChainId,
+		OriginToken:     quoteRequest.Transaction.OriginToken.Hex(),
+		DestToken:       quoteRequest.Transaction.DestToken.Hex(),
 	}
 	c.JSON(http.StatusOK, resp)
 }

--- a/services/rfq/relayer/relapi/model.go
+++ b/services/rfq/relayer/relapi/model.go
@@ -1,15 +1,5 @@
 package relapi
 
-// GetQuoteRequestStatusResponse contains the schema for a GET /quote response.
-type GetQuoteRequestStatusResponse struct {
-	Status        string `json:"status"`
-	TxID          string `json:"tx_id"`
-	OriginTxHash  string `json:"origin_tx_hash"`
-	OriginChainID uint32 `json:"origin_chain_id"`
-	DestTxHash    string `json:"dest_tx_hash"`
-	DestChainID   uint32 `json:"dest_chain_id"`
-}
-
 // GetTxRetryResponse contains the schema for a PUT /tx/retry response.
 type GetTxRetryResponse struct {
 	TxID      string `json:"tx_id"`
@@ -27,7 +17,11 @@ type PutRelayAckResponse struct {
 
 // GetQuoteRequestResponse is the response to a get quote request.
 type GetQuoteRequestResponse struct {
+	Status          string `json:"status"`
+	TxID            string `json:"tx_id"`
 	QuoteRequestRaw string `json:"quote_request"`
+	OriginTxHash    string `json:"origin_tx_hash"`
+	DestTxHash      string `json:"dest_tx_hash"`
 	OriginChainID   uint32 `json:"origin_chain_id"`
 	DestChainID     uint32 `json:"dest_chain_id"`
 	OriginToken     string `json:"origin_token"`

--- a/services/rfq/relayer/relapi/server_test.go
+++ b/services/rfq/relayer/relapi/server_test.go
@@ -63,10 +63,10 @@ func (c *RelayerServerSuite) TestGetQuoteRequestByTxHash() {
 	c.Equal(http.StatusOK, resp.StatusCode)
 
 	// Compare to expected result
-	var result relapi.GetQuoteRequestStatusResponse
+	var result relapi.GetQuoteRequestResponse
 	err = json.NewDecoder(resp.Body).Decode(&result)
 	c.Require().NoError(err)
-	expectedResult := relapi.GetQuoteRequestStatusResponse{
+	expectedResult := relapi.GetQuoteRequestResponse{
 		Status:        quoteRequest.Status.String(),
 		TxID:          hexutil.Encode(quoteRequest.TransactionID[:]),
 		OriginTxHash:  quoteRequest.OriginTxHash.String(),
@@ -102,10 +102,10 @@ func (c *RelayerServerSuite) TestGetQuoteRequestByTxID() {
 	c.Equal(http.StatusOK, resp.StatusCode)
 
 	// Compare to expected result
-	var result relapi.GetQuoteRequestStatusResponse
+	var result relapi.GetQuoteRequestResponse
 	err = json.NewDecoder(resp.Body).Decode(&result)
 	c.Require().NoError(err)
-	expectedResult := relapi.GetQuoteRequestStatusResponse{
+	expectedResult := relapi.GetQuoteRequestResponse{
 		Status:        quoteRequest.Status.String(),
 		TxID:          hexutil.Encode(quoteRequest.TransactionID[:]),
 		OriginTxHash:  quoteRequest.OriginTxHash.String(),


### PR DESCRIPTION
It was redundant and unclear, simply integrated the remaining fields into the existing `GetQuoteRequestResponse` model. 

