### PR TITLE
feat(listener): add listener_name as otel attribute

### DIFF
--- a/ethergo/listener/listener.go
+++ b/ethergo/listener/listener.go
@@ -53,6 +53,7 @@ type chainListener struct {
 	blockWait       uint64
 	// otelRecorder is the recorder for the otel metrics.
 	otelRecorder iOtelRecorder
+	name         string
 }
 
 var (
@@ -94,7 +95,7 @@ func (c *chainListener) Listen(ctx context.Context, handler HandleLog) (err erro
 	}
 
 	if c.otelRecorder == nil {
-		c.otelRecorder, err = newOtelRecorder(c.handler, int(c.chainID))
+		c.otelRecorder, err = newOtelRecorder(c.handler, int(c.chainID), c.name)
 		if err != nil {
 			return fmt.Errorf("could not create otel recorder: %w", err)
 		}

--- a/ethergo/listener/options.go
+++ b/ethergo/listener/options.go
@@ -54,6 +54,7 @@ func WithBlockWait(wait uint64) Option {
 // WithName sets the listener name.
 func WithName(name string) Option {
 	return func(c *chainListener) {
+		c.name = name
 		c.store.SetListenerName(name)
 	}
 }

--- a/ethergo/listener/otel.go
+++ b/ethergo/listener/otel.go
@@ -37,15 +37,18 @@ type otelRecorder struct {
 	lastBlockFetchTime *time.Time
 	// chainID is the chain ID for the listener.
 	chainID int
+	// listenerName is the name of the listener.
+	listenerName string
 }
 
-func newOtelRecorder(meterHandler metrics.Handler, chainID int) (_ iOtelRecorder, err error) {
+func newOtelRecorder(meterHandler metrics.Handler, chainID int, name string) (_ iOtelRecorder, err error) {
 	or := otelRecorder{
 		metrics:            meterHandler,
 		meter:              meterHandler.Meter(meterName),
 		lastBlock:          nil,
 		lastBlockFetchTime: nil,
 		chainID:            chainID,
+		listenerName:       name,
 	}
 
 	or.lastBlockGauge, err = or.meter.Int64ObservableGauge("last_block")
@@ -78,6 +81,7 @@ func (o *otelRecorder) recordLastBlock(_ context.Context, observer metric.Observ
 
 	opts := metric.WithAttributes(
 		attribute.Int(metrics.ChainID, o.chainID),
+		attribute.String("listener_name", o.listenerName),
 	)
 	observer.ObserveInt64(o.lastBlockGauge, int64(*o.lastBlock), opts)
 
@@ -92,6 +96,7 @@ func (o *otelRecorder) recordLastFetchedBlockAge(_ context.Context, observer met
 	age := time.Since(*o.lastBlockFetchTime).Seconds()
 	opts := metric.WithAttributes(
 		attribute.Int(metrics.ChainID, o.chainID),
+		attribute.String("listener_name", o.listenerName),
 	)
 	observer.ObserveFloat64(o.lastFetchedBlockAgeGauge, age, opts)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a naming feature for the chain listener, allowing users to assign and store a name for better identification.
	- Enhanced metrics tracking by including the listener's name in the recorded metrics.
  
- **Bug Fixes**
	- Fixed potential issues with metrics identification by ensuring that the listener's name is now part of the metrics.

- **Documentation**
	- Updated the functionality of the `WithName` option to store the listener's name in the chain listener instance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->