### PR TITLE
fixing explorer UI bug

### DIFF
--- a/packages/synapse-constants/constants/tokens/bridgeable.ts
+++ b/packages/synapse-constants/constants/tokens/bridgeable.ts
@@ -787,7 +787,7 @@ export const ETH = new Token({
     [CHAINS.BASE.id]: nullAddress,
     [CHAINS.ARBITRUM.id]: nullAddress,
     [CHAINS.DFK.id]: '0xfBDF0E31808d0aa7b9509AA6aBC9754E48C58852',
-    [CHAINS.BLAST.id]: zeroAddress,
+    [CHAINS.BLAST.id]: nullAddress,
     [CHAINS.SCROLL.id]: nullAddress,
     [CHAINS.LINEA.id]: nullAddress,
   },


### PR DESCRIPTION
changes the ETH address on blast from the null address to 0xEe....

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the initialization of the ETH token for improved interaction with the BLAST chain.
  
- **Bug Fixes**
	- Adjusted token representation for better alignment with other chains, enhancing overall token handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->