### PR TITLE
Feat/eip191recov

### DIFF
--- a/services/rfq/api/rest/server_test.go
+++ b/services/rfq/api/rest/server_test.go
@@ -67,6 +67,45 @@ func (c *ServerSuite) TestEIP191_SuccessfulSignature() {
 	c.Equal(http.StatusOK, resp.StatusCode)
 }
 
+// TestEIP191_SuccessfulSignature_vCodeNormalize tests the EIP191 signature process for successful authentication
+// using a recovery ID (v) value of 27 instead of the 0/1 value. Should be normalized & still authenticate successfully
+func (c *ServerSuite) TestEIP191_SuccessfulSignature_vCodeNormalize() {
+	// Start the API server in a separate goroutine and wait for it to initialize.
+	c.startQuoterAPIServer()
+
+	// Prepare the authorization header with a signed timestamp.
+	header, err := c.prepareAuthHeader(c.testWallet)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	// swap in v code 27/28 for 0/1 respectively
+	if header[len(header)-2:] == "00" {
+		header = header[:len(header)-2] + "1b"
+	} else if header[len(header)-2:] == "01" {
+		header = header[:len(header)-2] + "1c"
+	}
+
+	// Perform a PUT request to the API server with the authorization header.
+	resp, err := c.sendPutQuoteRequest(header)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+	defer func() {
+		err = resp.Body.Close()
+		c.Require().NoError(err)
+	}()
+
+	// Log the response body for debugging.
+	body, _ := io.ReadAll(resp.Body)
+	fmt.Println(string(body))
+
+	// Assert that the response status code is HTTP 200 OK.
+	c.Equal(http.StatusOK, resp.StatusCode)
+}
+
 // TestEIP191_UnsuccessfulSignature tests the EIP191 signature process with an incorrect wallet signature.
 func (c *ServerSuite) TestEIP191_UnsuccessfulSignature() {
 	// Start the API server in a separate goroutine and wait for it to initialize.

--- a/services/rfq/api/rest/server_test.go
+++ b/services/rfq/api/rest/server_test.go
@@ -59,16 +59,12 @@ func (c *ServerSuite) TestEIP191_SuccessfulSignature() {
 		c.Require().NoError(err)
 	}()
 
-	// Log the response body for debugging.
-	body, _ := io.ReadAll(resp.Body)
-	fmt.Println(string(body))
-
 	// Assert that the response status code is HTTP 200 OK.
 	c.Equal(http.StatusOK, resp.StatusCode)
 }
 
-// TestEIP191_SuccessfulSignature_vCodeNormalize tests the EIP191 signature process for successful authentication
-// using a recovery ID (v) value of 27 instead of the 0/1 value. Should be normalized & still authenticate successfully
+// TestEIP191_SuccessfulSignature_vCodeNormalize tests the EIP191 signature process for successful authentication.
+// using a recovery ID (v) value of 27/28 instead of the 0/1 value. Should be normalized & still authenticate successfully.
 func (c *ServerSuite) TestEIP191_SuccessfulSignature_vCodeNormalize() {
 	// Start the API server in a separate goroutine and wait for it to initialize.
 	c.startQuoterAPIServer()
@@ -80,7 +76,7 @@ func (c *ServerSuite) TestEIP191_SuccessfulSignature_vCodeNormalize() {
 		return
 	}
 
-	// swap in v code 27/28 for 0/1 respectively
+	// swap in v code 27/28 for 0/1 respectively.
 	if header[len(header)-2:] == "00" {
 		header = header[:len(header)-2] + "1b"
 	} else if header[len(header)-2:] == "01" {
@@ -97,10 +93,6 @@ func (c *ServerSuite) TestEIP191_SuccessfulSignature_vCodeNormalize() {
 		err = resp.Body.Close()
 		c.Require().NoError(err)
 	}()
-
-	// Log the response body for debugging.
-	body, _ := io.ReadAll(resp.Body)
-	fmt.Println(string(body))
 
 	// Assert that the response status code is HTTP 200 OK.
 	c.Equal(http.StatusOK, resp.StatusCode)


### PR DESCRIPTION
eip191 auth should accept recovery Id (aka "v") values of 0/1 or 27/28, as both methods are used inconsistently by various crypto libraries.

note that because the V value is not part of the actual encryption, we just normalize it before evaluating the signature

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced handling of Ethereum signature recovery IDs for improved authentication robustness.
	- Added validation for signature normalization to accommodate various recovery ID formats.

- **Tests**
	- Introduced a new test to validate the normalization of recovery ID values during the EIP191 signature process, ensuring accurate authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->