### PR TITLE
fix(synapse-interface): Prevents extra vertical scroll when disconnected

### DIFF
--- a/packages/synapse-interface/pages/index.tsx
+++ b/packages/synapse-interface/pages/index.tsx
@@ -18,7 +18,7 @@ const Home = () => {
       <LandingPageWrapper>
         <main
           data-test-id="bridge-page"
-          className="relative z-0 flex-1 h-full overflow-y-auto focus:outline-none"
+          className="relative z-0 flex-1 h-full overflow-y-none focus:outline-none"
         >
           <div className="flex flex-col-reverse justify-center gap-16 px-4 py-20 mx-auto lg:flex-row 2xl:w-3/4 sm:mt-6 sm:px-8 md:px-12">
             <Portfolio />


### PR DESCRIPTION
**Description**
When selecting the to chain/tokens, an extra scroll-bar would appear when the selector height when overflowing the screen. This happened when user was disconnected (because otherwise, the portfolio would provide the extra vertical buffer). PR removes the unnecessary scrollbar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the vertical overflow behavior of the main content area, preventing vertical scrolling when content exceeds the container height. This change may enhance user experience by providing a more stable view of the page without unexpected scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
30e18efa043db89f683e00ec17b48223e1b3405b: [synapse-interface preview link ](https://sanguine-synapse-interface-ca1yycpqs-synapsecns.vercel.app)