### PR TITLE
feat(synapse-interface): Adds simplified Chinese translation support

### DIFF
--- a/packages/synapse-interface/components/LanguageSelector.tsx
+++ b/packages/synapse-interface/components/LanguageSelector.tsx
@@ -12,6 +12,7 @@ const languages = [
   { code: 'es', name: 'Español' },
   { code: 'fr', name: 'Français' },
   { code: 'tr', name: 'Türkçe' },
+  { code: 'zh-CN', name: '中文（简体）' },
 ]
 
 export const LanguageSelector = () => {

--- a/packages/synapse-interface/next.config.js
+++ b/packages/synapse-interface/next.config.js
@@ -44,7 +44,7 @@ const nextConfig = {
     tsconfigPath: './tsconfig.json',
   },
   i18n: {
-    locales: ['en-US', 'fr', 'ar', 'tr', 'es'],
+    locales: ['en-US', 'fr', 'ar', 'tr', 'es', 'zh-CN'],
     defaultLocale: 'en-US',
   },
 }


### PR DESCRIPTION
**Description**
Adds locale `zh-CN` (simplified Chinese) support.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added Simplified Chinese (中文（简体）) as a new language option in the Language Selector.
	- Expanded the application's language support to include Simplified Chinese in the internationalization configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
84402201b2a68a6a2dc2167799e22a7f1a324c38: [synapse-interface preview link ](https://sanguine-synapse-interface-2lvtsijhk-synapsecns.vercel.app)