### PR TITLE
remove mnd linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -102,6 +102,8 @@ linters:
     - perfsprint
     # malfunctions on embedded structs
     - typecheck
+    # magic numbers
+    - mnd
   fast: false
 
 issues:


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**

Magic numbers rarely cause problems


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new linter to detect magic numbers in the codebase, enhancing code quality and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->