### PR TITLE
chore: solidity vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,11 +16,6 @@
   "eslint.format.enable": true,
   "editorconfig.generateAuto": false,
   "files.trimTrailingWhitespace": true,
-  "solidity.packageDefaultDependenciesContractsDirectory": "contracts",
-  "solidity.packageDefaultDependenciesDirectory": "lib",
-  "solidity.compileUsingRemoteVersion": "v0.8.17+commit.8df45f5f",
-  "solidity.formatter": "prettier",
-  "solidity.defaultCompiler": "remote",
   "tailwindCSS.classAttributes": [
     ".*class.*",
     ".*Class.*",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,8 @@
 {
   "editor.fontLigatures": "'calt', 'liga', 'ss01', 'ss02', 'ss03', 'ss04', 'ss05', 'ss06', 'ss07', 'ss08', 'ss09'",
+  "[solidity]": {
+    "editor.defaultFormatter": "JuanBlanco.solidity"
+  },
   "[typescript]": {
     "editor.defaultFormatter": "dbaeumer.vscode-eslint"
   },
@@ -16,6 +19,7 @@
   "eslint.format.enable": true,
   "editorconfig.generateAuto": false,
   "files.trimTrailingWhitespace": true,
+  "solidity.formatter": "forge",
   "solidity.monoRepoSupport": true,
   "tailwindCSS.classAttributes": [
     ".*class.*",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,6 +16,7 @@
   "eslint.format.enable": true,
   "editorconfig.generateAuto": false,
   "files.trimTrailingWhitespace": true,
+  "solidity.monoRepoSupport": true,
   "tailwindCSS.classAttributes": [
     ".*class.*",
     ".*Class.*",

--- a/packages/contracts-core/.vscode/settings.json
+++ b/packages/contracts-core/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "solidity.monoRepoSupport": false
+}

--- a/packages/contracts-core/.vscode/settings.json
+++ b/packages/contracts-core/.vscode/settings.json
@@ -1,3 +1,7 @@
 {
+  "[solidity]": {
+    "editor.defaultFormatter": "JuanBlanco.solidity"
+  },
+  "solidity.formatter": "forge",
   "solidity.monoRepoSupport": false
 }

--- a/packages/contracts-rfq/.vscode/settings.json
+++ b/packages/contracts-rfq/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "solidity.monoRepoSupport": false
+}

--- a/packages/contracts-rfq/.vscode/settings.json
+++ b/packages/contracts-rfq/.vscode/settings.json
@@ -1,3 +1,7 @@
 {
+  "[solidity]": {
+    "editor.defaultFormatter": "JuanBlanco.solidity"
+  },
+  "solidity.formatter": "forge",
   "solidity.monoRepoSupport": false
 }

--- a/packages/solidity-devops/.vscode/settings.json
+++ b/packages/solidity-devops/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "solidity.monoRepoSupport": false
+}

--- a/packages/solidity-devops/.vscode/settings.json
+++ b/packages/solidity-devops/.vscode/settings.json
@@ -1,3 +1,7 @@
 {
+  "[solidity]": {
+    "editor.defaultFormatter": "JuanBlanco.solidity"
+  },
+  "solidity.formatter": "forge",
   "solidity.monoRepoSupport": false
 }


### PR DESCRIPTION
**Description**
Adds a reasonable minimum set of settings for Solidity extension within VSCode and its forks.

Reasoning behind having settings files in the monorepo as well as in the packages: it's more convenient to use the package directory as workspace, when the changes are limited to that package. I have found turning off `monoRepoSupport` in this case to be helpful.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new settings for Solidity development in Visual Studio Code across multiple projects, ensuring consistent code formatting with "JuanBlanco.solidity" as the default formatter.
	- Updated the Solidity formatter to "forge" for improved development workflow.
	- Added support for monorepo configurations in select projects to enhance project organization.

- **Bug Fixes**
	- Removed outdated settings related to Solidity dependencies and compiler versions for a simplified configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->