### PR TITLE
boba pause

### DIFF
--- a/packages/synapse-interface/public/pauses/v1/paused-chains.json
+++ b/packages/synapse-interface/public/pauses/v1/paused-chains.json
@@ -35,7 +35,7 @@
   },
   {
     "id": "boba-chain-pause",
-    "pausedFromChains": [280],
+    "pausedFromChains": [],
     "pausedToChains": [280],
     "pauseBridge": true,
     "pauseSwap": true,

--- a/packages/synapse-interface/public/pauses/v1/paused-chains.json
+++ b/packages/synapse-interface/public/pauses/v1/paused-chains.json
@@ -32,5 +32,22 @@
     "disableBanner": false,
     "disableWarning": true,
     "disableCountdown": false
+  },
+  {
+    "id": "boba-chain-pause",
+    "pausedFromChains": [280],
+    "pausedToChains": [280],
+    "pauseBridge": true,
+    "pauseSwap": true,
+    "startTimePauseChain": "2024-09-20T17:35:00Z",
+    "endTimePauseChain": "2024-10-10T17:35:00Z",
+    "startTimeBanner": "2024-09-20T17:35:00Z",
+    "endTimeBanner": "2024-10-10T17:35:00Z",
+    "inputWarningMessage": "Boba chain paused due to chain upgrades.",
+    "bannerMessage": "Boba chain currently paused due to chain upgrades.",
+    "progressBarMessage": "Boba chain paused due to chain upgrades.",
+    "disableBanner": false,
+    "disableWarning": true,
+    "disableCountdown": false
   }
 ]


### PR DESCRIPTION
Pause the boba chain while node upgrades take place

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a pause for the Boba chain from September 20, 2024, to October 10, 2024, due to chain upgrades.
	- Added clear messaging for users regarding the pause, including a banner and warning messages.
	- Disabled bridge and swap functionalities during the pause period.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
a876f5617a21a4d32aecd2c9ac936661ca5e4ede: [synapse-interface preview link ](https://sanguine-synapse-interface-bb5y7jl77-synapsecns.vercel.app)
ca84c198b3850e3cefb5a5c7d484024339006607: [synapse-interface preview link ](https://sanguine-synapse-interface-7ryfshsfr-synapsecns.vercel.app)