### PR TITLE
Adds /destinationTokens route [SLT-204]

### DIFF
--- a/packages/rest-api/.eslintrc.js
+++ b/packages/rest-api/.eslintrc.js
@@ -5,11 +5,10 @@ module.exports = {
       files: ['jest.config.js'],
       rules: {
         'prettier/prettier': 'off',
-        'guard-for-in': 'off',
       },
     },
     {
-      files: ['**/*.ts', '**/*.tsx'],
+      files: ['**/*.ts'],
       rules: {
         'guard-for-in': 'off',
       },

--- a/packages/rest-api/.eslintrc.js
+++ b/packages/rest-api/.eslintrc.js
@@ -5,6 +5,13 @@ module.exports = {
       files: ['jest.config.js'],
       rules: {
         'prettier/prettier': 'off',
+        'guard-for-in': 'off',
+      },
+    },
+    {
+      files: ['**/*.ts', '**/*.tsx'],
+      rules: {
+        'guard-for-in': 'off',
       },
     },
   ],

--- a/packages/rest-api/src/constants/bridgeable.ts
+++ b/packages/rest-api/src/constants/bridgeable.ts
@@ -1,7 +1,6 @@
 import { BridgeableToken } from '../types'
 import { CHAINS } from './chains'
-
-const ZeroAddress = '0x0000000000000000000000000000000000000000'
+import { ZeroAddress } from '.'
 
 export const GOHM: BridgeableToken = {
   addresses: {

--- a/packages/rest-api/src/constants/index.ts
+++ b/packages/rest-api/src/constants/index.ts
@@ -3,3 +3,6 @@ export const VALID_BRIDGE_MODULES = [
   'SynapseCCTP',
   'SynapseRFQ',
 ]
+
+export const ZeroAddress = '0x0000000000000000000000000000000000000000'
+export const EthAddress = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'

--- a/packages/rest-api/src/constants/index.ts
+++ b/packages/rest-api/src/constants/index.ts
@@ -5,4 +5,4 @@ export const VALID_BRIDGE_MODULES = [
 ]
 
 export const ZeroAddress = '0x0000000000000000000000000000000000000000'
-export const EthAddress = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'
+export const NativeGasAddress = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'

--- a/packages/rest-api/src/controllers/destinationTokensController.ts
+++ b/packages/rest-api/src/controllers/destinationTokensController.ts
@@ -1,0 +1,28 @@
+import { validationResult } from 'express-validator'
+import { tokenAddressToToken } from '../utils/tokenAddressToToken'
+import { BRIDGE_ROUTE_MAPPING } from '../utils/bridgeRouteMapping'
+
+export const destinationTokensController = async (req, res) => {
+  const errors = validationResult(req)
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ errors: errors.array() })
+  }
+
+  try {
+    const { fromChain, fromToken } = req.query
+
+    const fromTokenInfo = tokenAddressToToken(fromChain.toString(), fromToken)
+
+    const constructedKey = `${fromTokenInfo.symbol}-${fromChain}`
+
+    const options = BRIDGE_ROUTE_MAPPING[constructedKey]
+
+    res.json(options)
+  } catch (err) {
+    res.status(500).json({
+      error:
+        'An unexpected error occurred in /destinationTokens. Please try again later.',
+      details: err.message,
+    })
+  }
+}

--- a/packages/rest-api/src/controllers/destinationTokensController.ts
+++ b/packages/rest-api/src/controllers/destinationTokensController.ts
@@ -1,4 +1,5 @@
 import { validationResult } from 'express-validator'
+
 import { tokenAddressToToken } from '../utils/tokenAddressToToken'
 import { BRIDGE_ROUTE_MAPPING } from '../utils/bridgeRouteMapping'
 

--- a/packages/rest-api/src/middleware/checksumAddresses.ts
+++ b/packages/rest-api/src/middleware/checksumAddresses.ts
@@ -1,0 +1,18 @@
+import { Request, Response, NextFunction } from 'express'
+import { getAddress } from 'ethers/lib/utils'
+
+export const checksumAddresses = (addressFields: string[]) => {
+  return (req: Request, _res: Response, next: NextFunction) => {
+    for (const field of addressFields) {
+      if (req.query[field] && typeof req.query[field] === 'string') {
+        try {
+          req.query[field] = getAddress(req.query[field] as string)
+        } catch (error) {
+          console.log(error)
+        }
+      }
+    }
+    console.log(req.query)
+    next()
+  }
+}

--- a/packages/rest-api/src/middleware/checksumAddresses.ts
+++ b/packages/rest-api/src/middleware/checksumAddresses.ts
@@ -1,15 +1,12 @@
 import { Request, Response, NextFunction } from 'express'
-import { getAddress } from 'ethers/lib/utils'
+import { getAddress, isAddress } from 'ethers/lib/utils'
 
 export const checksumAddresses = (addressFields: string[]) => {
   return (req: Request, _res: Response, next: NextFunction) => {
     for (const field of addressFields) {
-      if (req.query[field] && typeof req.query[field] === 'string') {
-        try {
-          req.query[field] = getAddress(req.query[field] as string)
-        } catch (error) {
-          console.log(error)
-        }
+      const address = req.query[field]
+      if (typeof address === 'string' && isAddress(address)) {
+        req.query[field] = getAddress(address)
       }
     }
     next()

--- a/packages/rest-api/src/middleware/checksumAddresses.ts
+++ b/packages/rest-api/src/middleware/checksumAddresses.ts
@@ -12,7 +12,6 @@ export const checksumAddresses = (addressFields: string[]) => {
         }
       }
     }
-    console.log(req.query)
     next()
   }
 }

--- a/packages/rest-api/src/routes/bridgeRoute.ts
+++ b/packages/rest-api/src/routes/bridgeRoute.ts
@@ -6,11 +6,13 @@ import { CHAINS_ARRAY } from '../constants/chains'
 import { showFirstValidationError } from '../middleware/showFirstValidationError'
 import { bridgeController } from '../controllers/bridgeController'
 import { isTokenSupportedOnChain } from '../utils/isTokenSupportedOnChain'
+import { checksumAddresses } from '../middleware/checksumAddresses'
 
 const router = express.Router()
 
 router.get(
   '/',
+  checksumAddresses(['fromToken', 'toToken']),
   [
     check('fromChain')
       .isNumeric()

--- a/packages/rest-api/src/routes/bridgeTxInfoRoute.ts
+++ b/packages/rest-api/src/routes/bridgeTxInfoRoute.ts
@@ -7,11 +7,13 @@ import { showFirstValidationError } from '../middleware/showFirstValidationError
 import { bridgeTxInfoController } from '../controllers/bridgeTxInfoController'
 import { isTokenAddress } from '../utils/isTokenAddress'
 import { isTokenSupportedOnChain } from '../utils/isTokenSupportedOnChain'
+import { checksumAddresses } from '../middleware/checksumAddresses'
 
 const router = express.Router()
 
 router.get(
   '/',
+  checksumAddresses(['fromToken', 'toToken']),
   [
     check('fromChain')
       .isNumeric()

--- a/packages/rest-api/src/routes/destinationTokensRoute.ts
+++ b/packages/rest-api/src/routes/destinationTokensRoute.ts
@@ -7,11 +7,13 @@ import { showFirstValidationError } from '../middleware/showFirstValidationError
 import { destinationTokensController } from '../controllers/destinationTokensController'
 import { isTokenAddress } from '../utils/isTokenAddress'
 import { isTokenSupportedOnChain } from '../utils/isTokenSupportedOnChain'
+import { checksumAddresses } from '../middleware/checksumAddresses'
 
 const router = express.Router()
 
 router.get(
   '/',
+  checksumAddresses(['fromToken']),
   [
     check('fromChain')
       .exists()

--- a/packages/rest-api/src/routes/destinationTokensRoute.ts
+++ b/packages/rest-api/src/routes/destinationTokensRoute.ts
@@ -1,0 +1,38 @@
+import express from 'express'
+import { check } from 'express-validator'
+import { isAddress } from 'ethers/lib/utils'
+
+import { CHAINS_ARRAY } from '../constants/chains'
+import { showFirstValidationError } from '../middleware/showFirstValidationError'
+import { destinationTokensController } from '../controllers/destinationTokensController'
+import { isTokenAddress } from '../utils/isTokenAddress'
+import { isTokenSupportedOnChain } from '../utils/isTokenSupportedOnChain'
+
+const router = express.Router()
+
+router.get(
+  '/',
+  [
+    check('fromChain')
+      .exists()
+      .withMessage('fromChain is required')
+      .isNumeric()
+      .custom((value) => CHAINS_ARRAY.some((c) => c.id === Number(value)))
+      .withMessage('Unsupported fromChain'),
+    check('fromToken')
+      .exists()
+      .withMessage('fromToken is required')
+      .custom((value) => isAddress(value))
+      .withMessage('Invalid fromToken address')
+      .custom((value) => isTokenAddress(value))
+      .withMessage('Unsupported fromToken address')
+      .custom((value, { req }) =>
+        isTokenSupportedOnChain(value, req.query.fromChain as string)
+      )
+      .withMessage('Token not supported on specified chain'),
+  ],
+  showFirstValidationError,
+  destinationTokensController
+)
+
+export default router

--- a/packages/rest-api/src/routes/index.ts
+++ b/packages/rest-api/src/routes/index.ts
@@ -9,6 +9,7 @@ import getSynapseTxIdRoute from './getSynapseTxIdRoute'
 import getBridgeTxStatusRoute from './getBridgeTxStatusRoute'
 import getDestinationTxRoute from './getDestinationTxRoute'
 import tokenListRoute from './tokenListRoute'
+import destinationTokensRoute from './destinationTokensRoute'
 
 const router = express.Router()
 
@@ -21,5 +22,6 @@ router.use('/getSynapseTxId', getSynapseTxIdRoute)
 router.use('/getBridgeTxStatus', getBridgeTxStatusRoute)
 router.use('/getDestinationTx', getDestinationTxRoute)
 router.use('/tokenList', tokenListRoute)
+router.use('/destinationTokens', destinationTokensRoute)
 
 export default router

--- a/packages/rest-api/src/routes/swapRoute.ts
+++ b/packages/rest-api/src/routes/swapRoute.ts
@@ -6,11 +6,13 @@ import { swapController } from '../controllers/swapController'
 import { CHAINS_ARRAY } from '../constants/chains'
 import { isTokenAddress } from '../utils/isTokenAddress'
 import { isTokenSupportedOnChain } from '../utils/isTokenSupportedOnChain'
+import { checksumAddresses } from '../middleware/checksumAddresses'
 
 const router = express.Router()
 
 router.get(
   '/',
+  checksumAddresses(['fromToken', 'toToken']),
   [
     check('chain')
       .isNumeric()

--- a/packages/rest-api/src/routes/swapTxInfoRoute.ts
+++ b/packages/rest-api/src/routes/swapTxInfoRoute.ts
@@ -7,11 +7,13 @@ import { showFirstValidationError } from '../middleware/showFirstValidationError
 import { swapTxInfoController } from '../controllers/swapTxInfoController'
 import { isTokenAddress } from '../utils/isTokenAddress'
 import { isTokenSupportedOnChain } from '../utils/isTokenSupportedOnChain'
+import { checksumAddresses } from '../middleware/checksumAddresses'
 
 const router = express.Router()
 
 router.get(
   '/',
+  checksumAddresses(['fromToken', 'toToken']),
   [
     check('chain')
       .isNumeric()

--- a/packages/rest-api/src/tests/destinationTokensRoute.test.ts
+++ b/packages/rest-api/src/tests/destinationTokensRoute.test.ts
@@ -1,0 +1,98 @@
+import request from 'supertest'
+import express from 'express'
+import destinationTokensRoute from '../routes/destinationTokensRoute'
+
+const app = express()
+app.use('/destinationTokens', destinationTokensRoute)
+
+describe('destinatonTokens Route', () => {
+  it('should return destination tokens for valid input', async () => {
+    const response = await request(app).get('/destinationTokens').query({
+      fromChain: '1',
+      fromToken: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+    })
+
+    expect(response.status).toBe(200)
+    expect(Array.isArray(response.body)).toBe(true)
+    expect(response.body.length).toBeGreaterThan(0)
+    expect(response.body[0]).toHaveProperty('symbol')
+    expect(response.body[0]).toHaveProperty('address')
+    expect(response.body[0]).toHaveProperty('chainId')
+  })
+
+  it('should return 400 for unsupported fromChain', async () => {
+    const response = await request(app).get('/destinationTokens').query({
+      fromChain: '999',
+      fromToken: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+    })
+
+    expect(response.status).toBe(400)
+    expect(response.body.error).toHaveProperty(
+      'message',
+      'Unsupported fromChain'
+    )
+  })
+
+  it('should return 400 for invalid fromToken address', async () => {
+    const response = await request(app).get('/destinationTokens').query({
+      fromChain: '1',
+      fromToken: 'invalid_address',
+    })
+
+    expect(response.status).toBe(400)
+    expect(response.body.error).toHaveProperty(
+      'message',
+      'Invalid fromToken address'
+    )
+  })
+
+  it('should return 400 for token not supported by Synapse', async () => {
+    const response = await request(app).get('/destinationTokens').query({
+      fromChain: '1',
+      fromToken: '0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F',
+    })
+
+    expect(response.status).toBe(400)
+    expect(response.body.error).toHaveProperty(
+      'message',
+      'Unsupported fromToken address'
+    )
+  })
+
+  it('should return 400 for token not supported on specified chain', async () => {
+    const response = await request(app).get('/destinationTokens').query({
+      fromChain: '10',
+      fromToken: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+    })
+
+    expect(response.status).toBe(400)
+    expect(response.body.error).toHaveProperty(
+      'message',
+      'Token not supported on specified chain'
+    )
+  })
+
+  it('should return 400 for missing fromChain', async () => {
+    const response = await request(app).get('/destinationTokens').query({
+      fromToken: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+    })
+
+    expect(response.status).toBe(400)
+    expect(response.body.error).toHaveProperty(
+      'message',
+      'fromChain is required'
+    )
+  })
+
+  it('should return 400 for missing fromToken', async () => {
+    const response = await request(app).get('/destinationTokens').query({
+      fromChain: '1',
+    })
+
+    expect(response.status).toBe(400)
+    expect(response.body.error).toHaveProperty(
+      'message',
+      'fromToken is required'
+    )
+  })
+})

--- a/packages/rest-api/src/tests/destinationTokensRoute.test.ts
+++ b/packages/rest-api/src/tests/destinationTokensRoute.test.ts
@@ -35,6 +35,22 @@ describe('destinatonTokens Route', () => {
     expect(response.body[0]).toHaveProperty('chainId')
   })
 
+  it('should return precisely the number of destination tokens', async () => {
+    // 'USDC-534352': [ 'USDC-1', 'USDC-10', 'USDC-8453', 'USDC-42161', 'USDC-59144' ]
+
+    const response = await request(app).get('/destinationTokens').query({
+      fromChain: '534352',
+      fromToken: '0x06eFdBFf2a14a7c8E15944D1F4A48F9F95F663A4',
+    })
+
+    expect(response.status).toBe(200)
+    expect(Array.isArray(response.body)).toBe(true)
+    expect(response.body.length).toBe(5)
+    expect(response.body[0]).toHaveProperty('symbol')
+    expect(response.body[0]).toHaveProperty('address')
+    expect(response.body[0]).toHaveProperty('chainId')
+  })
+
   it('should return destination tokens for non-checksummed address', async () => {
     const response = await request(app).get('/destinationTokens').query({
       fromChain: '43114',

--- a/packages/rest-api/src/tests/destinationTokensRoute.test.ts
+++ b/packages/rest-api/src/tests/destinationTokensRoute.test.ts
@@ -35,6 +35,20 @@ describe('destinatonTokens Route', () => {
     expect(response.body[0]).toHaveProperty('chainId')
   })
 
+  it('should return destination tokens for non-checksummed address', async () => {
+    const response = await request(app).get('/destinationTokens').query({
+      fromChain: '43114',
+      fromToken: '0x9702230a8ea53601f5cd2dc00fdbc13d4df4a8c7',
+    })
+
+    expect(response.status).toBe(200)
+    expect(Array.isArray(response.body)).toBe(true)
+    expect(response.body.length).toBeGreaterThan(0)
+    expect(response.body[0]).toHaveProperty('symbol')
+    expect(response.body[0]).toHaveProperty('address')
+    expect(response.body[0]).toHaveProperty('chainId')
+  })
+
   it('should return 400 for unsupported fromChain', async () => {
     const response = await request(app).get('/destinationTokens').query({
       fromChain: '999',

--- a/packages/rest-api/src/tests/destinationTokensRoute.test.ts
+++ b/packages/rest-api/src/tests/destinationTokensRoute.test.ts
@@ -1,5 +1,6 @@
 import request from 'supertest'
 import express from 'express'
+
 import destinationTokensRoute from '../routes/destinationTokensRoute'
 
 const app = express()

--- a/packages/rest-api/src/tests/destinationTokensRoute.test.ts
+++ b/packages/rest-api/src/tests/destinationTokensRoute.test.ts
@@ -21,6 +21,20 @@ describe('destinatonTokens Route', () => {
     expect(response.body[0]).toHaveProperty('chainId')
   })
 
+  it('should return destination tokens for valid gas Tokens', async () => {
+    const response = await request(app).get('/destinationTokens').query({
+      fromChain: '1',
+      fromToken: '0x0000000000000000000000000000000000000000',
+    })
+
+    expect(response.status).toBe(200)
+    expect(Array.isArray(response.body)).toBe(true)
+    expect(response.body.length).toBeGreaterThan(0)
+    expect(response.body[0]).toHaveProperty('symbol')
+    expect(response.body[0]).toHaveProperty('address')
+    expect(response.body[0]).toHaveProperty('chainId')
+  })
+
   it('should return 400 for unsupported fromChain', async () => {
     const response = await request(app).get('/destinationTokens').query({
       fromChain: '999',

--- a/packages/rest-api/src/utils/bridgeRouteMapping.ts
+++ b/packages/rest-api/src/utils/bridgeRouteMapping.ts
@@ -1,3 +1,4 @@
+import { EthAddress, ZeroAddress } from '../constants'
 import { BRIDGE_MAP } from '../constants/bridgeMap'
 
 interface TokenInfo {
@@ -21,7 +22,9 @@ const constructJSON = (
       const tokenA = swappableMap[chainA][addressA]
       const keyA = `${tokenA.symbol}-${chainA}`
 
-      if (exclusionList.includes(keyA)) continue
+      if (exclusionList.includes(keyA)) {
+        continue
+      }
 
       result[keyA] = []
 
@@ -31,7 +34,9 @@ const constructJSON = (
             const tokenB = swappableMap[chainB][addressB]
             const keyB = `${tokenB.symbol}-${chainB}`
 
-            if (exclusionList.includes(keyB)) continue
+            if (exclusionList.includes(keyB)) {
+              continue
+            }
 
             const canBridge = tokenA.origin.some(
               (bridgeSymbol) =>
@@ -42,7 +47,7 @@ const constructJSON = (
             if (canBridge) {
               result[keyA].push({
                 symbol: tokenB.symbol,
-                address: addressB,
+                address: addressB === EthAddress ? ZeroAddress : addressB,
                 chainId: chainB,
               })
             }

--- a/packages/rest-api/src/utils/bridgeRouteMapping.ts
+++ b/packages/rest-api/src/utils/bridgeRouteMapping.ts
@@ -1,4 +1,4 @@
-import { EthAddress, ZeroAddress } from '../constants'
+import { NativeGasAddress, ZeroAddress } from '../constants'
 import { BRIDGE_MAP } from '../constants/bridgeMap'
 
 interface TokenInfo {
@@ -47,7 +47,7 @@ const constructJSON = (
             if (canBridge) {
               result[keyA].push({
                 symbol: tokenB.symbol,
-                address: addressB === EthAddress ? ZeroAddress : addressB,
+                address: addressB === NativeGasAddress ? ZeroAddress : addressB,
                 chainId: chainB,
               })
             }

--- a/packages/rest-api/src/utils/bridgeRouteMapping.ts
+++ b/packages/rest-api/src/utils/bridgeRouteMapping.ts
@@ -1,0 +1,62 @@
+import { BRIDGE_MAP } from '../constants/bridgeMap'
+
+interface TokenInfo {
+  symbol: string
+  address: string
+  chainId: string
+}
+
+interface BridgeRoutes {
+  [key: string]: TokenInfo[]
+}
+
+const constructJSON = (
+  swappableMap: typeof BRIDGE_MAP,
+  exclusionList: string[]
+): BridgeRoutes => {
+  const result: BridgeRoutes = {}
+
+  for (const chainA in swappableMap) {
+    for (const addressA in swappableMap[chainA]) {
+      const tokenA = swappableMap[chainA][addressA]
+      const keyA = `${tokenA.symbol}-${chainA}`
+
+      if (exclusionList.includes(keyA)) continue
+
+      result[keyA] = []
+
+      for (const chainB in swappableMap) {
+        if (chainA !== chainB) {
+          for (const addressB in swappableMap[chainB]) {
+            const tokenB = swappableMap[chainB][addressB]
+            const keyB = `${tokenB.symbol}-${chainB}`
+
+            if (exclusionList.includes(keyB)) continue
+
+            const canBridge = tokenA.origin.some(
+              (bridgeSymbol) =>
+                tokenB.destination.includes(bridgeSymbol) ||
+                tokenB.origin.includes(bridgeSymbol)
+            )
+
+            if (canBridge) {
+              result[keyA].push({
+                symbol: tokenB.symbol,
+                address: addressB,
+                chainId: chainB,
+              })
+            }
+          }
+        }
+      }
+
+      if (result[keyA].length === 0) {
+        delete result[keyA]
+      }
+    }
+  }
+
+  return result
+}
+
+export const BRIDGE_ROUTE_MAPPING: BridgeRoutes = constructJSON(BRIDGE_MAP, [])

--- a/packages/rest-api/src/utils/tokenAddressToToken.ts
+++ b/packages/rest-api/src/utils/tokenAddressToToken.ts
@@ -1,4 +1,4 @@
-import { EthAddress, ZeroAddress } from '../constants'
+import { NativeGasAddress, ZeroAddress } from '../constants'
 import { BRIDGE_MAP } from '../constants/bridgeMap'
 
 export const tokenAddressToToken = (chain: string, tokenAddress: string) => {
@@ -7,7 +7,7 @@ export const tokenAddressToToken = (chain: string, tokenAddress: string) => {
     return null
   }
 
-  const address = tokenAddress === ZeroAddress ? EthAddress : tokenAddress
+  const address = tokenAddress === ZeroAddress ? NativeGasAddress : tokenAddress
 
   const tokenInfo = chainData[address]
   if (!tokenInfo) {

--- a/packages/rest-api/src/utils/tokenAddressToToken.ts
+++ b/packages/rest-api/src/utils/tokenAddressToToken.ts
@@ -1,3 +1,4 @@
+import { EthAddress, ZeroAddress } from '../constants'
 import { BRIDGE_MAP } from '../constants/bridgeMap'
 
 export const tokenAddressToToken = (chain: string, tokenAddress: string) => {
@@ -5,7 +6,10 @@ export const tokenAddressToToken = (chain: string, tokenAddress: string) => {
   if (!chainData) {
     return null
   }
-  const tokenInfo = chainData[tokenAddress]
+
+  const address = tokenAddress === ZeroAddress ? EthAddress : tokenAddress
+
+  const tokenInfo = chainData[address]
   if (!tokenInfo) {
     return null
   }


### PR DESCRIPTION
**Description**
Adds `/destinationTokens` route. Given query params from `fromChain` and `fromToken`, response returns list of possible destination tokens with `symbol`, `address`, and `chainId` metadata.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new endpoint for handling destination token transfers between blockchain networks.
  - Implemented robust validation for incoming requests to ensure only valid token transfer requests are processed.
  - Added predefined constants for Ethereum addresses to enhance code clarity.
  - Added a utility for constructing a mapping of bridge routes between different tokens across various blockchain networks.
  - Added middleware to validate token addresses for checksum format across multiple routes.

- **Bug Fixes**
  - Enhanced error handling to provide clearer responses for invalid requests.

- **Tests**
  - Added unit tests for the new destination tokens route to ensure proper functionality and error handling.

- **Chores**
  - Updated the API routing structure to include the new destination tokens functionality.
  - Modified ESLint configuration to relax linting rules for specific files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->