### PR TITLE
fix(rfq): use limit confirmations instead of finality

### DIFF
--- a/services/rfq/relayer/limiter/limiter.go
+++ b/services/rfq/relayer/limiter/limiter.go
@@ -98,7 +98,7 @@ func (l *limiterImpl) hasEnoughConfirmations(ctx context.Context, request *reldb
 		return false, fmt.Errorf("could not get block number: %w", err)
 	}
 
-	requiredConfirmations, err := l.cfg.GetFinalityConfirmations(int(request.Transaction.OriginChainId))
+	requiredConfirmations, err := l.cfg.GetLimitConfirmations(int(request.Transaction.OriginChainId))
 	if err != nil {
 		return false, fmt.Errorf("could not get required confirmations from config: %w", err)
 	}

--- a/services/rfq/relayer/relconfig/getters.go
+++ b/services/rfq/relayer/relconfig/getters.go
@@ -848,3 +848,11 @@ func (c Config) GetVolumeLimit(chainID int, addr common.Address) *big.Int {
 	volumeLimitScaled, _ := new(big.Float).Mul(volumeLimitFlt, new(big.Float).SetInt(denomDecimalsFactor)).Int(nil)
 	return volumeLimitScaled
 }
+
+func (c Config) GetLimitConfirmations(chainid int) (uint64, error) {
+	chainCfg, ok := c.Chains[chainid]
+	if !ok {
+		return 0, fmt.Errorf("no chain config for chain %d", chainid)
+	}
+	return chainCfg.LimitConfirmations, nil
+}


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**
A clear and concise description of the features you're adding in this pull request.

**Additional context**
Add any other context about the problem you're solving.

**Metadata**
- Fixes #[Link to Issue]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method for retrieving transaction confirmation limits based on the chain ID.
	- Enhanced configuration management for transaction confirmations across different blockchain networks.

- **Bug Fixes**
	- Updated logic for determining required confirmations for transactions to improve accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->