### PR TITLE
feat(rest-api): Adds Swagger for api docs [SLT-205]

### DIFF
--- a/packages/rest-api/.eslintrc.js
+++ b/packages/rest-api/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
       files: ['**/*.ts'],
       rules: {
         'guard-for-in': 'off',
+        'jsdoc/check-indentation': 'off',
       },
     },
   ],

--- a/packages/rest-api/package.json
+++ b/packages/rest-api/package.json
@@ -38,10 +38,14 @@
     "@babel/preset-typescript": "^7.24.7",
     "@types/jest": "^29.5.13",
     "@types/supertest": "^6.0.2",
+    "@types/swagger-jsdoc": "^6.0.4",
+    "@types/swagger-ui-express": "^4.1.6",
     "concurrently": "^8.2.0",
     "jest": "^29.7.0",
     "lodash": "^4.17.21",
     "nodemon": "^3.0.1",
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^5.0.1",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2"
   }

--- a/packages/rest-api/package.json
+++ b/packages/rest-api/package.json
@@ -9,7 +9,7 @@
     "build": "tsc",
     "build:go": " ",
     "build:slither": " ",
-    "dev": "nodemon --watch src --exec ts-node src/app.ts",
+    "dev": "NODE_ENV=development nodemon --watch src --exec ts-node src/app.ts",
     "start": "node dist/app.js",
     "lint:fix": "eslint src/**/*.ts --fix",
     "lint:check": "eslint . --max-warnings=0",

--- a/packages/rest-api/src/app.ts
+++ b/packages/rest-api/src/app.ts
@@ -1,4 +1,7 @@
 import express from 'express'
+import swaggerUi from 'swagger-ui-express'
+
+import { specs } from './swagger'
 
 import routes from './routes'
 
@@ -6,6 +9,9 @@ const app = express()
 const port = process.env.PORT || 3000
 
 app.use(express.json())
+
+app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(specs))
+
 app.use('/', routes)
 
 export const server = app.listen(port, () => {

--- a/packages/rest-api/src/app.ts
+++ b/packages/rest-api/src/app.ts
@@ -2,7 +2,6 @@ import express from 'express'
 import swaggerUi from 'swagger-ui-express'
 
 import { specs } from './swagger'
-
 import routes from './routes'
 
 const app = express()

--- a/packages/rest-api/src/controllers/bridgeTxStatusController.ts
+++ b/packages/rest-api/src/controllers/bridgeTxStatusController.ts
@@ -4,7 +4,7 @@ import { ethers } from 'ethers'
 import { Synapse } from '../services/synapseService'
 import { getTokenDecimals } from '../utils/getTokenDecimals'
 
-export const getBridgeTxStatusController = async (req, res) => {
+export const bridgeTxStatusController = async (req, res) => {
   const errors = validationResult(req)
   if (!errors.isEmpty()) {
     return res.status(400).json({ errors: errors.array() })
@@ -72,7 +72,7 @@ export const getBridgeTxStatusController = async (req, res) => {
   } catch (err) {
     res.status(500).json({
       error:
-        'An unexpected error occurred in /getBridgeTxStatus. Please try again later.',
+        'An unexpected error occurred in /bridgeTxStatus. Please try again later.',
       details: err.message,
     })
   }

--- a/packages/rest-api/src/controllers/destinationTxController.ts
+++ b/packages/rest-api/src/controllers/destinationTxController.ts
@@ -3,7 +3,7 @@ import { ethers } from 'ethers'
 
 import { getTokenDecimals } from '../utils/getTokenDecimals'
 
-export const getDestinationTxController = async (req, res) => {
+export const destinationTxController = async (req, res) => {
   const errors = validationResult(req)
   if (!errors.isEmpty()) {
     return res.status(400).json({ errors: errors.array() })
@@ -65,7 +65,7 @@ export const getDestinationTxController = async (req, res) => {
   } catch (err) {
     res.status(500).json({
       error:
-        'An unexpected error occurred in /getDestinationTx. Please try again later.',
+        'An unexpected error occurred in /destinationTx. Please try again later.',
       details: err.message,
     })
   }

--- a/packages/rest-api/src/controllers/getSynapseTxIdController.ts
+++ b/packages/rest-api/src/controllers/getSynapseTxIdController.ts
@@ -16,6 +16,7 @@ export const getSynapseTxIdController = async (req, res) => {
       bridgeModule,
       txHash
     )
+
     res.json({ synapseTxId })
   } catch (err) {
     res.status(500).json({

--- a/packages/rest-api/src/controllers/synapseTxIdController.ts
+++ b/packages/rest-api/src/controllers/synapseTxIdController.ts
@@ -2,7 +2,7 @@ import { validationResult } from 'express-validator'
 
 import { Synapse } from '../services/synapseService'
 
-export const getSynapseTxIdController = async (req, res) => {
+export const synapseTxIdController = async (req, res) => {
   const errors = validationResult(req)
   if (!errors.isEmpty()) {
     return res.status(400).json({ errors: errors.array() })
@@ -21,7 +21,7 @@ export const getSynapseTxIdController = async (req, res) => {
   } catch (err) {
     res.status(500).json({
       error:
-        'An unexpected error occurred in /getSynapseTxId. Please try again later.',
+        'An unexpected error occurred in /synapseTxId. Please try again later.',
       details: err.message,
     })
   }

--- a/packages/rest-api/src/routes/bridgeRoute.ts
+++ b/packages/rest-api/src/routes/bridgeRoute.ts
@@ -10,6 +10,181 @@ import { checksumAddresses } from '../middleware/checksumAddresses'
 
 const router = express.Router()
 
+/**
+ * @openapi
+ * /bridge:
+ *   get:
+ *     summary: Get quotes for bridging tokens between chains.
+ *     description: Retrieve list of detailed bridge quotes based on origin and destination chains based on tokens and amount.
+ *     parameters:
+ *       - in: query
+ *         name: fromChain
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The source chain ID
+ *       - in: query
+ *         name: toChain
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The destination chain ID
+ *       - in: query
+ *         name: fromToken
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The address of the token on the source chain
+ *       - in: query
+ *         name: toToken
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The address of the token on the destination chain
+ *       - in: query
+ *         name: amount
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The amount of tokens to bridge
+ *     responses:
+ *       200:
+ *         description: Successful response
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   id:
+ *                     type: string
+ *                   feeAmount:
+ *                     $ref: '#/components/schemas/BigNumber'
+ *                   feeConfig:
+ *                     type: object
+ *                     properties:
+ *                       bridgeFee:
+ *                         type: integer
+ *                       minFee:
+ *                         $ref: '#/components/schemas/BigNumber'
+ *                       maxFee:
+ *                         $ref: '#/components/schemas/BigNumber'
+ *                   routerAddress:
+ *                     type: string
+ *                   maxAmountOut:
+ *                     $ref: '#/components/schemas/BigNumber'
+ *                   originQuery:
+ *                     type: object
+ *                   destQuery:
+ *                     type: object
+ *                   estimatedTime:
+ *                     type: integer
+ *                   bridgeModuleName:
+ *                     type: string
+ *                   gasDropAmount:
+ *                     $ref: '#/components/schemas/BigNumber'
+ *                   originChainId:
+ *                     type: integer
+ *                   destChainId:
+ *                     type: integer
+ *                   maxAmountOutStr:
+ *                     type: string
+ *                   bridgeFeeFormatted:
+ *                     type: string
+ *             example:
+ *               - id: "01920c87-7f14-7cdf-90e1-e13b2d4af55f"
+ *                 feeAmount:
+ *                   type: "BigNumber"
+ *                   hex: "0x17d78400"
+ *                 feeConfig:
+ *                   bridgeFee: 4000000
+ *                   minFee:
+ *                     type: "BigNumber"
+ *                     hex: "0x3d0900"
+ *                   maxFee:
+ *                     type: "BigNumber"
+ *                     hex: "0x17d78400"
+ *                 routerAddress: "0xd5a597d6e7ddf373a92C8f477DAAA673b0902F48"
+ *                 maxAmountOut:
+ *                   type: "BigNumber"
+ *                   hex: "0xe89bd2cb27"
+ *                 originQuery:
+ *                   routerAdapter: "0x0000000000000000000000000000000000000000"
+ *                   tokenOut: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+ *                   minAmountOut:
+ *                     type: "BigNumber"
+ *                     hex: "0xe8d4a51000"
+ *                   deadline:
+ *                     type: "BigNumber"
+ *                     hex: "0x66ecb04b"
+ *                   rawParams: "0x"
+ *                 destQuery:
+ *                   routerAdapter: "0xd5a597d6e7ddf373a92C8f477DAAA673b0902F48"
+ *                   tokenOut: "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9"
+ *                   minAmountOut:
+ *                     type: "BigNumber"
+ *                     hex: "0xe89bd2cb27"
+ *                   deadline:
+ *                     type: "BigNumber"
+ *                     hex: "0x66f5e873"
+ *                   rawParams: "0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000009a2dea7b81cfe3e0011d44d41c5c5142b8d9abdf00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002"
+ *                 estimatedTime: 1020
+ *                 bridgeModuleName: "SynapseCCTP"
+ *                 gasDropAmount:
+ *                   type: "BigNumber"
+ *                   hex: "0x0110d9316ec000"
+ *                 originChainId: 1
+ *                 destChainId: 42161
+ *                 maxAmountOutStr: "999046.695719"
+ *                 bridgeFeeFormatted: "400"
+ *       400:
+ *         description: Invalid input
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: object
+ *                   properties:
+ *                     value:
+ *                       type: string
+ *                     message:
+ *                       type: string
+ *                     field:
+ *                       type: string
+ *                     location:
+ *                       type: string
+ *             example:
+ *               error:
+ *                 value: "999"
+ *                 message: "Unsupported fromChain"
+ *                 field: "fromChain"
+ *                 location: "query"
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                 details:
+ *                   type: string
+ *
+ * components:
+ *   schemas:
+ *     BigNumber:
+ *       type: object
+ *       properties:
+ *         type:
+ *           type: string
+ *           enum: [BigNumber]
+ *         hex:
+ *           type: string
+ */
 router.get(
   '/',
   checksumAddresses(['fromToken', 'toToken']),

--- a/packages/rest-api/src/routes/bridgeRoute.ts
+++ b/packages/rest-api/src/routes/bridgeRoute.ts
@@ -14,8 +14,8 @@ const router = express.Router()
  * @openapi
  * /bridge:
  *   get:
- *     summary: Get quotes for bridging tokens between chains.
- *     description: Retrieve list of detailed bridge quotes based on origin and destination chains based on tokens and amount.
+ *     summary: Get quotes for bridging tokens between chains
+ *     description: Retrieve list of detailed bridge quotes based on origin and destination chains based on tokens and amount
  *     parameters:
  *       - in: query
  *         name: fromChain

--- a/packages/rest-api/src/routes/bridgeRoute.ts
+++ b/packages/rest-api/src/routes/bridgeRoute.ts
@@ -21,13 +21,13 @@ const router = express.Router()
  *         name: fromChain
  *         required: true
  *         schema:
- *           type: string
+ *           type: integer
  *         description: The source chain ID
  *       - in: query
  *         name: toChain
  *         required: true
  *         schema:
- *           type: string
+ *           type: integer
  *         description: The destination chain ID
  *       - in: query
  *         name: fromToken
@@ -45,7 +45,7 @@ const router = express.Router()
  *         name: amount
  *         required: true
  *         schema:
- *           type: string
+ *           type: number
  *         description: The amount of tokens to bridge
  *     responses:
  *       200:

--- a/packages/rest-api/src/routes/bridgeTxInfoRoute.ts
+++ b/packages/rest-api/src/routes/bridgeTxInfoRoute.ts
@@ -11,6 +11,116 @@ import { checksumAddresses } from '../middleware/checksumAddresses'
 
 const router = express.Router()
 
+/**
+ * @openapi
+ * /bridgeTxInfo:
+ *   get:
+ *     summary: Get bridge transaction information
+ *     description: Retrieve transaction information for bridging tokens between chains
+ *     parameters:
+ *       - in: query
+ *         name: fromChain
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The source chain ID
+ *       - in: query
+ *         name: fromToken
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The address of the token on the source chain
+ *       - in: query
+ *         name: toChain
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The destination chain ID
+ *       - in: query
+ *         name: toToken
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The address of the token on the destination chain
+ *       - in: query
+ *         name: amount
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The amount of tokens to bridge
+ *       - in: query
+ *         name: destAddress
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The destination address for the bridged tokens
+ *     responses:
+ *       200:
+ *         description: Successful response
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   data:
+ *                     type: string
+ *                     description: Encoded transaction data
+ *                   to:
+ *                     type: string
+ *                     description: The address of the contract to interact with
+ *                   value:
+ *                     type: object
+ *                     properties:
+ *                       type:
+ *                         type: string
+ *                         enum: [BigNumber]
+ *                       hex:
+ *                         type: string
+ *                     description: The amount of native currency to send with the transaction
+ *             example:
+ *               - data: "0xc2288147000000000000000000000000abb4f79430002534df3f62e964d62659a010ef3c000000000000000000000000000000000000000000000000000000000000a4b1000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48000000000000000000000000000000000000000000000000000000174876e80000000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000001800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48000000000000000000000000000000000000000000000000000000174876e8000000000000000000000000000000000000000000000000000000000066ecbadf00000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000d5a597d6e7ddf373a92c8f477daaa673b0902f48000000000000000000000000fd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb90000000000000000000000000000000000000000000000000000001744e380400000000000000000000000000000000000000000000000000000000066f5f30700000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000009a2dea7b81cfe3e0011d44d41c5c5142b8d9abdf00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004"
+ *                 to: "0xd5a597d6e7ddf373a92C8f477DAAA673b0902F48"
+ *                 value:
+ *                   type: "BigNumber"
+ *                   hex: "0x00"
+ *       400:
+ *         description: Invalid input
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: object
+ *                   properties:
+ *                     value:
+ *                       type: string
+ *                     message:
+ *                       type: string
+ *                     field:
+ *                       type: string
+ *                     location:
+ *                       type: string
+ *             example:
+ *               error:
+ *                 value: "999"
+ *                 message: "Unsupported fromChain"
+ *                 field: "fromChain"
+ *                 location: "query"
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                 details:
+ *                   type: string
+ */
 router.get(
   '/',
   checksumAddresses(['fromToken', 'toToken']),

--- a/packages/rest-api/src/routes/bridgeTxInfoRoute.ts
+++ b/packages/rest-api/src/routes/bridgeTxInfoRoute.ts
@@ -22,7 +22,7 @@ const router = express.Router()
  *         name: fromChain
  *         required: true
  *         schema:
- *           type: string
+ *           type: integer
  *         description: The source chain ID
  *       - in: query
  *         name: fromToken
@@ -34,7 +34,7 @@ const router = express.Router()
  *         name: toChain
  *         required: true
  *         schema:
- *           type: string
+ *           type: integer
  *         description: The destination chain ID
  *       - in: query
  *         name: toToken
@@ -46,7 +46,7 @@ const router = express.Router()
  *         name: amount
  *         required: true
  *         schema:
- *           type: string
+ *           type: number
  *         description: The amount of tokens to bridge
  *       - in: query
  *         name: destAddress

--- a/packages/rest-api/src/routes/bridgeTxStatusRoute.ts
+++ b/packages/rest-api/src/routes/bridgeTxStatusRoute.ts
@@ -19,7 +19,7 @@ const router = express.Router()
  *         name: destChainId
  *         required: true
  *         schema:
- *           type: string
+ *           type: integer
  *         description: The ID of the destination chain
  *       - in: query
  *         name: bridgeModule

--- a/packages/rest-api/src/routes/destinationTokensRoute.ts
+++ b/packages/rest-api/src/routes/destinationTokensRoute.ts
@@ -95,6 +95,7 @@ const router = express.Router()
  *                 details:
  *                   type: string
  */
+
 router.get(
   '/',
   checksumAddresses(['fromToken']),

--- a/packages/rest-api/src/routes/destinationTokensRoute.ts
+++ b/packages/rest-api/src/routes/destinationTokensRoute.ts
@@ -22,7 +22,7 @@ const router = express.Router()
  *         name: fromChain
  *         required: true
  *         schema:
- *           type: string
+ *           type: integer
  *         description: The source chain ID
  *       - in: query
  *         name: fromToken

--- a/packages/rest-api/src/routes/destinationTokensRoute.ts
+++ b/packages/rest-api/src/routes/destinationTokensRoute.ts
@@ -11,6 +11,90 @@ import { checksumAddresses } from '../middleware/checksumAddresses'
 
 const router = express.Router()
 
+/**
+ * @openapi
+ * /destinationTokens:
+ *   get:
+ *     summary: Get possible destination tokens for a bridge
+ *     description: Retrieve possible destination tokens for a given source chain ID and token address
+ *     parameters:
+ *       - in: query
+ *         name: fromChain
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The source chain ID
+ *       - in: query
+ *         name: fromToken
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The address of the token on the source chain
+ *     responses:
+ *       200:
+ *         description: Successful response
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   symbol:
+ *                     type: string
+ *                     description: The token symbol
+ *                   chainId:
+ *                     type: string
+ *                     description: The chain ID where the token is available
+ *                   address:
+ *                     type: string
+ *                     description: The token contract address
+ *             example:
+ *               - symbol: "USDC"
+ *                 chainId: "1"
+ *                 address: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+ *               - symbol: "USDT"
+ *                 chainId: "42161"
+ *                 address: "0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9"
+ *               - symbol: "crvUSD"
+ *                 chainId: "8453"
+ *                 address: "0x417Ac0e078398C154EdFadD9Ef675d30Be60Af93"
+ *       400:
+ *         description: Invalid input
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: object
+ *                   properties:
+ *                     value:
+ *                       type: string
+ *                     message:
+ *                       type: string
+ *                     field:
+ *                       type: string
+ *                     location:
+ *                       type: string
+ *             example:
+ *               error:
+ *                 value: "100"
+ *                 message: "Unsupported fromChain"
+ *                 field: "fromChain"
+ *                 location: "query"
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                 details:
+ *                   type: string
+ */
 router.get(
   '/',
   checksumAddresses(['fromToken']),

--- a/packages/rest-api/src/routes/destinationTxRoute.ts
+++ b/packages/rest-api/src/routes/destinationTxRoute.ts
@@ -2,38 +2,29 @@ import express from 'express'
 import { check } from 'express-validator'
 
 import { showFirstValidationError } from '../middleware/showFirstValidationError'
-import { getBridgeTxStatusController } from '../controllers/getBridgeTxStatusController'
-import { CHAINS_ARRAY } from '../constants/chains'
-import { VALID_BRIDGE_MODULES } from '../constants'
+import { destinationTxController } from '../controllers/destinationTxController'
 
 const router = express.Router()
 
 /**
  * @openapi
- * /getBridgeTxStatus:
+ * /destinationTx:
  *   get:
- *     summary: Get Bridge Transaction Status
+ *     summary: Get Destination Transaction Information
  *     description: Used to get the status of a bridge transaction, and the destination transaction information if the transaction is finalized
  *     parameters:
  *       - in: query
- *         name: destChainId
+ *         name: originChainId
  *         required: true
  *         schema:
  *           type: string
- *         description: The ID of the destination chain
+ *         description: The ID of the origin chain where the transaction was initiated
  *       - in: query
- *         name: bridgeModule
+ *         name: txHash
  *         required: true
  *         schema:
  *           type: string
- *           enum: [SynapseRFQ, SynapseBridge, SynapseCCTP]
- *         description: The bridge module used for the transaction
- *       - in: query
- *         name: synapseTxId
- *         required: true
- *         schema:
- *           type: string
- *         description: The Synapse transaction ID
+ *         description: The transaction hash on the origin chain
  *     responses:
  *       200:
  *         description: Successful response
@@ -72,13 +63,13 @@ const router = express.Router()
  *             example:
  *               status: true
  *               toInfo:
- *                 chainID: 10
- *                 address: "0xRL3Bab0e4c09Ff447863f507E16090A9F22792d2"
- *                 txnHash: "0x4eff784e85df5265dcc8e3c30b9df4b5c8a0c940300f6d8ad7ed737e9beb6fab"
- *                 USDValue: 1.79848
+ *                 chainID: 8453
+ *                 address: "0xABb4F79430002534df3F62E964D62659A010Ef3C"
+ *                 txnHash: "0xc9284b2de9ba74ab618573884930e51575c1a3511216d9949da2955efb69afa8"
+ *                 USDValue: 5999.98657
  *                 tokenSymbol: "USDC"
- *                 formattedTime: "2024-09-01 17:10:41 +0000 UTC"
- *                 formattedValue: "1.797684"
+ *                 formattedTime: "2024-09-19 23:32:29 +0000 UTC"
+ *                 formattedValue: "5999.986575"
  *       400:
  *         description: Invalid input
  *         content:
@@ -100,8 +91,8 @@ const router = express.Router()
  *             example:
  *               error:
  *                 value: "999"
- *                 message: "Unsupported destChainId"
- *                 field: "destChainId"
+ *                 message: "originChainId is required"
+ *                 field: "originChainId"
  *                 location: "query"
  *       500:
  *         description: Server error
@@ -118,28 +109,14 @@ const router = express.Router()
 router.get(
   '/',
   [
-    check('destChainId')
+    check('originChainId')
       .exists()
-      .withMessage('destChainId is required')
-      .isNumeric()
-      .custom((value) => CHAINS_ARRAY.some((c) => c.id === Number(value)))
-      .withMessage('Unsupported destChainId'),
-    check('bridgeModule')
-      .exists()
-      .withMessage('bridgeModule is required')
-      .isString()
-      .isIn(VALID_BRIDGE_MODULES)
-      .withMessage(
-        'Invalid bridge module. Must be one of: ' +
-          VALID_BRIDGE_MODULES.join(', ')
-      ),
-    check('synapseTxId')
-      .exists()
-      .withMessage('synapseTxId is required')
-      .isString(),
+      .withMessage('originChainId is required')
+      .isNumeric(),
+    check('txHash').exists().withMessage('txHash is required').isString(),
   ],
   showFirstValidationError,
-  getBridgeTxStatusController
+  destinationTxController
 )
 
 export default router

--- a/packages/rest-api/src/routes/destinationTxRoute.ts
+++ b/packages/rest-api/src/routes/destinationTxRoute.ts
@@ -17,7 +17,7 @@ const router = express.Router()
  *         name: originChainId
  *         required: true
  *         schema:
- *           type: string
+ *           type: integer
  *         description: The ID of the origin chain where the transaction was initiated
  *       - in: query
  *         name: txHash

--- a/packages/rest-api/src/routes/getBridgeTxStatusRoute.ts
+++ b/packages/rest-api/src/routes/getBridgeTxStatusRoute.ts
@@ -8,6 +8,113 @@ import { VALID_BRIDGE_MODULES } from '../constants'
 
 const router = express.Router()
 
+/**
+ * @openapi
+ * /getBridgeTxStatus:
+ *   get:
+ *     summary: Get Bridge Transaction Status
+ *     description: Retrieve the status of a bridge transaction
+ *     parameters:
+ *       - in: query
+ *         name: destChainId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The ID of the destination chain
+ *       - in: query
+ *         name: bridgeModule
+ *         required: true
+ *         schema:
+ *           type: string
+ *           enum: [SynapseRFQ, SynapseBridge, SynapseCCTP]
+ *         description: The bridge module used for the transaction
+ *       - in: query
+ *         name: synapseTxId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The Synapse transaction ID
+ *     responses:
+ *       200:
+ *         description: Successful response
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: boolean
+ *                   description: The status of the transaction
+ *                 toInfo:
+ *                   type: object
+ *                   properties:
+ *                     chainID:
+ *                       type: integer
+ *                       description: The destination chain ID
+ *                     address:
+ *                       type: string
+ *                       description: The recipient address
+ *                     txnHash:
+ *                       type: string
+ *                       description: The transaction hash on the destination chain
+ *                     USDValue:
+ *                       type: number
+ *                       description: The USD value of the transaction
+ *                     tokenSymbol:
+ *                       type: string
+ *                       description: The symbol of the token transferred
+ *                     formattedTime:
+ *                       type: string
+ *                       description: The formatted time of the transaction
+ *                     formattedValue:
+ *                       type: string
+ *                       description: The formatted value of the transaction
+ *             example:
+ *               status: true
+ *               toInfo:
+ *                 chainID: 10
+ *                 address: "0xRL3Bab0e4c09Ff447863f507E16090A9F22792d2"
+ *                 txnHash: "0x4eff784e85df5265dcc8e3c30b9df4b5c8a0c940300f6d8ad7ed737e9beb6fab"
+ *                 USDValue: 1.79848
+ *                 tokenSymbol: "USDC"
+ *                 formattedTime: "2024-09-01 17:10:41 +0000 UTC"
+ *                 formattedValue: "1.797684"
+ *       400:
+ *         description: Invalid input
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: object
+ *                   properties:
+ *                     value:
+ *                       type: string
+ *                     message:
+ *                       type: string
+ *                     field:
+ *                       type: string
+ *                     location:
+ *                       type: string
+ *             example:
+ *               error:
+ *                 value: "999"
+ *                 message: "Unsupported destChainId"
+ *                 field: "destChainId"
+ *                 location: "query"
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                 details:
+ *                   type: string
+ */
 router.get(
   '/',
   [

--- a/packages/rest-api/src/routes/getBridgeTxStatusRoute.ts
+++ b/packages/rest-api/src/routes/getBridgeTxStatusRoute.ts
@@ -13,7 +13,7 @@ const router = express.Router()
  * /getBridgeTxStatus:
  *   get:
  *     summary: Get Bridge Transaction Status
- *     description: Retrieve the status of a bridge transaction
+ *     description: Used to get the status of a bridge transaction, and the destination transaction information if the transaction is finalized
  *     parameters:
  *       - in: query
  *         name: destChainId

--- a/packages/rest-api/src/routes/getDestinationTxRoute.ts
+++ b/packages/rest-api/src/routes/getDestinationTxRoute.ts
@@ -6,6 +6,106 @@ import { getDestinationTxController } from '../controllers/getDestinationTxContr
 
 const router = express.Router()
 
+/**
+ * @openapi
+ * /getDestinationTx:
+ *   get:
+ *     summary: Get Destination Transaction Information
+ *     description: Used to get the status of a bridge transaction, and the destination transaction information if the transaction is finalized
+ *     parameters:
+ *       - in: query
+ *         name: originChainId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The ID of the origin chain where the transaction was initiated
+ *       - in: query
+ *         name: txHash
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The transaction hash on the origin chain
+ *     responses:
+ *       200:
+ *         description: Successful response
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: boolean
+ *                   description: The status of the transaction
+ *                 toInfo:
+ *                   type: object
+ *                   properties:
+ *                     chainID:
+ *                       type: integer
+ *                       description: The destination chain ID
+ *                     address:
+ *                       type: string
+ *                       description: The recipient address
+ *                     txnHash:
+ *                       type: string
+ *                       description: The transaction hash on the destination chain
+ *                     USDValue:
+ *                       type: number
+ *                       description: The USD value of the transaction
+ *                     tokenSymbol:
+ *                       type: string
+ *                       description: The symbol of the token transferred
+ *                     formattedTime:
+ *                       type: string
+ *                       description: The formatted time of the transaction
+ *                     formattedValue:
+ *                       type: string
+ *                       description: The formatted value of the transaction
+ *             example:
+ *               status: true
+ *               toInfo:
+ *                 chainID: 8453
+ *                 address: "0xABb4F79430002534df3F62E964D62659A010Ef3C"
+ *                 txnHash: "0xc9284b2de9ba74ab618573884930e51575c1a3511216d9949da2955efb69afa8"
+ *                 USDValue: 5999.98657
+ *                 tokenSymbol: "USDC"
+ *                 formattedTime: "2024-09-19 23:32:29 +0000 UTC"
+ *                 formattedValue: "5999.986575"
+ *       400:
+ *         description: Invalid input
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: object
+ *                   properties:
+ *                     value:
+ *                       type: string
+ *                     message:
+ *                       type: string
+ *                     field:
+ *                       type: string
+ *                     location:
+ *                       type: string
+ *             example:
+ *               error:
+ *                 value: "999"
+ *                 message: "originChainId is required"
+ *                 field: "originChainId"
+ *                 location: "query"
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                 details:
+ *                   type: string
+ */
 router.get(
   '/',
   [

--- a/packages/rest-api/src/routes/getSynapseTxIdRoute.ts
+++ b/packages/rest-api/src/routes/getSynapseTxIdRoute.ts
@@ -9,17 +9,17 @@ const router = express.Router()
 
 /**
  * @openapi
- * /getBridgeTxStatus:
+ * /getSynapseTxId:
  *   get:
- *     summary: Get Bridge Transaction Status
- *     description: Retrieve the status of a bridge transaction
+ *     summary: Get Synapse Transaction ID
+ *     description: Retrieve the Synapse transaction ID for a given origin chain transaction
  *     parameters:
  *       - in: query
- *         name: destChainId
+ *         name: originChainId
  *         required: true
  *         schema:
  *           type: string
- *         description: The ID of the destination chain
+ *         description: The ID of the origin chain where the transaction was initiated
  *       - in: query
  *         name: bridgeModule
  *         required: true
@@ -28,11 +28,11 @@ const router = express.Router()
  *           enum: [SynapseRFQ, SynapseBridge, SynapseCCTP]
  *         description: The bridge module used for the transaction
  *       - in: query
- *         name: synapseTxId
+ *         name: txHash
  *         required: true
  *         schema:
  *           type: string
- *         description: The Synapse transaction ID
+ *         description: The transaction hash on the origin chain
  *     responses:
  *       200:
  *         description: Successful response
@@ -41,43 +41,11 @@ const router = express.Router()
  *             schema:
  *               type: object
  *               properties:
- *                 status:
- *                   type: boolean
- *                   description: The status of the transaction
- *                 toInfo:
- *                   type: object
- *                   properties:
- *                     chainID:
- *                       type: integer
- *                       description: The destination chain ID
- *                     address:
- *                       type: string
- *                       description: The recipient address
- *                     txnHash:
- *                       type: string
- *                       description: The transaction hash on the destination chain
- *                     USDValue:
- *                       type: number
- *                       description: The USD value of the transaction
- *                     tokenSymbol:
- *                       type: string
- *                       description: The symbol of the token transferred
- *                     formattedTime:
- *                       type: string
- *                       description: The formatted time of the transaction
- *                     formattedValue:
- *                       type: string
- *                       description: The formatted value of the transaction
+ *                 synapseTxId:
+ *                   type: string
+ *                   description: The Synapse transaction ID
  *             example:
- *               status: true
- *               toInfo:
- *                 chainID: 8453
- *                 address: "0xABb4F79430002534df3F62E964D62659A010Ef3C"
- *                 txnHash: "0xc9284b2de9ba74ab618573884930e51575c1a3511216d9949da2955efb69afa8"
- *                 USDValue: 5999.98657
- *                 tokenSymbol: "USDC"
- *                 formattedTime: "2024-09-19 23:32:29 +0000 UTC"
- *                 formattedValue: "5999.986575"
+ *               synapseTxId: "0x812516c5477aeeb4361ecbdd561abcd10f779a0fce22bad13635b8cae088760a"
  *       400:
  *         description: Invalid input
  *         content:
@@ -99,8 +67,8 @@ const router = express.Router()
  *             example:
  *               error:
  *                 value: "999"
- *                 message: "Unsupported destChainId"
- *                 field: "destChainId"
+ *                 message: "Invalid bridge module. Must be one of: SynapseRFQ, SynapseBridge, SynapseCCTP"
+ *                 field: "bridgeModule"
  *                 location: "query"
  *       500:
  *         description: Server error

--- a/packages/rest-api/src/routes/getSynapseTxIdRoute.ts
+++ b/packages/rest-api/src/routes/getSynapseTxIdRoute.ts
@@ -7,6 +7,81 @@ import { VALID_BRIDGE_MODULES } from '../constants'
 
 const router = express.Router()
 
+/**
+ * @openapi
+ * /getSynapseTxId:
+ *   get:
+ *     summary: Get Synapse Transaction ID
+ *     description: Retrieve the Synapse transaction ID for a given origin chain transaction
+ *     parameters:
+ *       - in: query
+ *         name: originChainId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The ID of the origin chain where the transaction was initiated
+ *       - in: query
+ *         name: bridgeModule
+ *         required: true
+ *         schema:
+ *           type: string
+ *           enum: [SynapseRFQ, SynapseBridge, SynapseCCTP]
+ *         description: The bridge module used for the transaction
+ *       - in: query
+ *         name: txHash
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The transaction hash on the origin chain
+ *     responses:
+ *       200:
+ *         description: Successful response
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 synapseTxId:
+ *                   type: string
+ *                   description: The Synapse transaction ID
+ *             example:
+ *               synapseTxId: "0x812516c5477aeeb4361ecbdd561abcd10f779a0fce22bad13635b8cae088760a"
+ *       400:
+ *         description: Invalid input
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: object
+ *                   properties:
+ *                     value:
+ *                       type: string
+ *                     message:
+ *                       type: string
+ *                     field:
+ *                       type: string
+ *                     location:
+ *                       type: string
+ *             example:
+ *               error:
+ *                 value: "SomeOtherModule"
+ *                 message: "Invalid bridge module. Must be one of: SynapseRFQ, SynapseBridge, SynapseCCTP"
+ *                 field: "bridgeModule"
+ *                 location: "query"
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                 details:
+ *                   type: string
+ */
 router.get(
   '/',
   [

--- a/packages/rest-api/src/routes/getSynapseTxIdRoute.ts
+++ b/packages/rest-api/src/routes/getSynapseTxIdRoute.ts
@@ -9,17 +9,17 @@ const router = express.Router()
 
 /**
  * @openapi
- * /getSynapseTxId:
+ * /getBridgeTxStatus:
  *   get:
- *     summary: Get Synapse Transaction ID
- *     description: Retrieve the Synapse transaction ID for a given origin chain transaction
+ *     summary: Get Bridge Transaction Status
+ *     description: Retrieve the status of a bridge transaction
  *     parameters:
  *       - in: query
- *         name: originChainId
+ *         name: destChainId
  *         required: true
  *         schema:
  *           type: string
- *         description: The ID of the origin chain where the transaction was initiated
+ *         description: The ID of the destination chain
  *       - in: query
  *         name: bridgeModule
  *         required: true
@@ -28,11 +28,11 @@ const router = express.Router()
  *           enum: [SynapseRFQ, SynapseBridge, SynapseCCTP]
  *         description: The bridge module used for the transaction
  *       - in: query
- *         name: txHash
+ *         name: synapseTxId
  *         required: true
  *         schema:
  *           type: string
- *         description: The transaction hash on the origin chain
+ *         description: The Synapse transaction ID
  *     responses:
  *       200:
  *         description: Successful response
@@ -41,11 +41,43 @@ const router = express.Router()
  *             schema:
  *               type: object
  *               properties:
- *                 synapseTxId:
- *                   type: string
- *                   description: The Synapse transaction ID
+ *                 status:
+ *                   type: boolean
+ *                   description: The status of the transaction
+ *                 toInfo:
+ *                   type: object
+ *                   properties:
+ *                     chainID:
+ *                       type: integer
+ *                       description: The destination chain ID
+ *                     address:
+ *                       type: string
+ *                       description: The recipient address
+ *                     txnHash:
+ *                       type: string
+ *                       description: The transaction hash on the destination chain
+ *                     USDValue:
+ *                       type: number
+ *                       description: The USD value of the transaction
+ *                     tokenSymbol:
+ *                       type: string
+ *                       description: The symbol of the token transferred
+ *                     formattedTime:
+ *                       type: string
+ *                       description: The formatted time of the transaction
+ *                     formattedValue:
+ *                       type: string
+ *                       description: The formatted value of the transaction
  *             example:
- *               synapseTxId: "0x812516c5477aeeb4361ecbdd561abcd10f779a0fce22bad13635b8cae088760a"
+ *               status: true
+ *               toInfo:
+ *                 chainID: 8453
+ *                 address: "0xABb4F79430002534df3F62E964D62659A010Ef3C"
+ *                 txnHash: "0xc9284b2de9ba74ab618573884930e51575c1a3511216d9949da2955efb69afa8"
+ *                 USDValue: 5999.98657
+ *                 tokenSymbol: "USDC"
+ *                 formattedTime: "2024-09-19 23:32:29 +0000 UTC"
+ *                 formattedValue: "5999.986575"
  *       400:
  *         description: Invalid input
  *         content:
@@ -66,9 +98,9 @@ const router = express.Router()
  *                       type: string
  *             example:
  *               error:
- *                 value: "SomeOtherModule"
- *                 message: "Invalid bridge module. Must be one of: SynapseRFQ, SynapseBridge, SynapseCCTP"
- *                 field: "bridgeModule"
+ *                 value: "999"
+ *                 message: "Unsupported destChainId"
+ *                 field: "destChainId"
  *                 location: "query"
  *       500:
  *         description: Server error

--- a/packages/rest-api/src/routes/index.ts
+++ b/packages/rest-api/src/routes/index.ts
@@ -5,9 +5,9 @@ import swapRoute from './swapRoute'
 import swapTxInfoRoute from './swapTxInfoRoute'
 import bridgeRoute from './bridgeRoute'
 import bridgeTxInfoRoute from './bridgeTxInfoRoute'
-import getSynapseTxIdRoute from './getSynapseTxIdRoute'
-import getBridgeTxStatusRoute from './getBridgeTxStatusRoute'
-import getDestinationTxRoute from './getDestinationTxRoute'
+import synapseTxIdRoute from './synapseTxIdRoute'
+import bridgeTxStatusRoute from './bridgeTxStatusRoute'
+import destinationTxRoute from './destinationTxRoute'
 import tokenListRoute from './tokenListRoute'
 import destinationTokensRoute from './destinationTokensRoute'
 
@@ -18,9 +18,9 @@ router.use('/swap', swapRoute)
 router.use('/swapTxInfo', swapTxInfoRoute)
 router.use('/bridge', bridgeRoute)
 router.use('/bridgeTxInfo', bridgeTxInfoRoute)
-router.use('/getSynapseTxId', getSynapseTxIdRoute)
-router.use('/getBridgeTxStatus', getBridgeTxStatusRoute)
-router.use('/getDestinationTx', getDestinationTxRoute)
+router.use('/synapseTxId', synapseTxIdRoute)
+router.use('/bridgeTxStatus', bridgeTxStatusRoute)
+router.use('/destinationTx', destinationTxRoute)
 router.use('/tokenList', tokenListRoute)
 router.use('/destinationTokens', destinationTokensRoute)
 

--- a/packages/rest-api/src/routes/indexRoute.ts
+++ b/packages/rest-api/src/routes/indexRoute.ts
@@ -4,6 +4,82 @@ import { indexController } from '../controllers/indexController'
 
 const router = express.Router()
 
+/**
+ * @openapi
+ * /:
+ *   get:
+ *     summary: Get API information
+ *     description: Retrieve general information about the Synapse REST API, including available chains and tokens
+ *     responses:
+ *       200:
+ *         description: Successful response
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   description: Welcome message for the API
+ *                 availableChains:
+ *                   type: array
+ *                   description: List of available blockchain networks
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       name:
+ *                         type: string
+ *                         description: Name of the blockchain network
+ *                       id:
+ *                         type: integer
+ *                         description: Chain ID of the blockchain network
+ *                 availableTokens:
+ *                   type: array
+ *                   description: List of available tokens across different chains
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       symbol:
+ *                         type: string
+ *                         description: Token symbol
+ *                       chains:
+ *                         type: array
+ *                         description: List of chains where the token is available
+ *                         items:
+ *                           type: object
+ *                           properties:
+ *                             chainId:
+ *                               type: string
+ *                               description: Chain ID where the token is available
+ *                             address:
+ *                               type: string
+ *                               description: Token contract address on the specific chain
+ *             example:
+ *               message: "Welcome to the Synapse REST API for swap and bridge quotes"
+ *               availableChains:
+ *                 - name: "Ethereum"
+ *                   id: 1
+ *                 - name: "Arbitrum"
+ *                   id: 42161
+ *               availableTokens:
+ *                 - symbol: "USDC"
+ *                   chains:
+ *                     - chainId: "1"
+ *                       address: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+ *                     - chainId: "42161"
+ *                       address: "0xaf88d065e77c8cc2239327c5edb3a432268e5831"
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                 details:
+ *                   type: string
+ */
 router.get('/', indexController)
 
 export default router

--- a/packages/rest-api/src/routes/swapRoute.ts
+++ b/packages/rest-api/src/routes/swapRoute.ts
@@ -21,7 +21,7 @@ const router = express.Router()
  *         name: chain
  *         required: true
  *         schema:
- *           type: string
+ *           type: integer
  *         description: The chain ID where the swap will occur
  *       - in: query
  *         name: fromToken
@@ -39,7 +39,7 @@ const router = express.Router()
  *         name: amount
  *         required: true
  *         schema:
- *           type: string
+ *           type: number
  *         description: The amount of tokens to swap
  *     responses:
  *       200:

--- a/packages/rest-api/src/routes/swapRoute.ts
+++ b/packages/rest-api/src/routes/swapRoute.ts
@@ -10,6 +10,127 @@ import { checksumAddresses } from '../middleware/checksumAddresses'
 
 const router = express.Router()
 
+/**
+ * @openapi
+ * /swap:
+ *   get:
+ *     summary: Get swap quote for tokens on a specific chain
+ *     description: Retrieve detailed swap quote for exchanging one token for another on a specified chain
+ *     parameters:
+ *       - in: query
+ *         name: chain
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The chain ID where the swap will occur
+ *       - in: query
+ *         name: fromToken
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The address of the token to swap from
+ *       - in: query
+ *         name: toToken
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The address of the token to swap to
+ *       - in: query
+ *         name: amount
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The amount of tokens to swap
+ *     responses:
+ *       200:
+ *         description: Successful response
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 routerAddress:
+ *                   type: string
+ *                   description: The address of the router contract
+ *                 maxAmountOut:
+ *                   type: string
+ *                   description: The maximum amount of tokens that will be received
+ *                 query:
+ *                   type: object
+ *                   properties:
+ *                     swapAdapter:
+ *                       type: string
+ *                       description: The address of the swap adapter
+ *                     tokenOut:
+ *                       type: string
+ *                       description: The address of the token being received
+ *                     minAmountOut:
+ *                       $ref: '#/components/schemas/BigNumber'
+ *                     deadline:
+ *                       $ref: '#/components/schemas/BigNumber'
+ *                     rawParams:
+ *                       type: string
+ *                       description: Raw parameters for the swap
+ *             example:
+ *               routerAddress: "0x7E7A0e201FD38d3ADAA9523Da6C109a07118C96a"
+ *               maxAmountOut: "999.746386"
+ *               query:
+ *                 swapAdapter: "0x7E7A0e201FD38d3ADAA9523Da6C109a07118C96a"
+ *                 tokenOut: "0xdAC17F958D2ee523a2206206994597C13D831ec7"
+ *                 minAmountOut:
+ *                   type: "BigNumber"
+ *                   hex: "0x3b96eb52"
+ *                 deadline:
+ *                   type: "BigNumber"
+ *                   hex: "0x66ecb470"
+ *                 rawParams: "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000001116898dda4015ed8ddefb84b6e8bc24528af2d800000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002"
+ *       400:
+ *         description: Invalid input
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: object
+ *                   properties:
+ *                     value:
+ *                       type: string
+ *                     message:
+ *                       type: string
+ *                     field:
+ *                       type: string
+ *                     location:
+ *                       type: string
+ *             example:
+ *               error:
+ *                 value: "999"
+ *                 message: "Unsupported chain"
+ *                 field: "chain"
+ *                 location: "query"
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                 details:
+ *                   type: string
+ *
+ * components:
+ *   schemas:
+ *     BigNumber:
+ *       type: object
+ *       properties:
+ *         type:
+ *           type: string
+ *           enum: [BigNumber]
+ *         hex:
+ *           type: string
+ */
 router.get(
   '/',
   checksumAddresses(['fromToken', 'toToken']),

--- a/packages/rest-api/src/routes/swapTxInfoRoute.ts
+++ b/packages/rest-api/src/routes/swapTxInfoRoute.ts
@@ -22,7 +22,7 @@ const router = express.Router()
  *         name: chain
  *         required: true
  *         schema:
- *           type: string
+ *           type: integer
  *         description: The chain ID where the swap will occur
  *       - in: query
  *         name: fromToken
@@ -40,7 +40,7 @@ const router = express.Router()
  *         name: amount
  *         required: true
  *         schema:
- *           type: string
+ *           type: number
  *         description: The amount of tokens to swap
  *       - in: query
  *         name: address

--- a/packages/rest-api/src/routes/swapTxInfoRoute.ts
+++ b/packages/rest-api/src/routes/swapTxInfoRoute.ts
@@ -11,6 +11,108 @@ import { checksumAddresses } from '../middleware/checksumAddresses'
 
 const router = express.Router()
 
+/**
+ * @openapi
+ * /swapTxInfo:
+ *   get:
+ *     summary: Get swap transaction information
+ *     description: Retrieve transaction information for swapping tokens on a specific chain
+ *     parameters:
+ *       - in: query
+ *         name: chain
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The chain ID where the swap will occur
+ *       - in: query
+ *         name: fromToken
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The address of the token to swap from
+ *       - in: query
+ *         name: toToken
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The address of the token to swap to
+ *       - in: query
+ *         name: amount
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The amount of tokens to swap
+ *       - in: query
+ *         name: address
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The Ethereum address of the user performing the swap
+ *     responses:
+ *       200:
+ *         description: Successful response
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: string
+ *                   description: Encoded transaction data
+ *                 to:
+ *                   type: string
+ *                   description: The address of the contract to interact with
+ *                 value:
+ *                   type: object
+ *                   properties:
+ *                     type:
+ *                       type: string
+ *                       enum: [BigNumber]
+ *                     hex:
+ *                       type: string
+ *                   description: The amount of native currency to send with the transaction
+ *             example:
+ *               data: "0xb5d1cdd4000000000000000000000000abb4f79430002534df3f62e964d62659a010ef3c000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48000000000000000000000000000000000000000000000000000000003b9aca0000000000000000000000000000000000000000000000000000000000000000800000000000000000000000007e7a0e201fd38d3adaa9523da6c109a07118c96a000000000000000000000000dac17f958d2ee523a2206206994597c13d831ec7000000000000000000000000000000000000000000000000000000003b96eaed0000000000000000000000000000000000000000000000000000000066ecbb7c00000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001116898dda4015ed8ddefb84b6e8bc24528af2d800000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002"
+ *               to: "0x7E7A0e201FD38d3ADAA9523Da6C109a07118C96a"
+ *               value:
+ *                 type: "BigNumber"
+ *                 hex: "0x00"
+ *       400:
+ *         description: Invalid input
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: object
+ *                   properties:
+ *                     value:
+ *                       type: string
+ *                     message:
+ *                       type: string
+ *                     field:
+ *                       type: string
+ *                     location:
+ *                       type: string
+ *             example:
+ *               error:
+ *                 value: "999"
+ *                 message: "Unsupported chain"
+ *                 field: "chain"
+ *                 location: "query"
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                 details:
+ *                   type: string
+ */
 router.get(
   '/',
   checksumAddresses(['fromToken', 'toToken']),

--- a/packages/rest-api/src/routes/synapseTxIdRoute.ts
+++ b/packages/rest-api/src/routes/synapseTxIdRoute.ts
@@ -18,7 +18,7 @@ const router = express.Router()
  *         name: originChainId
  *         required: true
  *         schema:
- *           type: string
+ *           type: integer
  *         description: The ID of the origin chain where the transaction was initiated
  *       - in: query
  *         name: bridgeModule

--- a/packages/rest-api/src/routes/synapseTxIdRoute.ts
+++ b/packages/rest-api/src/routes/synapseTxIdRoute.ts
@@ -2,14 +2,14 @@ import express from 'express'
 import { check } from 'express-validator'
 
 import { showFirstValidationError } from '../middleware/showFirstValidationError'
-import { getSynapseTxIdController } from '../controllers/getSynapseTxIdController'
+import { synapseTxIdController } from '../controllers/synapseTxIdController'
 import { VALID_BRIDGE_MODULES } from '../constants'
 
 const router = express.Router()
 
 /**
  * @openapi
- * /getSynapseTxId:
+ * /synapseTxId:
  *   get:
  *     summary: Get Synapse Transaction ID
  *     description: Retrieve the Synapse transaction ID for a given origin chain transaction
@@ -101,7 +101,7 @@ router.get(
     check('txHash').exists().withMessage('txHash is required').isString(),
   ],
   showFirstValidationError,
-  getSynapseTxIdController
+  synapseTxIdController
 )
 
 export default router

--- a/packages/rest-api/src/routes/tokenListRoute.ts
+++ b/packages/rest-api/src/routes/tokenListRoute.ts
@@ -4,6 +4,99 @@ import { tokenListController } from '../controllers/tokenListController'
 
 const router = express.Router()
 
+/**
+ * @openapi
+ * /tokenlist:
+ *   get:
+ *     summary: Get the list of bridgeable tokens & associated chain metadata
+ *     description: Retrieve the complete list of tokens that can be bridged across different chains
+ *     responses:
+ *       200:
+ *         description: Successful response
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               additionalProperties:
+ *                 type: object
+ *                 properties:
+ *                   addresses:
+ *                     type: object
+ *                     additionalProperties:
+ *                       type: string
+ *                   decimals:
+ *                     type: object
+ *                     additionalProperties:
+ *                       type: integer
+ *                   symbol:
+ *                     type: string
+ *                   name:
+ *                     type: string
+ *                   swapableType:
+ *                     type: string
+ *                   color:
+ *                     type: string
+ *                   priorityRank:
+ *                     type: integer
+ *                   routeSymbol:
+ *                     type: string
+ *                   imgUrl:
+ *                     type: string
+ *             example:
+ *               USDC:
+ *                 addresses:
+ *                   "1": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+ *                   "10": "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85"
+ *                 decimals:
+ *                   "1": 6
+ *                   "10": 6
+ *                 symbol: "USDC"
+ *                 name: "USD Coin"
+ *                 swapableType: "USD"
+ *                 color: "blue"
+ *                 priorityRank: 100
+ *                 routeSymbol: "USDC"
+ *                 imgUrl: "https://example.com/usdc.svg"
+ *               USDT:
+ *                 addresses:
+ *                   "1": "0xdac17f958d2ee523a2206206994597c13d831ec7"
+ *                   "10": "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58"
+ *                 decimals:
+ *                   "1": 6
+ *                   "10": 6
+ *                 symbol: "USDT"
+ *                 name: "USD Tether"
+ *                 swapableType: "USD"
+ *                 color: "lime"
+ *                 priorityRank: 100
+ *                 routeSymbol: "USDT"
+ *                 imgUrl: "https://example.com/usdt.svg"
+ *               NUSD:
+ *                 addresses:
+ *                   "1": "0x1B84765dE8B7566e4cEAF4D0fD3c5aF52D3DdE4F"
+ *                   "10": "0x67C10C397dD0Ba417329543c1a40eb48AAa7cd00"
+ *                 decimals:
+ *                   "1": 18
+ *                   "10": 18
+ *                 symbol: "nUSD"
+ *                 name: "Synapse nUSD"
+ *                 swapableType: "USD"
+ *                 color: "purple"
+ *                 priorityRank: 500
+ *                 routeSymbol: "nUSD"
+ *                 imgUrl: "https://example.com/nusd.svg"
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                 details:
+ *                   type: string
+ */
 router.get('/', tokenListController)
 
 export default router

--- a/packages/rest-api/src/swagger.ts
+++ b/packages/rest-api/src/swagger.ts
@@ -1,5 +1,10 @@
 import swaggerJsdoc from 'swagger-jsdoc'
 
+const isDevelopment = process.env.NODE_ENV === 'development'
+const serverUrl = isDevelopment
+  ? 'http://localhost:3000'
+  : 'https://api.synapseprotocol.com'
+
 const options: swaggerJsdoc.Options = {
   definition: {
     openapi: '3.0.0',
@@ -10,7 +15,7 @@ const options: swaggerJsdoc.Options = {
     },
     servers: [
       {
-        url: 'http://localhost:3000',
+        url: serverUrl,
       },
     ],
   },

--- a/packages/rest-api/src/swagger.ts
+++ b/packages/rest-api/src/swagger.ts
@@ -1,0 +1,20 @@
+import swaggerJsdoc from 'swagger-jsdoc'
+
+const options: swaggerJsdoc.Options = {
+  definition: {
+    openapi: '3.0.0',
+    info: {
+      title: 'Syanpse Protocol REST API',
+      version: '1.0.77',
+      description: 'API documentation for the Synapse Protocol REST API',
+    },
+    servers: [
+      {
+        url: 'http://localhost:3000',
+      },
+    ],
+  },
+  apis: ['./src/routes/*.ts', './src/*.ts'],
+}
+
+export const specs = swaggerJsdoc(options)

--- a/packages/rest-api/src/tests/bridgeTxStatusRoute.test.ts
+++ b/packages/rest-api/src/tests/bridgeTxStatusRoute.test.ts
@@ -1,14 +1,14 @@
 import request from 'supertest'
 import express from 'express'
 
-import getBridgeTxStatusRoute from '../routes/getBridgeTxStatusRoute'
+import bridgeTxStatusRoute from '../routes/bridgeTxStatusRoute'
 
 const app = express()
-app.use('/getBridgeTxStatus', getBridgeTxStatusRoute)
+app.use('/bridgeTxStatus', bridgeTxStatusRoute)
 
 describe('Get Bridge TX Status Route', () => {
   it('should return bridge transaction status for valid input', async () => {
-    const response = await request(app).get('/getBridgeTxStatus').query({
+    const response = await request(app).get('/bridgeTxStatus').query({
       destChainId: '42161',
       bridgeModule: 'SynapseRFQ',
       synapseTxId:
@@ -28,7 +28,7 @@ describe('Get Bridge TX Status Route', () => {
   }, 10000)
 
   it('should return 400 for unsupported destChainId', async () => {
-    const response = await request(app).get('/getBridgeTxStatus').query({
+    const response = await request(app).get('/bridgeTxStatus').query({
       destChainId: '999',
       bridgeModule: 'bridge',
       synapseTxId:
@@ -42,7 +42,7 @@ describe('Get Bridge TX Status Route', () => {
   }, 10000)
 
   it('should return 400 for invalid bridgeModule', async () => {
-    const response = await request(app).get('/getBridgeTxStatus').query({
+    const response = await request(app).get('/bridgeTxStatus').query({
       destChainId: '1',
       bridgeModule: 'invalidModule',
       synapseTxId:
@@ -56,7 +56,7 @@ describe('Get Bridge TX Status Route', () => {
   }, 10000)
 
   it('should return 400 for missing synapseTxId', async () => {
-    const response = await request(app).get('/getBridgeTxStatus').query({
+    const response = await request(app).get('/bridgeTxStatus').query({
       destChainId: '1',
       bridgeModule: 'SynapseRFQ',
     })
@@ -65,7 +65,7 @@ describe('Get Bridge TX Status Route', () => {
   }, 10000)
 
   it('should return 400 for missing destChainId', async () => {
-    const response = await request(app).get('/getBridgeTxStatus').query({
+    const response = await request(app).get('/bridgeTxStatus').query({
       bridgeModule: 'bridge',
       synapseTxId:
         '0x9beb59b36ff4570d6b823b075dcd4fa9acd82dc4a28bf93a456ab8c93990604a',
@@ -75,7 +75,7 @@ describe('Get Bridge TX Status Route', () => {
   }, 10000)
 
   it('should return 400 for missing bridgeModule', async () => {
-    const response = await request(app).get('/getBridgeTxStatus').query({
+    const response = await request(app).get('/bridgeTxStatus').query({
       destChainId: '137',
       synapseTxId:
         '0x9beb59b36ff4570d6b823b075dcd4fa9acd82dc4a28bf93a456ab8c93990604a',

--- a/packages/rest-api/src/tests/destinationTxRoute.test.ts
+++ b/packages/rest-api/src/tests/destinationTxRoute.test.ts
@@ -1,14 +1,14 @@
 import request from 'supertest'
 import express from 'express'
 
-import getDestinationTxRoute from '../routes/getDestinationTxRoute'
+import destinationTxRoute from '../routes/destinationTxRoute'
 
 const app = express()
-app.use('/getDestinationTx', getDestinationTxRoute)
+app.use('/destinationTx', destinationTxRoute)
 
 describe('Get Destination TX Route', () => {
   it('should return destination transaction info for valid input', async () => {
-    const response = await request(app).get('/getDestinationTx').query({
+    const response = await request(app).get('/destinationTx').query({
       originChainId: '8453',
       txHash:
         '0x13486d9eaefd68de6a20b704d70deb8436effbac1f77fddfc0c7ef14f08e96c3',
@@ -30,7 +30,7 @@ describe('Get Destination TX Route', () => {
   }, 10000)
 
   it('should return 400 for missing originChainId', async () => {
-    const response = await request(app).get('/getDestinationTx').query({
+    const response = await request(app).get('/destinationTx').query({
       txHash:
         '0x13486d9eaefd68de6a20b704d70deb8436effbac1f77fddfc0c7ef14f08e96c3',
     })
@@ -39,7 +39,7 @@ describe('Get Destination TX Route', () => {
   }, 10000)
 
   it('should return 400 for missing txHash', async () => {
-    const response = await request(app).get('/getDestinationTx').query({
+    const response = await request(app).get('/destinationTx').query({
       originChainId: '1',
     })
     expect(response.status).toBe(400)
@@ -47,7 +47,7 @@ describe('Get Destination TX Route', () => {
   }, 10000)
 
   it('should return 400 for non-numeric originChainId', async () => {
-    const response = await request(app).get('/getDestinationTx').query({
+    const response = await request(app).get('/destinationTx').query({
       originChainId: 'not-a-number',
       txHash:
         '0x13486d9eaefd68de6a20b704d70deb8436effbac1f77fddfc0c7ef14f08e96c3',

--- a/packages/rest-api/src/tests/synapseTxIdRoute.test.ts
+++ b/packages/rest-api/src/tests/synapseTxIdRoute.test.ts
@@ -1,14 +1,14 @@
 import request from 'supertest'
 import express from 'express'
 
-import getSynapseTxIdRoute from '../routes/getSynapseTxIdRoute'
+import synapseTxIdRoute from '../routes/synapseTxIdRoute'
 
 const app = express()
-app.use('/getSynapseTxId', getSynapseTxIdRoute)
+app.use('/synapseTxId', synapseTxIdRoute)
 
 describe('Get Synapse TX ID Route', () => {
   it('should return synapse transaction ID for valid input', async () => {
-    const response = await request(app).get('/getSynapseTxId').query({
+    const response = await request(app).get('/synapseTxId').query({
       originChainId: '8453',
       bridgeModule: 'SynapseRFQ',
       txHash:
@@ -19,7 +19,7 @@ describe('Get Synapse TX ID Route', () => {
   }, 10000)
 
   it('should return 400 for missing originChainId', async () => {
-    const response = await request(app).get('/getSynapseTxId').query({
+    const response = await request(app).get('/synapseTxId').query({
       bridgeModule: 'SynapseRFQ',
       txHash:
         '0x13486d9eaefd68de6a20b704d70deb8436effbac1f77fddfc0c7ef14f08e96c3',
@@ -29,7 +29,7 @@ describe('Get Synapse TX ID Route', () => {
   }, 10000)
 
   it('should return 400 for missing bridgeModule', async () => {
-    const response = await request(app).get('/getSynapseTxId').query({
+    const response = await request(app).get('/synapseTxId').query({
       originChainId: '1',
       txHash:
         '0x13486d9eaefd68de6a20b704d70deb8436effbac1f77fddfc0c7ef14f08e96c3',
@@ -39,7 +39,7 @@ describe('Get Synapse TX ID Route', () => {
   }, 10000)
 
   it('should return 400 for missing txHash', async () => {
-    const response = await request(app).get('/getSynapseTxId').query({
+    const response = await request(app).get('/synapseTxId').query({
       originChainId: '1',
       bridgeModule: 'SynapseRFQ',
     })
@@ -48,7 +48,7 @@ describe('Get Synapse TX ID Route', () => {
   }, 10000)
 
   it('should return 400 for non-numeric originChainId', async () => {
-    const response = await request(app).get('/getSynapseTxId').query({
+    const response = await request(app).get('/synapseTxId').query({
       originChainId: 'not-a-number',
       bridgeModule: 'SynapseRFQ',
       txHash:
@@ -59,7 +59,7 @@ describe('Get Synapse TX ID Route', () => {
   }, 10000)
 
   it('should return 400 for invalid bridgeModule', async () => {
-    const response = await request(app).get('/getSynapseTxId').query({
+    const response = await request(app).get('/synapseTxId').query({
       originChainId: '1',
       bridgeModule: 'invalid_module',
       txHash:

--- a/yarn.lock
+++ b/yarn.lock
@@ -205,6 +205,38 @@
     "@types/json-schema" "^7.0.15"
     js-yaml "^4.1.0"
 
+"@apidevtools/json-schema-ref-parser@^9.0.6":
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz#8ff5386b365d4c9faa7c8b566ff16a46a577d9b8"
+  integrity sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==
+  dependencies:
+    "@jsdevtools/ono" "^7.1.3"
+    "@types/json-schema" "^7.0.6"
+    call-me-maybe "^1.0.1"
+    js-yaml "^4.1.0"
+
+"@apidevtools/openapi-schemas@^2.0.4":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz#9fa08017fb59d80538812f03fc7cac5992caaa17"
+  integrity sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==
+
+"@apidevtools/swagger-methods@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz#b789a362e055b0340d04712eafe7027ddc1ac267"
+  integrity sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==
+
+"@apidevtools/swagger-parser@10.0.3":
+  version "10.0.3"
+  resolved "https://registry.yarnpkg.com/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz#32057ae99487872c4dd96b314a1ab4b95d89eaf5"
+  integrity sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==
+  dependencies:
+    "@apidevtools/json-schema-ref-parser" "^9.0.6"
+    "@apidevtools/openapi-schemas" "^2.0.4"
+    "@apidevtools/swagger-methods" "^3.0.2"
+    "@jsdevtools/ono" "^7.1.3"
+    call-me-maybe "^1.0.1"
+    z-schema "^5.0.1"
+
 "@apollo/client@^3.6.2":
   version "3.11.8"
   resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.11.8.tgz#f6bacdc7e1b243807c1387113e1d445a53471a9c"
@@ -1491,7 +1523,7 @@
     "@babel/parser" "^7.25.0"
     "@babel/types" "^7.25.0"
 
-"@babel/traverse@^7.1.0", "@babel/traverse@^7.1.6", "@babel/traverse@^7.11.5", "@babel/traverse@^7.12.11", "@babel/traverse@^7.12.9", "@babel/traverse@^7.13.0", "@babel/traverse@^7.14.0", "@babel/traverse@^7.16.8", "@babel/traverse@^7.22.8", "@babel/traverse@^7.23.2", "@babel/traverse@^7.24.7", "@babel/traverse@^7.24.8", "@babel/traverse@^7.25.0", "@babel/traverse@^7.25.1", "@babel/traverse@^7.25.2", "@babel/traverse@^7.25.3", "@babel/traverse@^7.25.4", "@babel/traverse@^7.7.0":
+"@babel/traverse@^7.1.0", "@babel/traverse@^7.1.6", "@babel/traverse@^7.11.5", "@babel/traverse@^7.12.11", "@babel/traverse@^7.12.9", "@babel/traverse@^7.13.0", "@babel/traverse@^7.14.0", "@babel/traverse@^7.16.8", "@babel/traverse@^7.22.8", "@babel/traverse@^7.23.2", "@babel/traverse@^7.24.7", "@babel/traverse@^7.24.8", "@babel/traverse@^7.25.0", "@babel/traverse@^7.25.1", "@babel/traverse@^7.25.2", "@babel/traverse@^7.25.3", "@babel/traverse@^7.25.4", "@babel/traverse@^7.7.0", "@babel/traverse@^7.7.2":
   version "7.25.6"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.25.6.tgz#04fad980e444f182ecf1520504941940a90fea41"
   integrity sha512-9Vrcx5ZW6UwK5tvqsj0nGpp/XzqthkT0dqIc9g1AdtygFToNtTF67XzYS//dm+SAK9cp3B9R4ZO/46p63SCjlQ==
@@ -4351,6 +4383,18 @@
     jest-util "^25.5.0"
     slash "^3.0.0"
 
+"@jest/console@^28.1.3":
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/@jest/console/-/console-28.1.3.tgz#2030606ec03a18c31803b8a36382762e447655df"
+  integrity sha512-QPAkP5EwKdK/bxIr6C1I4Vs0rm2nHiANzj/Z5X2JQkrZo6IqvC4ldZ9K95tF0HdidhA8Bo6egxSzUFPYKcEXLw==
+  dependencies:
+    "@jest/types" "^28.1.3"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    jest-message-util "^28.1.3"
+    jest-util "^28.1.3"
+    slash "^3.0.0"
+
 "@jest/console@^29.7.0":
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/@jest/console/-/console-29.7.0.tgz#cd4822dbdb84529265c5a2bdb529a3c9cc950ffc"
@@ -4393,6 +4437,41 @@
     micromatch "^4.0.2"
     p-each-series "^2.1.0"
     realpath-native "^2.0.0"
+    rimraf "^3.0.0"
+    slash "^3.0.0"
+    strip-ansi "^6.0.0"
+
+"@jest/core@^28.1.3":
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/@jest/core/-/core-28.1.3.tgz#0ebf2bd39840f1233cd5f2d1e6fc8b71bd5a1ac7"
+  integrity sha512-CIKBrlaKOzA7YG19BEqCw3SLIsEwjZkeJzf5bdooVnW4bH5cktqe3JX+G2YV1aK5vP8N9na1IGWFzYaTp6k6NA==
+  dependencies:
+    "@jest/console" "^28.1.3"
+    "@jest/reporters" "^28.1.3"
+    "@jest/test-result" "^28.1.3"
+    "@jest/transform" "^28.1.3"
+    "@jest/types" "^28.1.3"
+    "@types/node" "*"
+    ansi-escapes "^4.2.1"
+    chalk "^4.0.0"
+    ci-info "^3.2.0"
+    exit "^0.1.2"
+    graceful-fs "^4.2.9"
+    jest-changed-files "^28.1.3"
+    jest-config "^28.1.3"
+    jest-haste-map "^28.1.3"
+    jest-message-util "^28.1.3"
+    jest-regex-util "^28.0.2"
+    jest-resolve "^28.1.3"
+    jest-resolve-dependencies "^28.1.3"
+    jest-runner "^28.1.3"
+    jest-runtime "^28.1.3"
+    jest-snapshot "^28.1.3"
+    jest-util "^28.1.3"
+    jest-validate "^28.1.3"
+    jest-watcher "^28.1.3"
+    micromatch "^4.0.4"
+    pretty-format "^28.1.3"
     rimraf "^3.0.0"
     slash "^3.0.0"
     strip-ansi "^6.0.0"
@@ -4440,6 +4519,16 @@
     "@jest/types" "^25.5.0"
     jest-mock "^25.5.0"
 
+"@jest/environment@^28.1.3":
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-28.1.3.tgz#abed43a6b040a4c24fdcb69eab1f97589b2d663e"
+  integrity sha512-1bf40cMFTEkKyEf585R9Iz1WayDjHoHqvts0XFYEqyKM3cFWDpeMoqKKTAF9LSYQModPUlh8FKptoM2YcMWAXA==
+  dependencies:
+    "@jest/fake-timers" "^28.1.3"
+    "@jest/types" "^28.1.3"
+    "@types/node" "*"
+    jest-mock "^28.1.3"
+
 "@jest/environment@^29.7.0":
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-29.7.0.tgz#24d61f54ff1f786f3cd4073b4b94416383baf2a7"
@@ -4450,12 +4539,27 @@
     "@types/node" "*"
     jest-mock "^29.7.0"
 
+"@jest/expect-utils@^28.1.3":
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/@jest/expect-utils/-/expect-utils-28.1.3.tgz#58561ce5db7cd253a7edddbc051fb39dda50f525"
+  integrity sha512-wvbi9LUrHJLn3NlDW6wF2hvIMtd4JUl2QNVrjq+IBSHirgfrR3o9RnVtxzdEGO2n9JyIWwHnLfby5KzqBGg2YA==
+  dependencies:
+    jest-get-type "^28.0.2"
+
 "@jest/expect-utils@^29.7.0":
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/@jest/expect-utils/-/expect-utils-29.7.0.tgz#023efe5d26a8a70f21677d0a1afc0f0a44e3a1c6"
   integrity sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==
   dependencies:
     jest-get-type "^29.6.3"
+
+"@jest/expect@^28.1.3":
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/@jest/expect/-/expect-28.1.3.tgz#9ac57e1d4491baca550f6bdbd232487177ad6a72"
+  integrity sha512-lzc8CpUbSoE4dqT0U+g1qODQjBRHPpCPXissXD4mS9+sWQdmmpeJ9zSH1rS1HEkrsMN0fb7nKrJ9giAR1d3wBw==
+  dependencies:
+    expect "^28.1.3"
+    jest-snapshot "^28.1.3"
 
 "@jest/expect@^29.7.0":
   version "29.7.0"
@@ -4475,6 +4579,18 @@
     jest-mock "^25.5.0"
     jest-util "^25.5.0"
     lolex "^5.0.0"
+
+"@jest/fake-timers@^28.1.3":
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-28.1.3.tgz#230255b3ad0a3d4978f1d06f70685baea91c640e"
+  integrity sha512-D/wOkL2POHv52h+ok5Oj/1gOG9HSywdoPtFsRCUmlCILXNn5eIWmcnd3DIiWlJnpGvQtmajqBP95Ei0EimxfLw==
+  dependencies:
+    "@jest/types" "^28.1.3"
+    "@sinonjs/fake-timers" "^9.1.2"
+    "@types/node" "*"
+    jest-message-util "^28.1.3"
+    jest-mock "^28.1.3"
+    jest-util "^28.1.3"
 
 "@jest/fake-timers@^29.7.0":
   version "29.7.0"
@@ -4496,6 +4612,15 @@
     "@jest/environment" "^25.5.0"
     "@jest/types" "^25.5.0"
     expect "^25.5.0"
+
+"@jest/globals@^28.1.3":
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-28.1.3.tgz#a601d78ddc5fdef542728309894895b4a42dc333"
+  integrity sha512-XFU4P4phyryCXu1pbcqMO0GSQcYe1IsalYCDzRNyhetyeyxMcIxa11qPNDpVNLeretItNqEmYYQn1UYz/5x1NA==
+  dependencies:
+    "@jest/environment" "^28.1.3"
+    "@jest/expect" "^28.1.3"
+    "@jest/types" "^28.1.3"
 
 "@jest/globals@^29.7.0":
   version "29.7.0"
@@ -4539,6 +4664,37 @@
   optionalDependencies:
     node-notifier "^6.0.0"
 
+"@jest/reporters@^28.1.3":
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-28.1.3.tgz#9adf6d265edafc5fc4a434cfb31e2df5a67a369a"
+  integrity sha512-JuAy7wkxQZVNU/V6g9xKzCGC5LVXx9FDcABKsSXp5MiKPEE2144a/vXTEDoyzjUpZKfVwp08Wqg5A4WfTMAzjg==
+  dependencies:
+    "@bcoe/v8-coverage" "^0.2.3"
+    "@jest/console" "^28.1.3"
+    "@jest/test-result" "^28.1.3"
+    "@jest/transform" "^28.1.3"
+    "@jest/types" "^28.1.3"
+    "@jridgewell/trace-mapping" "^0.3.13"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    collect-v8-coverage "^1.0.0"
+    exit "^0.1.2"
+    glob "^7.1.3"
+    graceful-fs "^4.2.9"
+    istanbul-lib-coverage "^3.0.0"
+    istanbul-lib-instrument "^5.1.0"
+    istanbul-lib-report "^3.0.0"
+    istanbul-lib-source-maps "^4.0.0"
+    istanbul-reports "^3.1.3"
+    jest-message-util "^28.1.3"
+    jest-util "^28.1.3"
+    jest-worker "^28.1.3"
+    slash "^3.0.0"
+    string-length "^4.0.1"
+    strip-ansi "^6.0.0"
+    terminal-link "^2.0.0"
+    v8-to-istanbul "^9.0.1"
+
 "@jest/reporters@^29.7.0":
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-29.7.0.tgz#04b262ecb3b8faa83b0b3d321623972393e8f4c7"
@@ -4569,6 +4725,13 @@
     strip-ansi "^6.0.0"
     v8-to-istanbul "^9.0.1"
 
+"@jest/schemas@^28.1.3":
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-28.1.3.tgz#ad8b86a66f11f33619e3d7e1dcddd7f2d40ff905"
+  integrity sha512-/l/VWsdt/aBXgjshLWOFyFt3IVdYypu5y2Wn2rOO1un6nkqIn8SLXzgIMYXFyYsRWDyF5EthmKJMIdJvk08grg==
+  dependencies:
+    "@sinclair/typebox" "^0.24.1"
+
 "@jest/schemas@^29.6.3":
   version "29.6.3"
   resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-29.6.3.tgz#430b5ce8a4e0044a7e3819663305a7b3091c8e03"
@@ -4584,6 +4747,15 @@
     callsites "^3.0.0"
     graceful-fs "^4.2.4"
     source-map "^0.6.0"
+
+"@jest/source-map@^28.1.2":
+  version "28.1.2"
+  resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-28.1.2.tgz#7fe832b172b497d6663cdff6c13b0a920e139e24"
+  integrity sha512-cV8Lx3BeStJb8ipPHnqVw/IM2VCMWO3crWZzYodSIkxXnRcXJipCdx1JCK0K5MsJJouZQTH73mzf4vgxRaH9ww==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.13"
+    callsites "^3.0.0"
+    graceful-fs "^4.2.9"
 
 "@jest/source-map@^29.6.3":
   version "29.6.3"
@@ -4601,6 +4773,16 @@
   dependencies:
     "@jest/console" "^25.5.0"
     "@jest/types" "^25.5.0"
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    collect-v8-coverage "^1.0.0"
+
+"@jest/test-result@^28.1.3":
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-28.1.3.tgz#5eae945fd9f4b8fcfce74d239e6f725b6bf076c5"
+  integrity sha512-kZAkxnSE+FqE8YjW8gNuoVkkC9I7S1qmenl8sGcDOLropASP+BkcGKwhXoyqQuGOGeYY0y/ixjrd/iERpEXHNg==
+  dependencies:
+    "@jest/console" "^28.1.3"
+    "@jest/types" "^28.1.3"
     "@types/istanbul-lib-coverage" "^2.0.0"
     collect-v8-coverage "^1.0.0"
 
@@ -4624,6 +4806,16 @@
     jest-haste-map "^25.5.1"
     jest-runner "^25.5.4"
     jest-runtime "^25.5.4"
+
+"@jest/test-sequencer@^28.1.3":
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-28.1.3.tgz#9d0c283d906ac599c74bde464bc0d7e6a82886c3"
+  integrity sha512-NIMPEqqa59MWnDi1kvXXpYbqsfQmSJsIbnd85mdVGkiDfQ9WQQTXOLsvISUfonmnBT+w85WEgneCigEEdHDFxw==
+  dependencies:
+    "@jest/test-result" "^28.1.3"
+    graceful-fs "^4.2.9"
+    jest-haste-map "^28.1.3"
+    slash "^3.0.0"
 
 "@jest/test-sequencer@^29.7.0":
   version "29.7.0"
@@ -4677,6 +4869,27 @@
     slash "^3.0.0"
     source-map "^0.6.1"
     write-file-atomic "^3.0.0"
+
+"@jest/transform@^28.1.3":
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-28.1.3.tgz#59d8098e50ab07950e0f2fc0fc7ec462371281b0"
+  integrity sha512-u5dT5di+oFI6hfcLOHGTAfmUxFRrjK+vnaP0kkVow9Md/M7V/MxqQMOz/VV25UZO8pzeA9PjfTpOu6BDuwSPQA==
+  dependencies:
+    "@babel/core" "^7.11.6"
+    "@jest/types" "^28.1.3"
+    "@jridgewell/trace-mapping" "^0.3.13"
+    babel-plugin-istanbul "^6.1.1"
+    chalk "^4.0.0"
+    convert-source-map "^1.4.0"
+    fast-json-stable-stringify "^2.0.0"
+    graceful-fs "^4.2.9"
+    jest-haste-map "^28.1.3"
+    jest-regex-util "^28.0.2"
+    jest-util "^28.1.3"
+    micromatch "^4.0.4"
+    pirates "^4.0.4"
+    slash "^3.0.0"
+    write-file-atomic "^4.0.1"
 
 "@jest/transform@^29.7.0":
   version "29.7.0"
@@ -4740,6 +4953,18 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
+"@jest/types@^28.1.3":
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-28.1.3.tgz#b05de80996ff12512bc5ceb1d208285a7d11748b"
+  integrity sha512-RyjiyMUZrKz/c+zlMFO1pm70DcIlST8AeWTkoUdZevew44wcNZQHsEVOiCVtgVnlFFD82FPaXycys58cf2muVQ==
+  dependencies:
+    "@jest/schemas" "^28.1.3"
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^17.0.8"
+    chalk "^4.0.0"
+
 "@jest/types@^29.6.3":
   version "29.6.3"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-29.6.3.tgz#1131f8cf634e7e84c5e77bab12f052af585fba59"
@@ -4792,7 +5017,7 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.18", "@jridgewell/trace-mapping@^0.3.20", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25":
+"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.13", "@jridgewell/trace-mapping@^0.3.18", "@jridgewell/trace-mapping@^0.3.20", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25":
   version "0.3.25"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz#15f190e98895f3fc23276ee14bc76b675c2e50f0"
   integrity sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==
@@ -7282,6 +7507,11 @@
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.25.24.tgz#8c7688559979f7079aacaf31aa881c3aa410b718"
   integrity sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==
 
+"@sinclair/typebox@^0.24.1":
+  version "0.24.51"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.24.51.tgz#645f33fe4e02defe26f2f5c0410e1c094eac7f5f"
+  integrity sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==
+
 "@sinclair/typebox@^0.27.8":
   version "0.27.8"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
@@ -7327,6 +7557,13 @@
   integrity sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==
   dependencies:
     "@sinonjs/commons" "^3.0.0"
+
+"@sinonjs/fake-timers@^9.1.2":
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz#4eaab737fab77332ab132d396a3c0d364bd0ea8c"
+  integrity sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==
+  dependencies:
+    "@sinonjs/commons" "^1.7.0"
 
 "@slorber/remark-comment@^1.0.0":
   version "1.0.0"
@@ -8664,14 +8901,6 @@
     "@swc/counter" "^0.1.3"
     tslib "^2.4.0"
 
-"@synapsecns/coverage-aggregator@file:./packages/coverage-aggregator":
-  version "1.0.6"
-  dependencies:
-    glob "^8.0.3"
-    path "^0.12.7"
-    ts-jest "^29.0.5"
-    yargs "^17.6.2"
-
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421"
@@ -9556,7 +9785,7 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-1.19.1.tgz#33509849f8e679e4add158959fdb086440e9553f"
   integrity sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==
 
-"@types/prettier@^2.1.1":
+"@types/prettier@^2.1.1", "@types/prettier@^2.1.5":
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.7.3.tgz#3e51a17e291d01d17d3fc61422015a933af7a08f"
   integrity sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==
@@ -9762,6 +9991,19 @@
   dependencies:
     "@types/methods" "^1.1.4"
     "@types/superagent" "^8.1.0"
+
+"@types/swagger-jsdoc@^6.0.4":
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/@types/swagger-jsdoc/-/swagger-jsdoc-6.0.4.tgz#bb4f60f3a5f103818e022f2e29ff8935113fb83d"
+  integrity sha512-W+Xw5epcOZrF/AooUM/PccNMSAFOKWZA5dasNyMujTwsBkU74njSJBpvCCJhHAJ95XRMzQrrW844Btu0uoetwQ==
+
+"@types/swagger-ui-express@^4.1.6":
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/@types/swagger-ui-express/-/swagger-ui-express-4.1.6.tgz#d0929e3fabac1a96a8a9c6c7ee8d42362c5cdf48"
+  integrity sha512-UVSiGYXa5IzdJJG3hrc86e8KdZWLYxyEsVoUI4iPXc7CO4VZ3AfNP8d/8+hrDRIqz+HAaSMtZSqAsF3Nq2X/Dg==
+  dependencies:
+    "@types/express" "*"
+    "@types/serve-static" "*"
 
 "@types/tapable@^1", "@types/tapable@^1.0.5":
   version "1.0.12"
@@ -12138,6 +12380,19 @@ babel-jest@^25.2.6, babel-jest@^25.5.1:
     graceful-fs "^4.2.4"
     slash "^3.0.0"
 
+babel-jest@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-28.1.3.tgz#c1187258197c099072156a0a121c11ee1e3917d5"
+  integrity sha512-epUaPOEWMk3cWX0M/sPvCHHCe9fMFAa/9hXEgKP8nFfNl/jlGkE9ucq9NqkZGXLDduCJYS0UvSlPUwC0S+rH6Q==
+  dependencies:
+    "@jest/transform" "^28.1.3"
+    "@types/babel__core" "^7.1.14"
+    babel-plugin-istanbul "^6.1.1"
+    babel-preset-jest "^28.1.3"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.9"
+    slash "^3.0.0"
+
 babel-jest@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-29.7.0.tgz#f4369919225b684c56085998ac63dbd05be020d5"
@@ -12240,6 +12495,16 @@ babel-plugin-jest-hoist@^25.5.0:
   dependencies:
     "@babel/template" "^7.3.3"
     "@babel/types" "^7.3.3"
+    "@types/babel__traverse" "^7.0.6"
+
+babel-plugin-jest-hoist@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-28.1.3.tgz#1952c4d0ea50f2d6d794353762278d1d8cca3fbe"
+  integrity sha512-Ys3tUKAmfnkRUpPdpa98eYrAR0nV+sSFUZZEGuQ2EbFd1y4SOLtD5QDNHAq+bb9a+bbXvYQC4b+ID/THIMcU6Q==
+  dependencies:
+    "@babel/template" "^7.3.3"
+    "@babel/types" "^7.3.3"
+    "@types/babel__core" "^7.1.14"
     "@types/babel__traverse" "^7.0.6"
 
 babel-plugin-jest-hoist@^29.6.3:
@@ -12436,6 +12701,14 @@ babel-preset-jest@^25.5.0:
   dependencies:
     babel-plugin-jest-hoist "^25.5.0"
     babel-preset-current-node-syntax "^0.1.2"
+
+babel-preset-jest@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-28.1.3.tgz#5dfc20b99abed5db994406c2b9ab94c73aaa419d"
+  integrity sha512-L+fupJvlWAHbQfn74coNX3zf60LXMJsezNvvx8eIh7iOR1luJ1poxYgQk1F8PYtNq/6QODDHCqsSnTFSWC491A==
+  dependencies:
+    babel-plugin-jest-hoist "^28.1.3"
+    babel-preset-current-node-syntax "^1.0.0"
 
 babel-preset-jest@^29.6.3:
   version "29.6.3"
@@ -14149,6 +14422,11 @@ commander@3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/commander/-/commander-3.0.2.tgz#6837c3fb677ad9933d1cfba42dd14d5117d6b39e"
   integrity sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==
+
+commander@6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.0.tgz#b990bfb8ac030aedc6d11bc04d1488ffef56db75"
+  integrity sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==
 
 commander@^10.0.0, commander@^10.0.1:
   version "10.0.1"
@@ -15947,6 +16225,11 @@ diff-sequences@^25.2.6:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-25.2.6.tgz#5f467c00edd35352b7bca46d7927d60e687a76dd"
   integrity sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==
 
+diff-sequences@^28.1.1:
+  version "28.1.1"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-28.1.1.tgz#9989dc731266dc2903457a70e996f3a041913ac6"
+  integrity sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==
+
 diff-sequences@^29.6.3:
   version "29.6.3"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.6.3.tgz#4deaf894d11407c51efc8418012f9e70b84ea921"
@@ -16024,17 +16307,17 @@ doctoc@^2.2.0:
     underscore "^1.13.2"
     update-section "^0.3.3"
 
+doctrine@3.0.0, doctrine@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
+  integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
+  dependencies:
+    esutils "^2.0.2"
+
 doctrine@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
   integrity sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==
-  dependencies:
-    esutils "^2.0.2"
-
-doctrine@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
-  integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
 
@@ -16434,6 +16717,11 @@ elliptic@^6.4.0, elliptic@^6.5.2, elliptic@^6.5.3, elliptic@^6.5.4, elliptic@^6.
     inherits "^2.0.4"
     minimalistic-assert "^1.0.1"
     minimalistic-crypto-utils "^1.0.1"
+
+emittery@^0.10.2:
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.10.2.tgz#902eec8aedb8c41938c46e9385e9db7e03182933"
+  integrity sha512-aITqOwnLanpHLNXZJENbOgjUBeHocD+xsSJmNrjovKBW5HbSpW3d1pEls7GFQPUWXiwG9+0P4GtHfEqC/4M0Iw==
 
 emittery@^0.13.1:
   version "0.13.1"
@@ -18310,6 +18598,17 @@ expect@^25.5.0:
     jest-matcher-utils "^25.5.0"
     jest-message-util "^25.5.0"
     jest-regex-util "^25.2.6"
+
+expect@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-28.1.3.tgz#90a7c1a124f1824133dd4533cce2d2bdcb6603ec"
+  integrity sha512-eEh0xn8HlsuOBxFgIss+2mX85VAS4Qy3OSkjV7rlBWljtA4oWH37glVGyOZSZvErDT/yBywZdPGwCXuTvSG85g==
+  dependencies:
+    "@jest/expect-utils" "^28.1.3"
+    jest-get-type "^28.0.2"
+    jest-matcher-utils "^28.1.3"
+    jest-message-util "^28.1.3"
+    jest-util "^28.1.3"
 
 expect@^29.0.0, expect@^29.7.0:
   version "29.7.0"
@@ -22296,7 +22595,7 @@ istanbul-lib-instrument@^4.0.0:
     istanbul-lib-coverage "^3.0.0"
     semver "^6.3.0"
 
-istanbul-lib-instrument@^5.0.4:
+istanbul-lib-instrument@^5.0.4, istanbul-lib-instrument@^5.1.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz#d10c8885c2125574e1c231cacadf955675e1ce3d"
   integrity sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==
@@ -22416,6 +22715,14 @@ jest-changed-files@^25.5.0:
     execa "^3.2.0"
     throat "^5.0.0"
 
+jest-changed-files@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-28.1.3.tgz#d9aeee6792be3686c47cb988a8eaf82ff4238831"
+  integrity sha512-esaOfUWJXk2nfZt9SPyC8gA1kNfdKLkQWyzsMlqq8msYSlNKfmZxfRgZn4Cd4MGVUF+7v6dBs0d5TOAKa7iIiA==
+  dependencies:
+    execa "^5.0.0"
+    p-limit "^3.1.0"
+
 jest-changed-files@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-29.7.0.tgz#1c06d07e77c78e1585d020424dedc10d6e17ac3a"
@@ -22424,6 +22731,31 @@ jest-changed-files@^29.7.0:
     execa "^5.0.0"
     jest-util "^29.7.0"
     p-limit "^3.1.0"
+
+jest-circus@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-28.1.3.tgz#d14bd11cf8ee1a03d69902dc47b6bd4634ee00e4"
+  integrity sha512-cZ+eS5zc79MBwt+IhQhiEp0OeBddpc1n8MBo1nMB8A7oPMKEO+Sre+wHaLJexQUj9Ya/8NOBY0RESUgYjB6fow==
+  dependencies:
+    "@jest/environment" "^28.1.3"
+    "@jest/expect" "^28.1.3"
+    "@jest/test-result" "^28.1.3"
+    "@jest/types" "^28.1.3"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    co "^4.6.0"
+    dedent "^0.7.0"
+    is-generator-fn "^2.0.0"
+    jest-each "^28.1.3"
+    jest-matcher-utils "^28.1.3"
+    jest-message-util "^28.1.3"
+    jest-runtime "^28.1.3"
+    jest-snapshot "^28.1.3"
+    jest-util "^28.1.3"
+    p-limit "^3.1.0"
+    pretty-format "^28.1.3"
+    slash "^3.0.0"
+    stack-utils "^2.0.3"
 
 jest-circus@^29.7.0:
   version "29.7.0"
@@ -22471,6 +22803,24 @@ jest-cli@^25.5.4:
     realpath-native "^2.0.0"
     yargs "^15.3.1"
 
+jest-cli@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-28.1.3.tgz#558b33c577d06de55087b8448d373b9f654e46b2"
+  integrity sha512-roY3kvrv57Azn1yPgdTebPAXvdR2xfezaKKYzVxZ6It/5NCxzJym6tUI5P1zkdWhfUYkxEI9uZWcQdaFLo8mJQ==
+  dependencies:
+    "@jest/core" "^28.1.3"
+    "@jest/test-result" "^28.1.3"
+    "@jest/types" "^28.1.3"
+    chalk "^4.0.0"
+    exit "^0.1.2"
+    graceful-fs "^4.2.9"
+    import-local "^3.0.2"
+    jest-config "^28.1.3"
+    jest-util "^28.1.3"
+    jest-validate "^28.1.3"
+    prompts "^2.0.1"
+    yargs "^17.3.1"
+
 jest-cli@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-29.7.0.tgz#5592c940798e0cae677eec169264f2d839a37995"
@@ -22512,6 +22862,34 @@ jest-config@^25.5.4:
     micromatch "^4.0.2"
     pretty-format "^25.5.0"
     realpath-native "^2.0.0"
+
+jest-config@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-28.1.3.tgz#e315e1f73df3cac31447eed8b8740a477392ec60"
+  integrity sha512-MG3INjByJ0J4AsNBm7T3hsuxKQqFIiRo/AUqb1q9LRKI5UU6Aar9JHbr9Ivn1TVwfUD9KirRoM/T6u8XlcQPHQ==
+  dependencies:
+    "@babel/core" "^7.11.6"
+    "@jest/test-sequencer" "^28.1.3"
+    "@jest/types" "^28.1.3"
+    babel-jest "^28.1.3"
+    chalk "^4.0.0"
+    ci-info "^3.2.0"
+    deepmerge "^4.2.2"
+    glob "^7.1.3"
+    graceful-fs "^4.2.9"
+    jest-circus "^28.1.3"
+    jest-environment-node "^28.1.3"
+    jest-get-type "^28.0.2"
+    jest-regex-util "^28.0.2"
+    jest-resolve "^28.1.3"
+    jest-runner "^28.1.3"
+    jest-util "^28.1.3"
+    jest-validate "^28.1.3"
+    micromatch "^4.0.4"
+    parse-json "^5.2.0"
+    pretty-format "^28.1.3"
+    slash "^3.0.0"
+    strip-json-comments "^3.1.1"
 
 jest-config@^29.7.0:
   version "29.7.0"
@@ -22561,6 +22939,16 @@ jest-diff@^25.2.1, jest-diff@^25.5.0:
     jest-get-type "^25.2.6"
     pretty-format "^25.5.0"
 
+jest-diff@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-28.1.3.tgz#948a192d86f4e7a64c5264ad4da4877133d8792f"
+  integrity sha512-8RqP1B/OXzjjTWkqMX67iqgwBVJRgCyKD3L9nq+6ZqJMdvjE8RgHktqZ6jNrkdMT+dJuYNI3rhQpxaz7drJHfw==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^28.1.1"
+    jest-get-type "^28.0.2"
+    pretty-format "^28.1.3"
+
 jest-diff@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-29.7.0.tgz#017934a66ebb7ecf6f205e84699be10afd70458a"
@@ -22575,6 +22963,13 @@ jest-docblock@^25.3.0:
   version "25.3.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-25.3.0.tgz#8b777a27e3477cd77a168c05290c471a575623ef"
   integrity sha512-aktF0kCar8+zxRHxQZwxMy70stc9R1mOmrLsT5VO3pIT0uzGRSDAXxSlz4NqQWpuLjPpuMhPRl7H+5FRsvIQAg==
+  dependencies:
+    detect-newline "^3.0.0"
+
+jest-docblock@^28.1.1:
+  version "28.1.1"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-28.1.1.tgz#6f515c3bf841516d82ecd57a62eed9204c2f42a8"
+  integrity sha512-3wayBVNiOYx0cwAbl9rwm5kKFP8yHH3d/fkEaL02NPTkDojPtheGB7HZSFY4wzX+DxyrvhXz0KSCVksmCknCuA==
   dependencies:
     detect-newline "^3.0.0"
 
@@ -22595,6 +22990,17 @@ jest-each@^25.5.0:
     jest-get-type "^25.2.6"
     jest-util "^25.5.0"
     pretty-format "^25.5.0"
+
+jest-each@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-28.1.3.tgz#bdd1516edbe2b1f3569cfdad9acd543040028f81"
+  integrity sha512-arT1z4sg2yABU5uogObVPvSlSMQlDA48owx07BDPAiasW0yYpYHYOo4HHLz9q0BVzDVU4hILFjzJw0So9aCL/g==
+  dependencies:
+    "@jest/types" "^28.1.3"
+    chalk "^4.0.0"
+    jest-get-type "^28.0.2"
+    jest-util "^28.1.3"
+    pretty-format "^28.1.3"
 
 jest-each@^29.7.0:
   version "29.7.0"
@@ -22631,6 +23037,18 @@ jest-environment-node@^25.5.0:
     jest-util "^25.5.0"
     semver "^6.3.0"
 
+jest-environment-node@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-28.1.3.tgz#7e74fe40eb645b9d56c0c4b70ca4357faa349be5"
+  integrity sha512-ugP6XOhEpjAEhGYvp5Xj989ns5cB1K6ZdjBYuS30umT4CQEETaxSiPcZ/E1kFktX4GkrcM4qu07IIlDYX1gp+A==
+  dependencies:
+    "@jest/environment" "^28.1.3"
+    "@jest/fake-timers" "^28.1.3"
+    "@jest/types" "^28.1.3"
+    "@types/node" "*"
+    jest-mock "^28.1.3"
+    jest-util "^28.1.3"
+
 jest-environment-node@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-29.7.0.tgz#0b93e111dda8ec120bc8300e6d1fb9576e164376"
@@ -22660,6 +23078,11 @@ jest-get-type@^25.2.6:
   version "25.2.6"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-25.2.6.tgz#0b0a32fab8908b44d508be81681487dbabb8d877"
   integrity sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==
+
+jest-get-type@^28.0.2:
+  version "28.0.2"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-28.0.2.tgz#34622e628e4fdcd793d46db8a242227901fcf203"
+  integrity sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==
 
 jest-get-type@^29.6.3:
   version "29.6.3"
@@ -22706,6 +23129,25 @@ jest-haste-map@^26.6.2:
     walker "^1.0.7"
   optionalDependencies:
     fsevents "^2.1.2"
+
+jest-haste-map@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-28.1.3.tgz#abd5451129a38d9841049644f34b034308944e2b"
+  integrity sha512-3S+RQWDXccXDKSWnkHa/dPwt+2qwA8CJzR61w3FoYCvoo3Pn8tvGcysmMF0Bj0EX5RYvAI2EIvC57OmotfdtKA==
+  dependencies:
+    "@jest/types" "^28.1.3"
+    "@types/graceful-fs" "^4.1.3"
+    "@types/node" "*"
+    anymatch "^3.0.3"
+    fb-watchman "^2.0.0"
+    graceful-fs "^4.2.9"
+    jest-regex-util "^28.0.2"
+    jest-util "^28.1.3"
+    jest-worker "^28.1.3"
+    micromatch "^4.0.4"
+    walker "^1.0.8"
+  optionalDependencies:
+    fsevents "^2.3.2"
 
 jest-haste-map@^29.7.0:
   version "29.7.0"
@@ -22757,6 +23199,14 @@ jest-leak-detector@^25.5.0:
     jest-get-type "^25.2.6"
     pretty-format "^25.5.0"
 
+jest-leak-detector@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-28.1.3.tgz#a6685d9b074be99e3adee816ce84fd30795e654d"
+  integrity sha512-WFVJhnQsiKtDEo5lG2mM0v40QWnBM+zMdHHyJs8AWZ7J0QZJS59MsyKeJHWhpBZBH32S48FOVvGyOFT1h0DlqA==
+  dependencies:
+    jest-get-type "^28.0.2"
+    pretty-format "^28.1.3"
+
 jest-leak-detector@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz#5b7ec0dadfdfec0ca383dc9aa016d36b5ea4c728"
@@ -22774,6 +23224,16 @@ jest-matcher-utils@^25.5.0:
     jest-diff "^25.5.0"
     jest-get-type "^25.2.6"
     pretty-format "^25.5.0"
+
+jest-matcher-utils@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-28.1.3.tgz#5a77f1c129dd5ba3b4d7fc20728806c78893146e"
+  integrity sha512-kQeJ7qHemKfbzKoGjHHrRKH6atgxMk8Enkk2iPQ3XwO6oE/KYD8lMYOziCkeSB9G4adPM4nR1DE8Tf5JeWH6Bw==
+  dependencies:
+    chalk "^4.0.0"
+    jest-diff "^28.1.3"
+    jest-get-type "^28.0.2"
+    pretty-format "^28.1.3"
 
 jest-matcher-utils@^29.7.0:
   version "29.7.0"
@@ -22798,6 +23258,21 @@ jest-message-util@^25.5.0:
     micromatch "^4.0.2"
     slash "^3.0.0"
     stack-utils "^1.0.1"
+
+jest-message-util@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-28.1.3.tgz#232def7f2e333f1eecc90649b5b94b0055e7c43d"
+  integrity sha512-PFdn9Iewbt575zKPf1286Ht9EPoJmYT7P0kY+RibeYZ2XtOr53pDLEFoTWXbd1h4JiGiWpTBC84fc8xMXQMb7g==
+  dependencies:
+    "@babel/code-frame" "^7.12.13"
+    "@jest/types" "^28.1.3"
+    "@types/stack-utils" "^2.0.0"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.9"
+    micromatch "^4.0.4"
+    pretty-format "^28.1.3"
+    slash "^3.0.0"
+    stack-utils "^2.0.3"
 
 jest-message-util@^29.7.0:
   version "29.7.0"
@@ -22836,6 +23311,14 @@ jest-mock@^27.0.6:
     "@jest/types" "^27.5.1"
     "@types/node" "*"
 
+jest-mock@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-28.1.3.tgz#d4e9b1fc838bea595c77ab73672ebf513ab249da"
+  integrity sha512-o3J2jr6dMMWYVH4Lh/NKmDXdosrsJgi4AviS8oXLujcjpCMBb1FMsblDnOXKZKfSiHLxYub1eS0IHuRXsio9eA==
+  dependencies:
+    "@jest/types" "^28.1.3"
+    "@types/node" "*"
+
 jest-mock@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-29.7.0.tgz#4e836cf60e99c6fcfabe9f99d017f3fdd50a6347"
@@ -22860,6 +23343,11 @@ jest-regex-util@^26.0.0:
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-26.0.0.tgz#d25e7184b36e39fd466c3bc41be0971e821fee28"
   integrity sha512-Gv3ZIs/nA48/Zvjrl34bf+oD76JHiGDUxNOVgUjh3j890sblXryjY4rss71fPtD/njchl6PSE2hIhvyWa1eT0A==
 
+jest-regex-util@^28.0.2:
+  version "28.0.2"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-28.0.2.tgz#afdc377a3b25fb6e80825adcf76c854e5bf47ead"
+  integrity sha512-4s0IgyNIy0y9FK+cjoVYoxamT7Zeo7MhzqRGx7YDYmaQn1wucY9rotiGkBzzcMXTtjrCAP/f7f+E0F7+fxPNdw==
+
 jest-regex-util@^29.6.3:
   version "29.6.3"
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-29.6.3.tgz#4a556d9c776af68e1c5f48194f4d0327d24e8a52"
@@ -22873,6 +23361,14 @@ jest-resolve-dependencies@^25.5.4:
     "@jest/types" "^25.5.0"
     jest-regex-util "^25.2.6"
     jest-snapshot "^25.5.1"
+
+jest-resolve-dependencies@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-28.1.3.tgz#8c65d7583460df7275c6ea2791901fa975c1fe66"
+  integrity sha512-qa0QO2Q0XzQoNPouMbCc7Bvtsem8eQgVPNkwn9LnS+R2n8DaVDPL/U1gngC0LTl1RYXJU0uJa2BMC2DbTfFrHA==
+  dependencies:
+    jest-regex-util "^28.0.2"
+    jest-snapshot "^28.1.3"
 
 jest-resolve-dependencies@^29.7.0:
   version "29.7.0"
@@ -22895,6 +23391,21 @@ jest-resolve@^25.5.1:
     read-pkg-up "^7.0.1"
     realpath-native "^2.0.0"
     resolve "^1.17.0"
+    slash "^3.0.0"
+
+jest-resolve@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-28.1.3.tgz#cfb36100341ddbb061ec781426b3c31eb51aa0a8"
+  integrity sha512-Z1W3tTjE6QaNI90qo/BJpfnvpxtaFTFw5CDgwpyE/Kz8U/06N1Hjf4ia9quUhCh39qIGWF1ZuxFiBiJQwSEYKQ==
+  dependencies:
+    chalk "^4.0.0"
+    graceful-fs "^4.2.9"
+    jest-haste-map "^28.1.3"
+    jest-pnp-resolver "^1.2.2"
+    jest-util "^28.1.3"
+    jest-validate "^28.1.3"
+    resolve "^1.20.0"
+    resolve.exports "^1.1.0"
     slash "^3.0.0"
 
 jest-resolve@^29.7.0:
@@ -22936,6 +23447,33 @@ jest-runner@^25.5.4:
     jest-worker "^25.5.0"
     source-map-support "^0.5.6"
     throat "^5.0.0"
+
+jest-runner@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-28.1.3.tgz#5eee25febd730b4713a2cdfd76bdd5557840f9a1"
+  integrity sha512-GkMw4D/0USd62OVO0oEgjn23TM+YJa2U2Wu5zz9xsQB1MxWKDOlrnykPxnMsN0tnJllfLPinHTka61u0QhaxBA==
+  dependencies:
+    "@jest/console" "^28.1.3"
+    "@jest/environment" "^28.1.3"
+    "@jest/test-result" "^28.1.3"
+    "@jest/transform" "^28.1.3"
+    "@jest/types" "^28.1.3"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    emittery "^0.10.2"
+    graceful-fs "^4.2.9"
+    jest-docblock "^28.1.1"
+    jest-environment-node "^28.1.3"
+    jest-haste-map "^28.1.3"
+    jest-leak-detector "^28.1.3"
+    jest-message-util "^28.1.3"
+    jest-resolve "^28.1.3"
+    jest-runtime "^28.1.3"
+    jest-util "^28.1.3"
+    jest-watcher "^28.1.3"
+    jest-worker "^28.1.3"
+    p-limit "^3.1.0"
+    source-map-support "0.5.13"
 
 jest-runner@^29.7.0:
   version "29.7.0"
@@ -22995,6 +23533,34 @@ jest-runtime@^25.5.4:
     slash "^3.0.0"
     strip-bom "^4.0.0"
     yargs "^15.3.1"
+
+jest-runtime@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-28.1.3.tgz#a57643458235aa53e8ec7821949e728960d0605f"
+  integrity sha512-NU+881ScBQQLc1JHG5eJGU7Ui3kLKrmwCPPtYsJtBykixrM2OhVQlpMmFWJjMyDfdkGgBMNjXCGB/ebzsgNGQw==
+  dependencies:
+    "@jest/environment" "^28.1.3"
+    "@jest/fake-timers" "^28.1.3"
+    "@jest/globals" "^28.1.3"
+    "@jest/source-map" "^28.1.2"
+    "@jest/test-result" "^28.1.3"
+    "@jest/transform" "^28.1.3"
+    "@jest/types" "^28.1.3"
+    chalk "^4.0.0"
+    cjs-module-lexer "^1.0.0"
+    collect-v8-coverage "^1.0.0"
+    execa "^5.0.0"
+    glob "^7.1.3"
+    graceful-fs "^4.2.9"
+    jest-haste-map "^28.1.3"
+    jest-message-util "^28.1.3"
+    jest-mock "^28.1.3"
+    jest-regex-util "^28.0.2"
+    jest-resolve "^28.1.3"
+    jest-snapshot "^28.1.3"
+    jest-util "^28.1.3"
+    slash "^3.0.0"
+    strip-bom "^4.0.0"
 
 jest-runtime@^29.7.0:
   version "29.7.0"
@@ -23060,6 +23626,35 @@ jest-snapshot@^25.5.1:
     pretty-format "^25.5.0"
     semver "^6.3.0"
 
+jest-snapshot@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-28.1.3.tgz#17467b3ab8ddb81e2f605db05583d69388fc0668"
+  integrity sha512-4lzMgtiNlc3DU/8lZfmqxN3AYD6GGLbl+72rdBpXvcV+whX7mDrREzkPdp2RnmfIiWBg1YbuFSkXduF2JcafJg==
+  dependencies:
+    "@babel/core" "^7.11.6"
+    "@babel/generator" "^7.7.2"
+    "@babel/plugin-syntax-typescript" "^7.7.2"
+    "@babel/traverse" "^7.7.2"
+    "@babel/types" "^7.3.3"
+    "@jest/expect-utils" "^28.1.3"
+    "@jest/transform" "^28.1.3"
+    "@jest/types" "^28.1.3"
+    "@types/babel__traverse" "^7.0.6"
+    "@types/prettier" "^2.1.5"
+    babel-preset-current-node-syntax "^1.0.0"
+    chalk "^4.0.0"
+    expect "^28.1.3"
+    graceful-fs "^4.2.9"
+    jest-diff "^28.1.3"
+    jest-get-type "^28.0.2"
+    jest-haste-map "^28.1.3"
+    jest-matcher-utils "^28.1.3"
+    jest-message-util "^28.1.3"
+    jest-util "^28.1.3"
+    natural-compare "^1.4.0"
+    pretty-format "^28.1.3"
+    semver "^7.3.5"
+
 jest-snapshot@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-29.7.0.tgz#c2c574c3f51865da1bb329036778a69bf88a6be5"
@@ -23109,6 +23704,18 @@ jest-util@^26.6.2:
     is-ci "^2.0.0"
     micromatch "^4.0.2"
 
+jest-util@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-28.1.3.tgz#f4f932aa0074f0679943220ff9cbba7e497028b0"
+  integrity sha512-XdqfpHwpcSRko/C35uLYFM2emRAltIIKZiJ9eAmhjsj0CqZMa0p1ib0R5fWIqGhn1a103DebTbpqIaP1qCQ6tQ==
+  dependencies:
+    "@jest/types" "^28.1.3"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    ci-info "^3.2.0"
+    graceful-fs "^4.2.9"
+    picomatch "^2.2.3"
+
 jest-util@^29.0.0, jest-util@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-29.7.0.tgz#23c2b62bfb22be82b44de98055802ff3710fc0bc"
@@ -23132,6 +23739,18 @@ jest-validate@^25.5.0:
     jest-get-type "^25.2.6"
     leven "^3.1.0"
     pretty-format "^25.5.0"
+
+jest-validate@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-28.1.3.tgz#e322267fd5e7c64cea4629612c357bbda96229df"
+  integrity sha512-SZbOGBWEsaTxBGCOpsRWlXlvNkvTkY0XxRfh7zYmvd8uL5Qzyg0CHAXiXKROflh801quA6+/DsT4ODDthOC/OA==
+  dependencies:
+    "@jest/types" "^28.1.3"
+    camelcase "^6.2.0"
+    chalk "^4.0.0"
+    jest-get-type "^28.0.2"
+    leven "^3.1.0"
+    pretty-format "^28.1.3"
 
 jest-validate@^29.7.0:
   version "29.7.0"
@@ -23169,6 +23788,20 @@ jest-watcher@^25.2.4, jest-watcher@^25.5.0:
     chalk "^3.0.0"
     jest-util "^25.5.0"
     string-length "^3.1.0"
+
+jest-watcher@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-28.1.3.tgz#c6023a59ba2255e3b4c57179fc94164b3e73abd4"
+  integrity sha512-t4qcqj9hze+jviFPUN3YAtAEeFnr/azITXQEMARf5cMwKY2SMBRnCQTXLixTl20OR6mLh9KLMrgVJgJISym+1g==
+  dependencies:
+    "@jest/test-result" "^28.1.3"
+    "@jest/types" "^28.1.3"
+    "@types/node" "*"
+    ansi-escapes "^4.2.1"
+    chalk "^4.0.0"
+    emittery "^0.10.2"
+    jest-util "^28.1.3"
+    string-length "^4.0.1"
 
 jest-watcher@^29.7.0:
   version "29.7.0"
@@ -23218,6 +23851,15 @@ jest-worker@^27.4.5:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
+jest-worker@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-28.1.3.tgz#7e3c4ce3fa23d1bb6accb169e7f396f98ed4bb98"
+  integrity sha512-CqRA220YV/6jCo8VWvAt1KKx6eek1VIHMPeLEbpcfSfkEeWyBNppynM/o6q+Wmw+sOhos2ml34wZbSX3G13//g==
+  dependencies:
+    "@types/node" "*"
+    merge-stream "^2.0.0"
+    supports-color "^8.0.0"
+
 jest-worker@^29.1.2, jest-worker@^29.4.3, jest-worker@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-29.7.0.tgz#acad073acbbaeb7262bd5389e1bcf43e10058d4a"
@@ -23236,6 +23878,16 @@ jest@^25.3.0:
     "@jest/core" "^25.5.4"
     import-local "^3.0.2"
     jest-cli "^25.5.4"
+
+jest@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-28.1.3.tgz#e9c6a7eecdebe3548ca2b18894a50f45b36dfc6b"
+  integrity sha512-N4GT5on8UkZgH0O5LUavMRV1EDEhNTL0KEfRmDIeZHSV7p2XgLoY9t9VDUgL6o+yfdgYHVxuz81G8oB9VG5uyA==
+  dependencies:
+    "@jest/core" "^28.1.3"
+    "@jest/types" "^28.1.3"
+    import-local "^3.0.2"
+    jest-cli "^28.1.3"
 
 jest@^29.7.0:
   version "29.7.0"
@@ -24034,6 +24686,11 @@ lodash.flattendeep@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
   integrity sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==
 
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==
+
 lodash.isequal@4.5.0, lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
@@ -24058,6 +24715,11 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash.mergewith@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz#617121f89ac55f59047c7aec1ccd6654c6590f55"
+  integrity sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
@@ -29423,6 +30085,16 @@ pretty-format@^27.0.2:
     ansi-styles "^5.0.0"
     react-is "^17.0.1"
 
+pretty-format@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-28.1.3.tgz#c9fba8cedf99ce50963a11b27d982a9ae90970d5"
+  integrity sha512-8gFb/To0OmxHR9+ZTb14Df2vNxdGCX8g1xWGUTqUw5TiZvcQf5sHKObd5UcPyLLyowNwDAMTF3XWOG1B6mxl1Q==
+  dependencies:
+    "@jest/schemas" "^28.1.3"
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^18.0.0"
+
 pretty-format@^29.0.0, pretty-format@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.7.0.tgz#ca42c758310f365bfa71a0bda0a807160b776812"
@@ -31215,6 +31887,11 @@ resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==
+
+resolve.exports@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-1.1.1.tgz#05cfd5b3edf641571fd46fa608b610dda9ead999"
+  integrity sha512-/NtpHNDN7jWhAaQ9BvBUYZ6YTXsRBgfqWFWP7BZBaoMJO/I3G5OFzvTuWNlZC3aPjins1F+TNrLKsGbH4rfsRQ==
 
 resolve.exports@^2.0.0:
   version "2.0.2"
@@ -33669,6 +34346,37 @@ svgo@^3.0.2, svgo@^3.2.0:
     csso "^5.0.5"
     picocolors "^1.0.0"
 
+swagger-jsdoc@^6.2.8:
+  version "6.2.8"
+  resolved "https://registry.yarnpkg.com/swagger-jsdoc/-/swagger-jsdoc-6.2.8.tgz#6d33d9fb07ff4a7c1564379c52c08989ec7d0256"
+  integrity sha512-VPvil1+JRpmJ55CgAtn8DIcpBs0bL5L3q5bVQvF4tAW/k/9JYSj7dCpaYCAv5rufe0vcCbBRQXGvzpkWjvLklQ==
+  dependencies:
+    commander "6.2.0"
+    doctrine "3.0.0"
+    glob "7.1.6"
+    lodash.mergewith "^4.6.2"
+    swagger-parser "^10.0.3"
+    yaml "2.0.0-1"
+
+swagger-parser@^10.0.3:
+  version "10.0.3"
+  resolved "https://registry.yarnpkg.com/swagger-parser/-/swagger-parser-10.0.3.tgz#04cb01c18c3ac192b41161c77f81e79309135d03"
+  integrity sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==
+  dependencies:
+    "@apidevtools/swagger-parser" "10.0.3"
+
+swagger-ui-dist@>=5.0.0:
+  version "5.17.14"
+  resolved "https://registry.yarnpkg.com/swagger-ui-dist/-/swagger-ui-dist-5.17.14.tgz#e2c222e5bf9e15ccf80ec4bc08b4aaac09792fd6"
+  integrity sha512-CVbSfaLpstV65OnSjbXfVd6Sta3q3F7Cj/yYuvHMp1P90LztOLs6PfUnKEVAeiIVQt9u2SaPwv0LiH/OyMjHRw==
+
+swagger-ui-express@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz#fb8c1b781d2793a6bd2f8a205a3f4bd6fa020dd8"
+  integrity sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==
+  dependencies:
+    swagger-ui-dist ">=5.0.0"
+
 swagger2openapi@7.0.8, swagger2openapi@^7.0.8:
   version "7.0.8"
   resolved "https://registry.yarnpkg.com/swagger2openapi/-/swagger2openapi-7.0.8.tgz#12c88d5de776cb1cbba758994930f40ad0afac59"
@@ -35819,7 +36527,7 @@ validate.io-number@^1.0.3:
   resolved "https://registry.yarnpkg.com/validate.io-number/-/validate.io-number-1.0.3.tgz#f63ffeda248bf28a67a8d48e0e3b461a1665baf8"
   integrity sha512-kRAyotcbNaSYoDnXvb4MHg/0a1egJdLwS6oJ38TJY7aw9n93Fl/3blIXdyYvPOp55CNxywooG/3BcrwNrBpcSg==
 
-validator@~13.12.0:
+validator@^13.7.0, validator@~13.12.0:
   version "13.12.0"
   resolved "https://registry.yarnpkg.com/validator/-/validator-13.12.0.tgz#7d78e76ba85504da3fee4fd1922b385914d4b35f"
   integrity sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==
@@ -37451,7 +38159,7 @@ write-file-atomic@^3.0.0, write-file-atomic@^3.0.3:
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
 
-write-file-atomic@^4.0.2:
+write-file-atomic@^4.0.1, write-file-atomic@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-4.0.2.tgz#a9df01ae5b77858a027fd2e80768ee433555fcfd"
   integrity sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==
@@ -37680,6 +38388,11 @@ yaml@1.10.2, yaml@^1.10.0, yaml@^1.10.2, yaml@^1.7.2:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
+yaml@2.0.0-1:
+  version "2.0.0-1"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.0.0-1.tgz#8c3029b3ee2028306d5bcf396980623115ff8d18"
+  integrity sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ==
+
 yaml@^2.3.1, yaml@^2.3.4:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.5.1.tgz#c9772aacf62cb7494a95b0c4f1fb065b563db130"
@@ -37822,6 +38535,17 @@ youch@^3.2.2:
     cookie "^0.5.0"
     mustache "^4.2.0"
     stacktracey "^2.1.8"
+
+z-schema@^5.0.1:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/z-schema/-/z-schema-5.0.6.tgz#46d6a687b15e4a4369e18d6cb1c7b8618fc256c5"
+  integrity sha512-+XR1GhnWklYdfr8YaZv/iu+vY+ux7V5DS5zH1DQf6bO5ufrt/5cgNhVO5qyhsjFXvsqQb/f08DWE9b6uPscyAg==
+  dependencies:
+    lodash.get "^4.4.2"
+    lodash.isequal "^4.5.0"
+    validator "^13.7.0"
+  optionalDependencies:
+    commander "^10.0.0"
 
 zen-observable-ts@^1.2.5:
   version "1.2.5"


### PR DESCRIPTION
**Description**
* Adds Swagger for `/api-docs`
* Initial docs with `/destinationTokens` endpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Integrated Swagger UI for enhanced API documentation, accessible at `/api-docs`.
	- Introduced a new endpoint to retrieve destination tokens based on source chain ID and token address.
	- Added OpenAPI documentation for the `/bridge` endpoint to retrieve quotes for bridging tokens.
	- Added OpenAPI documentation for the `/synapseTxId` endpoint to retrieve Synapse transaction IDs.
	- Added OpenAPI documentation for the `/swap` endpoint to provide detailed swap quotes.
	- Added a new endpoint to retrieve swap transaction information.
	- Added a new endpoint to retrieve bridge transaction status.

- **Improvements**
	- Added new dependencies to support Swagger documentation features.
	- Disabled strict indentation checks for JSDoc comments, allowing more flexible formatting.

These changes enhance usability and provide developers with interactive documentation for better API integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->