### PR TITLE
Require vs import due to file location

### DIFF
--- a/packages/rest-api/src/swagger.ts
+++ b/packages/rest-api/src/swagger.ts
@@ -1,6 +1,6 @@
 import swaggerJsdoc from 'swagger-jsdoc'
 
-import { version } from '../package.json'
+const packageJson = require('../package.json')
 
 const isDevelopment = process.env.NODE_ENV === 'development'
 const serverUrl = isDevelopment
@@ -12,7 +12,7 @@ const options: swaggerJsdoc.Options = {
     openapi: '3.0.0',
     info: {
       title: 'Syanpse Protocol REST API',
-      version,
+      version: packageJson.version,
       description: 'API documentation for the Synapse Protocol REST API',
     },
     servers: [

--- a/packages/rest-api/src/swagger.ts
+++ b/packages/rest-api/src/swagger.ts
@@ -1,5 +1,6 @@
 import swaggerJsdoc from 'swagger-jsdoc'
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const packageJson = require('../package.json')
 
 const isDevelopment = process.env.NODE_ENV === 'development'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the method for retrieving the API version from the `package.json` file for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->