### PR TITLE
feat(rest-api): Prevent caching of api docs

### DIFF
--- a/packages/rest-api/src/app.ts
+++ b/packages/rest-api/src/app.ts
@@ -9,7 +9,21 @@ const port = process.env.PORT || 3000
 
 app.use(express.json())
 
-app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(specs))
+app.use(
+  '/api-docs',
+  (_req, res, next) => {
+    res.set(
+      'Cache-Control',
+      'no-store, no-cache, must-revalidate, proxy-revalidate'
+    )
+    res.set('Pragma', 'no-cache')
+    res.set('Expires', '0')
+    res.set('Surrogate-Control', 'no-store')
+    next()
+  },
+  swaggerUi.serve,
+  swaggerUi.setup(specs)
+)
 
 app.use('/', routes)
 


### PR DESCRIPTION
**Description**
Ensures fresh docs on each `/api-docs` visit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced middleware for the `/api-docs` route to manage HTTP cache control headers, ensuring up-to-date API documentation delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->