### PR TITLE
fix(rfq): change block confirmation requirement config field to per chain and fix limiter test

### DIFF
--- a/services/rfq/e2e/setup_test.go
+++ b/services/rfq/e2e/setup_test.go
@@ -287,6 +287,7 @@ func (i *IntegrationSuite) getRelayerConfig() relconfig.Config {
 					},
 				},
 				NativeToken: "ETH",
+				VolumeLimit: 10_000,
 			},
 			destBackendChainID: {
 				RFQAddress: i.manager.Get(i.GetTestContext(), i.destBackend, testutil.FastBridgeType).Address().String(),
@@ -304,6 +305,7 @@ func (i *IntegrationSuite) getRelayerConfig() relconfig.Config {
 					},
 				},
 				NativeToken: "ETH",
+				VolumeLimit: 10_000,
 			},
 		},
 		OmniRPCURL: i.omniServer,
@@ -329,7 +331,6 @@ func (i *IntegrationSuite) getRelayerConfig() relconfig.Config {
 			TokenPriceCacheTTLSeconds: 60,
 		},
 		RebalanceInterval: 0,
-		VolumeLimit:       10_000,
 	}
 }
 

--- a/services/rfq/relayer/limiter/limiter.go
+++ b/services/rfq/relayer/limiter/limiter.go
@@ -98,7 +98,7 @@ func (l *limiterImpl) hasEnoughConfirmations(ctx context.Context, request *reldb
 		return false, fmt.Errorf("could not get block number: %w", err)
 	}
 
-	requiredConfirmations, err := l.cfg.GetFinalityConfirmations(int(request.Transaction.OriginChainId))
+	requiredConfirmations := l.cfg.GetLimitConfirmations(int(request.Transaction.OriginChainId))
 	if err != nil {
 		return false, fmt.Errorf("could not get required confirmations from config: %w", err)
 	}

--- a/services/rfq/relayer/limiter/limiter_test.go
+++ b/services/rfq/relayer/limiter/limiter_test.go
@@ -105,10 +105,6 @@ func (l *LimiterSuite) TestOverLimitNotEnoughConfirmations() {
 	l.False(allowed)
 }
 
-func (l *LimiterSuite) TestRateLimitOverWindow() {
-	l.T().Skip("TODO: implement the sliding window: queue up requests and process them in order if cumulative volume is above limit")
-}
-
 func buildMockQuoter(price float64) *mocks.Quoter {
 	mockQuoter := new(mocks.Quoter)
 	mockQuoter.On("GetPrice", mock.Anything, mock.Anything).Once().Return(price, nil)

--- a/services/rfq/relayer/limiter/suite_test.go
+++ b/services/rfq/relayer/limiter/suite_test.go
@@ -45,10 +45,10 @@ func (s *LimiterSuite) SetupTest() {
 						Decimals: 18,
 					},
 				},
-				Confirmations: 1,
+				LimitConfirmations: 1,
+				VolumeLimit:        10000, // 10k usd
 			},
 		},
-		VolumeLimit: 10000, // 10k usd
 	}
 	s.metrics = metrics.NewNullHandler()
 }

--- a/services/rfq/relayer/relconfig/config.go
+++ b/services/rfq/relayer/relconfig/config.go
@@ -65,8 +65,6 @@ type Config struct {
 	UseEmbeddedGuard bool `yaml:"enable_guard"`
 	// SubmitSingleQuotes enables submitting single quotes.
 	SubmitSingleQuotes bool `yaml:"submit_single_quotes"`
-	// VolumeLimit is the maximum dollar value of relayed transactions in the BlockWindow.
-	VolumeLimit float64 `yaml:"volume_limit"`
 }
 
 // ChainConfig represents the configuration for a chain.
@@ -110,6 +108,8 @@ type ChainConfig struct {
 	RebalanceConfigs RebalanceConfigs `yaml:"rebalance_configs"`
 	// LimitConfirmations is the number of confirmations to wait for before processing a quote.
 	LimitConfirmations uint64 `yaml:"limit_confirmations"`
+	// VolumeLimit is the maximum dollar value of relayed transactions in the BlockWindow.
+	VolumeLimit float64 `yaml:"volume_limit"`
 }
 
 // TokenConfig represents the configuration for a token.

--- a/services/rfq/relayer/relconfig/getters.go
+++ b/services/rfq/relayer/relconfig/getters.go
@@ -823,6 +823,16 @@ func (c Config) GetQuoteSubmissionTimeout() time.Duration {
 	return timeout
 }
 
+// GetLimitConfirmations returns the limit confirmations for the given chain.
+func (c Config) GetLimitConfirmations(chainID int) uint64 {
+	chainConfig, ok := c.Chains[chainID]
+	if !ok {
+		return 0
+	}
+
+	return chainConfig.LimitConfirmations
+}
+
 var defaultVolumeLimit = core.CopyBigInt(big.NewInt(-1))
 
 // GetVolumeLimit returns the volume limit for the relayer.
@@ -840,7 +850,7 @@ func (c Config) GetVolumeLimit(chainID int, addr common.Address) *big.Int {
 		}
 	}
 
-	volumeLimitFlt := new(big.Float).SetFloat64(c.VolumeLimit)
+	volumeLimitFlt := new(big.Float).SetFloat64(chainCfg.VolumeLimit)
 
 	// Scale the minBalance by the token decimals.
 	//nolint: mnd


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**
A clear and concise description of the features you're adding in this pull request.

**Additional context**
Add any other context about the problem you're solving.

**Metadata**
- Fixes #[Link to Issue]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method to retrieve limit confirmations for specific blockchains.
	- Added a `VolumeLimit` field to chain-specific configurations.

- **Bug Fixes**
	- Simplified error handling in the confirmation retrieval process.

- **Refactor**
	- Adjusted the structure of configuration settings to localize `VolumeLimit` to specific backends.

- **Chores**
	- Removed obsolete test case related to the sliding window mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->