### PR TITLE
fix(contracts-rfq): limit the amount of solhint warnings [SLT-245]

### DIFF
--- a/packages/contracts-rfq/contracts/FastBridgeV2.sol
+++ b/packages/contracts-rfq/contracts/FastBridgeV2.sol
@@ -3,14 +3,14 @@ pragma solidity 0.8.24;
 
 import {SafeERC20, IERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
-import "./libs/Errors.sol";
 import {UniversalTokenLib} from "./libs/UniversalToken.sol";
 
 import {Admin} from "./Admin.sol";
 import {IFastBridge} from "./interfaces/IFastBridge.sol";
 import {IFastBridgeV2} from "./interfaces/IFastBridgeV2.sol";
+import {IFastBridgeV2Errors} from "./interfaces/IFastBridgeV2Errors.sol";
 
-contract FastBridgeV2 is Admin, IFastBridgeV2 {
+contract FastBridgeV2 is Admin, IFastBridgeV2, IFastBridgeV2Errors {
     using SafeERC20 for IERC20;
     using UniversalTokenLib for address;
 

--- a/packages/contracts-rfq/contracts/interfaces/IFastBridgeV2Errors.sol
+++ b/packages/contracts-rfq/contracts/interfaces/IFastBridgeV2Errors.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IFastBridgeV2Errors {
+    error AmountIncorrect();
+    error ChainIncorrect();
+    error MsgValueIncorrect();
+    error SenderIncorrect();
+    error StatusIncorrect();
+    error ZeroAddress();
+
+    error DeadlineExceeded();
+    error DeadlineNotExceeded();
+    error DeadlineTooShort();
+    error DisputePeriodNotPassed();
+    error DisputePeriodPassed();
+
+    error TransactionRelayed();
+}

--- a/packages/contracts-rfq/package.json
+++ b/packages/contracts-rfq/package.json
@@ -24,7 +24,7 @@
     "lint:check": "forge fmt --check && npm run solhint:check",
     "ci:lint": "npm run lint:check",
     "build:go": "./flatten.sh contracts/*.sol test/*.sol",
-    "solhint": "solhint '{contracts,script,test}/**/*.sol' --fix --noPrompt",
-    "solhint:check": "solhint '{contracts,script,test}/**/*.sol'"
+    "solhint": "solhint '{contracts,script,test}/**/*.sol' --fix --noPrompt --max-warnings 3",
+    "solhint:check": "solhint '{contracts,script,test}/**/*.sol' --max-warnings 3"
   }
 }

--- a/packages/contracts-rfq/test/FastBridgeV2.Dst.t.sol
+++ b/packages/contracts-rfq/test/FastBridgeV2.Dst.t.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {ChainIncorrect, DeadlineExceeded, TransactionRelayed} from "../contracts/libs/Errors.sol";
-
 import {FastBridgeV2, FastBridgeV2Test, IFastBridge} from "./FastBridgeV2.t.sol";
 
 // solhint-disable func-name-mixedcase, ordering

--- a/packages/contracts-rfq/test/FastBridgeV2.Parity.t.sol
+++ b/packages/contracts-rfq/test/FastBridgeV2.Parity.t.sol
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.20;
 
-import {FastBridgeTest, SenderIncorrect} from "./FastBridge.t.sol";
+import {IFastBridgeV2Errors} from "../contracts/interfaces/IFastBridgeV2Errors.sol";
+
+import {FastBridgeTest} from "./FastBridge.t.sol";
 
 // solhint-disable func-name-mixedcase, ordering
-contract FastBridgeV2ParityTest is FastBridgeTest {
+contract FastBridgeV2ParityTest is FastBridgeTest, IFastBridgeV2Errors {
     address public anotherRelayer = makeAddr("Another Relayer");
 
     function deployFastBridge() internal virtual override returns (address) {

--- a/packages/contracts-rfq/test/FastBridgeV2.Src.t.sol
+++ b/packages/contracts-rfq/test/FastBridgeV2.Src.t.sol
@@ -1,19 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {
-    AmountIncorrect,
-    ChainIncorrect,
-    DisputePeriodNotPassed,
-    DisputePeriodPassed,
-    DeadlineNotExceeded,
-    DeadlineTooShort,
-    MsgValueIncorrect,
-    SenderIncorrect,
-    StatusIncorrect,
-    ZeroAddress
-} from "../contracts/libs/Errors.sol";
-
 import {FastBridgeV2, FastBridgeV2Test, IFastBridge} from "./FastBridgeV2.t.sol";
 
 // solhint-disable func-name-mixedcase, ordering

--- a/packages/contracts-rfq/test/FastBridgeV2.t.sol
+++ b/packages/contracts-rfq/test/FastBridgeV2.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.20;
 
 import {IFastBridge} from "../contracts/interfaces/IFastBridge.sol";
+import {IFastBridgeV2Errors} from "../contracts/interfaces/IFastBridgeV2Errors.sol";
 import {FastBridgeV2} from "../contracts/FastBridgeV2.sol";
 
 import {MockERC20} from "./MockERC20.sol";
@@ -11,7 +12,7 @@ import {Test} from "forge-std/Test.sol";
 import {stdStorage, StdStorage} from "forge-std/Test.sol";
 
 // solhint-disable no-empty-blocks, ordering
-abstract contract FastBridgeV2Test is Test {
+abstract contract FastBridgeV2Test is Test, IFastBridgeV2Errors {
     using stdStorage for StdStorage;
 
     uint32 public constant SRC_CHAIN_ID = 1337;


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**
A clear and concise description of the features you're adding in this pull request.

**Additional context**
Add any other context about the problem you're solving.

**Metadata**
- Fixes #[Link to Issue]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a warning limit for the solhint scripts, enhancing error management.
	- Added a new interface for error handling in the Fast Bridge V2 contract, improving clarity and efficiency in error reporting.
- **Bug Fixes**
	- Resolved the issue of unlimited warnings during script execution by setting a cap at three warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->