### PR TITLE
reduce solhint warnings on FbV2

### DIFF
--- a/packages/contracts-rfq/contracts/FastBridgeV2.sol
+++ b/packages/contracts-rfq/contracts/FastBridgeV2.sol
@@ -186,7 +186,8 @@ contract FastBridgeV2 is Admin, IFastBridgeV2, IFastBridgeV2Errors {
         // update bridge tx status given proof provided
         if (bridgeStatuses[transactionId] != BridgeStatus.REQUESTED) revert StatusIncorrect();
         bridgeStatuses[transactionId] = BridgeStatus.RELAYER_PROVED;
-        bridgeProofs[transactionId] = BridgeProof({timestamp: uint96(block.timestamp), relayer: relayer}); // overflow ok
+         // overflow ok
+        bridgeProofs[transactionId] = BridgeProof({timestamp: uint96(block.timestamp), relayer: relayer});
 
         emit BridgeProofProvided(transactionId, relayer, destTxHash);
     }

--- a/packages/contracts-rfq/contracts/FastBridgeV2.sol
+++ b/packages/contracts-rfq/contracts/FastBridgeV2.sol
@@ -186,7 +186,7 @@ contract FastBridgeV2 is Admin, IFastBridgeV2, IFastBridgeV2Errors {
         // update bridge tx status given proof provided
         if (bridgeStatuses[transactionId] != BridgeStatus.REQUESTED) revert StatusIncorrect();
         bridgeStatuses[transactionId] = BridgeStatus.RELAYER_PROVED;
-         // overflow ok
+        // overflow ok
         bridgeProofs[transactionId] = BridgeProof({timestamp: uint96(block.timestamp), relayer: relayer});
 
         emit BridgeProofProvided(transactionId, relayer, destTxHash);

--- a/packages/contracts-rfq/contracts/interfaces/IFastBridgeV2.sol
+++ b/packages/contracts-rfq/contracts/interfaces/IFastBridgeV2.sol
@@ -15,7 +15,8 @@ interface IFastBridgeV2 is IFastBridge {
     /// @param relayer The address of the relaying entity which should have control of the origin funds when claimed
     function prove(bytes memory request, bytes32 destTxHash, address relayer) external;
 
-    /// @notice Completes bridge transaction on origin chain by claiming originally deposited capital. Can only send funds to the relayer address on the proof.
+    /// @notice Completes bridge transaction on origin chain by claiming originally deposited capital.
+    /// @notice Can only send funds to the relayer address on the proof.
     /// @param request The encoded bridge transaction to claim on origin chain
     function claim(bytes memory request) external;
 }


### PR DESCRIPTION
CI improvements introduced solhint gates - FBv2 is already at warning limit - this reduces to 1

Not fixing the final warning right now because it cascades & results in a reordering of most of the contract

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Enhanced clarity of the `claim` function documentation in the `IFastBridgeV2` interface.
- **Chores**
  - Added comments regarding overflow in the `FastBridgeV2` contract to improve code understanding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->