### PR TITLE
adding originUserAddress for refunds [SLT-281]

### DIFF
--- a/packages/rest-api/src/controllers/bridgeController.ts
+++ b/packages/rest-api/src/controllers/bridgeController.ts
@@ -11,7 +11,14 @@ export const bridgeController = async (req, res) => {
     return res.status(400).json({ errors: errors.array() })
   }
   try {
-    const { fromChain, toChain, amount, fromToken, toToken } = req.query
+    const {
+      fromChain,
+      toChain,
+      amount,
+      fromToken,
+      toToken,
+      originUserAddress,
+    } = req.query
 
     const fromTokenInfo = tokenAddressToToken(fromChain.toString(), fromToken)
     const toTokenInfo = tokenAddressToToken(toChain.toString(), toToken)
@@ -23,7 +30,10 @@ export const bridgeController = async (req, res) => {
       Number(toChain),
       fromToken,
       toToken,
-      amountInWei
+      amountInWei,
+      originUserAddress
+        ? { originUserAddress: originUserAddress.toString() }
+        : {}
     )
 
     const payload = resp.map((quote) => {

--- a/packages/rest-api/src/controllers/bridgeTxInfoController.ts
+++ b/packages/rest-api/src/controllers/bridgeTxInfoController.ts
@@ -11,8 +11,15 @@ export const bridgeTxInfoController = async (req, res) => {
   }
 
   try {
-    const { fromChain, toChain, amount, destAddress, fromToken, toToken } =
-      req.query
+    const {
+      fromChain,
+      toChain,
+      amount,
+      destAddress,
+      fromToken,
+      toToken,
+      originUserAddress,
+    } = req.query
 
     const fromTokenInfo = tokenAddressToToken(fromChain.toString(), fromToken)
 
@@ -23,7 +30,10 @@ export const bridgeTxInfoController = async (req, res) => {
       Number(toChain),
       fromToken,
       toToken,
-      amountInWei
+      amountInWei,
+      originUserAddress
+        ? { originUserAddress: originUserAddress.toString() }
+        : {}
     )
 
     const txInfoArray = await Promise.all(

--- a/packages/rest-api/src/routes/bridgeRoute.ts
+++ b/packages/rest-api/src/routes/bridgeRoute.ts
@@ -1,5 +1,6 @@
 import express from 'express'
 import { check } from 'express-validator'
+import { isAddress } from 'ethers/lib/utils'
 
 import { isTokenAddress } from '../utils/isTokenAddress'
 import { CHAINS_ARRAY } from '../constants/chains'
@@ -236,6 +237,10 @@ router.get(
         return validateRouteExists(fromChain, fromToken, toChain, toToken)
       })
       .withMessage('No valid route exists for the chain/token combination'),
+    check('originUserAddress')
+      .optional()
+      .custom((value) => isAddress(value))
+      .withMessage('Invalid originUserAddress address'),
   ],
   showFirstValidationError,
   bridgeController

--- a/packages/rest-api/src/routes/bridgeRoute.ts
+++ b/packages/rest-api/src/routes/bridgeRoute.ts
@@ -49,6 +49,12 @@ const router = express.Router()
  *         schema:
  *           type: number
  *         description: The amount of tokens to bridge
+ *       - in: query
+ *         name: originUserAddress
+ *         required: false
+ *         schema:
+ *           type: string
+ *         description: The address of the user on the origin chain
  *     responses:
  *       200:
  *         description: Successful response

--- a/packages/rest-api/src/routes/bridgeTxInfoRoute.ts
+++ b/packages/rest-api/src/routes/bridgeTxInfoRoute.ts
@@ -51,6 +51,12 @@ const router = express.Router()
  *           type: number
  *         description: The amount of tokens to bridge
  *       - in: query
+ *         name: originUserAddress
+ *         required: false
+ *         schema:
+ *           type: string
+ *         description: The address of the user on the origin chain
+ *       - in: query
  *         name: destAddress
  *         required: true
  *         schema:

--- a/packages/rest-api/src/routes/bridgeTxInfoRoute.ts
+++ b/packages/rest-api/src/routes/bridgeTxInfoRoute.ts
@@ -177,6 +177,10 @@ router.get(
         return validateRouteExists(fromChain, fromToken, toChain, toToken)
       })
       .withMessage('No valid route exists for the chain/token combination'),
+    check('originUserAddress')
+      .optional()
+      .custom((value) => isAddress(value))
+      .withMessage('Invalid originUserAddress address'),
   ],
   showFirstValidationError,
   bridgeTxInfoController

--- a/packages/rest-api/src/routes/bridgeTxInfoRoute.ts
+++ b/packages/rest-api/src/routes/bridgeTxInfoRoute.ts
@@ -51,17 +51,17 @@ const router = express.Router()
  *           type: number
  *         description: The amount of tokens to bridge
  *       - in: query
- *         name: originUserAddress
- *         required: false
- *         schema:
- *           type: string
- *         description: The address of the user on the origin chain
- *       - in: query
  *         name: destAddress
  *         required: true
  *         schema:
  *           type: string
  *         description: The destination address for the bridged tokens
+ *       - in: query
+ *         name: originUserAddress
+ *         required: false
+ *         schema:
+ *           type: string
+ *         description: The address of the user on the origin chain
  *     responses:
  *       200:
  *         description: Successful response

--- a/packages/rest-api/src/tests/bridgeRoute.test.ts
+++ b/packages/rest-api/src/tests/bridgeRoute.test.ts
@@ -25,6 +25,23 @@ describe('Bridge Route with Real Synapse Service', () => {
     expect(response.body[0]).toHaveProperty('bridgeFeeFormatted')
   }, 15000)
 
+  it('should return bridge quotes for valid originUserAddress', async () => {
+    const response = await request(app).get('/bridge').query({
+      fromChain: '1',
+      toChain: '10',
+      fromToken: USDC.addresses[1],
+      toToken: USDC.addresses[10],
+      amount: '1000',
+      originUserAddress: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+    })
+
+    expect(response.status).toBe(200)
+    expect(Array.isArray(response.body)).toBe(true)
+    expect(response.body.length).toBeGreaterThan(0)
+    expect(response.body[0]).toHaveProperty('maxAmountOutStr')
+    expect(response.body[0]).toHaveProperty('bridgeFeeFormatted')
+  }, 15000)
+
   it('should return bridge quotes for ZeroAddress', async () => {
     const response = await request(app).get('/bridge').query({
       fromChain: '1',
@@ -54,6 +71,23 @@ describe('Bridge Route with Real Synapse Service', () => {
     expect(response.body.length).toBeGreaterThan(0)
     expect(response.body[0]).toHaveProperty('maxAmountOutStr')
     expect(response.body[0]).toHaveProperty('bridgeFeeFormatted')
+  }, 15000)
+
+  it('should return 400 for invalid originUserAddress', async () => {
+    const response = await request(app).get('/bridge').query({
+      fromChain: '1',
+      toChain: '10',
+      fromToken: USDC.addresses[1],
+      toToken: USDC.addresses[10],
+      amount: '1000',
+      originUserAddress: 'invalid_address',
+    })
+
+    expect(response.status).toBe(400)
+    expect(response.body.error).toHaveProperty(
+      'message',
+      'Invalid originUserAddress address'
+    )
   }, 15000)
 
   it('should return 400 for unsupported route', async () => {

--- a/packages/rest-api/src/tests/bridgeTxInfoRoute.test.ts
+++ b/packages/rest-api/src/tests/bridgeTxInfoRoute.test.ts
@@ -29,6 +29,45 @@ describe('Bridge TX Info Route', () => {
     )
   }, 10_000)
 
+  it('should return bridge transaction info for valid input with valid originUserAddress', async () => {
+    const response = await request(app).get('/bridgeTxInfo').query({
+      fromChain: '1',
+      toChain: '137',
+      fromToken: USDC.addresses[1],
+      toToken: USDC.addresses[137],
+      amount: '1000',
+      destAddress: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+      originUserAddress: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+    })
+
+    expect(response.status).toBe(200)
+    expect(Array.isArray(response.body)).toBe(true)
+    expect(response.body.length).toBeGreaterThan(0)
+    expect(response.body[0]).toHaveProperty('data')
+    expect(response.body[0]).toHaveProperty(
+      'to',
+      '0xd5a597d6e7ddf373a92C8f477DAAA673b0902F48'
+    )
+  }, 10_000)
+
+  it('should return 400 for invalid originUserAddress', async () => {
+    const response = await request(app).get('/bridgeTxInfo').query({
+      fromChain: '1',
+      toChain: '137',
+      fromToken: USDC.addresses[1],
+      toToken: USDC.addresses[137],
+      amount: '1000',
+      destAddress: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+      originUserAddress: 'invalid_address',
+    })
+
+    expect(response.status).toBe(400)
+    expect(response.body.error).toHaveProperty(
+      'message',
+      'Invalid originUserAddress address'
+    )
+  }, 10_000)
+
   it('should return 400 for unsupported route', async () => {
     const response = await request(app).get('/bridgeTxInfo').query({
       fromChain: '1',


### PR DESCRIPTION
For aggregator integrations using the UI, the aggregator should supply the origin user address so that SynapseRFQ can refund in the case of a refund. 

Simply adds the logic from the SDK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an optional `originUserAddress` parameter to the bridging API routes, enhancing request capabilities.
	- Updated controllers to process the new `originUserAddress` parameter for improved transaction handling.
	- Added validation for `originUserAddress` to ensure it is a valid address format.

- **Tests**
	- Added test cases to validate responses for both valid and invalid `originUserAddress` inputs in the bridge routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->