### PR TITLE
Add height/width fields for future constants upgrade integration

### DIFF
--- a/packages/explorer-ui/components/misc/AssetImage.tsx
+++ b/packages/explorer-ui/components/misc/AssetImage.tsx
@@ -11,7 +11,13 @@ export const AssetImage = ({ tokenAddress, chainId, className }) => {
         <div className="relative w-full">
           <div className="flex justify-between ">
             <div className="flex flex-row w-[90%] items-center">
-              <Image className={`${className}`} src={t?.icon} alt="" />
+              <Image
+                className={`${className}`}
+                src={t?.icon}
+                alt=""
+                height={16}
+                width={16}
+              />
             </div>
           </div>
         </div>
@@ -29,13 +35,21 @@ export const AssetImage = ({ tokenAddress, chainId, className }) => {
           className={`inline mr-[.5rem] rounded-full ${className}`}
           src={t?.icon}
           alt=""
+          height={16}
+          width={16}
         />
       </a>
     )
   } else {
     return (
       // temporary fix until either symbolToToken works better as a function or explorer indexer has the right token addresses
-      <Image className={`${className}`} src={USDC?.icon} alt="" />
+      <Image
+        className={`${className}`}
+        src={USDC?.icon}
+        alt=""
+        height={16}
+        width={16}
+      />
       // <QuestionMarkCircleIcon
       //   className={`inline w-5 h-5 mr-2 rounded-md ${className}`}
       //   strokeWidth={2}

--- a/packages/explorer-ui/components/misc/ChainImage.tsx
+++ b/packages/explorer-ui/components/misc/ChainImage.tsx
@@ -12,6 +12,8 @@ export const ChainImage = ({ chainId, imgSize = 'w-4 h-4', className }) => {
         src={chain.chainImg}
         className={`${imgSize} rounded-full mr-2 inline ${className}`}
         alt={chain.name}
+        height={16}
+        width={16}
       />
     )
   } else {

--- a/packages/explorer-ui/components/misc/ChainInfo.tsx
+++ b/packages/explorer-ui/components/misc/ChainInfo.tsx
@@ -45,6 +45,8 @@ export const ChainInfo = ({
               className={`inline rounded-full ${imgClassName}`}
               src={chain?.chainImg}
               alt={chain?.name}
+              height={16}
+              width={16}
             />
             <p
               className={`${textClassName} group-hover:text-[#8FEBFF] transition-colors duration-200`}


### PR DESCRIPTION
**Description**
Add required height/width fields in prep for new constants package.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added explicit height and width attributes to the `Image` components in multiple areas, enhancing rendering control and layout stability for asset and chain images. 

- **Bug Fixes**
	- Improved image rendering consistency across different components by defining image dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
7df86092a1da79e09c03f960d64aee67eb745341: [explorer-ui preview link ](https://sanguine-prdrf1ew8-synapsecns.vercel.app)