### PR TITLE
bump constants version

### DIFF
--- a/packages/synapse-constants/package.json
+++ b/packages/synapse-constants/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-constants",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "This is an npm package that maintains all synapse constants",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version number of the `synapse-constants` package from 1.5.4 to 1.5.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->