### PR TITLE
FbV2 sender nonces [SLT-183]

### DIFF
--- a/packages/contracts-rfq/.gitignore
+++ b/packages/contracts-rfq/.gitignore
@@ -1,3 +1,5 @@
 flattened
 .deployments
 broadcast
+
+lcov.info

--- a/packages/contracts-rfq/contracts/FastBridgeV2.sol
+++ b/packages/contracts-rfq/contracts/FastBridgeV2.sol
@@ -31,7 +31,10 @@ contract FastBridgeV2 is Admin, IFastBridgeV2, IFastBridgeV2Errors {
     /// @notice Unique bridge nonces tracked per originSender
     mapping(address => uint256) public senderNonces;
 
-    // @dev the block the contract was deployed at
+    /// @notice This is deprecated and should not be used.
+    /// @dev Replaced by senderNonces
+    uint256 public immutable nonce = 0;
+    /// @notice the block the contract was deployed at
     uint256 public immutable deployBlock;
 
     constructor(address _owner) Admin(_owner) {
@@ -110,12 +113,6 @@ contract FastBridgeV2 is Admin, IFastBridgeV2, IFastBridgeV2Errors {
         if (bridgeTxDetails[transactionId].status != BridgeStatus.RELAYER_PROVED) revert StatusIncorrect();
         if (bridgeTxDetails[transactionId].proofRelayer != relayer) revert SenderIncorrect();
         return _timeSince(bridgeTxDetails[transactionId].proofBlockTimestamp) > DISPUTE_PERIOD;
-    }
-
-    /// @notice This function is deprecated and should not be used.
-    /// @dev Replaced by senderNonces
-    function nonce() external pure returns (uint256) {
-        return 0;
     }
 
     /// @inheritdoc IFastBridge

--- a/packages/contracts-rfq/test/FastBridgeV2.Src.Base.t.sol
+++ b/packages/contracts-rfq/test/FastBridgeV2.Src.Base.t.sol
@@ -96,8 +96,9 @@ abstract contract FastBridgeV2SrcBaseTest is FastBridgeV2Test {
     }
 
     function test_nonce() public view {
+        uint256 result = fastBridge.nonce();
         // deprecated. should always return zero in FbV2.
-        assertEq(fastBridge.nonce(), 0);
+        assertEq(result, 0);
     }
 
     function assertEq(FastBridgeV2.BridgeStatus a, FastBridgeV2.BridgeStatus b) public pure {

--- a/packages/contracts-rfq/test/FastBridgeV2.Src.Base.t.sol
+++ b/packages/contracts-rfq/test/FastBridgeV2.Src.Base.t.sol
@@ -95,6 +95,11 @@ abstract contract FastBridgeV2SrcBaseTest is FastBridgeV2Test {
         fastBridge.refund(abi.encode(bridgeTx));
     }
 
+    function test_nonce() public view {
+        // deprecated. should always return zero in FbV2.
+        assertEq(fastBridge.nonce(), 0);
+    }
+
     function assertEq(FastBridgeV2.BridgeStatus a, FastBridgeV2.BridgeStatus b) public pure {
         assertEq(uint8(a), uint8(b));
     }


### PR DESCRIPTION
Description
Replace chain-scoped nonce with one that increments per-sender

Additional context
Reduces risk of reorgs resulting in a different nonce

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced nonce management for improved security, allowing unique tracking per sender.
	- Deprecated the old nonce mechanism, introducing a new public function that always returns zero.

- **Bug Fixes**
	- Added assertions to ensure correct nonce incrementing for users during bridge operations.

- **Documentation**
	- Updated comments to reflect changes in nonce management and deprecation notices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->