### PR TITLE
Docs/fix

### DIFF
--- a/docs/bridge/docs/05-Contracts/05-CCTP.md
+++ b/docs/bridge/docs/05-Contracts/05-CCTP.md
@@ -6,9 +6,9 @@ The canonical list is hosted within the SynapseCNS on [Github](https://github.co
 
 # CCTP
 
-Synapse CCTP contracts route through the [SynapseBridge](https://github.com/synapsecns/synapse-contracts/blob/ed93453430635e2d43704d5599d3318c43a23033/contracts/bridge/SynapseBridge.sol#L63-L118) contract to interact with [Circle CCTP contracts](https://developers.circle.com/stablecoins/docs/evm-smart-contracts) which mint and burn USDC across supported chains.
+Synapse CCTP transactions primarily interact with the Synapse CCTP Router contract, which is responsible for routing transactions with the proper meta data to the Synapse CCTP contract on the relevant chain, which utilizes the base [Circle CCTP contracts](https://developers.circle.com/stablecoins/docs/evm-smart-contracts) to mint and burn USDC across supported chains.
 
-**Address**: `0xd5a597d6e7ddf373a92c8f477daaa673b0902f48`\
+**Synapse CCTP Router Address**: `0xd5a597d6e7ddf373a92c8f477daaa673b0902f48`\
 **Contract**: [SynapseCCTP.sol](https://github.com/synapsecns/synapse-contracts/blob/master/contracts/cctp/SynapseCCTP.sol)
 
 | Chain     | Address                                      |

--- a/docs/bridge/docs/05-Contracts/06-RFQ.md
+++ b/docs/bridge/docs/05-Contracts/06-RFQ.md
@@ -10,11 +10,11 @@ The canonical list is hosted within the SynapseCNS on [Github](https://github.co
 
 # RFQ
 
-RFQ contracts route through the [SynapseBridge](https://github.com/synapsecns/synapse-contracts/blob/ed93453430635e2d43704d5599d3318c43a23033/contracts/bridge/SynapseBridge.sol#L63-L118) contract.
+RFQ transactions primarily interact with the Router Address, which is responsible for routing transactions with the proper meta data to the RFQ contract on the relevant chain.
 
 **Source code**: [SynapseCNS (Github)](https://github.com/synapsecns/sanguine/tree/master/packages/contracts-rfq)\
 **Generated docs**: [RFQ docs](https://vercel-rfq-docs.vercel.app/contracts/FastBridge.sol/contract.FastBridge.html)\
-**Address**: `0x00cD000000003f7F682BE4813200893d4e690000`
+**RFQ Router Address**: `0x00cD000000003f7F682BE4813200893d4e690000`
 
 | Chain    | Address |
 | -------- | ------- |

--- a/docs/bridge/docs/06-Services/06-RFQ-Indexer-API.md
+++ b/docs/bridge/docs/06-Services/06-RFQ-Indexer-API.md
@@ -1,0 +1,14 @@
+# RFQ Indexer API
+
+The RFQ Indexer API is a service designed to provide access to indexed RFQ bridge event data. It offers crucial monitoring and operational capabilities, serving as a supplemental tool to existing relayer infrastructure. This API is particularly useful for tracking pending bridge transactions and identifying missing relays, proofs, or claims.
+
+## API-docs
+
+[`https://triumphant-magic-production.up.railway.app/api-docs/`](https://triumphant-magic-production.up.railway.app/api-docs/)
+
+## Key Features
+1. **Real-Time and Historical Data** Indexes from a specified start block up to real-time events.
+2. **On-chain Tracing** Tracks all on-chain transactions and events, helping to debug.
+4. **GraphQL API**: Provides a GraphQL/IQL endpoint for easy data querying.
+
+

--- a/packages/rfq-indexer/api/README.md
+++ b/packages/rfq-indexer/api/README.md
@@ -2,6 +2,8 @@
 
 This API provides access to the indexed bridge event data.
 
+To make requests, use:  https://triumphant-magic-production.up.railway.app , and Swagger docs can be found [here](https://triumphant-magic-production.up.railway.app/api-docs)
+
 ## API Calls
 
 1. GET /api/hello


### PR DESCRIPTION
The following are updated: 
- RFQ Indexer API readme
- Adds RFQ Indexer API to the user facing docs
- Changes the language in the contracts section of the user facing docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated Synapse CCTP documentation to clarify the role of the Synapse CCTP Router contract and revised address labels for better context.
	- Modified RFQ documentation to emphasize the Router Address's role in RFQ transactions and improved overall clarity.
	- Introduced new documentation for the RFQ Indexer API, detailing its capabilities for monitoring bridge transactions and providing a GraphQL API endpoint.
	- Enhanced the RFQ Indexer API README with the base URL and a link to the Swagger documentation for easier access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
39f1d89d85f3b3f428b343a084218514a0293de2: [docs preview link ](https://bridge-docs-fd2sxwgat-synapsecns.vercel.app)