### PR TITLE
Hide Routes component

### DIFF
--- a/docs/bridge/docs/01-About/03-Routes.md
+++ b/docs/bridge/docs/01-About/03-Routes.md
@@ -1,7 +1,0 @@
-import Routes from '@site/src/components/Routes'
-
-# Chains & Tokens
-
-This page contains a list of supported tokens, listed per-chain. For a given pair, use the [Synapse Bridge](https://synapseprotocol.com) to see if a route between them exists.
-
-<Routes />

--- a/docs/bridge/docs/02-Bridge/04-Sample-Code.md
+++ b/docs/bridge/docs/02-Bridge/04-Sample-Code.md
@@ -1,8 +1,8 @@
 ---
-sidebar_label: Examples
+sidebar_label: Sample Code
 ---
 
-# Example Code
+# Sample Code
 
 Example SDK & API implementations
 

--- a/docs/bridge/docs/02-Bridge/05-Supported-Routes.md
+++ b/docs/bridge/docs/02-Bridge/05-Supported-Routes.md
@@ -1,0 +1,14 @@
+---
+sidebar_label: Supported Rotues
+---
+
+# Supported Routes
+
+Use the [Synapse Bridge](https://synapseprotocol.com) to browse supported tokens and chains.
+
+:::tip Routes
+
+Route availability is determined by the amount you wish to bridge. Use the [Synapse Bridge](https://synapseprotocol.com) to see if a route between a given pair exists.
+
+:::
+

--- a/docs/bridge/docs/02-Bridge/_05-Supported-Routes.md
+++ b/docs/bridge/docs/02-Bridge/_05-Supported-Routes.md
@@ -1,0 +1,17 @@
+---
+sidebar_label: Supported Rotues
+---
+
+import Routes from '@site/src/components/Routes'
+
+# Supported Routes
+
+Supported tokens for each chain. 
+
+:::tip Routes
+
+Route availability is determined by the amount you wish to bridge. Use the [Synapse Bridge](https://synapseprotocol.com) to see if a route between a given pair exists.
+
+:::
+
+<Routes />

--- a/docs/bridge/docs/02-Bridge/index.md
+++ b/docs/bridge/docs/02-Bridge/index.md
@@ -7,7 +7,7 @@ import SVGBridge from '@site/src/components/SVGBridge'
 
 # Synapse Bridge
 
-The [Synapse Bridge](https://synapseprotocol.com) and [Solana Bridge](https://solana.synapseprotocol.com/) seamlessly swap on-chain assets between [20+ EVM and non-EVM blockchains](/docs/About/Routes) in a safe and secure manner.
+The [Synapse Bridge](https://synapseprotocol.com) and [Solana Bridge](https://solana.synapseprotocol.com/) seamlessly swap on-chain assets between [20+ EVM and non-EVM blockchains](/Routes) in a safe and secure manner.
 
 <br />
 

--- a/docs/bridge/docs/02-Bridge/index.md
+++ b/docs/bridge/docs/02-Bridge/index.md
@@ -7,7 +7,7 @@ import SVGBridge from '@site/src/components/SVGBridge'
 
 # Synapse Bridge
 
-The [Synapse Bridge](https://synapseprotocol.com) and [Solana Bridge](https://solana.synapseprotocol.com/) seamlessly swap on-chain assets between [20+ EVM and non-EVM blockchains](/Routes) in a safe and secure manner.
+The [Synapse Bridge](https://synapseprotocol.com) and [Solana Bridge](https://solana.synapseprotocol.com/) seamlessly swap on-chain assets between [20+ EVM and non-EVM blockchains](./Supported-Routes) in a safe and secure manner.
 
 <br />
 


### PR DESCRIPTION
Hides the `<Routes />` component until the Synapse `@constants` package is ready.

* `05-Supported-Routes.md` is a placeholde that directs users to the Synapse Bridge to see supported tokens, chains, and routes.
* `_05-Supported-Routes.md` uses `synapse-constants` to show supported tokens and chains inline, which can replace the placeholder when ready.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new documentation file detailing supported routes for the Synapse Bridge.
	- Added a sidebar label titled "Supported Routes" for easier navigation.

- **Documentation**
	- Removed outdated routes documentation.
	- Renamed "Example Code" to "Sample Code" for clarity.
	- Updated hyperlink references for improved URL structure.
	- Added a new markdown file with routing information and a `Routes` component for display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
8e3874ba689821d64894201f7814395b680da68d: [docs preview link ](https://bridge-docs-9aumlhpss-synapsecns.vercel.app)