### PR TITLE
respect prefers-color-scheme

### DIFF
--- a/docs/bridge/docusaurus.config.ts
+++ b/docs/bridge/docusaurus.config.ts
@@ -74,6 +74,9 @@ const config: Config = {
   ],
 
   themeConfig: {
+    colorMode: {
+      respectPrefersColorScheme: true,
+    },
     // Replace with your project's social card
     image: 'img/docusaurus-social-card.jpg',
     announcementBar: {


### PR DESCRIPTION
Config change to default browser preference for light or dark mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a color mode setting that respects user preferences for light and dark themes, enhancing the overall user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
8478df1f5299c891bb1b34cd6522532eecfee1ff: [docs preview link ](https://bridge-docs-k1cb5fjbm-synapsecns.vercel.app)