### PR TITLE
ci: add `contracts-core` to the ignored paths list

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,6 +17,7 @@
   "draftPR": true,
   "cloneSubmodules": true,
   "forkProcessing": "enabled",
+  "ignorePaths": ["packages/contracts-core/**"],
   "packageRules": [
     {
       "matchUpdateTypes": [


### PR DESCRIPTION
**Description**
Small edit to keep PRs like #3241 from popping up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated configuration to ignore specific paths in the Renovate settings, enhancing the update management process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->