### PR TITLE
fix(rest-api): Adds validSwap validation [SLT-321]

### DIFF
--- a/packages/rest-api/src/routes/swapRoute.ts
+++ b/packages/rest-api/src/routes/swapRoute.ts
@@ -169,7 +169,7 @@ router.get(
 
         return validSwap(chain, fromToken, toToken)
       })
-      .withMessage('Swap not supported'),
+      .withMessage('Swap not supported for given tokens'),
   ],
   showFirstValidationError,
   swapController

--- a/packages/rest-api/src/routes/swapRoute.ts
+++ b/packages/rest-api/src/routes/swapRoute.ts
@@ -8,6 +8,7 @@ import { isTokenAddress } from '../utils/isTokenAddress'
 import { isTokenSupportedOnChain } from '../utils/isTokenSupportedOnChain'
 import { checksumAddresses } from '../middleware/checksumAddresses'
 import { normalizeNativeTokenAddress } from '../middleware/normalizeNativeTokenAddress'
+import { validSwap } from '../validations/validSwap'
 
 const router = express.Router()
 
@@ -162,6 +163,13 @@ router.get(
       )
       .withMessage('Token not supported on specified chain'),
     check('amount').exists().withMessage('amount is required').isNumeric(),
+    check()
+      .custom((_value, { req }) => {
+        const { chain, fromToken, toToken } = req.query
+
+        return validSwap(chain, fromToken, toToken)
+      })
+      .withMessage('Swap not supported'),
   ],
   showFirstValidationError,
   swapController

--- a/packages/rest-api/src/tests/swapRoute.test.ts
+++ b/packages/rest-api/src/tests/swapRoute.test.ts
@@ -87,10 +87,7 @@ describe('Swap Route with Real Synapse Service', () => {
     })
 
     expect(response.status).toBe(400)
-    expect(response.body.error).toHaveProperty(
-      'message',
-      'Swap route not supported'
-    )
+    expect(response.body.error).toHaveProperty('message', 'Swap not supported')
   })
 
   it('should return 400 for token not supported on specified chain', async () => {

--- a/packages/rest-api/src/tests/swapRoute.test.ts
+++ b/packages/rest-api/src/tests/swapRoute.test.ts
@@ -87,7 +87,10 @@ describe('Swap Route with Real Synapse Service', () => {
     })
 
     expect(response.status).toBe(400)
-    expect(response.body.error).toHaveProperty('message', 'Swap not supported')
+    expect(response.body.error).toHaveProperty(
+      'message',
+      'Swap not supported for given tokens'
+    )
   })
 
   it('should return 400 for token not supported on specified chain', async () => {

--- a/packages/rest-api/src/tests/swapRoute.test.ts
+++ b/packages/rest-api/src/tests/swapRoute.test.ts
@@ -3,7 +3,7 @@ import express from 'express'
 
 import swapRoute from '../routes/swapRoute'
 import { NativeGasAddress, ZeroAddress } from '../constants'
-import { DAI, NETH, USDC } from '../constants/bridgeable'
+import { DAI, ETH, NETH, USDC } from '../constants/bridgeable'
 
 const app = express()
 app.use('/swap', swapRoute)
@@ -77,6 +77,21 @@ describe('Swap Route with Real Synapse Service', () => {
       'Invalid toToken address'
     )
   }, 10_000)
+
+  it('should return 400 for invalid fromToken + toToken combo', async () => {
+    const response = await request(app).get('/swap').query({
+      chain: '1',
+      fromToken: ETH.addresses[1],
+      toToken: USDC.addresses[1],
+      amount: '1000',
+    })
+
+    expect(response.status).toBe(400)
+    expect(response.body.error).toHaveProperty(
+      'message',
+      'Swap route not supported'
+    )
+  })
 
   it('should return 400 for token not supported on specified chain', async () => {
     const response = await request(app).get('/swap').query({

--- a/packages/rest-api/src/utils/tokenAddressToToken.ts
+++ b/packages/rest-api/src/utils/tokenAddressToToken.ts
@@ -16,5 +16,6 @@ export const tokenAddressToToken = (chain: string, tokenAddress: string) => {
     address: tokenAddress,
     symbol: tokenInfo.symbol,
     decimals: tokenInfo.decimals,
+    swappable: tokenInfo.swappable,
   }
 }

--- a/packages/rest-api/src/validations/validSwap.ts
+++ b/packages/rest-api/src/validations/validSwap.ts
@@ -1,0 +1,12 @@
+import { tokenAddressToToken } from '../utils/tokenAddressToToken'
+
+export const validSwap = (chain, fromToken, toToken) => {
+  const fromTokenInfo = tokenAddressToToken(chain.toString(), fromToken)
+  const toTokenInfo = tokenAddressToToken(chain.toString(), toToken)
+
+  if (!fromTokenInfo || !toTokenInfo) {
+    return false
+  }
+
+  return fromTokenInfo.swappable.includes(toToken)
+}

--- a/packages/rest-api/src/validations/validSwap.ts
+++ b/packages/rest-api/src/validations/validSwap.ts
@@ -1,6 +1,10 @@
 import { tokenAddressToToken } from '../utils/tokenAddressToToken'
 
-export const validSwap = (chain, fromToken, toToken) => {
+export const validSwap = (
+  chain: number | string,
+  fromToken: string,
+  toToken: string
+) => {
   const fromTokenInfo = tokenAddressToToken(chain.toString(), fromToken)
   const toTokenInfo = tokenAddressToToken(chain.toString(), toToken)
 


### PR DESCRIPTION
**Description**
When a user requests an invalid swap through the api, the response is a 500 instead of a 400 with error message. This adds a validation to the `swapRoute` to check tha the from and to token are swappable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a validation step for swap operations to ensure supported token swaps.
	- Added a new function to check if a swap between specified tokens is valid based on their swappability.

- **Bug Fixes**
	- Enhanced test coverage for invalid token swap scenarios, ensuring proper error handling.

- **Improvements**
	- Updated token information output to include swappability details, providing users with more comprehensive data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->