### PR TITLE
fix(contracts-rfq): add bridge/relay revert tests [SLT-322]

### DIFF
--- a/packages/contracts-rfq/contracts/FastBridgeV2.sol
+++ b/packages/contracts-rfq/contracts/FastBridgeV2.sol
@@ -340,10 +340,11 @@ contract FastBridgeV2 is Admin, IFastBridgeV2, IFastBridgeV2Errors {
     function _pullToken(address recipient, address token, uint256 amount) internal returns (uint256 amountPulled) {
         if (token != UniversalTokenLib.ETH_ADDRESS) {
             token.assertIsContract();
-            // Record token balance before transfer
-            amountPulled = IERC20(token).balanceOf(recipient);
             // Token needs to be pulled only if msg.value is zero
             // This way user can specify WETH as the origin asset
+            if (msg.value != 0) revert MsgValueIncorrect();
+            // Record token balance before transfer
+            amountPulled = IERC20(token).balanceOf(recipient);
             IERC20(token).safeTransferFrom(msg.sender, recipient, amount);
             // Use the difference between the recorded balance and the current balance as the amountPulled
             amountPulled = IERC20(token).balanceOf(recipient) - amountPulled;

--- a/packages/contracts-rfq/test/FastBridgeV2.Dst.t.sol
+++ b/packages/contracts-rfq/test/FastBridgeV2.Dst.t.sol
@@ -360,4 +360,38 @@ contract FastBridgeV2DstTest is FastBridgeV2DstBaseTest {
         vm.expectRevert(ZeroAddress.selector);
         relayWithAddress({caller: relayerA, relayer: address(0), msgValue: 0, bridgeTx: tokenTx});
     }
+
+    function test_relay_token_revert_approvedZero() public {
+        vm.prank(relayerA);
+        dstToken.approve(address(fastBridge), 0);
+        vm.expectRevert();
+        relay({caller: relayerA, msgValue: 0, bridgeTx: tokenTx});
+    }
+
+    function test_relay_token_revert_approvedNotEnough() public {
+        vm.prank(relayerA);
+        dstToken.approve(address(fastBridge), tokenParams.destAmount - 1);
+        vm.expectRevert();
+        relay({caller: relayerA, msgValue: 0, bridgeTx: tokenTx});
+    }
+
+    function test_relay_token_revert_nonZeroMsgValue() public {
+        vm.expectRevert();
+        relay({caller: relayerA, msgValue: tokenParams.destAmount, bridgeTx: tokenTx});
+    }
+
+    function test_relay_eth_revert_lowerMsgValue() public {
+        vm.expectRevert();
+        relay({caller: relayerA, msgValue: ethParams.destAmount - 1, bridgeTx: ethTx});
+    }
+
+    function test_relay_eth_revert_higherMsgValue() public {
+        vm.expectRevert();
+        relay({caller: relayerA, msgValue: ethParams.destAmount + 1, bridgeTx: ethTx});
+    }
+
+    function test_relay_eth_revert_zeroMsgValue() public {
+        vm.expectRevert();
+        relay({caller: relayerA, msgValue: 0, bridgeTx: ethTx});
+    }
 }

--- a/packages/contracts-rfq/test/FastBridgeV2.Src.t.sol
+++ b/packages/contracts-rfq/test/FastBridgeV2.Src.t.sol
@@ -177,6 +177,25 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         checkEthBalancesAfterBridge(userB);
     }
 
+    function test_bridge_token_revert_approvedZero() public {
+        vm.prank(userA);
+        srcToken.approve(address(fastBridge), 0);
+        vm.expectRevert();
+        bridge({caller: userA, msgValue: 0, params: tokenParams});
+    }
+
+    function test_bridge_token_revert_approvedNotEnough() public {
+        vm.prank(userA);
+        srcToken.approve(address(fastBridge), tokenParams.originAmount - 1);
+        vm.expectRevert();
+        bridge({caller: userA, msgValue: 0, params: tokenParams});
+    }
+
+    function test_bridge_token_revert_nonZeroMsgValue() public {
+        vm.expectRevert();
+        bridge({caller: userA, msgValue: tokenParams.originAmount, params: tokenParams});
+    }
+
     function test_bridge_eth_revert_lowerMsgValue() public {
         vm.expectRevert(MsgValueIncorrect.selector);
         bridge({caller: userA, msgValue: ethParams.originAmount - 1, params: ethParams});


### PR DESCRIPTION
**Description**
All of the following must end up in a revert to avoid stuck funds in the contract:

- Not approving the necessary amount of ERC20 for bridging (this was already passing)
- Supplying non-zero `msg.value` for bridging/relaying an ERC20 (this wasn't passing in e40195d22a6e1a1ae327a3eebdc6c6bcef9417fe and got fixed in e5a852fc0895e796fd5a2012c0d85d5ce97efc7e)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved error handling in the token transfer process to prevent unintended behavior with ETH and ERC20 tokens.
	- Enhanced testing coverage for the bridging functionality, including new test cases for token approval scenarios and message value conditions.

- **Bug Fixes**
	- Implemented checks to ensure the `bridge` function behaves correctly under specific conditions, preventing errors related to token approvals and message values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->