### PR TITLE
fix(solidity-devops): always add verifier options to `forge script`

### DIFF
--- a/packages/solidity-devops/js/forgeScriptRun.js
+++ b/packages/solidity-devops/js/forgeScriptRun.js
@@ -18,7 +18,7 @@ const { logInfo } = require('./utils/logger.js')
 const {
   parseCommandLineArgs,
   isBroadcasted,
-  addVerifyOptions,
+  addVerifyIfNotPresent,
   addOptions,
 } = require('./utils/options.js')
 const { assertCondition } = require('./utils/utils.js')
@@ -47,7 +47,7 @@ let forgeOptions = addOptions(
 forgeOptions = addOptions(forgeOptions, readChainSpecificOptions(chainName))
 forgeOptions = addOptions(forgeOptions, options)
 if (isBroadcast && isVerifierEnabled(chainName)) {
-  forgeOptions = addVerifyOptions(forgeOptions)
+  forgeOptions = addVerifyIfNotPresent(forgeOptions)
 }
 
 const currentTimestamp = Date.now()

--- a/packages/solidity-devops/js/forgeScriptRun.js
+++ b/packages/solidity-devops/js/forgeScriptRun.js
@@ -3,6 +3,7 @@ const fs = require('fs')
 
 const {
   readChainSpecificOptions,
+  readChainVerificationOptions,
   logWallet,
   isVerifierEnabled,
 } = require('./utils/chain.js')
@@ -47,6 +48,10 @@ let forgeOptions = addOptions(
 forgeOptions = addOptions(forgeOptions, readChainSpecificOptions(chainName))
 forgeOptions = addOptions(forgeOptions, options)
 if (isBroadcast && isVerifierEnabled(chainName)) {
+  forgeOptions = addOptions(
+    forgeOptions,
+    readChainVerificationOptions(chainName)
+  )
   forgeOptions = addVerifyIfNotPresent(forgeOptions)
 }
 

--- a/packages/solidity-devops/js/utils/options.js
+++ b/packages/solidity-devops/js/utils/options.js
@@ -28,7 +28,7 @@ const isBroadcasted = (options) => {
   return options.includes('--broadcast')
 }
 
-const addVerifyOptions = (options) => {
+const addVerifyIfNotPresent = (options) => {
   return options.includes('--verify') ? options : `${options} --verify`
 }
 
@@ -39,6 +39,6 @@ const addOptions = (options, newOptions) => {
 module.exports = {
   parseCommandLineArgs,
   isBroadcasted,
-  addVerifyOptions,
+  addVerifyIfNotPresent,
   addOptions,
 }

--- a/packages/solidity-devops/test/GasBenchmark.t.sol
+++ b/packages/solidity-devops/test/GasBenchmark.t.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.23;
+
+import {Test} from "forge-std/Test.sol";
+
+/// @notice No gas benchmark is required for solidity-devops
+contract GasBenchmarkTest is Test {
+    // solhint-disable-next-line no-empty-blocks
+    function testGasBenchmark() public {}
+}


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**
A clear and concise description of the features you're adding in this pull request.

**Additional context**
Add any other context about the problem you're solving.

**Metadata**
- Fixes #[Link to Issue]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of verification options during deployment.
	- Introduced a method to read chain verification options.
	- Added a new Solidity contract for gas benchmarking tests.

- **Bug Fixes**
	- Improved logic to ensure verification options are only added if not already present.

- **Refactor**
	- Renamed function for clarity in options handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->