### PR TITLE
ci: fix matrix exclude for solidity packages

### DIFF
--- a/.github/workflows/solidity.yml
+++ b/.github/workflows/solidity.yml
@@ -129,9 +129,9 @@ jobs:
       fail-fast: false
       matrix:
         package: ${{ fromJson(needs.changes.outputs.packages) }}
-        # Slither is irrelevant for solidity-devops, as it only contains devops scripts rather than deployed contracts
-        exclude:
-          - package: solidity-devops
+      # Slither is irrelevant for solidity-devops, as it only contains devops scripts rather than deployed contracts
+      exclude:
+        - package: solidity-devops
     permissions:
       # always required
       security-events: write
@@ -246,8 +246,8 @@ jobs:
       matrix:
         package: ${{ fromJson(needs.changes.outputs.packages) }}
         # Gas diff is irrelevant for solidity-devops, as it only contains devops scripts rather than deployed contracts
-        exclude:
-          - package: solidity-devops
+      exclude:
+        - package: solidity-devops
     steps:
       - uses: actions/checkout@v4
         with:
@@ -296,9 +296,9 @@ jobs:
       fail-fast: false
       matrix:
         package: ${{ fromJson(needs.changes.outputs.packages) }}
-        # Size check is irrelevant for solidity-devops, as it only contains devops scripts rather than deployed contracts
-        exclude:
-          - package: solidity-devops
+      # Size check is irrelevant for solidity-devops, as it only contains devops scripts rather than deployed contracts
+      exclude:
+        - package: solidity-devops
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/solidity.yml
+++ b/.github/workflows/solidity.yml
@@ -129,9 +129,9 @@ jobs:
       fail-fast: false
       matrix:
         package: ${{ fromJson(needs.changes.outputs.packages) }}
-      # Slither is irrelevant for solidity-devops, as it only contains devops scripts rather than deployed contracts
-      exclude:
-        - package: solidity-devops
+        # Slither is irrelevant for solidity-devops, as it only contains devops scripts rather than deployed contracts
+        exclude:
+          - package: solidity-devops
     permissions:
       # always required
       security-events: write
@@ -246,8 +246,8 @@ jobs:
       matrix:
         package: ${{ fromJson(needs.changes.outputs.packages) }}
         # Gas diff is irrelevant for solidity-devops, as it only contains devops scripts rather than deployed contracts
-      exclude:
-        - package: solidity-devops
+        exclude:
+          - package: solidity-devops
     steps:
       - uses: actions/checkout@v4
         with:
@@ -296,9 +296,9 @@ jobs:
       fail-fast: false
       matrix:
         package: ${{ fromJson(needs.changes.outputs.packages) }}
-      # Size check is irrelevant for solidity-devops, as it only contains devops scripts rather than deployed contracts
-      exclude:
-        - package: solidity-devops
+        # Size check is irrelevant for solidity-devops, as it only contains devops scripts rather than deployed contracts
+        exclude:
+          - package: solidity-devops
     steps:
       - uses: actions/checkout@v4
         with:

--- a/packages/contracts-core/test/GasBenchmark.t.sol
+++ b/packages/contracts-core/test/GasBenchmark.t.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {Test} from "forge-std/Test.sol";
+
+/// @notice No gas benchmark is required for contracts-core
+contract GasBenchmarkTest is Test {
+    // solhint-disable-next-line no-empty-blocks
+    function testGasBenchmark() public {}
+}

--- a/packages/solidity-devops/test/GasBenchmark.t.sol
+++ b/packages/solidity-devops/test/GasBenchmark.t.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {Test} from "forge-std/Test.sol";
+
+/// @notice No gas benchmark is required for solidity-devops
+contract GasBenchmarkTest is Test {
+    // solhint-disable-next-line no-empty-blocks
+    function testGasBenchmark() public {}
+}


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**
A clear and concise description of the features you're adding in this pull request.

**Additional context**
Add any other context about the problem you're solving.

**Metadata**
- Fixes #[Link to Issue]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced `GasBenchmarkTest` contracts in both `contracts-core` and `solidity-devops` packages for future gas benchmarking tests.
- **Documentation**
	- Added comments to clarify the exclusion of the `solidity-devops` package from specific jobs in the workflow configuration.
- **Chores**
	- Restructured the exclusion logic for improved clarity and consistency in the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->