### PR TITLE
Fixes title

### DIFF
--- a/packages/rest-api/src/swagger.ts
+++ b/packages/rest-api/src/swagger.ts
@@ -12,7 +12,7 @@ const options: swaggerJsdoc.Options = {
   definition: {
     openapi: '3.0.0',
     info: {
-      title: 'Syanpse Protocol REST API',
+      title: 'Synapse Protocol REST API',
       version: packageJson.version,
       description: 'API documentation for the Synapse Protocol REST API',
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected a typographical error in the Swagger documentation title from "Syanpse Protocol REST API" to "Synapse Protocol REST API."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->