### PR TITLE
feat(synapse-constants): adds preinstall step

### DIFF
--- a/docs/bridge/README.md
+++ b/docs/bridge/README.md
@@ -5,17 +5,18 @@ This website is built using [Docusaurus](https://docusaurus.io/), a modern stati
 ## Generating API Docs
 
 <!--TODO: needs to be done from ci to ensure regenration is done.-->
+
 `yarn docusaurus gen-api-docs all`.
 
 ### Installation
 
-```
+```bash
 $ yarn
 ```
 
 ### Local Development
 
-```
+```bash
 $ yarn start
 ```
 
@@ -23,8 +24,16 @@ This command starts a local development server and opens up a browser window. Mo
 
 ### Build
 
-```
+```bash
 $ yarn build
 ```
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.
+
+### Serve
+
+This step is needed to create a searchable index.
+
+```bash
+$ yarn serve
+```

--- a/packages/explorer-ui/README.md
+++ b/packages/explorer-ui/README.md
@@ -1,59 +1,18 @@
 # Explorer UI
 
 ## TODO:
- - add readme describing explorer ui
- - add integration tests
 
-# Getting Started with Create React App
+- add readme describing explorer ui
+- add integration tests
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+## To get started
 
-## Available Scripts
+run
 
-In the project directory, you can run:
+```bash
+yarn install
+```
 
-### `npm start`
-
-Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
-
-The page will reload when you make changes.\
-You may also see any lint errors in the console.
-
-### `npm test`
-
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
-
-### `npm run build`
-
-Builds the app for production to the `build` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
-
-The build is minified and the filenames include the hashes.\
-Your app is ready to be deployed!
-
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
-
-### `npm run eject`
-
-**Note: this is a one-way operation. Once you `eject`, you can't go back!**
-
-If you aren't satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
-
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you're on your own.
-
-You don't have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn't feel obligated to use this feature. However we understand that this tool wouldn't be useful if you couldn't customize it when you are ready for it.
-
-## Learn More
-
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
-
-To learn React, check out the [React documentation](https://reactjs.org/).
-
-### Code Splitting
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/code-splitting](https://facebook.github.io/create-react-app/docs/code-splitting)
-
-
-
+```bash
+yarn dev
+```

--- a/packages/synapse-constants/package.json
+++ b/packages/synapse-constants/package.json
@@ -27,7 +27,7 @@
     "lint:check": "eslint . --max-warnings=0 --config .eslintrc.cjs",
     "prepare": "rollup -c --bundleConfigAsCjs",
     "build": "rollup -c --bundleConfigAsCjs",
-    "preinstall": "yarn build",
+    "preinstall": "command -v rollup >/dev/null 2>&1 && rollup -c --buildConfigAsCjs || echo 'rollup not found'",
     "prepublish": "yarn build",
     "maps:generate": "node ./src/scripts/generateMaps.cjs && node ./src/scripts/findMissing.cjs && yarn build"
   },

--- a/packages/synapse-constants/package.json
+++ b/packages/synapse-constants/package.json
@@ -27,6 +27,7 @@
     "lint:check": "eslint . --max-warnings=0 --config .eslintrc.cjs",
     "prepare": "rollup -c --bundleConfigAsCjs",
     "build": "rollup -c --bundleConfigAsCjs",
+    "preinstall": "yarn build",
     "prepublish": "yarn build",
     "maps:generate": "node ./src/scripts/generateMaps.cjs && node ./src/scripts/findMissing.cjs && yarn build"
   },


### PR DESCRIPTION
**Description**
Adds preinstall step to avoid requiring local installation of `@synapsecns/synapse-constants`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the `README.md` for the Bridge project to enhance clarity on using Docusaurus for API documentation, including a new "Serve" section.
  - Revised the Explorer UI `README.md` to replace the Create React App section with a new "To get started" section.

- **Chores**
  - Added a pre-install script in the Synapse Constants package to ensure the build process runs before installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
6cd79f2f1e5ffb15d3d0418f3c7e2120d6ccb7cb: [docs preview link ](https://bridge-docs-oktrqm9ev-synapsecns.vercel.app)
6cd79f2f1e5ffb15d3d0418f3c7e2120d6ccb7cb: [explorer-ui preview link ](https://sanguine-bfxmjeq8m-synapsecns.vercel.app)