### PR TITLE
RFQ Indexer: adding search by origin tx

### DIFF
--- a/packages/rfq-indexer/api/src/controllers/transactionIdController.ts
+++ b/packages/rfq-indexer/api/src/controllers/transactionIdController.ts
@@ -10,7 +10,12 @@ export const getTransactionById = async (req: Request, res: Response) => {
   try {
     const query = db
       .with('deposits', () =>
-        qDeposits().where('transactionId', '=', transactionId as string)
+        qDeposits().where((eb) =>
+          eb.or([
+            eb('transactionId', '=', transactionId as string),
+            eb('transactionHash', '=', transactionId as string)
+          ])
+        )
       )
       .with('relays', () => qRelays())
       .with('proofs', () => qProofs({activeOnly: false})) // display proofs even if they have been invalidated/replaced by a dispute

--- a/packages/rfq-indexer/api/src/routes/transactionIdRoute.ts
+++ b/packages/rfq-indexer/api/src/routes/transactionIdRoute.ts
@@ -8,7 +8,7 @@ const router = express.Router()
  * @openapi
  * /transaction-id/{transactionId}:
  *   get:
- *     summary: Get transaction details by ID
+ *     summary: Get transaction details by ID or the origin transaction hash
  *     description: Retrieves detailed information about a transaction, including deposit, relay, proof, claim, and refund data if available
  *     parameters:
  *       - in: path
@@ -16,7 +16,7 @@ const router = express.Router()
  *         required: true
  *         schema:
  *           type: string
- *         description: The unique identifier of the transaction
+ *         description: The unique identifier of the transaction or the origin transaction hash
  *     responses:
  *       200:
  *         description: Successful response


### PR DESCRIPTION
Adding search by origin txn hash and not just transactionID. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced transaction retrieval to support both transaction ID and transaction hash.
- **Documentation**
	- Updated OpenAPI documentation to clarify the dual functionality of the `/transaction-id/{transactionId}` endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->