### PR TITLE
feat(promexporter): add pagination to dfk [SLT-332] 

### DIFF
--- a/contrib/promexporter/internal/gql/dfk/client.gen.go
+++ b/contrib/promexporter/internal/gql/dfk/client.gen.go
@@ -59,9 +59,10 @@ const StuckHeroesDocument = `query StuckHeroes ($skip: Int, $owner: String) {
 }
 `
 
-func (c *Client) StuckHeroes(ctx context.Context, skip *int64, owner *string, httpRequestOptions ...client.HTTPRequestOption) (*StuckHeroes, error) {
+func (c *Client) StuckHeroes(ctx context.Context, skip *int64, limit *int64, owner *string, httpRequestOptions ...client.HTTPRequestOption) (*StuckHeroes, error) {
 	vars := map[string]interface{}{
 		"skip":  skip,
+		"limit": limit,
 		"owner": owner,
 	}
 


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**
A clear and concise description of the features you're adding in this pull request.

**Additional context**
Add any other context about the problem you're solving.

**Metadata**
- Fixes #[Link to Issue]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced pagination for retrieving stuck heroes, allowing users to fetch results in increments of 100.
	- Added a parameter to specify the limit on results returned for stuck heroes.

- **Bug Fixes**
	- Improved data retrieval to ensure all relevant stuck hero data is captured effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->