### PR TITLE
fix dispute emit & revamp deposit xfer [SLT-295] [SLT-326]

### DIFF
--- a/packages/contracts-rfq/contracts/FastBridgeV2.sol
+++ b/packages/contracts-rfq/contracts/FastBridgeV2.sol
@@ -114,11 +114,13 @@ contract FastBridgeV2 is Admin, IFastBridgeV2, IFastBridgeV2Errors {
 
         // transfer origin collateral back to original sender
         uint256 amount = transaction.originAmount + transaction.originFeeAmount;
+        address to = transaction.originSender;
+        address token = transaction.originToken;
 
-        if (transaction.originToken == UniversalTokenLib.ETH_ADDRESS) {
-            Address.sendValue(payable(transaction.originSender), amount);
+        if (token == UniversalTokenLib.ETH_ADDRESS) {
+            Address.sendValue(payable(to), amount);
         } else {
-            IERC20(transaction.originToken).safeTransfer(transaction.originSender, amount);
+            IERC20(token).safeTransfer(to, amount);
         }
 
         emit BridgeDepositRefunded(transactionId, transaction.originSender, transaction.originToken, amount);
@@ -305,14 +307,16 @@ contract FastBridgeV2 is Admin, IFastBridgeV2, IFastBridgeV2Errors {
         // update protocol fees if origin fee amount exists
         if (transaction.originFeeAmount > 0) protocolFees[transaction.originToken] += transaction.originFeeAmount;
 
+        address token = transaction.originToken;
+        uint256 amount = transaction.originAmount;
+
         // transfer origin collateral to specified address (protocol fee was pre-deducted at deposit)
-        if (transaction.originToken == UniversalTokenLib.ETH_ADDRESS) {
-            Address.sendValue(payable(to), transaction.originAmount);
+        if (token == UniversalTokenLib.ETH_ADDRESS) {
+            Address.sendValue(payable(to), amount);
         } else {
-            IERC20(transaction.originToken).safeTransfer(to, transaction.originAmount);
+            IERC20(token).safeTransfer(to, amount);
         }
 
-        // solhint-disable-next-line max-line-length
         emit BridgeDepositClaimed(
             transactionId,
             bridgeTxDetails[transactionId].proofRelayer,

--- a/packages/contracts-rfq/contracts/FastBridgeV2.sol
+++ b/packages/contracts-rfq/contracts/FastBridgeV2.sol
@@ -82,13 +82,15 @@ contract FastBridgeV2 is Admin, IFastBridgeV2, IFastBridgeV2Errors {
             revert DisputePeriodPassed();
         }
 
+        address disputedRelayer = bridgeTxDetails[transactionId].proofRelayer;
+
         // @dev relayer gets slashed effectively if dest relay has gone thru
         bridgeTxDetails[transactionId].status = BridgeStatus.REQUESTED;
         bridgeTxDetails[transactionId].proofRelayer = address(0);
         bridgeTxDetails[transactionId].proofBlockTimestamp = 0;
         bridgeTxDetails[transactionId].proofBlockNumber = 0;
 
-        emit BridgeProofDisputed(transactionId, msg.sender);
+        emit BridgeProofDisputed(transactionId, disputedRelayer);
     }
 
     /// @inheritdoc IFastBridge
@@ -111,12 +113,15 @@ contract FastBridgeV2 is Admin, IFastBridgeV2, IFastBridgeV2Errors {
         bridgeTxDetails[transactionId].status = BridgeStatus.REFUNDED;
 
         // transfer origin collateral back to original sender
-        address to = transaction.originSender;
-        address token = transaction.originToken;
         uint256 amount = transaction.originAmount + transaction.originFeeAmount;
-        token.universalTransfer(to, amount);
 
-        emit BridgeDepositRefunded(transactionId, to, token, amount);
+        if (transaction.originToken == UniversalTokenLib.ETH_ADDRESS) {
+            Address.sendValue(payable(transaction.originSender), amount);
+        } else {
+            IERC20(transaction.originToken).safeTransfer(transaction.originSender, amount);
+        }
+
+        emit BridgeDepositRefunded(transactionId, transaction.originSender, transaction.originToken, amount);
     }
 
     /// @inheritdoc IFastBridge
@@ -166,8 +171,10 @@ contract FastBridgeV2 is Admin, IFastBridgeV2, IFastBridgeV2Errors {
 
         // track amount of origin token owed to protocol
         uint256 originFeeAmount;
-        if (protocolFeeRate > 0) originFeeAmount = (originAmount * protocolFeeRate) / FEE_BPS;
-        originAmount -= originFeeAmount; // remove from amount used in request as not relevant for relayers
+        if (protocolFeeRate > 0) {
+            originFeeAmount = (originAmount * protocolFeeRate) / FEE_BPS;
+            originAmount -= originFeeAmount; // remove from amount used in request as not relevant for relayers
+        }
 
         // set status to requested
         bytes memory request = abi.encode(
@@ -298,12 +305,21 @@ contract FastBridgeV2 is Admin, IFastBridgeV2, IFastBridgeV2Errors {
         // update protocol fees if origin fee amount exists
         if (transaction.originFeeAmount > 0) protocolFees[transaction.originToken] += transaction.originFeeAmount;
 
-        // transfer origin collateral less fee to specified address
-        address token = transaction.originToken;
-        uint256 amount = transaction.originAmount;
-        token.universalTransfer(to, amount);
+        // transfer origin collateral to specified address (protocol fee was pre-deducted at deposit)
+        if (transaction.originToken == UniversalTokenLib.ETH_ADDRESS) {
+            Address.sendValue(payable(to), transaction.originAmount);
+        } else {
+            IERC20(transaction.originToken).safeTransfer(to, transaction.originAmount);
+        }
 
-        emit BridgeDepositClaimed(transactionId, bridgeTxDetails[transactionId].proofRelayer, to, token, amount);
+        // solhint-disable-next-line max-line-length
+        emit BridgeDepositClaimed(
+            transactionId,
+            bridgeTxDetails[transactionId].proofRelayer,
+            to,
+            transaction.originToken,
+            transaction.originAmount
+        );
     }
 
     function bridgeStatuses(bytes32 transactionId) public view returns (BridgeStatus status) {

--- a/packages/contracts-rfq/test/FastBridgeV2.Src.t.sol
+++ b/packages/contracts-rfq/test/FastBridgeV2.Src.t.sol
@@ -74,10 +74,9 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         });
     }
 
-    function expectBridgeProofDisputed(bytes32 txId, address guard) public {
+    function expectBridgeProofDisputed(bytes32 txId, address relayer) public {
         vm.expectEmit(address(fastBridge));
-        // Note: BridgeProofDisputed event has a mislabeled address parameter, this is actually the guard
-        emit BridgeProofDisputed({transactionId: txId, relayer: guard});
+        emit BridgeProofDisputed({transactionId: txId, relayer: relayer});
     }
 
     function expectBridgeDepositRefunded(IFastBridge.BridgeParams memory bridgeParams, bytes32 txId) public {
@@ -384,11 +383,11 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         bridge({caller: userA, msgValue: ethParams.originAmount, params: ethParams});
         expectBridgeProofProvided({txId: txId, relayer: relayerA, destTxHash: hex"01"});
         prove({caller: relayerB, transactionId: txId, destTxHash: hex"01", relayer: relayerA});
-        expectBridgeProofDisputed(txId, guard);
+        expectBridgeProofDisputed(txId, relayerA);
         dispute(guard, txId);
         expectBridgeProofProvided({txId: txId, relayer: relayerA, destTxHash: hex"02"});
         prove({caller: relayerB, transactionId: txId, destTxHash: hex"02", relayer: relayerA});
-        expectBridgeProofDisputed(txId, guard);
+        expectBridgeProofDisputed(txId, relayerA);
         dispute(guard, txId);
         expectBridgeProofProvided({txId: txId, relayer: relayerA, destTxHash: hex"03"});
         prove({caller: relayerB, transactionId: txId, destTxHash: hex"03", relayer: relayerA});
@@ -660,7 +659,7 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         bytes32 txId = getTxId(tokenTx);
         bridge({caller: userA, msgValue: 0, params: tokenParams});
         prove({caller: relayerA, bridgeTx: tokenTx, destTxHash: hex"01"});
-        expectBridgeProofDisputed({txId: txId, guard: guard});
+        expectBridgeProofDisputed({txId: txId, relayer: relayerA});
         dispute({caller: guard, txId: txId});
         assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.REQUESTED);
         assertEq(fastBridge.protocolFees(address(srcToken)), INITIAL_PROTOCOL_FEES_TOKEN);
@@ -672,7 +671,7 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         bridge({caller: userA, msgValue: 0, params: tokenParams});
         prove({caller: relayerA, bridgeTx: tokenTx, destTxHash: hex"01"});
         skip(CLAIM_DELAY);
-        expectBridgeProofDisputed({txId: txId, guard: guard});
+        expectBridgeProofDisputed({txId: txId, relayer: relayerA});
         dispute({caller: guard, txId: txId});
         assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.REQUESTED);
         assertEq(fastBridge.protocolFees(address(srcToken)), INITIAL_PROTOCOL_FEES_TOKEN);
@@ -684,7 +683,7 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         bytes32 txId = getTxId(ethTx);
         bridge({caller: userA, msgValue: ethParams.originAmount, params: ethParams});
         prove({caller: relayerA, bridgeTx: ethTx, destTxHash: hex"01"});
-        expectBridgeProofDisputed({txId: txId, guard: guard});
+        expectBridgeProofDisputed({txId: txId, relayer: relayerA});
         dispute({caller: guard, txId: txId});
         assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.REQUESTED);
         assertEq(fastBridge.protocolFees(ETH_ADDRESS), INITIAL_PROTOCOL_FEES_ETH);
@@ -697,7 +696,7 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         bridge({caller: userA, msgValue: ethParams.originAmount, params: ethParams});
         prove({caller: relayerA, bridgeTx: ethTx, destTxHash: hex"01"});
         skip(CLAIM_DELAY);
-        expectBridgeProofDisputed({txId: txId, guard: guard});
+        expectBridgeProofDisputed({txId: txId, relayer: relayerA});
         dispute({caller: guard, txId: txId});
         assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.REQUESTED);
         assertEq(fastBridge.protocolFees(ETH_ADDRESS), INITIAL_PROTOCOL_FEES_ETH);


### PR DESCRIPTION
gas optimized claim/refund transfers -- no longer using universalTransfer


dispute (& respective tests) switched to emitting relayer (as was always indicated by the output param label), not guard address.


storage-read optimizations to come in a follow-up PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced dispute, refund, claim, and bridge functionalities for improved transaction management.
	- Implemented conditional logic for handling ETH and ERC20 token transfers.

- **Bug Fixes**
	- Improved error handling and checks throughout the contract to ensure correct behavior under various conditions.

- **Documentation**
	- Updated parameter names in function signatures for clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->