### PR TITLE
ci: disable Solidity workflows for PRs into `fe-release`

### DIFF
--- a/.github/workflows/solidity.yml
+++ b/.github/workflows/solidity.yml
@@ -7,6 +7,9 @@ on:
       - 'packages/contracts-rfq/**'
       - '.github/workflows/solidity.yml'
       - 'packages/solidity-devops/**'
+    branches:
+      # Solidity workflows are irrelevant for the FE release branch
+      - '!fe-release'
   push:
     paths:
       - 'packages/contracts-core/**'


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**
A clear and concise description of the features you're adding in this pull request.

**Additional context**
Add any other context about the problem you're solving.

**Metadata**
- Fixes #[Link to Issue]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated workflow configurations to enhance control over job executions based on branch and package modifications.
	- Introduced a branch exclusion rule for pull requests to prevent the `fe-release` branch from triggering specific workflows.
	- Refined conditions for running jobs related to `slither`, `gas-diff`, `coverage`, and `size-check`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->