### PR TITLE
fix(rest-api): `/destinationTokens` returns empty list when bridgeable token doesnt exist in bridge map

### DIFF
--- a/packages/rest-api/src/controllers/destinationTokensController.ts
+++ b/packages/rest-api/src/controllers/destinationTokensController.ts
@@ -10,28 +10,34 @@ export const destinationTokensController = async (req, res) => {
     return res.status(400).json({ errors: errors.array() })
   }
 
+  let payload
+
   try {
     const { fromChain, fromToken } = req.query
 
     const fromTokenInfo = tokenAddressToToken(fromChain.toString(), fromToken)
 
-    const constructedKey = `${fromTokenInfo.symbol}-${fromChain}`
+    if (!fromTokenInfo) {
+      payload = []
+    } else {
+      const constructedKey = `${fromTokenInfo.symbol}-${fromChain}`
 
-    const payload = BRIDGE_ROUTE_MAPPING[constructedKey]
+      payload = BRIDGE_ROUTE_MAPPING[constructedKey]
+    }
 
     logger.info(`Successful destinationTokensController response`, {
       query: req.query,
       payload,
     })
 
-    res.json(payload)
+    return res.json(payload)
   } catch (err) {
     logger.error(`Error in destinationTokensController`, {
       query: req.query,
       error: err.message,
       stack: err.stack,
     })
-    res.status(500).json({
+    return res.status(500).json({
       error:
         'An unexpected error occurred in /destinationTokens. Please try again later.',
     })

--- a/packages/rest-api/src/tests/destinationTokensRoute.test.ts
+++ b/packages/rest-api/src/tests/destinationTokensRoute.test.ts
@@ -3,7 +3,7 @@ import express from 'express'
 
 import destinationTokensRoute from '../routes/destinationTokensRoute'
 import { NativeGasAddress, ZeroAddress } from '../constants'
-import { USDC, USDT } from '../constants/bridgeable'
+import { ONEETH, USDC, USDT } from '../constants/bridgeable'
 
 const app = express()
 app.use('/destinationTokens', destinationTokensRoute)
@@ -79,6 +79,17 @@ describe('destinatonTokens Route', () => {
     expect(response.body[0]).toHaveProperty('symbol')
     expect(response.body[0]).toHaveProperty('address')
     expect(response.body[0]).toHaveProperty('chainId')
+  })
+
+  it('should return empty list if there are no destinations', async () => {
+    const response = await request(app).get('/destinationTokens').query({
+      fromChain: '1666600000',
+      fromToken: ONEETH.addresses[1666600000].toLowerCase(),
+    })
+
+    expect(response.status).toBe(200)
+    expect(Array.isArray(response.body)).toBe(true)
+    expect(response.body.length).toEqual(0)
   })
 
   it('should return 400 for unsupported fromChain', async () => {


### PR DESCRIPTION
**Description**
Not all `bridgeable` tokens exist in bridgemap, so this handles the case by returning an empty list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling and response logic in the destination tokens functionality.
	- Added a new test case to verify behavior when no destination tokens are available.

- **Bug Fixes**
	- Improved response consistency with explicit return statements in the error handling.

- **Tests**
	- Introduced a new test scenario for empty responses while maintaining existing test checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->