### PR TITLE
exclusivityEndtime default 0 [SLT-391]

### DIFF
--- a/packages/contracts-rfq/contracts/FastBridgeV2.sol
+++ b/packages/contracts-rfq/contracts/FastBridgeV2.sol
@@ -177,7 +177,7 @@ contract FastBridgeV2 is Admin, IFastBridgeV2, IFastBridgeV2Errors {
 
     /// @inheritdoc IFastBridgeV2
     function bridge(BridgeParams memory params, BridgeParamsV2 memory paramsV2) public payable {
-        int256 exclusivityEndTime = paramsV2.quoteExclusivitySeconds != 0
+        int256 exclusivityEndTime = paramsV2.quoteRelayer != address(0)
             ? int256(block.timestamp) + paramsV2.quoteExclusivitySeconds
             : int256(0);
         _validateBridgeParams(params, paramsV2, exclusivityEndTime);

--- a/packages/contracts-rfq/contracts/FastBridgeV2.sol
+++ b/packages/contracts-rfq/contracts/FastBridgeV2.sol
@@ -211,7 +211,7 @@ contract FastBridgeV2 is Admin, IFastBridgeV2, IFastBridgeV2Errors {
                 deadline: params.deadline,
                 nonce: senderNonces[params.sender]++, // increment nonce on every bridge
                 exclusivityRelayer: paramsV2.quoteRelayer,
-                // We checked exclusivityEndTime to be in range (0 .. params.deadline] above, so can safely cast
+                // We checked exclusivityEndTime to be in range (0 .. params.deadline) above, so can safely cast
                 exclusivityEndTime: uint256(exclusivityEndTime),
                 callValue: paramsV2.callValue,
                 callParams: paramsV2.callParams
@@ -448,7 +448,7 @@ contract FastBridgeV2 is Admin, IFastBridgeV2, IFastBridgeV2Errors {
         if (paramsV2.callValue != 0 && params.destToken == UniversalTokenLib.ETH_ADDRESS) {
             revert NativeTokenCallValueNotSupported();
         }
-        // exclusivityEndTime must be in range (0 .. params.deadline]
+        // exclusivityEndTime must be in range (0 .. params.deadline)
         if (exclusivityEndTime < 0 || exclusivityEndTime > int256(params.deadline)) {
             revert ExclusivityParamsIncorrect();
         }

--- a/packages/contracts-rfq/contracts/FastBridgeV2.sol
+++ b/packages/contracts-rfq/contracts/FastBridgeV2.sol
@@ -211,7 +211,7 @@ contract FastBridgeV2 is Admin, IFastBridgeV2, IFastBridgeV2Errors {
                 deadline: params.deadline,
                 nonce: senderNonces[params.sender]++, // increment nonce on every bridge
                 exclusivityRelayer: paramsV2.quoteRelayer,
-                // We checked exclusivityEndTime to be in range (0 .. params.deadline) above, so can safely cast
+                // We checked exclusivityEndTime to be in range [0 .. params.deadline] above, so can safely cast
                 exclusivityEndTime: uint256(exclusivityEndTime),
                 callValue: paramsV2.callValue,
                 callParams: paramsV2.callParams
@@ -448,7 +448,7 @@ contract FastBridgeV2 is Admin, IFastBridgeV2, IFastBridgeV2Errors {
         if (paramsV2.callValue != 0 && params.destToken == UniversalTokenLib.ETH_ADDRESS) {
             revert NativeTokenCallValueNotSupported();
         }
-        // exclusivityEndTime must be in range (0 .. params.deadline)
+        // exclusivityEndTime must be in range [0 .. params.deadline]
         if (exclusivityEndTime < 0 || exclusivityEndTime > int256(params.deadline)) {
             revert ExclusivityParamsIncorrect();
         }

--- a/packages/contracts-rfq/contracts/FastBridgeV2.sol
+++ b/packages/contracts-rfq/contracts/FastBridgeV2.sol
@@ -177,7 +177,9 @@ contract FastBridgeV2 is Admin, IFastBridgeV2, IFastBridgeV2Errors {
 
     /// @inheritdoc IFastBridgeV2
     function bridge(BridgeParams memory params, BridgeParamsV2 memory paramsV2) public payable {
-        int256 exclusivityEndTime = int256(block.timestamp) + paramsV2.quoteExclusivitySeconds;
+        int256 exclusivityEndTime = paramsV2.quoteExclusivitySeconds != 0
+            ? int256(block.timestamp) + paramsV2.quoteExclusivitySeconds
+            : int256(0);
         _validateBridgeParams(params, paramsV2, exclusivityEndTime);
 
         // transfer tokens to bridge contract
@@ -444,7 +446,7 @@ contract FastBridgeV2 is Admin, IFastBridgeV2, IFastBridgeV2Errors {
             revert NativeTokenCallValueNotSupported();
         }
         // exclusivityEndTime must be in range (0 .. params.deadline]
-        if (exclusivityEndTime <= 0 || exclusivityEndTime > int256(params.deadline)) {
+        if (exclusivityEndTime < 0 || exclusivityEndTime > int256(params.deadline)) {
             revert ExclusivityParamsIncorrect();
         }
     }

--- a/packages/contracts-rfq/contracts/FastBridgeV2.sol
+++ b/packages/contracts-rfq/contracts/FastBridgeV2.sol
@@ -177,10 +177,12 @@ contract FastBridgeV2 is Admin, IFastBridgeV2, IFastBridgeV2Errors {
 
     /// @inheritdoc IFastBridgeV2
     function bridge(BridgeParams memory params, BridgeParamsV2 memory paramsV2) public payable {
-        int256 exclusivityEndTime = paramsV2.quoteRelayer != address(0)
-            // prettier-ignore
-            ? int256(block.timestamp) + paramsV2.quoteExclusivitySeconds
-            : int256(0);
+        int256 exclusivityEndTime = 0;
+        // if relayer exclusivity is not intended for this bridge, set exclusivityEndTime to static zero
+        // otherwise, set exclusivity to expire at the current block ts offset by quoteExclusivitySeconds
+        if (paramsV2.quoteRelayer != address(0)) {
+            exclusivityEndTime = int256(block.timestamp) + paramsV2.quoteExclusivitySeconds;
+        }
         _validateBridgeParams(params, paramsV2, exclusivityEndTime);
 
         // transfer tokens to bridge contract

--- a/packages/contracts-rfq/contracts/FastBridgeV2.sol
+++ b/packages/contracts-rfq/contracts/FastBridgeV2.sol
@@ -178,6 +178,7 @@ contract FastBridgeV2 is Admin, IFastBridgeV2, IFastBridgeV2Errors {
     /// @inheritdoc IFastBridgeV2
     function bridge(BridgeParams memory params, BridgeParamsV2 memory paramsV2) public payable {
         int256 exclusivityEndTime = paramsV2.quoteRelayer != address(0)
+            // prettier-ignore
             ? int256(block.timestamp) + paramsV2.quoteExclusivitySeconds
             : int256(0);
         _validateBridgeParams(params, paramsV2, exclusivityEndTime);

--- a/packages/contracts-rfq/test/FastBridgeV2.GasBench.Src.t.sol
+++ b/packages/contracts-rfq/test/FastBridgeV2.GasBench.Src.t.sol
@@ -48,17 +48,6 @@ contract FastBridgeV2GasBenchmarkSrcTest is FastBridgeV2SrcBaseTest {
         ethTx.nonce = 5;
     }
 
-    function createFixturesV2() public virtual override {
-        super.createFixturesV2();
-        bridgedTokenTx.exclusivityEndTime = 0;
-        provenTokenTx.exclusivityEndTime = 0;
-        bridgedEthTx.exclusivityEndTime = 0;
-        provenEthTx.exclusivityEndTime = 0;
-        // Actual tx will be submitted one block later
-        tokenTx.exclusivityEndTime = 0;
-        ethTx.exclusivityEndTime = 0;
-    }
-
     function mintTokens() public virtual override {
         super.mintTokens();
         srcToken.mint(relayerA, INITIAL_RELAYER_BALANCE);

--- a/packages/contracts-rfq/test/FastBridgeV2.GasBench.Src.t.sol
+++ b/packages/contracts-rfq/test/FastBridgeV2.GasBench.Src.t.sol
@@ -50,13 +50,13 @@ contract FastBridgeV2GasBenchmarkSrcTest is FastBridgeV2SrcBaseTest {
 
     function createFixturesV2() public virtual override {
         super.createFixturesV2();
-        bridgedTokenTx.exclusivityEndTime = block.timestamp;
-        provenTokenTx.exclusivityEndTime = block.timestamp;
-        bridgedEthTx.exclusivityEndTime = block.timestamp;
-        provenEthTx.exclusivityEndTime = block.timestamp;
+        bridgedTokenTx.exclusivityEndTime = 0;
+        provenTokenTx.exclusivityEndTime = 0;
+        bridgedEthTx.exclusivityEndTime = 0;
+        provenEthTx.exclusivityEndTime = 0;
         // Actual tx will be submitted one block later
-        tokenTx.exclusivityEndTime = block.timestamp + BLOCK_TIME;
-        ethTx.exclusivityEndTime = block.timestamp + BLOCK_TIME;
+        tokenTx.exclusivityEndTime = 0;
+        ethTx.exclusivityEndTime = 0;
     }
 
     function mintTokens() public virtual override {

--- a/packages/contracts-rfq/test/FastBridgeV2.Src.Exclusivity.Negative.t.sol
+++ b/packages/contracts-rfq/test/FastBridgeV2.Src.Exclusivity.Negative.t.sol
@@ -23,9 +23,8 @@ contract FastBridgeV2SrcExclusivityNegativeTest is FastBridgeV2SrcTest {
         bridge(caller, msgValue, params, paramsV2);
     }
 
-    function test_bridge_revert_exclusivityEndTimeZero() public {
+    function test_bridge_exclusivityEndTimeZero() public {
         tokenParamsV2.quoteExclusivitySeconds = -int256(block.timestamp);
-        vm.expectRevert(ExclusivityParamsIncorrect.selector);
         bridge({caller: userA, msgValue: 0, params: tokenParams, paramsV2: tokenParamsV2});
     }
 
@@ -35,9 +34,8 @@ contract FastBridgeV2SrcExclusivityNegativeTest is FastBridgeV2SrcTest {
         bridge({caller: userA, msgValue: 0, params: tokenParams, paramsV2: tokenParamsV2});
     }
 
-    function test_bridge_eth_revert_exclusivityEndTimeZero() public {
+    function test_bridge_eth_exclusivityEndTimeZero() public {
         ethParamsV2.quoteExclusivitySeconds = -int256(block.timestamp);
-        vm.expectRevert(ExclusivityParamsIncorrect.selector);
         bridge({caller: userA, msgValue: ethParams.originAmount, params: ethParams, paramsV2: ethParamsV2});
     }
 

--- a/packages/contracts-rfq/test/FastBridgeV2.t.sol
+++ b/packages/contracts-rfq/test/FastBridgeV2.t.sol
@@ -173,9 +173,9 @@ abstract contract FastBridgeV2Test is Test, IFastBridgeV2Errors {
         });
 
         tokenTx.exclusivityRelayer = address(0);
-        tokenTx.exclusivityEndTime = block.timestamp;
+        tokenTx.exclusivityEndTime = 0;
         ethTx.exclusivityRelayer = address(0);
-        ethTx.exclusivityEndTime = block.timestamp;
+        ethTx.exclusivityEndTime = 0;
     }
 
     function setStorageBridgeTxV2(


### PR DESCRIPTION
Previously if bridge was not intended to be exclusive it would still end up with exclusivityEndtime = block.timestamp as a default from excl offset being 0.

This is generally fine & efficient, except it adds reorg risk to even non-exclusive relays whereby the bridge params are dependent upon block.timestamp and will change if reorged into a different block.

This approach will instead pay slightly more gas to default to a static exclusivityEndtime value (0) if no exclusivity is intended - inferred by quoteRelayer being address 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of bridge transaction exclusivity with updated conditions for `exclusivityEndTime`.

- **Bug Fixes**
	- Improved validation logic for exclusivity parameters during bridge transactions.

- **Tests**
	- Refined test function names for clarity regarding exclusivity checks.
	- Adjusted handling of exclusivity end times in gas benchmarking tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->