### PR TITLE
sleep cmd

### DIFF
--- a/services/rfq/relayer/cmd/cmd.go
+++ b/services/rfq/relayer/cmd/cmd.go
@@ -23,7 +23,7 @@ func Start(args []string, buildInfo config.BuildInfo) {
 	}
 
 	// commands
-	app.Commands = cli.Commands{runCommand, withdrawCommand}
+	app.Commands = cli.Commands{runCommand, withdrawCommand, sleepCommand}
 	shellCommand := commandline.GenerateShellCommand(app.Commands)
 	app.Commands = append(app.Commands, shellCommand)
 	app.Action = shellCommand.Action

--- a/services/rfq/relayer/cmd/commands.go
+++ b/services/rfq/relayer/cmd/commands.go
@@ -53,6 +53,17 @@ var runCommand = &cli.Command{
 	},
 }
 
+// runCommand runs the rfq relayer.
+var sleepCommand = &cli.Command{
+	Name:        "sleep",
+	Description: "run the relayer",
+	Flags:       []cli.Flag{configFlag, &commandline.LogLevel},
+	Action: func(c *cli.Context) (err error) {
+		time.Sleep(time.Hour)
+		return nil
+	},
+}
+
 var relayerURLFlag = &cli.StringFlag{
 	Name:  "relayer-url",
 	Usage: "relayer url",


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**

one off for db migration


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new command, `sleepCommand`, to the command-line interface of the RFQ relayer service, allowing users to pause execution for one hour.
- **Bug Fixes**
	- No bug fixes were made in this release.
- **Documentation**
	- Updated documentation to reflect the addition of the `sleepCommand`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->