### PR TITLE
Widget Config Change [SLT-399]

### DIFF
--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -46,6 +46,7 @@
     "react-dom": ">=17.0.1"
   },
   "devDependencies": {
+    "@codecov/rollup-plugin": "^0.0.1-beta.10",
     "@rollup/plugin-commonjs": "^25.0.7",
     "@rollup/plugin-json": "^6.0.1",
     "@rollup/plugin-node-resolve": "^15.2.3",
@@ -64,7 +65,6 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "@codecov/rollup-plugin": "^0.0.1-beta.10",
     "@ethersproject/providers": "^5.7.2",
     "@ethersproject/units": "^5.7.0",
     "@reduxjs/toolkit": "^2.0.1",


### PR DESCRIPTION
Moves the codecov/rollup-plugin to dev dependencies to prevent unnecessary package bloat.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated development dependencies for improved code coverage reporting.
	- Shifted `@codecov/rollup-plugin` from runtime to development-only dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->