### PR TITLE
feat(contracts-rfq): save destination chain ID for requested bridges [SLT-423]

### DIFF
--- a/packages/contracts-rfq/contracts/FastBridgeV2.sol
+++ b/packages/contracts-rfq/contracts/FastBridgeV2.sol
@@ -89,7 +89,7 @@ contract FastBridgeV2 is Admin, MulticallTarget, IFastBridgeV2, IFastBridgeV2Err
         // Aggregate the read operations from the same storage slot
         address disputedRelayer = $.proofRelayer;
         BridgeStatus status = $.status;
-        uint40 proofBlockTimestamp = $.proofBlockTimestamp;
+        uint56 proofBlockTimestamp = $.proofBlockTimestamp;
         // Can only dispute a RELAYER_PROVED transaction within the dispute period
         if (status != BridgeStatus.RELAYER_PROVED) revert StatusIncorrect();
         if (_timeSince(proofBlockTimestamp) > DISPUTE_PERIOD) {
@@ -314,7 +314,7 @@ contract FastBridgeV2 is Admin, MulticallTarget, IFastBridgeV2, IFastBridgeV2Err
         // Update status to RELAYER_PROVED and store the proof details
         // Note: these are storage writes
         $.status = BridgeStatus.RELAYER_PROVED;
-        $.proofBlockTimestamp = uint40(block.timestamp);
+        $.proofBlockTimestamp = uint56(block.timestamp);
         $.proofRelayer = relayer;
 
         emit BridgeProofProvided(transactionId, relayer, destTxHash);
@@ -328,7 +328,7 @@ contract FastBridgeV2 is Admin, MulticallTarget, IFastBridgeV2, IFastBridgeV2Err
         // Aggregate the read operations from the same storage slot
         address proofRelayer = $.proofRelayer;
         BridgeStatus status = $.status;
-        uint40 proofBlockTimestamp = $.proofBlockTimestamp;
+        uint56 proofBlockTimestamp = $.proofBlockTimestamp;
 
         // Can only claim a RELAYER_PROVED transaction after the dispute period
         if (status != BridgeStatus.RELAYER_PROVED) revert StatusIncorrect();
@@ -425,14 +425,14 @@ contract FastBridgeV2 is Admin, MulticallTarget, IFastBridgeV2, IFastBridgeV2Err
     }
 
     /// @notice Calculates time since proof submitted
-    /// @dev proof.timestamp stores casted uint40(block.timestamp) block timestamps for gas optimization
-    ///      _timeSince(proof) can accomodate rollover case when block.timestamp > type(uint40).max but
-    ///      proof.timestamp < type(uint40).max via unchecked statement
+    /// @dev proof.timestamp stores casted uint56(block.timestamp) block timestamps for gas optimization
+    ///      _timeSince(proof) can accomodate rollover case when block.timestamp > type(uint56).max but
+    ///      proof.timestamp < type(uint56).max via unchecked statement
     /// @param proofBlockTimestamp The bridge proof block timestamp
     /// @return delta Time delta since proof submitted
-    function _timeSince(uint40 proofBlockTimestamp) internal view returns (uint256 delta) {
+    function _timeSince(uint56 proofBlockTimestamp) internal view returns (uint256 delta) {
         unchecked {
-            delta = uint40(block.timestamp) - proofBlockTimestamp;
+            delta = uint56(block.timestamp) - proofBlockTimestamp;
         }
     }
 

--- a/packages/contracts-rfq/contracts/FastBridgeV2.sol
+++ b/packages/contracts-rfq/contracts/FastBridgeV2.sol
@@ -220,7 +220,9 @@ contract FastBridgeV2 is Admin, MulticallTarget, IFastBridgeV2, IFastBridgeV2Err
             })
         );
         bytes32 transactionId = keccak256(request);
+        // Note: the tx status will be updated throughout the tx lifecycle, while destChainId is set once here
         bridgeTxDetails[transactionId].status = BridgeStatus.REQUESTED;
+        bridgeTxDetails[transactionId].destChainId = params.dstChainId;
 
         emit BridgeRequested({
             transactionId: transactionId,

--- a/packages/contracts-rfq/contracts/FastBridgeV2.sol
+++ b/packages/contracts-rfq/contracts/FastBridgeV2.sol
@@ -100,7 +100,6 @@ contract FastBridgeV2 is Admin, MulticallTarget, IFastBridgeV2, IFastBridgeV2Err
         $.status = BridgeStatus.REQUESTED;
         $.proofRelayer = address(0);
         $.proofBlockTimestamp = 0;
-        $.proofBlockNumber = 0;
 
         emit BridgeProofDisputed(transactionId, disputedRelayer);
     }
@@ -314,7 +313,6 @@ contract FastBridgeV2 is Admin, MulticallTarget, IFastBridgeV2, IFastBridgeV2Err
         // Note: these are storage writes
         $.status = BridgeStatus.RELAYER_PROVED;
         $.proofBlockTimestamp = uint40(block.timestamp);
-        $.proofBlockNumber = uint48(block.number);
         $.proofRelayer = relayer;
 
         emit BridgeProofProvided(transactionId, relayer, destTxHash);

--- a/packages/contracts-rfq/contracts/interfaces/IFastBridgeV2.sol
+++ b/packages/contracts-rfq/contracts/interfaces/IFastBridgeV2.sol
@@ -15,7 +15,7 @@ interface IFastBridgeV2 is IFastBridge {
     struct BridgeTxDetails {
         BridgeStatus status;
         uint32 destChainId;
-        uint40 proofBlockTimestamp;
+        uint56 proofBlockTimestamp;
         address proofRelayer;
     }
 

--- a/packages/contracts-rfq/contracts/interfaces/IFastBridgeV2.sol
+++ b/packages/contracts-rfq/contracts/interfaces/IFastBridgeV2.sol
@@ -14,6 +14,7 @@ interface IFastBridgeV2 is IFastBridge {
 
     struct BridgeTxDetails {
         BridgeStatus status;
+        uint32 destChainId;
         uint40 proofBlockTimestamp;
         address proofRelayer;
     }

--- a/packages/contracts-rfq/contracts/interfaces/IFastBridgeV2.sol
+++ b/packages/contracts-rfq/contracts/interfaces/IFastBridgeV2.sol
@@ -15,7 +15,6 @@ interface IFastBridgeV2 is IFastBridge {
     struct BridgeTxDetails {
         BridgeStatus status;
         uint40 proofBlockTimestamp;
-        uint48 proofBlockNumber;
         address proofRelayer;
     }
 

--- a/packages/contracts-rfq/test/FastBridgeV2.Src.t.sol
+++ b/packages/contracts-rfq/test/FastBridgeV2.Src.t.sol
@@ -96,9 +96,10 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
 
     function checkStatusAndProofAfterBridge(bytes32 txId) public view {
         assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.REQUESTED);
-        (IFastBridgeV2.BridgeStatus status, uint256 proofBlockTimestamp, address proofRelayer) =
+        (IFastBridgeV2.BridgeStatus status, uint32 destChainId, uint256 proofBlockTimestamp, address proofRelayer) =
             fastBridge.bridgeTxDetails(txId);
         assertEq(status, IFastBridgeV2.BridgeStatus.REQUESTED);
+        assertEq(destChainId, DST_CHAIN_ID);
         assertEq(proofBlockTimestamp, 0);
         assertEq(proofRelayer, address(0));
         (proofBlockTimestamp, proofRelayer) = fastBridge.bridgeProofs(txId);
@@ -283,9 +284,10 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
 
     function checkStatusAndProofAfterProve(bytes32 txId, address relayer) public view {
         assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.RELAYER_PROVED);
-        (IFastBridgeV2.BridgeStatus status, uint256 proofBlockTimestamp, address proofRelayer) =
+        (IFastBridgeV2.BridgeStatus status, uint32 destChainId, uint256 proofBlockTimestamp, address proofRelayer) =
             fastBridge.bridgeTxDetails(txId);
         assertEq(status, IFastBridgeV2.BridgeStatus.RELAYER_PROVED);
+        assertEq(destChainId, DST_CHAIN_ID);
         assertEq(proofBlockTimestamp, block.timestamp);
         assertEq(proofRelayer, relayer);
         (proofBlockTimestamp, proofRelayer) = fastBridge.bridgeProofs(txId);
@@ -470,9 +472,10 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
 
     function checkStatusAndProofAfterClaim(bytes32 txId, address relayer, uint256 expectedProofTS) public view {
         assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.RELAYER_CLAIMED);
-        (IFastBridgeV2.BridgeStatus status, uint256 proofBlockTimestamp, address proofRelayer) =
+        (IFastBridgeV2.BridgeStatus status, uint32 destChainId, uint256 proofBlockTimestamp, address proofRelayer) =
             fastBridge.bridgeTxDetails(txId);
         assertEq(status, IFastBridgeV2.BridgeStatus.RELAYER_CLAIMED);
+        assertEq(destChainId, DST_CHAIN_ID);
         assertEq(proofBlockTimestamp, expectedProofTS);
         assertEq(proofRelayer, relayer);
         (proofBlockTimestamp, proofRelayer) = fastBridge.bridgeProofs(txId);
@@ -803,9 +806,10 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
 
     function checkStatusAndProofAfterRefund(bytes32 txId) public view {
         assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.REFUNDED);
-        (IFastBridgeV2.BridgeStatus status, uint256 proofBlockTimestamp, address proofRelayer) =
+        (IFastBridgeV2.BridgeStatus status, uint32 destChainId, uint256 proofBlockTimestamp, address proofRelayer) =
             fastBridge.bridgeTxDetails(txId);
         assertEq(status, IFastBridgeV2.BridgeStatus.REFUNDED);
+        assertEq(destChainId, DST_CHAIN_ID);
         assertEq(proofBlockTimestamp, 0);
         assertEq(proofRelayer, address(0));
         (proofBlockTimestamp, proofRelayer) = fastBridge.bridgeProofs(txId);

--- a/packages/contracts-rfq/test/FastBridgeV2.Src.t.sol
+++ b/packages/contracts-rfq/test/FastBridgeV2.Src.t.sol
@@ -94,6 +94,18 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
 
     // ══════════════════════════════════════════════════ BRIDGE ═══════════════════════════════════════════════════════
 
+    function checkStatusAndProofAfterBridge(bytes32 txId) public view {
+        assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.REQUESTED);
+        (IFastBridgeV2.BridgeStatus status, uint256 proofBlockTimestamp, address proofRelayer) =
+            fastBridge.bridgeTxDetails(txId);
+        assertEq(status, IFastBridgeV2.BridgeStatus.REQUESTED);
+        assertEq(proofBlockTimestamp, 0);
+        assertEq(proofRelayer, address(0));
+        (proofBlockTimestamp, proofRelayer) = fastBridge.bridgeProofs(txId);
+        assertEq(proofBlockTimestamp, 0);
+        assertEq(proofRelayer, address(0));
+    }
+
     function checkTokenBalancesAfterBridge(address caller) public view {
         assertEq(fastBridge.protocolFees(address(srcToken)), INITIAL_PROTOCOL_FEES_TOKEN);
         assertEq(srcToken.balanceOf(caller), LEFTOVER_BALANCE);
@@ -107,7 +119,7 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         bridge({caller: userA, msgValue: 0, params: tokenParams});
         assertEq(fastBridge.senderNonces(userA), 1);
         assertEq(fastBridge.senderNonces(userB), 0);
-        assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.REQUESTED);
+        checkStatusAndProofAfterBridge(txId);
         checkTokenBalancesAfterBridge(userA);
     }
 
@@ -118,7 +130,7 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         bridge({caller: userB, msgValue: 0, params: tokenParams});
         assertEq(fastBridge.senderNonces(userA), 1);
         assertEq(fastBridge.senderNonces(userB), 0);
-        assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.REQUESTED);
+        checkStatusAndProofAfterBridge(txId);
         assertEq(srcToken.balanceOf(userA), LEFTOVER_BALANCE + tokenParams.originAmount);
         checkTokenBalancesAfterBridge(userB);
     }
@@ -140,7 +152,7 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         bridge({caller: userA, msgValue: ethParams.originAmount, params: ethParams});
         assertEq(fastBridge.senderNonces(userA), 2);
         assertEq(fastBridge.senderNonces(userB), 0);
-        assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.REQUESTED);
+        checkStatusAndProofAfterBridge(txId);
         checkEthBalancesAfterBridge(userA);
     }
 
@@ -156,7 +168,7 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         bridge({caller: userB, msgValue: ethParams.originAmount, params: ethParams});
         assertEq(fastBridge.senderNonces(userA), 2);
         assertEq(fastBridge.senderNonces(userB), 0);
-        assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.REQUESTED);
+        checkStatusAndProofAfterBridge(txId);
         assertEq(userA.balance, LEFTOVER_BALANCE + ethParams.originAmount);
         checkEthBalancesAfterBridge(userB);
     }
@@ -175,7 +187,7 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         bridge({caller: userB, msgValue: ethParams.originAmount, params: ethParams});
         assertEq(fastBridge.senderNonces(userA), 1);
         assertEq(fastBridge.senderNonces(userB), 1);
-        assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.REQUESTED);
+        checkStatusAndProofAfterBridge(txId);
         checkEthBalancesAfterBridge(userB);
     }
 
@@ -269,14 +281,24 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
 
     // ═══════════════════════════════════════════════════ PROVE ═══════════════════════════════════════════════════════
 
+    function checkStatusAndProofAfterProve(bytes32 txId, address relayer) public view {
+        assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.RELAYER_PROVED);
+        (IFastBridgeV2.BridgeStatus status, uint256 proofBlockTimestamp, address proofRelayer) =
+            fastBridge.bridgeTxDetails(txId);
+        assertEq(status, IFastBridgeV2.BridgeStatus.RELAYER_PROVED);
+        assertEq(proofBlockTimestamp, block.timestamp);
+        assertEq(proofRelayer, relayer);
+        (proofBlockTimestamp, proofRelayer) = fastBridge.bridgeProofs(txId);
+        assertEq(proofBlockTimestamp, block.timestamp);
+        assertEq(proofRelayer, relayer);
+    }
+
     function test_prove_token() public {
         bytes32 txId = getTxId(tokenTx);
         bridge({caller: userA, msgValue: 0, params: tokenParams});
         expectBridgeProofProvided({txId: txId, relayer: relayerA, destTxHash: hex"01"});
         prove({caller: relayerA, bridgeTx: tokenTx, destTxHash: hex"01"});
-        (uint96 timestamp, address relayer) = fastBridge.bridgeProofs(txId);
-        assertEq(timestamp, block.timestamp);
-        assertEq(relayer, relayerA);
+        checkStatusAndProofAfterProve(txId, relayerA);
         assertEq(srcToken.balanceOf(address(fastBridge)), INITIAL_PROTOCOL_FEES_TOKEN + tokenParams.originAmount);
         assertEq(fastBridge.protocolFees(address(srcToken)), INITIAL_PROTOCOL_FEES_TOKEN);
     }
@@ -288,9 +310,7 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         bridge({caller: userA, msgValue: ethParams.originAmount, params: ethParams});
         expectBridgeProofProvided({txId: txId, relayer: relayerA, destTxHash: hex"01"});
         prove({caller: relayerA, bridgeTx: ethTx, destTxHash: hex"01"});
-        (uint96 timestamp, address relayer) = fastBridge.bridgeProofs(txId);
-        assertEq(timestamp, block.timestamp);
-        assertEq(relayer, relayerA);
+        checkStatusAndProofAfterProve(txId, relayerA);
         assertEq(address(fastBridge).balance, INITIAL_PROTOCOL_FEES_ETH + ethParams.originAmount);
         assertEq(fastBridge.protocolFees(ETH_ADDRESS), INITIAL_PROTOCOL_FEES_ETH);
     }
@@ -338,9 +358,7 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         bridge({caller: userA, msgValue: 0, params: tokenParams});
         expectBridgeProofProvided({txId: txId, relayer: relayerA, destTxHash: hex"01"});
         prove({caller: relayerB, transactionId: txId, destTxHash: hex"01", relayer: relayerA});
-        (uint96 timestamp, address relayer) = fastBridge.bridgeProofs(txId);
-        assertEq(timestamp, block.timestamp);
-        assertEq(relayer, relayerA);
+        checkStatusAndProofAfterProve(txId, relayerA);
         assertEq(srcToken.balanceOf(address(fastBridge)), INITIAL_PROTOCOL_FEES_TOKEN + tokenParams.originAmount);
         assertEq(fastBridge.protocolFees(address(srcToken)), INITIAL_PROTOCOL_FEES_TOKEN);
     }
@@ -352,9 +370,7 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         bridge({caller: userA, msgValue: ethParams.originAmount, params: ethParams});
         expectBridgeProofProvided({txId: txId, relayer: relayerA, destTxHash: hex"01"});
         prove({caller: relayerB, transactionId: txId, destTxHash: hex"01", relayer: relayerA});
-        (uint96 timestamp, address relayer) = fastBridge.bridgeProofs(txId);
-        assertEq(timestamp, block.timestamp);
-        assertEq(relayer, relayerA);
+        checkStatusAndProofAfterProve(txId, relayerA);
         assertEq(address(fastBridge).balance, INITIAL_PROTOCOL_FEES_ETH + ethParams.originAmount);
         assertEq(fastBridge.protocolFees(ETH_ADDRESS), INITIAL_PROTOCOL_FEES_ETH);
     }
@@ -365,9 +381,7 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         bridge({caller: userA, msgValue: 0, params: tokenParams});
         expectBridgeProofProvided({txId: txId, relayer: relayerA, destTxHash: hex"01"});
         prove({caller: relayerA, transactionId: txId, destTxHash: hex"01", relayer: relayerA});
-        (uint96 timestamp, address relayer) = fastBridge.bridgeProofs(txId);
-        assertEq(timestamp, block.timestamp);
-        assertEq(relayer, relayerA);
+        checkStatusAndProofAfterProve(txId, relayerA);
         assertEq(srcToken.balanceOf(address(fastBridge)), INITIAL_PROTOCOL_FEES_TOKEN + tokenParams.originAmount);
         assertEq(fastBridge.protocolFees(address(srcToken)), INITIAL_PROTOCOL_FEES_TOKEN);
     }
@@ -379,9 +393,7 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         bridge({caller: userA, msgValue: 0, params: tokenParams});
         expectBridgeProofProvided({txId: txId, relayer: address(0x1234), destTxHash: hex"01"});
         prove({caller: relayerA, transactionId: txId, destTxHash: hex"01", relayer: address(0x1234)});
-        (uint96 timestamp, address relayer) = fastBridge.bridgeProofs(txId);
-        assertEq(timestamp, block.timestamp);
-        assertEq(relayer, address(0x1234));
+        checkStatusAndProofAfterProve(txId, address(0x1234));
         assertEq(srcToken.balanceOf(address(fastBridge)), INITIAL_PROTOCOL_FEES_TOKEN + tokenParams.originAmount);
         assertEq(fastBridge.protocolFees(address(srcToken)), INITIAL_PROTOCOL_FEES_TOKEN);
     }
@@ -392,17 +404,17 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         bridge({caller: userA, msgValue: ethParams.originAmount, params: ethParams});
         expectBridgeProofProvided({txId: txId, relayer: relayerA, destTxHash: hex"01"});
         prove({caller: relayerB, transactionId: txId, destTxHash: hex"01", relayer: relayerA});
+        checkStatusAndProofAfterProve(txId, relayerA);
         expectBridgeProofDisputed(txId, relayerA);
         dispute(guard, txId);
         expectBridgeProofProvided({txId: txId, relayer: relayerA, destTxHash: hex"02"});
         prove({caller: relayerB, transactionId: txId, destTxHash: hex"02", relayer: relayerA});
+        checkStatusAndProofAfterProve(txId, relayerA);
         expectBridgeProofDisputed(txId, relayerA);
         dispute(guard, txId);
         expectBridgeProofProvided({txId: txId, relayer: relayerA, destTxHash: hex"03"});
         prove({caller: relayerB, transactionId: txId, destTxHash: hex"03", relayer: relayerA});
-        (uint96 timestamp, address relayer) = fastBridge.bridgeProofs(txId);
-        assertEq(timestamp, block.timestamp);
-        assertEq(relayer, relayerA);
+        checkStatusAndProofAfterProve(txId, relayerA);
         assertEq(srcToken.balanceOf(address(fastBridge)), INITIAL_PROTOCOL_FEES_TOKEN + tokenParams.originAmount);
         assertEq(fastBridge.protocolFees(address(srcToken)), INITIAL_PROTOCOL_FEES_TOKEN);
     }
@@ -414,9 +426,7 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         skip(10 days);
         expectBridgeProofProvided({txId: txId, relayer: relayerA, destTxHash: hex"01"});
         prove({caller: relayerA, transactionId: txId, destTxHash: hex"01", relayer: relayerA});
-        (uint96 timestamp, address relayer) = fastBridge.bridgeProofs(txId);
-        assertEq(timestamp, block.timestamp);
-        assertEq(relayer, relayerA);
+        checkStatusAndProofAfterProve(txId, relayerA);
         assertEq(srcToken.balanceOf(address(fastBridge)), INITIAL_PROTOCOL_FEES_TOKEN + tokenParams.originAmount);
         assertEq(fastBridge.protocolFees(address(srcToken)), INITIAL_PROTOCOL_FEES_TOKEN);
     }
@@ -458,6 +468,18 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
 
     // ═══════════════════════════════════════════════════ CLAIM ═══════════════════════════════════════════════════════
 
+    function checkStatusAndProofAfterClaim(bytes32 txId, address relayer, uint256 expectedProofTS) public view {
+        assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.RELAYER_CLAIMED);
+        (IFastBridgeV2.BridgeStatus status, uint256 proofBlockTimestamp, address proofRelayer) =
+            fastBridge.bridgeTxDetails(txId);
+        assertEq(status, IFastBridgeV2.BridgeStatus.RELAYER_CLAIMED);
+        assertEq(proofBlockTimestamp, expectedProofTS);
+        assertEq(proofRelayer, relayer);
+        (proofBlockTimestamp, proofRelayer) = fastBridge.bridgeProofs(txId);
+        assertEq(proofBlockTimestamp, expectedProofTS);
+        assertEq(proofRelayer, relayer);
+    }
+
     function checkTokenBalancesAfterClaim(address relayer) public view {
         uint256 expectedProtocolFees = INITIAL_PROTOCOL_FEES_TOKEN + tokenTx.originFeeAmount;
         assertEq(fastBridge.protocolFees(address(srcToken)), expectedProtocolFees);
@@ -469,11 +491,12 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         bytes32 txId = getTxId(tokenTx);
         bridge({caller: userA, msgValue: 0, params: tokenParams});
         prove({caller: relayerA, bridgeTx: tokenTx, destTxHash: hex"01"});
+        uint256 expectedProofTS = block.timestamp;
         skip(CLAIM_DELAY + 1);
         assertTrue(fastBridge.canClaim(txId, relayerA));
         expectBridgeDepositClaimed({bridgeTx: tokenTx, txId: txId, relayer: relayerA, to: relayerA});
         claim({caller: relayerA, bridgeTx: tokenTx, to: relayerA});
-        assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.RELAYER_CLAIMED);
+        checkStatusAndProofAfterClaim(txId, relayerA, expectedProofTS);
         checkTokenBalancesAfterClaim(relayerA);
     }
 
@@ -482,10 +505,11 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         bytes32 txId = getTxId(tokenTx);
         bridge({caller: userA, msgValue: 0, params: tokenParams});
         prove({caller: relayerA, bridgeTx: tokenTx, destTxHash: hex"01"});
+        uint256 expectedProofTS = block.timestamp;
         skip(CLAIM_DELAY + 1);
         expectBridgeDepositClaimed({bridgeTx: tokenTx, txId: txId, relayer: relayerA, to: relayerA});
         claim({caller: caller, bridgeTx: tokenTx});
-        assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.RELAYER_CLAIMED);
+        checkStatusAndProofAfterClaim(txId, relayerA, expectedProofTS);
         checkTokenBalancesAfterClaim(relayerA);
     }
 
@@ -494,10 +518,11 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         bytes32 txId = getTxId(tokenTx);
         bridge({caller: userA, msgValue: 0, params: tokenParams});
         prove({caller: relayerA, bridgeTx: tokenTx, destTxHash: hex"01"});
+        uint256 expectedProofTS = block.timestamp;
         skip(CLAIM_DELAY + 1);
         expectBridgeDepositClaimed({bridgeTx: tokenTx, txId: txId, relayer: relayerA, to: relayerA});
         claim({caller: caller, bridgeTx: tokenTx, to: address(0)});
-        assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.RELAYER_CLAIMED);
+        checkStatusAndProofAfterClaim(txId, relayerA, expectedProofTS);
         checkTokenBalancesAfterClaim(relayerA);
     }
 
@@ -505,10 +530,11 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         bytes32 txId = getTxId(tokenTx);
         bridge({caller: userA, msgValue: 0, params: tokenParams});
         prove({caller: relayerA, bridgeTx: tokenTx, destTxHash: hex"01"});
+        uint256 expectedProofTS = block.timestamp;
         skip(CLAIM_DELAY + 1);
         expectBridgeDepositClaimed({bridgeTx: tokenTx, txId: txId, relayer: relayerA, to: claimTo});
         claim({caller: relayerA, bridgeTx: tokenTx, to: claimTo});
-        assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.RELAYER_CLAIMED);
+        checkStatusAndProofAfterClaim(txId, relayerA, expectedProofTS);
         assertEq(srcToken.balanceOf(relayerA), 0);
         checkTokenBalancesAfterClaim(claimTo);
     }
@@ -517,10 +543,11 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         bytes32 txId = getTxId(tokenTx);
         bridge({caller: userA, msgValue: 0, params: tokenParams});
         prove({caller: relayerA, bridgeTx: tokenTx, destTxHash: hex"01"});
+        uint256 expectedProofTS = block.timestamp;
         skip(CLAIM_DELAY + 30 days);
         expectBridgeDepositClaimed({bridgeTx: tokenTx, txId: txId, relayer: relayerA, to: relayerA});
         claim({caller: relayerA, bridgeTx: tokenTx, to: relayerA});
-        assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.RELAYER_CLAIMED);
+        checkStatusAndProofAfterClaim(txId, relayerA, expectedProofTS);
         checkTokenBalancesAfterClaim(relayerA);
     }
 
@@ -536,11 +563,12 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         bytes32 txId = getTxId(ethTx);
         bridge({caller: userA, msgValue: ethParams.originAmount, params: ethParams});
         prove({caller: relayerA, bridgeTx: ethTx, destTxHash: hex"01"});
+        uint256 expectedProofTS = block.timestamp;
         skip(CLAIM_DELAY + 1);
         assertTrue(fastBridge.canClaim(txId, relayerA));
         expectBridgeDepositClaimed({bridgeTx: ethTx, txId: txId, relayer: relayerA, to: relayerA});
         claim({caller: relayerA, bridgeTx: ethTx, to: relayerA});
-        assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.RELAYER_CLAIMED);
+        checkStatusAndProofAfterClaim(txId, relayerA, expectedProofTS);
         checkEthBalancesAfterClaim(relayerA);
     }
 
@@ -550,10 +578,11 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         bytes32 txId = getTxId(ethTx);
         bridge({caller: userA, msgValue: ethParams.originAmount, params: ethParams});
         prove({caller: relayerA, bridgeTx: ethTx, destTxHash: hex"01"});
+        uint256 expectedProofTS = block.timestamp;
         skip(CLAIM_DELAY + 1);
         expectBridgeDepositClaimed({bridgeTx: ethTx, txId: txId, relayer: relayerA, to: relayerA});
         claim({caller: caller, bridgeTx: ethTx});
-        assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.RELAYER_CLAIMED);
+        checkStatusAndProofAfterClaim(txId, relayerA, expectedProofTS);
         checkEthBalancesAfterClaim(relayerA);
     }
 
@@ -563,10 +592,11 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         bytes32 txId = getTxId(ethTx);
         bridge({caller: userA, msgValue: ethParams.originAmount, params: ethParams});
         prove({caller: relayerA, bridgeTx: ethTx, destTxHash: hex"01"});
+        uint256 expectedProofTS = block.timestamp;
         skip(CLAIM_DELAY + 1);
         expectBridgeDepositClaimed({bridgeTx: ethTx, txId: txId, relayer: relayerA, to: relayerA});
         claim({caller: caller, bridgeTx: ethTx, to: address(0)});
-        assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.RELAYER_CLAIMED);
+        checkStatusAndProofAfterClaim(txId, relayerA, expectedProofTS);
         checkEthBalancesAfterClaim(relayerA);
     }
 
@@ -575,10 +605,11 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         bytes32 txId = getTxId(ethTx);
         bridge({caller: userA, msgValue: ethParams.originAmount, params: ethParams});
         prove({caller: relayerA, bridgeTx: ethTx, destTxHash: hex"01"});
+        uint256 expectedProofTS = block.timestamp;
         skip(CLAIM_DELAY + 1);
         expectBridgeDepositClaimed({bridgeTx: ethTx, txId: txId, relayer: relayerA, to: claimTo});
         claim({caller: relayerA, bridgeTx: ethTx, to: claimTo});
-        assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.RELAYER_CLAIMED);
+        checkStatusAndProofAfterClaim(txId, relayerA, expectedProofTS);
         checkEthBalancesAfterClaim(claimTo);
     }
 
@@ -587,10 +618,11 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         bytes32 txId = getTxId(ethTx);
         bridge({caller: userA, msgValue: ethParams.originAmount, params: ethParams});
         prove({caller: relayerA, bridgeTx: ethTx, destTxHash: hex"01"});
+        uint256 expectedProofTS = block.timestamp;
         skip(CLAIM_DELAY + 30 days);
         expectBridgeDepositClaimed({bridgeTx: ethTx, txId: txId, relayer: relayerA, to: relayerA});
         claim({caller: relayerA, bridgeTx: ethTx, to: relayerA});
-        assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.RELAYER_CLAIMED);
+        checkStatusAndProofAfterClaim(txId, relayerA, expectedProofTS);
         checkEthBalancesAfterClaim(relayerA);
     }
 
@@ -664,13 +696,18 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
 
     // ══════════════════════════════════════════════════ DISPUTE ══════════════════════════════════════════════════════
 
+    function checkStatusAndProofAfterDispute(bytes32 txId) public view {
+        // Should be identical to a requested tx that was never proven
+        checkStatusAndProofAfterBridge(txId);
+    }
+
     function test_dispute_token() public {
         bytes32 txId = getTxId(tokenTx);
         bridge({caller: userA, msgValue: 0, params: tokenParams});
         prove({caller: relayerA, bridgeTx: tokenTx, destTxHash: hex"01"});
         expectBridgeProofDisputed({txId: txId, relayer: relayerA});
         dispute({caller: guard, txId: txId});
-        assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.REQUESTED);
+        checkStatusAndProofAfterDispute(txId);
         assertEq(fastBridge.protocolFees(address(srcToken)), INITIAL_PROTOCOL_FEES_TOKEN);
         assertEq(srcToken.balanceOf(address(fastBridge)), INITIAL_PROTOCOL_FEES_TOKEN + tokenParams.originAmount);
     }
@@ -682,7 +719,7 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         skip(CLAIM_DELAY);
         expectBridgeProofDisputed({txId: txId, relayer: relayerA});
         dispute({caller: guard, txId: txId});
-        assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.REQUESTED);
+        checkStatusAndProofAfterDispute(txId);
         assertEq(fastBridge.protocolFees(address(srcToken)), INITIAL_PROTOCOL_FEES_TOKEN);
         assertEq(srcToken.balanceOf(address(fastBridge)), INITIAL_PROTOCOL_FEES_TOKEN + tokenParams.originAmount);
     }
@@ -694,7 +731,7 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         prove({caller: relayerA, bridgeTx: ethTx, destTxHash: hex"01"});
         expectBridgeProofDisputed({txId: txId, relayer: relayerA});
         dispute({caller: guard, txId: txId});
-        assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.REQUESTED);
+        checkStatusAndProofAfterDispute(txId);
         assertEq(fastBridge.protocolFees(ETH_ADDRESS), INITIAL_PROTOCOL_FEES_ETH);
         assertEq(address(fastBridge).balance, INITIAL_PROTOCOL_FEES_ETH + ethParams.originAmount);
     }
@@ -707,7 +744,7 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         skip(CLAIM_DELAY);
         expectBridgeProofDisputed({txId: txId, relayer: relayerA});
         dispute({caller: guard, txId: txId});
-        assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.REQUESTED);
+        checkStatusAndProofAfterDispute(txId);
         assertEq(fastBridge.protocolFees(ETH_ADDRESS), INITIAL_PROTOCOL_FEES_ETH);
         assertEq(address(fastBridge).balance, INITIAL_PROTOCOL_FEES_ETH + ethParams.originAmount);
     }
@@ -764,13 +801,25 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
 
     // ══════════════════════════════════════════════════ REFUND ═══════════════════════════════════════════════════════
 
+    function checkStatusAndProofAfterRefund(bytes32 txId) public view {
+        assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.REFUNDED);
+        (IFastBridgeV2.BridgeStatus status, uint256 proofBlockTimestamp, address proofRelayer) =
+            fastBridge.bridgeTxDetails(txId);
+        assertEq(status, IFastBridgeV2.BridgeStatus.REFUNDED);
+        assertEq(proofBlockTimestamp, 0);
+        assertEq(proofRelayer, address(0));
+        (proofBlockTimestamp, proofRelayer) = fastBridge.bridgeProofs(txId);
+        assertEq(proofBlockTimestamp, 0);
+        assertEq(proofRelayer, address(0));
+    }
+
     function test_refund_token() public {
         bytes32 txId = getTxId(tokenTx);
         bridge({caller: userA, msgValue: 0, params: tokenParams});
         skip(DEADLINE + 1);
         expectBridgeDepositRefunded({bridgeParams: tokenParams, txId: txId});
         refund({caller: refunder, bridgeTx: tokenTx});
-        assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.REFUNDED);
+        checkStatusAndProofAfterRefund(txId);
         assertEq(fastBridge.protocolFees(address(srcToken)), INITIAL_PROTOCOL_FEES_TOKEN);
         assertEq(srcToken.balanceOf(userA), LEFTOVER_BALANCE + tokenParams.originAmount);
         assertEq(srcToken.balanceOf(address(fastBridge)), INITIAL_PROTOCOL_FEES_TOKEN);
@@ -783,7 +832,7 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         skip(DEADLINE + 1);
         expectBridgeDepositRefunded({bridgeParams: tokenParams, txId: txId});
         refund({caller: refunder, bridgeTx: tokenTx});
-        assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.REFUNDED);
+        checkStatusAndProofAfterRefund(txId);
         assertEq(fastBridge.protocolFees(address(srcToken)), INITIAL_PROTOCOL_FEES_TOKEN);
         assertEq(srcToken.balanceOf(userA), LEFTOVER_BALANCE + 2 * tokenParams.originAmount);
         assertEq(srcToken.balanceOf(userB), LEFTOVER_BALANCE);
@@ -796,7 +845,7 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         skip(DEADLINE + 30 days);
         expectBridgeDepositRefunded({bridgeParams: tokenParams, txId: txId});
         refund({caller: refunder, bridgeTx: tokenTx});
-        assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.REFUNDED);
+        checkStatusAndProofAfterRefund(txId);
         assertEq(fastBridge.protocolFees(address(srcToken)), INITIAL_PROTOCOL_FEES_TOKEN);
         assertEq(srcToken.balanceOf(userA), LEFTOVER_BALANCE + tokenParams.originAmount);
         assertEq(srcToken.balanceOf(address(fastBridge)), INITIAL_PROTOCOL_FEES_TOKEN);
@@ -809,7 +858,7 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         skip(DEADLINE + PERMISSIONLESS_REFUND_DELAY + 1);
         expectBridgeDepositRefunded({bridgeParams: tokenParams, txId: txId});
         refund({caller: caller, bridgeTx: tokenTx});
-        assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.REFUNDED);
+        checkStatusAndProofAfterRefund(txId);
         assertEq(fastBridge.protocolFees(address(srcToken)), INITIAL_PROTOCOL_FEES_TOKEN);
         assertEq(srcToken.balanceOf(userA), LEFTOVER_BALANCE + tokenParams.originAmount);
         assertEq(srcToken.balanceOf(address(fastBridge)), INITIAL_PROTOCOL_FEES_TOKEN);
@@ -822,7 +871,7 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         skip(DEADLINE + 1);
         expectBridgeDepositRefunded({bridgeParams: ethParams, txId: txId});
         refund({caller: refunder, bridgeTx: ethTx});
-        assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.REFUNDED);
+        checkStatusAndProofAfterRefund(txId);
         assertEq(fastBridge.protocolFees(ETH_ADDRESS), INITIAL_PROTOCOL_FEES_ETH);
         assertEq(userA.balance, LEFTOVER_BALANCE + ethParams.originAmount);
         assertEq(address(fastBridge).balance, INITIAL_PROTOCOL_FEES_ETH);
@@ -836,7 +885,7 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         skip(DEADLINE + 1);
         expectBridgeDepositRefunded({bridgeParams: ethParams, txId: txId});
         refund({caller: refunder, bridgeTx: ethTx});
-        assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.REFUNDED);
+        checkStatusAndProofAfterRefund(txId);
         assertEq(fastBridge.protocolFees(ETH_ADDRESS), INITIAL_PROTOCOL_FEES_ETH);
         assertEq(userA.balance, LEFTOVER_BALANCE + 2 * ethParams.originAmount);
         assertEq(userB.balance, LEFTOVER_BALANCE);
@@ -850,7 +899,7 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         skip(DEADLINE + 30 days);
         expectBridgeDepositRefunded({bridgeParams: ethParams, txId: txId});
         refund({caller: refunder, bridgeTx: ethTx});
-        assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.REFUNDED);
+        checkStatusAndProofAfterRefund(txId);
         assertEq(fastBridge.protocolFees(ETH_ADDRESS), INITIAL_PROTOCOL_FEES_ETH);
         assertEq(userA.balance, LEFTOVER_BALANCE + ethParams.originAmount);
         assertEq(address(fastBridge).balance, INITIAL_PROTOCOL_FEES_ETH);
@@ -864,7 +913,7 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         skip(DEADLINE + PERMISSIONLESS_REFUND_DELAY + 1);
         expectBridgeDepositRefunded({bridgeParams: ethParams, txId: txId});
         refund({caller: caller, bridgeTx: ethTx});
-        assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.REFUNDED);
+        checkStatusAndProofAfterRefund(txId);
         assertEq(fastBridge.protocolFees(ETH_ADDRESS), INITIAL_PROTOCOL_FEES_ETH);
         assertEq(userA.balance, LEFTOVER_BALANCE + ethParams.originAmount);
         assertEq(address(fastBridge).balance, INITIAL_PROTOCOL_FEES_ETH);


### PR DESCRIPTION
**Description**
Swaps out proof block number for destination chain ID in the `BridgeTxDetails` struct that tracks relevant fields for a bridge request on the origin chain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced timestamp handling with increased precision for bridge transactions.
	- Introduction of new parameters and structures for improved cross-chain transaction management.
  
- **Bug Fixes**
	- Improved validation of transaction statuses and proofs in testing functions.

- **Documentation**
	- Updated comments to reflect changes in timestamp management and transaction structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->