### PR TITLE
refactor(contracts-rfq): fix compiler warnings in tests

### DIFF
--- a/packages/contracts-rfq/test/FastBridge.t.sol
+++ b/packages/contracts-rfq/test/FastBridge.t.sol
@@ -60,9 +60,9 @@ contract FastBridgeTest is Test {
         internal
         virtual
     {
-        (uint96 timestamp, address relayer) = fastBridge.bridgeProofs(transactionId);
-        assertEq(timestamp, uint96(expectedTimestamp));
-        assertEq(relayer, expectedRelayer);
+        (uint96 proofTimestamp, address proofRelayer) = fastBridge.bridgeProofs(transactionId);
+        assertEq(proofTimestamp, uint96(expectedTimestamp));
+        assertEq(proofRelayer, expectedRelayer);
     }
 
     function _getBridgeRequestAndId(

--- a/packages/contracts-rfq/test/FastBridgeMock.sol
+++ b/packages/contracts-rfq/test/FastBridgeMock.sol
@@ -39,6 +39,7 @@ contract FastBridgeMock is IFastBridge, Admin {
     }
 
     function mockBridgeRequest(bytes32 transactionId, address sender, BridgeParams memory params) external {
+        sender;
         uint256 originFeeAmount = (params.originAmount * protocolFeeRate) / FEE_BPS;
         params.originAmount -= originFeeAmount;
 
@@ -73,6 +74,7 @@ contract FastBridgeMock is IFastBridge, Admin {
     }
 
     function mockBridgeRequestRaw(bytes32 transactionId, address sender, bytes memory request) external {
+        sender;
         BridgeTransaction memory transaction = getBridgeTransaction(request);
         emit BridgeRequested(
             transactionId,
@@ -105,31 +107,31 @@ contract FastBridgeMock is IFastBridge, Admin {
         );
     }
 
-    function bridge(BridgeParams memory params) external payable {
+    function bridge(BridgeParams memory) external payable {
         revert("not implemented");
     }
 
-    function relay(bytes memory request) external payable {
+    function relay(bytes memory) external payable {
         revert("not implemented");
     }
 
-    function prove(bytes memory request, bytes32 destTxHash) external {
+    function prove(bytes memory, bytes32) external pure {
         revert("not implemented");
     }
 
-    function canClaim(bytes32 transactionid, address relayer) external view returns (bool) {
+    function canClaim(bytes32, address) external pure returns (bool) {
         revert("not implemented");
     }
 
-    function claim(bytes memory request, address to) external {
+    function claim(bytes memory, address) external pure {
         revert("not implemented");
     }
 
-    function dispute(bytes32 transactionId) external {
+    function dispute(bytes32) external pure {
         revert("not implemented");
     }
 
-    function refund(bytes memory request) external {
+    function refund(bytes memory) external pure {
         revert("not implemented");
     }
 }

--- a/packages/contracts-rfq/test/integration/FastBridge.MulticallTarget.t.sol
+++ b/packages/contracts-rfq/test/integration/FastBridge.MulticallTarget.t.sol
@@ -14,7 +14,7 @@ contract FastBridgeMulticallTargetTest is MulticallTargetIntegrationTest {
 
     function getEncodedBridgeTx(IFastBridge.BridgeTransaction memory bridgeTx)
         public
-        view
+        pure
         override
         returns (bytes memory)
     {


### PR DESCRIPTION
**Description**
See title.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved variable naming for clarity in proof-related data within the `FastBridgeTest` contract.
	- Updated function visibility to `pure` for `getEncodedBridgeTx`, ensuring it does not read from state.

- **Refactor**
	- Simplified function signatures in `FastBridgeMock` by removing parameter names.
	- Added unused variable references to avoid compiler warnings. 

These changes enhance code readability and maintainability without altering existing functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->