### PR TITLE
chore(rest-api): rename swagger.json to openapi.json [SLT-449]

### DIFF
--- a/docs/bridge/docs/02-Bridge/02-REST-API.md
+++ b/docs/bridge/docs/02-Bridge/02-REST-API.md
@@ -10,6 +10,8 @@ Get read-only data from on-chain Synapse contracts, and generate Bridge and Swap
 
 [`api.synapseprotocol.com/api-docs`](https://api.synapseprotocol.com/api-docs)
 
+**Note:** The OpenAPI 3.0 specification is available at `https://api.synapseprotocol.com/openapi.json` for client generation.
+
 ## Previous versions
 
 | Date                   | Description                                                                                                                                                        |

--- a/packages/rest-api/src/app.ts
+++ b/packages/rest-api/src/app.ts
@@ -56,7 +56,7 @@ app.listen(port, () => {
   logger.info(`Server is listening on port ${port}`)
 })
 
-app.get('/swagger.json', (_req, res) => {
+app.get('/openapi.json', (_req, res) => {
   res.json(specs)
 })
 

--- a/packages/rest-api/src/app.ts
+++ b/packages/rest-api/src/app.ts
@@ -57,10 +57,13 @@ app.listen(port, () => {
 })
 
 app.get('/openapi.json', (_req, res) => {
-  res.set('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
-  res.set('Pragma', 'no-cache');
-  res.set('Expires', '0');
-  res.set('Surrogate-Control', 'no-store');
+  res.set(
+    'Cache-Control',
+    'no-store, no-cache, must-revalidate, proxy-revalidate'
+  )
+  res.set('Pragma', 'no-cache')
+  res.set('Expires', '0')
+  res.set('Surrogate-Control', 'no-store')
   res.json(specs)
 })
 

--- a/packages/rest-api/src/app.ts
+++ b/packages/rest-api/src/app.ts
@@ -57,6 +57,10 @@ app.listen(port, () => {
 })
 
 app.get('/openapi.json', (_req, res) => {
+  res.set('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
+  res.set('Pragma', 'no-cache');
+  res.set('Expires', '0');
+  res.set('Surrogate-Control', 'no-store');
   res.json(specs)
 })
 


### PR DESCRIPTION
see #3361

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**



39609388fd5e596ee89227ef4caeb6d44e09b584: [docs preview link ](https://bridge-docs-ec35y688v-synapsecns.vercel.app)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated REST API documentation to include a note on the availability of the OpenAPI 3.0 specification for client generation.
  - Clarified that the previous API version URL is deprecated as of October 2024.

- **New Features**
  - Renamed the endpoint from `/swagger.json` to `/openapi.json` for serving OpenAPI specifications.
  
- **Bug Fixes**
  - Adjusted logging behavior to truncate outgoing response bodies for specific paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
245dfc0eea92f28cd37f61ff31b1ae430fcfb7ba: [docs preview link ](https://bridge-docs-9hgbq7b90-synapsecns.vercel.app)
8a431b390fdd685787dc13173542605a39c88a90: [docs preview link ](https://bridge-docs-obqqij17q-synapsecns.vercel.app)