### PR TITLE
test(sdk-router): error console cleanup

### DIFF
--- a/packages/sdk-router/src/rfq/api.integration.test.ts
+++ b/packages/sdk-router/src/rfq/api.integration.test.ts
@@ -2,6 +2,9 @@ import { getAllQuotes } from './api'
 
 global.fetch = require('node-fetch')
 
+// Retry the flaky tests up to 3 times
+jest.retryTimes(3)
+
 describe('getAllQuotes', () => {
   it('Integration test', async () => {
     const result = await getAllQuotes()

--- a/packages/sdk-router/src/rfq/api.test.ts
+++ b/packages/sdk-router/src/rfq/api.test.ts
@@ -76,6 +76,10 @@ describe('getAllQuotes', () => {
   })
 
   describe('Returns an empty array', () => {
+    beforeAll(() => {
+      console.error = jest.fn()
+    })
+
     it('when the response is not ok', async () => {
       fetchMock.mockResponseOnce(JSON.stringify(quotesAPI), { status: 500 })
       const result = await getAllQuotes()

--- a/packages/sdk-router/src/rfq/api.test.ts
+++ b/packages/sdk-router/src/rfq/api.test.ts
@@ -76,20 +76,28 @@ describe('getAllQuotes', () => {
   })
 
   describe('Returns an empty array', () => {
-    beforeAll(() => {
-      console.error = jest.fn()
+    beforeEach(() => {
+      jest.spyOn(console, 'error').mockImplementation(() => {
+        // Do nothing
+      })
+    })
+
+    afterEach(() => {
+      jest.restoreAllMocks()
     })
 
     it('when the response is not ok', async () => {
       fetchMock.mockResponseOnce(JSON.stringify(quotesAPI), { status: 500 })
       const result = await getAllQuotes()
       expect(result).toEqual([])
+      expect(console.error).toHaveBeenCalled()
     })
 
     it('when fetch throws an error', async () => {
       fetchMock.mockRejectOnce(new Error('Error fetching quotes'))
       const result = await getAllQuotes()
       expect(result).toEqual([])
+      expect(console.error).toHaveBeenCalled()
     })
 
     it('when the response takes too long to return', async () => {
@@ -98,6 +106,7 @@ describe('getAllQuotes', () => {
       )
       const result = await getAllQuotes()
       expect(result).toEqual([])
+      expect(console.error).toHaveBeenCalled()
     })
   })
 })

--- a/packages/sdk-router/src/sdk.test.ts
+++ b/packages/sdk-router/src/sdk.test.ts
@@ -53,6 +53,9 @@ global.fetch = jest.fn(() =>
   })
 ) as any
 
+// Retry the flaky tests up to 3 times
+jest.retryTimes(3)
+
 const EXPECTED_GAS_DROP: { [chainId: number]: BigNumber } = {
   [SupportedChainId.ETH]: BigNumber.from(0),
   // TODO: reenable once both ARB airdrops are adjusted

--- a/packages/sdk-router/src/sdk.test.ts
+++ b/packages/sdk-router/src/sdk.test.ts
@@ -48,7 +48,8 @@ import * as operations from './operations'
 // Override fetch to exclude RFQ from tests
 global.fetch = jest.fn(() =>
   Promise.resolve({
-    json: () => Promise.resolve({}),
+    ok: true,
+    json: () => Promise.resolve([]),
   })
 ) as any
 


### PR DESCRIPTION
**Description**
Removes the unnecessary console.error printouts in the SDK tests, making the SDK CO workflow easier to digest.

For context, the successful runs currently end up in lots of error logs:
https://github.com/synapsecns/sanguine/actions/runs/11725167069/job/32662351819?pr=3378#step:10:170

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Enhanced test suite for `getAllQuotes` with improved error handling and console output tracking.
	- Updated `SynapseSDK` tests to modify mocked fetch responses and include detailed assertions for bridge quote properties.
	- Added tests for gas drop edge cases and improved error handling scenarios.
	- Introduced a retry mechanism for flaky tests across multiple test suites to increase robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->