### PR TITLE
feat(contracts-rfq): rework permisionless cancellation [SLT-489]

### DIFF
--- a/packages/contracts-rfq/contracts/AdminV2.sol
+++ b/packages/contracts-rfq/contracts/AdminV2.sol
@@ -42,10 +42,16 @@ contract AdminV2 is AccessControlEnumerable, IAdminV2, IAdminV2Errors {
         _setCancelDelay(DEFAULT_CANCEL_DELAY);
     }
 
+    /// @notice Allows the contract governor to set the cancel delay. The cancel delay is the time after the transaction
+    /// deadline after which it can be permissionlessly cancelled, if it hasn't been proven by any of the Relayers.
     function setCancelDelay(uint256 newCancelDelay) external onlyRole(GOVERNOR_ROLE) {
         _setCancelDelay(newCancelDelay);
     }
 
+    /// @notice Allows the contract governor to set the protocol fee rate. The protocol fee is taken from the origin
+    /// amount only for completed and claimed transactions.
+    /// @dev The protocol fee is abstracted away from the relayers, they always operate using the amounts after fees:
+    /// what they see as the origin amount emitted in the log is what they get credited with.
     function setProtocolFeeRate(uint256 newFeeRate) external onlyRole(GOVERNOR_ROLE) {
         if (newFeeRate > FEE_RATE_MAX) revert FeeRateAboveMax();
         uint256 oldFeeRate = protocolFeeRate;
@@ -53,17 +59,19 @@ contract AdminV2 is AccessControlEnumerable, IAdminV2, IAdminV2Errors {
         emit FeeRateUpdated(oldFeeRate, newFeeRate);
     }
 
+    /// @notice Allows the contract governor to sweep the accumulated protocol fees in the contract.
     function sweepProtocolFees(address token, address recipient) external onlyRole(GOVERNOR_ROLE) {
         uint256 feeAmount = protocolFees[token];
         if (feeAmount == 0) return; // skip if no accumulated fees
 
         protocolFees[token] = 0;
+        emit FeesSwept(token, recipient, feeAmount);
+        /// Sweep the fees as the last transaction action
         if (token == NATIVE_GAS_TOKEN) {
             Address.sendValue(payable(recipient), feeAmount);
         } else {
             IERC20(token).safeTransfer(recipient, feeAmount);
         }
-        emit FeesSwept(token, recipient, feeAmount);
     }
 
     /// @notice Internal function to set the cancel delay. Security checks are performed outside of this function.

--- a/packages/contracts-rfq/contracts/AdminV2.sol
+++ b/packages/contracts-rfq/contracts/AdminV2.sol
@@ -34,9 +34,14 @@ contract AdminV2 is AccessControlEnumerable, IAdminV2, IAdminV2Errors {
     /// @dev Only addresses with this role can perform administrative tasks within the contract.
     bytes32 public constant GOVERNOR_ROLE = keccak256("GOVERNOR_ROLE");
 
+    /// @notice Denominator for fee rates, represents 100%.
     uint256 public constant FEE_BPS = 1e6;
-    uint256 public constant FEE_RATE_MAX = 0.01e6; // max 1% on origin amount
+    /// @notice Maximum protocol fee rate: 1% on origin amount.
+    uint256 public constant FEE_RATE_MAX = 0.01e6;
+
+    /// @notice Minimum cancel delay that can be set by the governor.
     uint256 public constant MIN_CANCEL_DELAY = 1 hours;
+    /// @notice Default cancel delay set during the contract deployment.
     uint256 public constant DEFAULT_CANCEL_DELAY = 1 days;
 
     /// @notice Protocol fee rate taken on origin amount deposited in origin chain

--- a/packages/contracts-rfq/contracts/AdminV2.sol
+++ b/packages/contracts-rfq/contracts/AdminV2.sol
@@ -29,8 +29,9 @@ contract AdminV2 is AccessControlEnumerable, IAdminV2, IAdminV2Errors {
     /// @notice Delay for a transaction after which it could be permisionlessly cancelled
     uint256 public cancelDelay;
 
-    /// @notice Chain gas amount to forward as rebate if requested
-    uint256 public chainGasAmount;
+    /// @notice This is deprecated and should not be used.
+    /// @dev Use ZapNative V2 requests instead.
+    uint256 public immutable chainGasAmount = 0;
 
     constructor(address _owner) {
         _grantRole(DEFAULT_ADMIN_ROLE, _owner);
@@ -55,12 +56,6 @@ contract AdminV2 is AccessControlEnumerable, IAdminV2, IAdminV2Errors {
         protocolFees[token] = 0;
         token.universalTransfer(recipient, feeAmount);
         emit FeesSwept(token, recipient, feeAmount);
-    }
-
-    function setChainGasAmount(uint256 newChainGasAmount) external onlyRole(GOVERNOR_ROLE) {
-        uint256 oldChainGasAmount = chainGasAmount;
-        chainGasAmount = newChainGasAmount;
-        emit ChainGasAmountUpdated(oldChainGasAmount, newChainGasAmount);
     }
 
     /// @notice Internal function to set the cancel delay. Security checks are performed outside of this function.

--- a/packages/contracts-rfq/contracts/AdminV2.sol
+++ b/packages/contracts-rfq/contracts/AdminV2.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {AccessControlEnumerable} from "@openzeppelin/contracts/access/extensions/AccessControlEnumerable.sol";
+
+import {UniversalTokenLib} from "./libs/UniversalToken.sol";
+import {IAdminV2} from "./interfaces/IAdminV2.sol";
+
+contract AdminV2 is IAdminV2, AccessControlEnumerable {
+    using UniversalTokenLib for address;
+
+    bytes32 public constant RELAYER_ROLE = keccak256("RELAYER_ROLE");
+    bytes32 public constant REFUNDER_ROLE = keccak256("REFUNDER_ROLE");
+    bytes32 public constant GUARD_ROLE = keccak256("GUARD_ROLE");
+    bytes32 public constant GOVERNOR_ROLE = keccak256("GOVERNOR_ROLE");
+
+    uint256 public constant FEE_BPS = 1e6;
+    uint256 public constant FEE_RATE_MAX = 0.01e6; // max 1% on origin amount
+
+    /// @notice Protocol fee rate taken on origin amount deposited in origin chain
+    uint256 public protocolFeeRate;
+
+    /// @notice Protocol fee amounts accumulated
+    mapping(address => uint256) public protocolFees;
+
+    /// @notice Chain gas amount to forward as rebate if requested
+    uint256 public chainGasAmount;
+
+    constructor(address _owner) {
+        _grantRole(DEFAULT_ADMIN_ROLE, _owner);
+    }
+
+    function setProtocolFeeRate(uint256 newFeeRate) external onlyRole(GOVERNOR_ROLE) {
+        require(newFeeRate <= FEE_RATE_MAX, "newFeeRate > max");
+        uint256 oldFeeRate = protocolFeeRate;
+        protocolFeeRate = newFeeRate;
+        emit FeeRateUpdated(oldFeeRate, newFeeRate);
+    }
+
+    function sweepProtocolFees(address token, address recipient) external onlyRole(GOVERNOR_ROLE) {
+        uint256 feeAmount = protocolFees[token];
+        if (feeAmount == 0) return; // skip if no accumulated fees
+
+        protocolFees[token] = 0;
+        token.universalTransfer(recipient, feeAmount);
+        emit FeesSwept(token, recipient, feeAmount);
+    }
+
+    function setChainGasAmount(uint256 newChainGasAmount) external onlyRole(GOVERNOR_ROLE) {
+        uint256 oldChainGasAmount = chainGasAmount;
+        chainGasAmount = newChainGasAmount;
+        emit ChainGasAmountUpdated(oldChainGasAmount, newChainGasAmount);
+    }
+}

--- a/packages/contracts-rfq/contracts/AdminV2.sol
+++ b/packages/contracts-rfq/contracts/AdminV2.sol
@@ -5,8 +5,9 @@ import {AccessControlEnumerable} from "@openzeppelin/contracts/access/extensions
 
 import {UniversalTokenLib} from "./libs/UniversalToken.sol";
 import {IAdminV2} from "./interfaces/IAdminV2.sol";
+import {IAdminV2Errors} from "./interfaces/IAdminV2Errors.sol";
 
-contract AdminV2 is IAdminV2, AccessControlEnumerable {
+contract AdminV2 is AccessControlEnumerable, IAdminV2, IAdminV2Errors {
     using UniversalTokenLib for address;
 
     bytes32 public constant RELAYER_ROLE = keccak256("RELAYER_ROLE");
@@ -33,11 +34,11 @@ contract AdminV2 is IAdminV2, AccessControlEnumerable {
 
     constructor(address _owner) {
         _grantRole(DEFAULT_ADMIN_ROLE, _owner);
-        // TODO: set default cancel delay
+        _setCancelDelay(DEFAULT_CANCEL_DELAY);
     }
 
     function setCancelDelay(uint256 newCancelDelay) external onlyRole(GOVERNOR_ROLE) {
-        // TODO: implement
+        _setCancelDelay(newCancelDelay);
     }
 
     function setProtocolFeeRate(uint256 newFeeRate) external onlyRole(GOVERNOR_ROLE) {
@@ -60,5 +61,13 @@ contract AdminV2 is IAdminV2, AccessControlEnumerable {
         uint256 oldChainGasAmount = chainGasAmount;
         chainGasAmount = newChainGasAmount;
         emit ChainGasAmountUpdated(oldChainGasAmount, newChainGasAmount);
+    }
+
+    /// @notice Internal function to set the cancel delay. Security checks are performed outside of this function.
+    function _setCancelDelay(uint256 newCancelDelay) private {
+        if (newCancelDelay < MIN_CANCEL_DELAY) revert CancelDelayBelowMin();
+        uint256 oldCancelDelay = cancelDelay;
+        cancelDelay = newCancelDelay;
+        emit CancelDelayUpdated(oldCancelDelay, newCancelDelay);
     }
 }

--- a/packages/contracts-rfq/contracts/AdminV2.sol
+++ b/packages/contracts-rfq/contracts/AdminV2.sol
@@ -16,6 +16,8 @@ contract AdminV2 is IAdminV2, AccessControlEnumerable {
 
     uint256 public constant FEE_BPS = 1e6;
     uint256 public constant FEE_RATE_MAX = 0.01e6; // max 1% on origin amount
+    uint256 public constant MIN_CANCEL_DELAY = 1 hours;
+    uint256 public constant DEFAULT_CANCEL_DELAY = 1 days;
 
     /// @notice Protocol fee rate taken on origin amount deposited in origin chain
     uint256 public protocolFeeRate;
@@ -23,11 +25,19 @@ contract AdminV2 is IAdminV2, AccessControlEnumerable {
     /// @notice Protocol fee amounts accumulated
     mapping(address => uint256) public protocolFees;
 
+    /// @notice Delay for a transaction after which it could be permisionlessly cancelled
+    uint256 public cancelDelay;
+
     /// @notice Chain gas amount to forward as rebate if requested
     uint256 public chainGasAmount;
 
     constructor(address _owner) {
         _grantRole(DEFAULT_ADMIN_ROLE, _owner);
+        // TODO: set default cancel delay
+    }
+
+    function setCancelDelay(uint256 newCancelDelay) external onlyRole(GOVERNOR_ROLE) {
+        // TODO: implement
     }
 
     function setProtocolFeeRate(uint256 newFeeRate) external onlyRole(GOVERNOR_ROLE) {

--- a/packages/contracts-rfq/contracts/AdminV2.sol
+++ b/packages/contracts-rfq/contracts/AdminV2.sol
@@ -10,7 +10,7 @@ contract AdminV2 is IAdminV2, AccessControlEnumerable {
     using UniversalTokenLib for address;
 
     bytes32 public constant RELAYER_ROLE = keccak256("RELAYER_ROLE");
-    bytes32 public constant REFUNDER_ROLE = keccak256("REFUNDER_ROLE");
+    bytes32 public constant CANCELER_ROLE = keccak256("CANCELER_ROLE");
     bytes32 public constant GUARD_ROLE = keccak256("GUARD_ROLE");
     bytes32 public constant GOVERNOR_ROLE = keccak256("GOVERNOR_ROLE");
 

--- a/packages/contracts-rfq/contracts/AdminV2.sol
+++ b/packages/contracts-rfq/contracts/AdminV2.sol
@@ -42,7 +42,7 @@ contract AdminV2 is AccessControlEnumerable, IAdminV2, IAdminV2Errors {
     }
 
     function setProtocolFeeRate(uint256 newFeeRate) external onlyRole(GOVERNOR_ROLE) {
-        require(newFeeRate <= FEE_RATE_MAX, "newFeeRate > max");
+        if (newFeeRate > FEE_RATE_MAX) revert FeeRateAboveMax();
         uint256 oldFeeRate = protocolFeeRate;
         protocolFeeRate = newFeeRate;
         emit FeeRateUpdated(oldFeeRate, newFeeRate);

--- a/packages/contracts-rfq/contracts/AdminV2.sol
+++ b/packages/contracts-rfq/contracts/AdminV2.sol
@@ -14,10 +14,24 @@ contract AdminV2 is AccessControlEnumerable, IAdminV2, IAdminV2Errors {
     /// @notice Address reserved for native gas token (ETH on Ethereum and most L2s, AVAX on Avalanche, etc)
     address public constant NATIVE_GAS_TOKEN = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
 
-    bytes32 public constant RELAYER_ROLE = keccak256("RELAYER_ROLE");
+    /// @notice Role identifier for Quoter API's off-chain authentication.
+    /// @dev Only addresses with this role can post FastBridge quotes to the API.
+    bytes32 public constant QUOTER_ROLE = keccak256("QUOTER_ROLE");
+
+    /// @notice Role identifier for Prover's on-chain authentication in FastBridge.
+    /// @dev Only addresses with this role can provide proofs that a FastBridge request has been relayed.
     bytes32 public constant PROVER_ROLE = keccak256("PROVER_ROLE");
-    bytes32 public constant CANCELER_ROLE = keccak256("CANCELER_ROLE");
+
+    /// @notice Role identifier for Guard's on-chain authentication in FastBridge.
+    /// @dev Only addresses with this role can dispute submitted relay proofs during the dispute period.
     bytes32 public constant GUARD_ROLE = keccak256("GUARD_ROLE");
+
+    /// @notice Role identifier for Canceler's on-chain authentication in FastBridge.
+    /// @dev Only addresses with this role can cancel a FastBridge transaction without the cancel delay.
+    bytes32 public constant CANCELER_ROLE = keccak256("CANCELER_ROLE");
+
+    /// @notice Role identifier for Governor's on-chain administrative authority.
+    /// @dev Only addresses with this role can perform administrative tasks within the contract.
     bytes32 public constant GOVERNOR_ROLE = keccak256("GOVERNOR_ROLE");
 
     uint256 public constant FEE_BPS = 1e6;

--- a/packages/contracts-rfq/contracts/AdminV2.sol
+++ b/packages/contracts-rfq/contracts/AdminV2.sol
@@ -14,6 +14,7 @@ contract AdminV2 is AccessControlEnumerable, IAdminV2, IAdminV2Errors {
     /// @notice Address reserved for native gas token (ETH on Ethereum and most L2s, AVAX on Avalanche, etc)
     address public constant NATIVE_GAS_TOKEN = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
 
+    bytes32 public constant RELAYER_ROLE = keccak256("RELAYER_ROLE");
     bytes32 public constant PROVER_ROLE = keccak256("PROVER_ROLE");
     bytes32 public constant CANCELER_ROLE = keccak256("CANCELER_ROLE");
     bytes32 public constant GUARD_ROLE = keccak256("GUARD_ROLE");

--- a/packages/contracts-rfq/contracts/AdminV2.sol
+++ b/packages/contracts-rfq/contracts/AdminV2.sol
@@ -14,7 +14,7 @@ contract AdminV2 is AccessControlEnumerable, IAdminV2, IAdminV2Errors {
     /// @notice Address reserved for native gas token (ETH on Ethereum and most L2s, AVAX on Avalanche, etc)
     address public constant NATIVE_GAS_TOKEN = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
 
-    bytes32 public constant RELAYER_ROLE = keccak256("RELAYER_ROLE");
+    bytes32 public constant PROVER_ROLE = keccak256("PROVER_ROLE");
     bytes32 public constant CANCELER_ROLE = keccak256("CANCELER_ROLE");
     bytes32 public constant GUARD_ROLE = keccak256("GUARD_ROLE");
     bytes32 public constant GOVERNOR_ROLE = keccak256("GOVERNOR_ROLE");

--- a/packages/contracts-rfq/contracts/FastBridgeV2.sol
+++ b/packages/contracts-rfq/contracts/FastBridgeV2.sol
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.24;
 
-import {SafeERC20, IERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import {Address} from "@openzeppelin/contracts/utils/Address.sol";
-
 import {BridgeTransactionV2Lib} from "./libs/BridgeTransactionV2.sol";
 
 import {AdminV2} from "./AdminV2.sol";
@@ -14,13 +11,13 @@ import {IZapRecipient} from "./interfaces/IZapRecipient.sol";
 
 import {MulticallTarget} from "./utils/MulticallTarget.sol";
 
+import {SafeERC20, IERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
 /// @notice FastBridgeV2 is a contract for bridging tokens across chains.
 contract FastBridgeV2 is AdminV2, MulticallTarget, IFastBridgeV2, IFastBridgeV2Errors {
     using BridgeTransactionV2Lib for bytes;
     using SafeERC20 for IERC20;
-
-    /// @notice Address reserved for native gas token (ETH on Ethereum and most L2s, AVAX on Avalanche, etc)
-    address public constant NATIVE_GAS_TOKEN = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
 
     /// @notice Dispute period for relayed transactions
     uint256 public constant DISPUTE_PERIOD = 30 minutes;

--- a/packages/contracts-rfq/contracts/FastBridgeV2.sol
+++ b/packages/contracts-rfq/contracts/FastBridgeV2.sol
@@ -6,7 +6,7 @@ import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 
 import {BridgeTransactionV2Lib} from "./libs/BridgeTransactionV2.sol";
 
-import {Admin} from "./Admin.sol";
+import {AdminV2} from "./AdminV2.sol";
 import {IFastBridge} from "./interfaces/IFastBridge.sol";
 import {IFastBridgeV2} from "./interfaces/IFastBridgeV2.sol";
 import {IFastBridgeV2Errors} from "./interfaces/IFastBridgeV2Errors.sol";
@@ -15,7 +15,7 @@ import {IZapRecipient} from "./interfaces/IZapRecipient.sol";
 import {MulticallTarget} from "./utils/MulticallTarget.sol";
 
 /// @notice FastBridgeV2 is a contract for bridging tokens across chains.
-contract FastBridgeV2 is Admin, MulticallTarget, IFastBridgeV2, IFastBridgeV2Errors {
+contract FastBridgeV2 is AdminV2, MulticallTarget, IFastBridgeV2, IFastBridgeV2Errors {
     using BridgeTransactionV2Lib for bytes;
     using SafeERC20 for IERC20;
 
@@ -47,7 +47,7 @@ contract FastBridgeV2 is Admin, MulticallTarget, IFastBridgeV2, IFastBridgeV2Err
     /// @notice the block the contract was deployed at
     uint256 public immutable deployBlock;
 
-    constructor(address _owner) Admin(_owner) {
+    constructor(address _owner) AdminV2(_owner) {
         deployBlock = block.number;
     }
 

--- a/packages/contracts-rfq/contracts/FastBridgeV2.sol
+++ b/packages/contracts-rfq/contracts/FastBridgeV2.sol
@@ -277,7 +277,7 @@ contract FastBridgeV2 is AdminV2, MulticallTarget, IFastBridgeV2, IFastBridgeV2E
     }
 
     /// @inheritdoc IFastBridgeV2
-    function prove(bytes32 transactionId, bytes32 destTxHash, address relayer) public onlyRole(RELAYER_ROLE) {
+    function prove(bytes32 transactionId, bytes32 destTxHash, address relayer) public onlyRole(PROVER_ROLE) {
         BridgeTxDetails storage $ = bridgeTxDetails[transactionId];
 
         // Can only prove a REQUESTED transaction

--- a/packages/contracts-rfq/contracts/FastBridgeV2.sol
+++ b/packages/contracts-rfq/contracts/FastBridgeV2.sol
@@ -25,9 +25,6 @@ contract FastBridgeV2 is AdminV2, MulticallTarget, IFastBridgeV2, IFastBridgeV2E
     /// @notice Dispute period for relayed transactions
     uint256 public constant DISPUTE_PERIOD = 30 minutes;
 
-    /// @notice Delay for a transaction after which it could be permisionlessly cancelled
-    uint256 public constant CANCEL_DELAY = 7 days;
-
     /// @notice Minimum deadline period to relay a requested bridge transaction
     uint256 public constant MIN_DEADLINE_PERIOD = 30 minutes;
 
@@ -348,8 +345,8 @@ contract FastBridgeV2 is AdminV2, MulticallTarget, IFastBridgeV2, IFastBridgeV2E
         // Can only cancel a REQUESTED transaction after its deadline expires
         if ($.status != BridgeStatus.REQUESTED) revert StatusIncorrect();
         uint256 deadline = request.deadline();
-        // Permissionless cancel is only allowed after CANCEL_DELAY on top of the deadline
-        if (!hasRole(CANCELER_ROLE, msg.sender)) deadline += CANCEL_DELAY;
+        // Permissionless cancel is only allowed after `cancelDelay` on top of the deadline
+        if (!hasRole(CANCELER_ROLE, msg.sender)) deadline += cancelDelay;
         if (block.timestamp <= deadline) revert DeadlineNotExceeded();
         // Update status to REFUNDED and return the full amount (collateral + protocol fees) to the original sender.
         // The protocol fees are only updated when the transaction is claimed, so we don't need to update them here.

--- a/packages/contracts-rfq/contracts/interfaces/IAdminV2.sol
+++ b/packages/contracts-rfq/contracts/interfaces/IAdminV2.sol
@@ -6,13 +6,9 @@ interface IAdminV2 {
     event FeeRateUpdated(uint256 oldFeeRate, uint256 newFeeRate);
     event FeesSwept(address token, address recipient, uint256 amount);
 
-    event ChainGasAmountUpdated(uint256 oldChainGasAmount, uint256 newChainGasAmount);
-
     function setCancelDelay(uint256 newCancelDelay) external;
 
     function setProtocolFeeRate(uint256 newFeeRate) external;
 
     function sweepProtocolFees(address token, address recipient) external;
-
-    function setChainGasAmount(uint256 newChainGasAmount) external;
 }

--- a/packages/contracts-rfq/contracts/interfaces/IAdminV2.sol
+++ b/packages/contracts-rfq/contracts/interfaces/IAdminV2.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+interface IAdminV2 {
+    // ============ Events ============
+
+    event FeeRateUpdated(uint256 oldFeeRate, uint256 newFeeRate);
+    event FeesSwept(address token, address recipient, uint256 amount);
+
+    event ChainGasAmountUpdated(uint256 oldChainGasAmount, uint256 newChainGasAmount);
+
+    // ============ Methods ============
+
+    function setProtocolFeeRate(uint256 newFeeRate) external;
+
+    function sweepProtocolFees(address token, address recipient) external;
+
+    function setChainGasAmount(uint256 newChainGasAmount) external;
+}

--- a/packages/contracts-rfq/contracts/interfaces/IAdminV2.sol
+++ b/packages/contracts-rfq/contracts/interfaces/IAdminV2.sol
@@ -2,14 +2,13 @@
 pragma solidity ^0.8.4;
 
 interface IAdminV2 {
-    // ============ Events ============
-
+    event CancelDelayUpdated(uint256 oldCancelDelay, uint256 newCancelDelay);
     event FeeRateUpdated(uint256 oldFeeRate, uint256 newFeeRate);
     event FeesSwept(address token, address recipient, uint256 amount);
 
     event ChainGasAmountUpdated(uint256 oldChainGasAmount, uint256 newChainGasAmount);
 
-    // ============ Methods ============
+    function setCancelDelay(uint256 newCancelDelay) external;
 
     function setProtocolFeeRate(uint256 newFeeRate) external;
 

--- a/packages/contracts-rfq/contracts/interfaces/IAdminV2Errors.sol
+++ b/packages/contracts-rfq/contracts/interfaces/IAdminV2Errors.sol
@@ -3,4 +3,5 @@ pragma solidity ^0.8.4;
 
 interface IAdminV2Errors {
     error CancelDelayBelowMin();
+    error FeeRateAboveMax();
 }

--- a/packages/contracts-rfq/contracts/interfaces/IAdminV2Errors.sol
+++ b/packages/contracts-rfq/contracts/interfaces/IAdminV2Errors.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+interface IAdminV2Errors {
+    error CancelDelayBelowMin();
+}

--- a/packages/contracts-rfq/contracts/interfaces/IFastBridgeV2.sol
+++ b/packages/contracts-rfq/contracts/interfaces/IFastBridgeV2.sol
@@ -88,6 +88,12 @@ interface IFastBridgeV2 is IFastBridge {
     /// @notice Can only send funds to the relayer address on the proof.
     /// @param request The encoded bridge transaction to claim on origin chain
     function claim(bytes memory request) external;
+
+    /// @notice Cancels an outstanding bridge transaction in case optimistic bridging failed and returns the full amount
+    /// to the original sender.
+    /// @param request The encoded bridge transaction to refund
+    function cancel(bytes memory request) external;
+
     /// @notice Checks if a transaction has been relayed
     /// @param transactionId The ID of the transaction to check
     /// @return True if the transaction has been relayed, false otherwise

--- a/packages/contracts-rfq/test/FastBridgeV2.GasBench.Src.t.sol
+++ b/packages/contracts-rfq/test/FastBridgeV2.GasBench.Src.t.sol
@@ -152,19 +152,19 @@ contract FastBridgeV2GasBenchmarkSrcTest is FastBridgeV2SrcBaseTest {
         assertEq(srcToken.balanceOf(address(fastBridge)), initialFastBridgeBalanceToken);
     }
 
-    function test_refundPermissioned_token() public {
+    function test_cancelPermissioned_token() public {
         bytes32 txId = getTxId(bridgedTokenTx);
         skipTimeAtLeast({time: DEADLINE});
-        refund({caller: refunder, bridgeTx: bridgedTokenTx});
+        cancel({caller: canceler, bridgeTx: bridgedTokenTx});
         assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.REFUNDED);
         assertEq(srcToken.balanceOf(userA), initialUserBalanceToken + tokenParams.originAmount);
         assertEq(srcToken.balanceOf(address(fastBridge)), initialFastBridgeBalanceToken - tokenParams.originAmount);
     }
 
-    function test_refundPermissionless_token() public {
+    function test_cancelPermissionless_token() public {
         bytes32 txId = getTxId(bridgedTokenTx);
-        skipTimeAtLeast({time: DEADLINE + PERMISSIONLESS_REFUND_DELAY});
-        refund({caller: userB, bridgeTx: bridgedTokenTx});
+        skipTimeAtLeast({time: DEADLINE + PERMISSIONLESS_CANCEL_DELAY});
+        cancel({caller: userB, bridgeTx: bridgedTokenTx});
         assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.REFUNDED);
         assertEq(srcToken.balanceOf(userA), initialUserBalanceToken + tokenParams.originAmount);
         assertEq(srcToken.balanceOf(address(fastBridge)), initialFastBridgeBalanceToken - tokenParams.originAmount);
@@ -236,19 +236,19 @@ contract FastBridgeV2GasBenchmarkSrcTest is FastBridgeV2SrcBaseTest {
         assertEq(address(fastBridge).balance, initialFastBridgeBalanceEth);
     }
 
-    function test_refundPermissioned_eth() public {
+    function test_cancelPermissioned_eth() public {
         bytes32 txId = getTxId(bridgedEthTx);
         skipTimeAtLeast({time: DEADLINE});
-        refund({caller: refunder, bridgeTx: bridgedEthTx});
+        cancel({caller: canceler, bridgeTx: bridgedEthTx});
         assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.REFUNDED);
         assertEq(userA.balance, initialUserBalanceEth + ethParams.originAmount);
         assertEq(address(fastBridge).balance, initialFastBridgeBalanceEth - ethParams.originAmount);
     }
 
-    function test_refundPermissionless_eth() public {
+    function test_cancelPermissionless_eth() public {
         bytes32 txId = getTxId(bridgedEthTx);
-        skipTimeAtLeast({time: DEADLINE + PERMISSIONLESS_REFUND_DELAY});
-        refund({caller: userB, bridgeTx: bridgedEthTx});
+        skipTimeAtLeast({time: DEADLINE + PERMISSIONLESS_CANCEL_DELAY});
+        cancel({caller: userB, bridgeTx: bridgedEthTx});
         assertEq(fastBridge.bridgeStatuses(txId), IFastBridgeV2.BridgeStatus.REFUNDED);
         assertEq(userA.balance, initialUserBalanceEth + ethParams.originAmount);
         assertEq(address(fastBridge).balance, initialFastBridgeBalanceEth - ethParams.originAmount);

--- a/packages/contracts-rfq/test/FastBridgeV2.Management.t.sol
+++ b/packages/contracts-rfq/test/FastBridgeV2.Management.t.sol
@@ -123,7 +123,7 @@ contract FastBridgeV2ManagementTest is FastBridgeV2Test, IAdminV2Errors {
     }
 
     function test_setProtocolFeeRate_revert_tooHigh() public {
-        vm.expectRevert("newFeeRate > max");
+        vm.expectRevert(IAdminV2Errors.FeeRateAboveMax.selector);
         setProtocolFeeRate(governor, FEE_RATE_MAX + 1);
     }
 

--- a/packages/contracts-rfq/test/FastBridgeV2.Management.t.sol
+++ b/packages/contracts-rfq/test/FastBridgeV2.Management.t.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {IAdmin} from "../contracts/interfaces/IAdmin.sol";
 import {IAdminV2Errors} from "../contracts/interfaces/IAdminV2Errors.sol";
 
 import {FastBridgeV2, FastBridgeV2Test} from "./FastBridgeV2.t.sol";
@@ -19,7 +20,6 @@ contract FastBridgeV2ManagementTest is FastBridgeV2Test, IAdminV2Errors {
     event CancelDelayUpdated(uint256 oldCancelDelay, uint256 newCancelDelay);
     event FeeRateUpdated(uint256 oldFeeRate, uint256 newFeeRate);
     event FeesSwept(address token, address recipient, uint256 amount);
-    event ChainGasAmountUpdated(uint256 oldChainGasAmount, uint256 newChainGasAmount);
 
     function deployFastBridge() public override returns (FastBridgeV2) {
         return new FastBridgeV2(admin);
@@ -54,11 +54,6 @@ contract FastBridgeV2ManagementTest is FastBridgeV2Test, IAdminV2Errors {
     function sweepProtocolFees(address caller, address token, address recipient) public {
         vm.prank(caller);
         fastBridge.sweepProtocolFees(token, recipient);
-    }
-
-    function setChainGasAmount(address caller, uint256 newChainGasAmount) public {
-        vm.prank(caller);
-        fastBridge.setChainGasAmount(newChainGasAmount);
     }
 
     function test_grantGovernorRole() public {
@@ -161,24 +156,14 @@ contract FastBridgeV2ManagementTest is FastBridgeV2Test, IAdminV2Errors {
 
     // ═══════════════════════════════════════════ SET CHAIN GAS AMOUNT ════════════════════════════════════════════════
 
-    function test_setChainGasAmount() public {
-        vm.expectEmit(address(fastBridge));
-        emit ChainGasAmountUpdated(0, 123);
-        setChainGasAmount(governor, 123);
-        assertEq(fastBridge.chainGasAmount(), 123);
+    function test_chainGasAmountZero() public view {
+        assertEq(fastBridge.chainGasAmount(), 0);
     }
 
-    function test_setChainGasAmount_twice() public {
-        test_setChainGasAmount();
-        vm.expectEmit(address(fastBridge));
-        emit ChainGasAmountUpdated(123, 456);
-        setChainGasAmount(governor, 456);
-        assertEq(fastBridge.chainGasAmount(), 456);
-    }
-
-    function test_setChainGasAmount_revertNotGovernor(address caller) public {
-        vm.assume(caller != governor);
-        expectUnauthorized(caller, fastBridge.GOVERNOR_ROLE());
-        setChainGasAmount(caller, 123);
+    function test_setChainGasAmount_revert() public {
+        // Generic revert: this function should not be in the V2 interface
+        vm.expectRevert();
+        vm.prank(governor);
+        IAdmin(address(fastBridge)).setChainGasAmount(123);
     }
 }

--- a/packages/contracts-rfq/test/FastBridgeV2.Src.Base.t.sol
+++ b/packages/contracts-rfq/test/FastBridgeV2.Src.Base.t.sol
@@ -9,7 +9,7 @@ import {FastBridgeV2, FastBridgeV2Test, IFastBridge, IFastBridgeV2} from "./Fast
 abstract contract FastBridgeV2SrcBaseTest is FastBridgeV2Test {
     uint256 public constant MIN_DEADLINE = 30 minutes;
     uint256 public constant CLAIM_DELAY = 30 minutes;
-    uint256 public constant PERMISSIONLESS_REFUND_DELAY = 7 days;
+    uint256 public constant PERMISSIONLESS_CANCEL_DELAY = 7 days;
 
     uint256 public constant LEFTOVER_BALANCE = 10 ether;
     uint256 public constant INITIAL_PROTOCOL_FEES_TOKEN = 456_789;
@@ -28,7 +28,7 @@ abstract contract FastBridgeV2SrcBaseTest is FastBridgeV2Test {
         fastBridge.grantRole(fastBridge.RELAYER_ROLE(), relayerA);
         fastBridge.grantRole(fastBridge.RELAYER_ROLE(), relayerB);
         fastBridge.grantRole(fastBridge.GUARD_ROLE(), guard);
-        fastBridge.grantRole(fastBridge.REFUNDER_ROLE(), refunder);
+        fastBridge.grantRole(fastBridge.CANCELER_ROLE(), canceler);
     }
 
     function mintTokens() public virtual override {
@@ -92,9 +92,9 @@ abstract contract FastBridgeV2SrcBaseTest is FastBridgeV2Test {
         fastBridge.dispute(txId);
     }
 
-    function refund(address caller, IFastBridgeV2.BridgeTransactionV2 memory bridgeTx) public {
+    function cancel(address caller, IFastBridgeV2.BridgeTransactionV2 memory bridgeTx) public virtual {
         vm.prank({msgSender: caller, txOrigin: caller});
-        fastBridge.refund(BridgeTransactionV2Lib.encodeV2(bridgeTx));
+        fastBridge.cancel(BridgeTransactionV2Lib.encodeV2(bridgeTx));
     }
 
     function test_nonce() public view {

--- a/packages/contracts-rfq/test/FastBridgeV2.Src.Base.t.sol
+++ b/packages/contracts-rfq/test/FastBridgeV2.Src.Base.t.sol
@@ -9,7 +9,8 @@ import {FastBridgeV2, FastBridgeV2Test, IFastBridge, IFastBridgeV2} from "./Fast
 abstract contract FastBridgeV2SrcBaseTest is FastBridgeV2Test {
     uint256 public constant MIN_DEADLINE = 30 minutes;
     uint256 public constant CLAIM_DELAY = 30 minutes;
-    uint256 public constant PERMISSIONLESS_CANCEL_DELAY = 7 days;
+    // Use a value different from the default to ensure it's being set correctly.
+    uint256 public constant PERMISSIONLESS_CANCEL_DELAY = 13.37 hours;
 
     uint256 public constant LEFTOVER_BALANCE = 10 ether;
     uint256 public constant INITIAL_PROTOCOL_FEES_TOKEN = 456_789;
@@ -29,6 +30,9 @@ abstract contract FastBridgeV2SrcBaseTest is FastBridgeV2Test {
         fastBridge.grantRole(fastBridge.RELAYER_ROLE(), relayerB);
         fastBridge.grantRole(fastBridge.GUARD_ROLE(), guard);
         fastBridge.grantRole(fastBridge.CANCELER_ROLE(), canceler);
+
+        fastBridge.grantRole(fastBridge.GOVERNOR_ROLE(), address(this));
+        fastBridge.setCancelDelay(PERMISSIONLESS_CANCEL_DELAY);
     }
 
     function mintTokens() public virtual override {

--- a/packages/contracts-rfq/test/FastBridgeV2.Src.Base.t.sol
+++ b/packages/contracts-rfq/test/FastBridgeV2.Src.Base.t.sol
@@ -26,8 +26,8 @@ abstract contract FastBridgeV2SrcBaseTest is FastBridgeV2Test {
     }
 
     function configureFastBridge() public virtual override {
-        fastBridge.grantRole(fastBridge.RELAYER_ROLE(), relayerA);
-        fastBridge.grantRole(fastBridge.RELAYER_ROLE(), relayerB);
+        fastBridge.grantRole(fastBridge.PROVER_ROLE(), relayerA);
+        fastBridge.grantRole(fastBridge.PROVER_ROLE(), relayerB);
         fastBridge.grantRole(fastBridge.GUARD_ROLE(), guard);
         fastBridge.grantRole(fastBridge.CANCELER_ROLE(), canceler);
 

--- a/packages/contracts-rfq/test/FastBridgeV2.Src.RefundV1.t.sol
+++ b/packages/contracts-rfq/test/FastBridgeV2.Src.RefundV1.t.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {FastBridgeV2SrcTest, BridgeTransactionV2Lib, IFastBridgeV2} from "./FastBridgeV2.Src.t.sol";
+
+// solhint-disable func-name-mixedcase, ordering
+contract FastBridgeV2SrcRefundV1Test is FastBridgeV2SrcTest {
+    function cancel(address caller, IFastBridgeV2.BridgeTransactionV2 memory bridgeTx) public virtual override {
+        vm.prank({msgSender: caller, txOrigin: caller});
+        fastBridge.refund(BridgeTransactionV2Lib.encodeV2(bridgeTx));
+    }
+}

--- a/packages/contracts-rfq/test/FastBridgeV2.Src.t.sol
+++ b/packages/contracts-rfq/test/FastBridgeV2.Src.t.sol
@@ -349,7 +349,7 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
     function test_prove_revert_callerNotRelayer(address caller) public {
         vm.assume(caller != relayerA && caller != relayerB);
         bridge({caller: userA, msgValue: 0, params: tokenParams});
-        expectUnauthorized(caller, fastBridge.RELAYER_ROLE());
+        expectUnauthorized(caller, fastBridge.PROVER_ROLE());
         prove({caller: caller, bridgeTx: tokenTx, destTxHash: hex"01"});
     }
 
@@ -464,7 +464,7 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         bytes32 txId = getTxId(tokenTx);
         vm.assume(caller != relayerA && caller != relayerB);
         bridge({caller: userA, msgValue: 0, params: tokenParams});
-        expectUnauthorized(caller, fastBridge.RELAYER_ROLE());
+        expectUnauthorized(caller, fastBridge.PROVER_ROLE());
         prove({caller: caller, transactionId: txId, destTxHash: hex"01", relayer: relayerA});
     }
 

--- a/packages/contracts-rfq/test/FastBridgeV2.t.sol
+++ b/packages/contracts-rfq/test/FastBridgeV2.t.sol
@@ -36,7 +36,7 @@ abstract contract FastBridgeV2Test is Test, IFastBridgeV2Errors {
     address public userA = makeAddr("User A");
     address public userB = makeAddr("User B");
     address public governor = makeAddr("Governor");
-    address public refunder = makeAddr("Refunder");
+    address public canceler = makeAddr("Canceler");
 
     IFastBridgeV2.BridgeTransactionV2 internal tokenTx;
     IFastBridgeV2.BridgeTransactionV2 internal ethTx;

--- a/packages/contracts-rfq/test/integration/FastBridgeV2.MulticallTarget.t.sol
+++ b/packages/contracts-rfq/test/integration/FastBridgeV2.MulticallTarget.t.sol
@@ -9,7 +9,7 @@ import {MulticallTargetIntegrationTest, IFastBridge} from "./MulticallTarget.t.s
 contract FastBridgeV2MulticallTargetTest is MulticallTargetIntegrationTest {
     function deployAndConfigureFastBridge() public override returns (address) {
         FastBridgeV2 fastBridge = new FastBridgeV2(address(this));
-        fastBridge.grantRole(fastBridge.RELAYER_ROLE(), relayer);
+        fastBridge.grantRole(fastBridge.PROVER_ROLE(), relayer);
         return address(fastBridge);
     }
 


### PR DESCRIPTION
**Description**
- Users can permisionlessly cancel their orders after they expire, and additional `cancelDelay` passes.
- `cancelDelay` is configurable by the governance
  - Default value after contract deployment: 1 day
  - Can not be set lower than 1 hour.

Misc additional deprecations that became possible by dropping old `Admin` template:
- `chainGasAmount` and `setChainGasAmount` are deprecated, as they are replaced by the "zap native" V2 feature.
- `setProtocolFeeRate` uses a custom error instead of a string error message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced the `AdminV2` smart contract for enhanced access control and fee management.
	- Added a `cancel` function to replace the previous refund mechanism in `FastBridgeV2`, allowing cancellation of transactions.
	- Implemented new administrative functions for setting cancellation delays and protocol fee rates.
	- Enhanced the `IFastBridgeV2` interface with new transaction management capabilities.

- **Bug Fixes**
	- Improved error handling with custom errors for cancellation delays and fee rates.

- **Documentation**
	- Updated comments and documentation to reflect changes in functionality and naming conventions.

- **Tests**
	- Refactored tests to align with the new cancellation logic and updated function names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->