### PR TITLE
fix(rfq-api): enforce max quote age for passive quotes [SLT-463]

### DIFF
--- a/services/rfq/api/config/config.go
+++ b/services/rfq/api/config/config.go
@@ -38,7 +38,7 @@ func (c Config) GetRelayAckTimeout() time.Duration {
 	return c.RelayAckTimeout
 }
 
-const defaultMaxQuoteAge = 1 * time.Hour
+const defaultMaxQuoteAge = 5 * time.Minute
 
 // GetMaxQuoteAge returns the max quote age.
 func (c Config) GetMaxQuoteAge() time.Duration {

--- a/services/rfq/api/rest/export_test.go
+++ b/services/rfq/api/rest/export_test.go
@@ -3,9 +3,15 @@ package rest
 import (
 	"github.com/synapsecns/sanguine/services/rfq/api/config"
 	"github.com/synapsecns/sanguine/services/rfq/api/db"
+	"github.com/synapsecns/sanguine/services/rfq/api/model"
 )
 
 // FilterQuoteAge exports filterQuoteAge for testing.
 func FilterQuoteAge(cfg config.Config, dbQuotes []*db.Quote) []*db.Quote {
 	return filterQuoteAge(cfg, dbQuotes)
+}
+
+// GetPassiveQuote exports getPassiveQuote for testing.
+func GetPassiveQuote(cfg config.Config, quotes []*db.Quote, request *model.PutRFQRequest) (*model.QuoteData, error) {
+	return getPassiveQuote(cfg, quotes, request)
 }

--- a/services/rfq/api/rest/rfq.go
+++ b/services/rfq/api/rest/rfq.go
@@ -225,6 +225,7 @@ func (r *QuoterAPIServer) handlePassiveRFQ(ctx context.Context, request *model.P
 	if err != nil {
 		return nil, fmt.Errorf("failed to get quotes: %w", err)
 	}
+	quotes = filterQuoteAge(r.cfg, quotes)
 
 	originAmount, ok := new(big.Int).SetString(request.Data.OriginAmountExact, 10)
 	if !ok {

--- a/services/rfq/api/rest/rfq.go
+++ b/services/rfq/api/rest/rfq.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/synapsecns/sanguine/core/metrics"
+	"github.com/synapsecns/sanguine/services/rfq/api/config"
 	"github.com/synapsecns/sanguine/services/rfq/api/db"
 	"github.com/synapsecns/sanguine/services/rfq/api/model"
 	"go.opentelemetry.io/otel/attribute"
@@ -225,7 +226,17 @@ func (r *QuoterAPIServer) handlePassiveRFQ(ctx context.Context, request *model.P
 	if err != nil {
 		return nil, fmt.Errorf("failed to get quotes: %w", err)
 	}
-	quotes = filterQuoteAge(r.cfg, quotes)
+
+	quote, err := getPassiveQuote(r.cfg, quotes, request)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get passive quote: %w", err)
+	}
+
+	return quote, nil
+}
+
+func getPassiveQuote(cfg config.Config, quotes []*db.Quote, request *model.PutRFQRequest) (*model.QuoteData, error) {
+	quotes = filterQuoteAge(cfg, quotes)
 
 	originAmount, ok := new(big.Int).SetString(request.Data.OriginAmountExact, 10)
 	if !ok {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new function to retrieve passive quotes, enhancing RFQ handling.
	- Improved error handling for passive quote retrieval processes.

- **Bug Fixes**
	- Enhanced logic for calculating destination amounts and handling invalid origin amounts.

- **Tests**
	- Added a new test for retrieving the best passive quote, ensuring functionality aligns with user request parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->