### PR TITLE
feat(rfq-relayer): apply zap fee to dest amount for active quotes [SLT-465]

### DIFF
--- a/services/rfq/api/model/request.go
+++ b/services/rfq/api/model/request.go
@@ -55,7 +55,6 @@ type QuoteData struct {
 	DestChainID       int     `json:"dest_chain_id"`
 	OriginTokenAddr   string  `json:"origin_token_addr"`
 	DestTokenAddr     string  `json:"dest_token_addr"`
-	OriginAmount      string  `json:"origin_amount"`
 	ExpirationWindow  int64   `json:"expiration_window"`
 	ZapData           string  `json:"zap_data"`
 	ZapNative         string  `json:"zap_native"`

--- a/services/rfq/relayer/quoter/export_test.go
+++ b/services/rfq/relayer/quoter/export_test.go
@@ -22,6 +22,10 @@ func (m *Manager) GetDestAmount(ctx context.Context, quoteAmount *big.Int, token
 	return m.getDestAmount(ctx, quoteAmount, tokenName, input)
 }
 
+func (m *Manager) GenerateActiveRFQ(ctx context.Context, msg *model.ActiveRFQMessage) (resp *model.ActiveRFQMessage, err error) {
+	return m.generateActiveRFQ(ctx, msg)
+}
+
 func (m *Manager) SetConfig(cfg relconfig.Config) {
 	m.config = cfg
 }

--- a/services/rfq/relayer/quoter/quoter.go
+++ b/services/rfq/relayer/quoter/quoter.go
@@ -407,7 +407,11 @@ func (m *Manager) generateActiveRFQ(ctx context.Context, msg *model.ActiveRFQMes
 	if !ok {
 		return nil, fmt.Errorf("invalid fixed fee: %s", rawQuote.FixedFee)
 	}
-	rawQuote.DestAmount = new(big.Int).Sub(destAmountBigInt, fixedFeeBigInt).String()
+	destAmountAdj := new(big.Int).Sub(destAmountBigInt, fixedFeeBigInt)
+	if destAmountAdj.Sign() < 0 {
+		destAmountAdj = big.NewInt(0)
+	}
+	rawQuote.DestAmount = destAmountAdj.String()
 	span.SetAttributes(attribute.String("dest_amount", rawQuote.DestAmount))
 
 	rfqResp := model.WsRFQResponse{

--- a/services/rfq/relayer/quoter/quoter.go
+++ b/services/rfq/relayer/quoter/quoter.go
@@ -338,7 +338,7 @@ func (m *Manager) SubscribeActiveRFQ(ctx context.Context) (err error) {
 
 // getActiveRFQ handles an active RFQ message.
 //
-//nolint:nilnil
+//nolint:nilnil,cyclop
 func (m *Manager) generateActiveRFQ(ctx context.Context, msg *model.ActiveRFQMessage) (resp *model.ActiveRFQMessage, err error) {
 	ctx, span := m.metricsHandler.Tracer().Start(ctx, "generateActiveRFQ", trace.WithAttributes(
 		attribute.String("op", msg.Op),

--- a/services/rfq/relayer/quoter/quoter.go
+++ b/services/rfq/relayer/quoter/quoter.go
@@ -397,6 +397,17 @@ func (m *Manager) generateActiveRFQ(ctx context.Context, msg *model.ActiveRFQMes
 	if err != nil {
 		return nil, fmt.Errorf("error generating quote: %w", err)
 	}
+
+	// adjust dest amount by fixed fee
+	destAmountBigInt, ok := new(big.Int).SetString(rawQuote.DestAmount, 10)
+	if !ok {
+		return nil, fmt.Errorf("invalid dest amount: %s", rawQuote.DestAmount)
+	}
+	fixedFeeBigInt, ok := new(big.Int).SetString(rawQuote.FixedFee, 10)
+	if !ok {
+		return nil, fmt.Errorf("invalid fixed fee: %s", rawQuote.FixedFee)
+	}
+	rawQuote.DestAmount = new(big.Int).Sub(destAmountBigInt, fixedFeeBigInt).String()
 	span.SetAttributes(attribute.String("dest_amount", rawQuote.DestAmount))
 
 	rfqResp := model.WsRFQResponse{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced quote generation process by incorporating new parameters (`ZapNative` and `ZapData`).
	- Introduced a new method for generating active RFQs.

- **Bug Fixes**
	- Adjusted destination amount calculations to accurately reflect fees, preventing negative values.

- **Tests**
	- Added new test cases for generating active RFQs to ensure correct handling of requests and expected outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->