### PR TITLE
Fixing REST API docs to include route changes

### DIFF
--- a/docs/bridge/docs/02-Bridge/02-REST-API.md
+++ b/docs/bridge/docs/02-Bridge/02-REST-API.md
@@ -4,7 +4,16 @@ title: REST API
 
 # REST API
 
-Get read-only data from on-chain Synapse contracts, and generate Bridge and Swap quotes, plus additional transaction information.
+The Synapse REST API is a read-only API that allows you to integrate the Synapse liquidity network into your application.
+
+Through HTTP requests, developers can integrate Synapse cross-chain tokens and liquidity transfers dynamically into their applications. Developers can retrieve quotes, as well as generate the relevant call data for Synapse Bridges and Swaps.  Example requests can be found below in the [API-docs](#api-docs) section.
+
+
+The Synapse REST API is built on top of the [Synapse Bridge SDK](https://docs.synapseprotocol.com/docs/Bridge/SDK).
+
+
+The API is available at [`https://api.synapseprotocol.com/`](https://api.synapseprotocol.com/).
+
 
 ## API-docs
 
@@ -17,6 +26,7 @@ Get read-only data from on-chain Synapse contracts, and generate Bridge and Swap
 | Date                   | Description                                                                                                                                                        |
 | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | 2024&#8209;10&#8209;01 | [https://synapse-rest-api-v2.herokuapp.com/](https://synapse-rest-api-v2.herokuapp.com/) is no longer maintained and has been fully deprecated as of October 2024. |
+| 2024&#8209;11&#8209;19 | [https://api.synapseprotocol.com/](https://api.synapseprotocol.com/) the /bridgeTxInfo endpoint has been consolidated into the /bridge endpoint, which now returns call data                   |
 
 ## Support
 

--- a/packages/rest-api/src/routes/bridgeTxInfoRoute.ts
+++ b/packages/rest-api/src/routes/bridgeTxInfoRoute.ts
@@ -19,8 +19,8 @@ const router: express.Router = express.Router()
  * @openapi
  * /bridgeTxInfo:
  *   get:
- *     summary: [Deprecated] Get bridge transaction information
- *     description: [Deprecated] in favor of using the /bridge endpoint, which now returns call data.
+ *     summary: "[Deprecated] in favor of using the /bridge endpoint, which now returns call data"
+ *     description: "[Deprecated] Originally used to get Bridge transaction information"
  *     parameters:
  *       - in: query
  *         name: fromChain

--- a/packages/rest-api/src/routes/bridgeTxInfoRoute.ts
+++ b/packages/rest-api/src/routes/bridgeTxInfoRoute.ts
@@ -19,8 +19,8 @@ const router: express.Router = express.Router()
  * @openapi
  * /bridgeTxInfo:
  *   get:
- *     summary: Get bridge transaction information
- *     description: Retrieve transaction information for bridging tokens between chains
+ *     summary: [Deprecated] Get bridge transaction information
+ *     description: [Deprecated] in favor of using the /bridge endpoint, which now returns call data.
  *     parameters:
  *       - in: query
  *         name: fromChain

--- a/packages/rest-api/src/routes/swapTxInfoRoute.ts
+++ b/packages/rest-api/src/routes/swapTxInfoRoute.ts
@@ -18,8 +18,8 @@ const router: express.Router = express.Router()
  * @openapi
  * /swapTxInfo:
  *   get:
- *     summary: Get swap transaction information
- *     description: Retrieve transaction information for swapping tokens on a specific chain
+ *     summary: [Deprecated] Get swap transaction information
+ *     description: [Deprecated] in favor of using the /swap endpoint, which now returns call data.
  *     parameters:
  *       - in: query
  *         name: chain

--- a/packages/rest-api/src/routes/swapTxInfoRoute.ts
+++ b/packages/rest-api/src/routes/swapTxInfoRoute.ts
@@ -18,8 +18,8 @@ const router: express.Router = express.Router()
  * @openapi
  * /swapTxInfo:
  *   get:
- *     summary: [Deprecated] Get swap transaction information
- *     description: [Deprecated] in favor of using the /swap endpoint, which now returns call data.
+ *     summary: "[Deprecated] in favor of using the /swap endpoint, which now returns call data
+ *     description: "[Deprecated] Originally used to get Swap transaction information
  *     parameters:
  *       - in: query
  *         name: chain

--- a/packages/rest-api/swagger.json
+++ b/packages/rest-api/swagger.json
@@ -396,8 +396,8 @@
     },
     "/bridgeTxInfo": {
       "get": {
-        "summary": "[Deprecated] Get bridge transaction information",
-        "description": "[Deprecated] in favor of using the /bridge endpoint, which now returns call data.",
+        "summary": "[Deprecated] in favor of using the /bridge endpoint, which now returns call data",
+        "description": "[Deprecated] Originally used to get Bridge transaction information",
         "parameters": [
           {
             "in": "query",
@@ -1345,8 +1345,8 @@
     },
     "/swapTxInfo": {
       "get": {
-        "summary": "[Deprecated] Get swap transaction information",
-        "description": "[Deprecated] in favor of using the /swap endpoint, which now returns call data.",
+        "summary": "[Deprecated] in favor of using the /swap endpoint, which now returns call data",
+        "description": "[Deprecated] Originally used to get Swap transaction information",
         "parameters": [
           {
             "in": "query",

--- a/packages/rest-api/swagger.json
+++ b/packages/rest-api/swagger.json
@@ -396,8 +396,8 @@
     },
     "/bridgeTxInfo": {
       "get": {
-        "summary": "Get bridge transaction information",
-        "description": "Retrieve transaction information for bridging tokens between chains",
+        "summary": "[Deprecated] Get bridge transaction information",
+        "description": "[Deprecated] in favor of using the /bridge endpoint, which now returns call data.",
         "parameters": [
           {
             "in": "query",
@@ -1345,8 +1345,8 @@
     },
     "/swapTxInfo": {
       "get": {
-        "summary": "Get swap transaction information",
-        "description": "Retrieve transaction information for swapping tokens on a specific chain",
+        "summary": "[Deprecated] Get swap transaction information",
+        "description": "[Deprecated] in favor of using the /swap endpoint, which now returns call data.",
         "parameters": [
           {
             "in": "query",


### PR DESCRIPTION
Merging the /txInfo endpoints with their relevant /swap or /bridge endpoints. Updating the docs to reflect this and then also adding more clarity on how the docs work. 

Docs likely need more iteration. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Revised Synapse REST API documentation for clarity on read-only status and integration capabilities.
	- Added new API endpoint information and consolidated deprecated endpoints into updated versions.
	- Enhanced descriptions for `/bridge` endpoint, including new required parameters and detailed response structures.
	- Improved overall formatting and consistency across API documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
4b78d548675238ce2b05767914b3442254bd2f26: [docs preview link ](https://bridge-docs-l815o6zui-synapsecns.vercel.app)