### PR TITLE
refactor(contracts-rfq): mark new methods as `V2`

### DIFF
--- a/packages/contracts-rfq/contracts/FastBridgeV2.sol
+++ b/packages/contracts-rfq/contracts/FastBridgeV2.sol
@@ -65,7 +65,7 @@ contract FastBridgeV2 is AdminV2, MulticallTarget, IFastBridgeV2, IFastBridgeV2E
 
     /// @inheritdoc IFastBridge
     function bridge(BridgeParams memory params) external payable {
-        bridge({
+        bridgeV2({
             params: params,
             paramsV2: BridgeParamsV2({
                 quoteRelayer: address(0),
@@ -81,7 +81,7 @@ contract FastBridgeV2 is AdminV2, MulticallTarget, IFastBridgeV2, IFastBridgeV2E
     /// @dev Replaced by `cancel`.
     /// @inheritdoc IFastBridge
     function refund(bytes calldata request) external {
-        cancel(request);
+        cancelV2(request);
     }
 
     // ══════════════════════════════════════ EXTERNAL MUTABLE (AGENT FACING) ══════════════════════════════════════════
@@ -89,17 +89,17 @@ contract FastBridgeV2 is AdminV2, MulticallTarget, IFastBridgeV2, IFastBridgeV2E
     /// @inheritdoc IFastBridge
     function relay(bytes calldata request) external payable {
         // `relay` override will validate the request.
-        relay({request: request, relayer: msg.sender});
+        relayV2({request: request, relayer: msg.sender});
     }
 
     /// @inheritdoc IFastBridge
     function prove(bytes calldata request, bytes32 destTxHash) external {
         request.validateV2();
-        prove({transactionId: keccak256(request), destTxHash: destTxHash, relayer: msg.sender});
+        proveV2({transactionId: keccak256(request), destTxHash: destTxHash, relayer: msg.sender});
     }
 
     /// @inheritdoc IFastBridgeV2
-    function claim(bytes calldata request) external {
+    function claimV2(bytes calldata request) external {
         // `claim` override will validate the request.
         claim({request: request, to: address(0)});
     }
@@ -177,7 +177,7 @@ contract FastBridgeV2 is AdminV2, MulticallTarget, IFastBridgeV2, IFastBridgeV2E
     // ═══════════════════════════════════════ PUBLIC MUTABLE (USER FACING) ════════════════════════════════════════════
 
     /// @inheritdoc IFastBridgeV2
-    function bridge(BridgeParams memory params, BridgeParamsV2 memory paramsV2) public payable {
+    function bridgeV2(BridgeParams memory params, BridgeParamsV2 memory paramsV2) public payable {
         // If relayer exclusivity is not intended for this bridge, set exclusivityEndTime to static zero.
         // Otherwise, set exclusivity to expire at the current block ts offset by quoteExclusivitySeconds.
         int256 exclusivityEndTime = 0;
@@ -240,7 +240,7 @@ contract FastBridgeV2 is AdminV2, MulticallTarget, IFastBridgeV2, IFastBridgeV2E
     }
 
     /// @inheritdoc IFastBridgeV2
-    function cancel(bytes calldata request) public {
+    function cancelV2(bytes calldata request) public {
         // Decode the request and check that it could be cancelled.
         request.validateV2();
         bytes32 transactionId = keccak256(request);
@@ -278,7 +278,7 @@ contract FastBridgeV2 is AdminV2, MulticallTarget, IFastBridgeV2, IFastBridgeV2E
     // ═══════════════════════════════════════ PUBLIC MUTABLE (AGENT FACING) ═══════════════════════════════════════════
 
     /// @inheritdoc IFastBridgeV2
-    function relay(bytes calldata request, address relayer) public payable {
+    function relayV2(bytes calldata request, address relayer) public payable {
         // Decode the request and check that it could be relayed.
         request.validateV2();
         bytes32 transactionId = keccak256(request);
@@ -347,7 +347,7 @@ contract FastBridgeV2 is AdminV2, MulticallTarget, IFastBridgeV2, IFastBridgeV2E
     }
 
     /// @inheritdoc IFastBridgeV2
-    function prove(bytes32 transactionId, bytes32 destTxHash, address relayer) public onlyRole(PROVER_ROLE) {
+    function proveV2(bytes32 transactionId, bytes32 destTxHash, address relayer) public onlyRole(PROVER_ROLE) {
         // Can only prove a REQUESTED transaction.
         BridgeTxDetails storage $ = bridgeTxDetails[transactionId];
         if ($.status != BridgeStatus.REQUESTED) revert StatusIncorrect();

--- a/packages/contracts-rfq/contracts/interfaces/IFastBridgeV2.sol
+++ b/packages/contracts-rfq/contracts/interfaces/IFastBridgeV2.sol
@@ -70,28 +70,28 @@ interface IFastBridgeV2 is IFastBridge {
     /// to provide temporary exclusivity fill rights for the quote relayer.
     /// @param params   The parameters required to bridge
     /// @param paramsV2 The parameters for exclusivity fill rights (optional, can be left empty)
-    function bridge(BridgeParams memory params, BridgeParamsV2 memory paramsV2) external payable;
+    function bridgeV2(BridgeParams memory params, BridgeParamsV2 memory paramsV2) external payable;
 
     /// @notice Relays destination side of bridge transaction by off-chain relayer
     /// @param request The encoded bridge transaction to relay on destination chain
     /// @param relayer The address of the relaying entity which should have control of the origin funds when claimed
-    function relay(bytes memory request, address relayer) external payable;
+    function relayV2(bytes memory request, address relayer) external payable;
 
     /// @notice Provides proof on origin side that relayer provided funds on destination side of bridge transaction
     /// @param transactionId The transaction id associated with the encoded bridge transaction to prove
     /// @param destTxHash The destination tx hash proving bridge transaction was relayed
     /// @param relayer The address of the relaying entity which should have control of the origin funds when claimed
-    function prove(bytes32 transactionId, bytes32 destTxHash, address relayer) external;
+    function proveV2(bytes32 transactionId, bytes32 destTxHash, address relayer) external;
 
     /// @notice Completes bridge transaction on origin chain by claiming originally deposited capital.
     /// @notice Can only send funds to the relayer address on the proof.
     /// @param request The encoded bridge transaction to claim on origin chain
-    function claim(bytes memory request) external;
+    function claimV2(bytes memory request) external;
 
     /// @notice Cancels an outstanding bridge transaction in case optimistic bridging failed and returns the full amount
     /// to the original sender.
     /// @param request The encoded bridge transaction to refund
-    function cancel(bytes memory request) external;
+    function cancelV2(bytes memory request) external;
 
     /// @notice Checks if a transaction has been relayed
     /// @param transactionId The ID of the transaction to check

--- a/packages/contracts-rfq/test/FastBridgeV2.Dst.Base.t.sol
+++ b/packages/contracts-rfq/test/FastBridgeV2.Dst.Base.t.sol
@@ -50,6 +50,6 @@ contract FastBridgeV2DstBaseTest is FastBridgeV2Test {
     {
         bytes memory request = BridgeTransactionV2Lib.encodeV2(bridgeTx);
         vm.prank({msgSender: caller, txOrigin: caller});
-        fastBridge.relay{value: msgValue}(request, relayer);
+        fastBridge.relayV2{value: msgValue}(request, relayer);
     }
 }

--- a/packages/contracts-rfq/test/FastBridgeV2.Dst.t.sol
+++ b/packages/contracts-rfq/test/FastBridgeV2.Dst.t.sol
@@ -453,19 +453,19 @@ contract FastBridgeV2DstTest is FastBridgeV2DstBaseTest {
         // V1 doesn't have any version field
         expectRevertUnsupportedVersion(0);
         vm.prank({msgSender: relayerA, txOrigin: relayerA});
-        fastBridge.relay(mockRequestV1, relayerB);
+        fastBridge.relayV2(mockRequestV1, relayerB);
     }
 
     function test_relay_withRelayerAddress_revert_invalidRequestV2() public {
         expectRevertInvalidEncodedTx();
         vm.prank({msgSender: relayerA, txOrigin: relayerA});
-        fastBridge.relay(invalidRequestV2, relayerB);
+        fastBridge.relayV2(invalidRequestV2, relayerB);
     }
 
     function test_relay_withRelayerAddress_revert_requestV3() public {
         expectRevertUnsupportedVersion(3);
         vm.prank({msgSender: relayerA, txOrigin: relayerA});
-        fastBridge.relay(mockRequestV3, relayerB);
+        fastBridge.relayV2(mockRequestV3, relayerB);
     }
 
     function test_relay_withRelayerAddress_revert_chainIncorrect() public {

--- a/packages/contracts-rfq/test/FastBridgeV2.Src.Base.t.sol
+++ b/packages/contracts-rfq/test/FastBridgeV2.Src.Base.t.sol
@@ -68,12 +68,12 @@ abstract contract FastBridgeV2SrcBaseTest is FastBridgeV2Test {
         public
     {
         vm.prank({msgSender: caller, txOrigin: caller});
-        fastBridge.bridge{value: msgValue}(params, paramsV2);
+        fastBridge.bridgeV2{value: msgValue}(params, paramsV2);
     }
 
     function prove(address caller, bytes32 transactionId, bytes32 destTxHash, address relayer) public {
         vm.prank({msgSender: caller, txOrigin: caller});
-        fastBridge.prove(transactionId, destTxHash, relayer);
+        fastBridge.proveV2(transactionId, destTxHash, relayer);
     }
 
     function prove(address caller, IFastBridgeV2.BridgeTransactionV2 memory bridgeTx, bytes32 destTxHash) public {
@@ -83,7 +83,7 @@ abstract contract FastBridgeV2SrcBaseTest is FastBridgeV2Test {
 
     function claim(address caller, IFastBridgeV2.BridgeTransactionV2 memory bridgeTx) public {
         vm.prank({msgSender: caller, txOrigin: caller});
-        fastBridge.claim(BridgeTransactionV2Lib.encodeV2(bridgeTx));
+        fastBridge.claimV2(BridgeTransactionV2Lib.encodeV2(bridgeTx));
     }
 
     function claim(address caller, IFastBridgeV2.BridgeTransactionV2 memory bridgeTx, address to) public {
@@ -98,7 +98,7 @@ abstract contract FastBridgeV2SrcBaseTest is FastBridgeV2Test {
 
     function cancel(address caller, IFastBridgeV2.BridgeTransactionV2 memory bridgeTx) public virtual {
         vm.prank({msgSender: caller, txOrigin: caller});
-        fastBridge.cancel(BridgeTransactionV2Lib.encodeV2(bridgeTx));
+        fastBridge.cancelV2(BridgeTransactionV2Lib.encodeV2(bridgeTx));
     }
 
     function test_nonce() public view {

--- a/packages/contracts-rfq/test/FastBridgeV2.Src.t.sol
+++ b/packages/contracts-rfq/test/FastBridgeV2.Src.t.sol
@@ -998,19 +998,19 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         // V1 doesn't have any version field
         expectRevertUnsupportedVersion(0);
         vm.prank({msgSender: relayerA, txOrigin: relayerA});
-        fastBridge.claim(mockRequestV1);
+        fastBridge.claimV2(mockRequestV1);
     }
 
     function test_claim_revert_invalidRequestV2() public {
         expectRevertInvalidEncodedTx();
         vm.prank({msgSender: relayerA, txOrigin: relayerA});
-        fastBridge.claim(invalidRequestV2);
+        fastBridge.claimV2(invalidRequestV2);
     }
 
     function test_claim_revert_requestV3() public {
         expectRevertUnsupportedVersion(3);
         vm.prank({msgSender: relayerA, txOrigin: relayerA});
-        fastBridge.claim(mockRequestV3);
+        fastBridge.claimV2(mockRequestV3);
     }
 
     function test_claim_toDiffAddress_revert_requestV1() public {
@@ -1036,18 +1036,18 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         // V1 doesn't have any version field
         expectRevertUnsupportedVersion(0);
         vm.prank({msgSender: relayerA, txOrigin: relayerA});
-        fastBridge.cancel(mockRequestV1);
+        fastBridge.cancelV2(mockRequestV1);
     }
 
     function test_cancel_revert_invalidRequestV2() public {
         expectRevertInvalidEncodedTx();
         vm.prank({msgSender: relayerA, txOrigin: relayerA});
-        fastBridge.cancel(invalidRequestV2);
+        fastBridge.cancelV2(invalidRequestV2);
     }
 
     function test_cancel_revert_requestV3() public {
         expectRevertUnsupportedVersion(3);
         vm.prank({msgSender: relayerA, txOrigin: relayerA});
-        fastBridge.cancel(mockRequestV3);
+        fastBridge.cancelV2(mockRequestV3);
     }
 }

--- a/packages/contracts-rfq/test/integration/FastBridgeV2.TokenZapV1.Src.t.sol
+++ b/packages/contracts-rfq/test/integration/FastBridgeV2.TokenZapV1.Src.t.sol
@@ -37,7 +37,7 @@ contract FastBridgeV2TokenZapV1SrcTest is TokenZapV1IntegrationTest {
         public
     {
         vm.prank({msgSender: user, txOrigin: user});
-        fastBridge.bridge{value: isToken ? 0 : SRC_AMOUNT}(params, paramsV2);
+        fastBridge.bridgeV2{value: isToken ? 0 : SRC_AMOUNT}(params, paramsV2);
     }
 
     function expectEventBridgeRequested(


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**
A clear and concise description of the features you're adding in this pull request.

**Additional context**
Add any other context about the problem you're solving.

**Metadata**
- Fixes #[Link to Issue]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced versioned functions for bridging, claiming, canceling, relaying, and proving transactions (e.g., `bridgeV2`, `claimV2`).
	- Added new parameters in the `BridgeParamsV2` structure to enhance transaction handling.

- **Bug Fixes**
	- Updated tests to ensure correct invocation of new versioned functions and error handling for various scenarios.

- **Documentation**
	- Improved clarity in the interface for bridge transactions with updated method signatures reflecting the new versioning system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->