### PR TITLE
fix(contracts-rfq): `TokenZapV1` native gas token behaviour [SLT-389]

### DIFF
--- a/packages/contracts-rfq/contracts/zaps/TokenZapV1.sol
+++ b/packages/contracts-rfq/contracts/zaps/TokenZapV1.sol
@@ -29,6 +29,10 @@ contract TokenZapV1 is IZapRecipient {
     error TokenZapV1__AmountIncorrect();
     error TokenZapV1__PayloadLengthAboveMax();
 
+    /// @notice Allows the contract to receive ETH.
+    /// @dev Leftover ETH can be claimed by anyone, make sure to spend the full balance during the Zaps.
+    receive() external payable {}
+
     /// @notice Performs a Zap action using the specified token and amount. This amount must be previously
     /// transferred to this contract (or supplied as msg.value if the token is native gas token).
     /// @dev The provided ZapData contains the target address and calldata for the Zap action, and must be

--- a/packages/contracts-rfq/contracts/zaps/TokenZapV1.sol
+++ b/packages/contracts-rfq/contracts/zaps/TokenZapV1.sol
@@ -27,6 +27,7 @@ contract TokenZapV1 is IZapRecipient {
     address public constant NATIVE_GAS_TOKEN = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
 
     error TokenZapV1__PayloadLengthAboveMax();
+    error TokenZapV1__TargetZeroAddress();
 
     /// @notice Allows the contract to receive ETH.
     /// @dev Leftover ETH can be claimed by anyone. Ensure the full balance is spent during Zaps.
@@ -47,10 +48,11 @@ contract TokenZapV1 is IZapRecipient {
         // Validate the ZapData format and extract the target address.
         zapData.validateV1();
         address target = zapData.target();
-        uint256 msgValue = msg.value;
+        if (target == address(0)) revert TokenZapV1__TargetZeroAddress();
         // Note: we don't check the amount that was transferred to TokenZapV1 (or msg.value for native gas tokens).
         // Transferring more than `amount` will lead to remaining funds in TokenZapV1, which can be claimed by anyone.
         // Ensure that you send the exact amount for a single Zap or spend the full balance for multiple `zap()` calls.
+        uint256 msgValue = msg.value;
         if (token == NATIVE_GAS_TOKEN) {
             // For native gas tokens, we forward the requested amount to the target contract during the Zap action.
             // Similar to ERC20s, we allow using pre-transferred native tokens for the Zap.

--- a/packages/contracts-rfq/contracts/zaps/TokenZapV1.sol
+++ b/packages/contracts-rfq/contracts/zaps/TokenZapV1.sol
@@ -34,6 +34,7 @@ contract TokenZapV1 is IZapRecipient {
 
     /// @notice Performs a Zap action using the specified token and amount. This amount must be previously
     /// transferred to this contract (could also be supplied as msg.value if the token is native gas token).
+    /// Zap action will be performed forwarding full `msg.value` for ERC20s or `amount` for native gas token.
     /// Note: all funds remaining after the Zap action is performed can be claimed by anyone.
     /// Make sure to spend the full balance during the Zaps and avoid sending extra funds if a single Zap is performed.
     /// @dev The provided ZapData contains the target address and calldata for the Zap action, and must be
@@ -73,7 +74,7 @@ contract TokenZapV1 is IZapRecipient {
             // revert with a generic custom error should the target contract revert on incoming transfer.
             Address.sendValue({recipient: payable(target), amount: msgValue});
         } else {
-            // Perform the Zap action, forwarding full msg.value to the target contract.
+            // Perform the Zap action, forwarding requested native value to the target contract.
             // Note: this will bubble up any revert from the target contract.
             Address.functionCallWithValue({target: target, data: payload, value: msgValue});
         }

--- a/packages/contracts-rfq/test/mocks/WETHMock.sol
+++ b/packages/contracts-rfq/test/mocks/WETHMock.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 
+// solhint-disable no-empty-blocks
 /// @notice WETH mock for testing purposes. DO NOT USE IN PRODUCTION.
 contract WETHMock is ERC20 {
     constructor() ERC20("Mock Wrapped Ether", "Mock WETH") {}

--- a/packages/contracts-rfq/test/mocks/WETHMock.sol
+++ b/packages/contracts-rfq/test/mocks/WETHMock.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+/// @notice WETH mock for testing purposes. DO NOT USE IN PRODUCTION.
+contract WETHMock is ERC20 {
+    constructor() ERC20("Mock Wrapped Ether", "Mock WETH") {}
+
+    receive() external payable {
+        deposit();
+    }
+
+    /// @notice We include an empty "test" function so that this contract does not appear in the coverage report.
+    function testWETHMock() external {}
+
+    function withdraw(uint256 amount) external {
+        _burn(msg.sender, amount);
+        Address.sendValue(payable(msg.sender), amount);
+    }
+
+    function deposit() public payable {
+        _mint(msg.sender, msg.value);
+    }
+}


### PR DESCRIPTION
**Description**
Modified `TokenZapV1` handling of the native gas token, making it more similar to approach it uses for ERC20s:

- Added `receive()` to allow the contract to receive native gas token outside of `zap()` call.
- Added the option for `TokenZapV1` to use previously transferred or otherwise acquired native gas token.
- Added the support for native gas token transfers to EOA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a `receive()` function in the `TokenZapV1` contract to accept ETH directly.
	- Added a mock Wrapped Ether (WETH) token for testing, enabling deposit and withdrawal functionalities.

- **Bug Fixes**
	- Enhanced error handling for transfers and reverts in the `TokenZapV1` contract.

- **Tests**
	- Expanded test coverage for various scenarios in the `TokenZapV1Test` contract, including edge cases for deposits and withdrawals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->