### PR TITLE
fix: update klaytn/kaia rpc url

### DIFF
--- a/packages/rest-api/src/constants/chains.ts
+++ b/packages/rest-api/src/constants/chains.ts
@@ -176,7 +176,7 @@ export const KLAYTN: Chain = {
   name: 'Klaytn',
   rpcUrls: {
     primary: getOmniRpcUrl(8217),
-    fallback: 'https://klaytn.blockpi.network/v1/rpc/public',
+    fallback: 'https://kaia.blockpi.network/v1/rpc/public',
   },
   explorerUrl: 'https://scope.klaytn.com',
   explorerName: 'Klaytn Explorer',

--- a/packages/synapse-constants/src/constants/chains/master.ts
+++ b/packages/synapse-constants/src/constants/chains/master.ts
@@ -192,7 +192,7 @@ export const KLAYTN: Chain = {
   codeName: 'klaytn',
   blockTime: 1000,
   rpcUrls: {
-    primary: 'https://klaytn.blockpi.network/v1/rpc/public',
+    primary: 'https://kaia.blockpi.network/v1/rpc/public',
     fallback: 'https://klaytn.api.onfinality.io/public',
   },
   nativeCurrency: { name: 'Klaytn', symbol: 'KLAY', decimals: 18 },

--- a/packages/synapse-interface/constants/chains/master.tsx
+++ b/packages/synapse-interface/constants/chains/master.tsx
@@ -247,7 +247,7 @@ export const KLAYTN: Chain = {
   layer: 1,
   blockTime: 1000,
   rpcUrls: {
-    primary: 'https://klaytn.blockpi.network/v1/rpc/public',
+    primary: 'https://kaia.blockpi.network/v1/rpc/public',
     fallback: 'https://internal.klaytn.rpc.defikingdoms.com/api=654302102',
   },
   nativeCurrency: {

--- a/packages/widget/src/constants/chains.ts
+++ b/packages/widget/src/constants/chains.ts
@@ -173,7 +173,7 @@ export const KLAYTN: Chain = {
   id: 8217,
   name: 'Klaytn',
   rpcUrls: {
-    primary: 'https://klaytn.blockpi.network/v1/rpc/public',
+    primary: 'https://kaia.blockpi.network/v1/rpc/public',
     fallback: 'https://klaytn.api.onfinality.io/public',
   },
   explorerUrl: 'https://scope.klaytn.com',


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**
A clear and concise description of the features you're adding in this pull request.

**Additional context**
Add any other context about the problem you're solving.

**Metadata**
- Fixes #[Link to Issue]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the primary and fallback RPC URLs for the KLAYTN chain to enhance connectivity and performance.
  
- **Bug Fixes**
	- Resolved issues related to KLAYTN network connections by changing outdated RPC endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
66901b97edfb813663010c089d67289b2c08dd33: [synapse-interface preview link ](https://sanguine-synapse-interface-63ukxzk3z-synapsecns.vercel.app)