### PR TITLE
SIN relabels + typos

### DIFF
--- a/docs/bridge/docs/03-RFQ/10-Quoting/Quoter API/index.md
+++ b/docs/bridge/docs/03-RFQ/10-Quoting/Quoter API/index.md
@@ -39,7 +39,7 @@ sidebar_label: Quoter API
 
 :::info
 
-This guide is intended for builders who are integrating a quoter or frontend with the Synapse RFQ system.
+This guide is intended for builders who are integrating a quoter or frontend with the Synapse Intent Network (SIN) system.
 
 If you are interested in running a relayer, please also see [Relaying] and [Canonical Relayer](/docs/RFQ/CanonicalRelayer/) .
 

--- a/docs/bridge/docs/03-RFQ/10-Quoting/index.md
+++ b/docs/bridge/docs/03-RFQ/10-Quoting/index.md
@@ -35,9 +35,9 @@ title: Quoting
 [Canceler]: /docs/RFQ/#entities
 
 
-The Synapse RFQ systems allows [Quoter] entities (aka market makers / solvers / relayers) to post quotes via an off-chain [Quoter API]. These quotes are matched to `User` bridge inputs to achieve the optimal parameters (eg: the best price) for the [User]'s bridge transaction.
+The Synapse Intent Network (SIN) systems allows [Quoter] entities (aka market makers / solvers / relayers) to post quotes via an off-chain [Quoter API]. These quotes are matched to `User` bridge inputs to achieve the optimal parameters (eg: the best price) for the [User]'s bridge transaction.
 
-There are two types of quoting methods supported by the Synapse RFQ system:
+There are two types of quoting methods supported by the Synapse Intent Network (SIN) system:
 
 ## [Passive Quoting](/docs/RFQ/Quoting/Quoter%20API/#passive-quotes)
 

--- a/docs/bridge/docs/03-RFQ/15-Bridging/index.md
+++ b/docs/bridge/docs/03-RFQ/15-Bridging/index.md
@@ -37,11 +37,11 @@ title: Bridging
 
 Once a quote has been obtained via [Quoting], the details of the quote can be used to construct a bridge transaction for the user to sign and submit to the origin chain.
 
-Bridges through Synapse RFQ utilize the [Synapse Router](/docs/Routers/Synapse-Router/) - Refer to those docs for more detail.
+Bridges through Synapse Intent Network (SIN) utilize the [Synapse Router](/docs/Routers/Synapse-Router/) - Refer to those docs for more detail.
 
 
 :::info
-If you are interested in integrating with Synapse RFQ Bridging, refer to the [Synapse Bridge SDK](/docs/Bridge/SDK).
+If you are interested in integrating with Synapse Intent Network (SIN) Bridging, refer to the [Synapse Bridge SDK](/docs/Bridge/SDK).
 
 Alternatively, you can explore the [Bridge REST API](https://api.synapseprotocol.com/api-docs/).
 

--- a/docs/bridge/docs/03-RFQ/20-Relaying/index.md
+++ b/docs/bridge/docs/03-RFQ/20-Relaying/index.md
@@ -37,7 +37,7 @@ title: Relaying
 
 # Relaying
 
-In the Synapse RFQ System, Relayers fulfill the intent of [User] [bridge] transactions by providing the liquidity and executing the [relay] transaction on the destination chain .
+In the Synapse Intent Network (SIN) System, Relayers fulfill the intent of [User] [bridge] transactions by providing the liquidity and executing the [relay] transaction on the destination chain .
 
 :::info
 

--- a/docs/bridge/docs/03-RFQ/20-Relaying/riskFactors.md
+++ b/docs/bridge/docs/03-RFQ/20-Relaying/riskFactors.md
@@ -39,7 +39,7 @@ title: Risk Factors
 
 As is the case with many cross-chain systems, there are inherent risks involved with providing liquidity as a [Relayer].
 
-Although the system is designed to minimize these risks, it is ultimately the sole responsibility and liability of the [Relayer] to fully understand and manage the risks involved with participating as a [Relayer] in the Synapse RFQ system.
+Although the system is designed to minimize these risks, it is ultimately the sole responsibility and liability of the [Relayer] to fully understand and manage the risks involved with participating as a [Relayer] in the Synapse Intent Network (SIN) system.
 
 :::
 

--- a/docs/bridge/docs/03-RFQ/30-Proving/index.md
+++ b/docs/bridge/docs/03-RFQ/30-Proving/index.md
@@ -78,6 +78,6 @@ As of FastBridgeV2, it is possible to batch many [prove] transactions together w
 
 ## Next steps
 
-Following the [prove] transation, a [Dispute Period] begins - after which the [Relayer] may proceed to [Claiming]
+Following the [prove] transaction, a [Dispute Period] begins - after which the [Relayer] may proceed to [Claiming]
 
 Although disputes are unlikely, monitoring should occur during the [Dispute Period] to verify there are no issues.

--- a/docs/bridge/docs/03-RFQ/40-Claiming/index.md
+++ b/docs/bridge/docs/03-RFQ/40-Claiming/index.md
@@ -70,4 +70,4 @@ As of FastBridgeV2, it is possible to batch many [claim] transactions together w
 
 ## Next steps
 
-Following the [claim] transation, the bridge deposit funds have been reimbursed to the [Relayer] and are ready to be used for another relay. The bridge cycle is fully complete.
+Following the [claim] transaction, the bridge deposit funds have been reimbursed to the [Relayer] and are ready to be used for another relay. The bridge cycle is fully complete.

--- a/docs/bridge/docs/03-RFQ/60-Security/index.md
+++ b/docs/bridge/docs/03-RFQ/60-Security/index.md
@@ -35,7 +35,7 @@ title: Security
 [Canceler]: /docs/RFQ/#entities
 
 
-Synapse RFQ is an optimistic cross-chain system. This means that any ambiguous actions in the system are assumed to be accurate and honest by default unless they are challenged/disputed within a short timeframe.
+Synapse Intent Network (SIN) is an optimistic cross-chain system. This means that any ambiguous actions in the system are assumed to be accurate and honest by default unless they are challenged/disputed within a short timeframe.
 
 
 ### Proofs
@@ -49,7 +49,7 @@ Each [prove] transaction sets the [proof] data for the bridge and initiates a di
 
 After a [prove] transaction is posted and the [proof] data is set, a window of time called the [Dispute Period](https://rfq-contracts.synapseprotocol.com/contracts/FastBridgeV2.sol/contract.FastBridgeV2.html#dispute_period) begins.
 
-During this time, the prove/proof is eligible to be dispuated by [Guard] entities.
+During this time, the prove/proof is eligible to be disputed by [Guard] entities.
 
 After the [Dispute Period](https://rfq-contracts.synapseprotocol.com/contracts/FastBridgeV2.sol/contract.FastBridgeV2.html#dispute_period) has passed without any disputes, the funds in escrow from the original bridge transaction can be released via a [claim] transaction, which will reimburse the rightful [Relayer].
 

--- a/docs/bridge/docs/03-RFQ/70-CanonicalRelayer/index.md
+++ b/docs/bridge/docs/03-RFQ/70-CanonicalRelayer/index.md
@@ -34,7 +34,7 @@ sidebar_label: Canonical Relayer
 [Guard]: /docs/RFQ/#entities
 [Canceler]: /docs/RFQ/#entities
 
-# Canonical RFQ Relayer
+# Canonical Relayer
 
 :::info
 
@@ -44,7 +44,7 @@ If you are interested in participating as a Relayer, contact us.
 
 :::
 
-The Canonical RFQ Relayer is the official relayer app built and operated by Synapse which performs all necessary automated functions that are necessary for a Relayer participating in the Synapse RFQ network.
+The Canonical Relayer is the official relayer app built and operated by Synapse which performs all necessary automated functions that are necessary for a Relayer participating in the Synapse Intent Network (SIN) network.
 
 These functions include:
 

--- a/docs/bridge/docs/03-RFQ/index.md
+++ b/docs/bridge/docs/03-RFQ/index.md
@@ -38,7 +38,7 @@ import { RFQFlow } from '@site/src/components/RFQFlow'
 
 # Synapse Intent Network
 
-Synapse Intent Network is an RFQ (Request-For-Quote) based <abbr title="'Intent' refers to a user authorizing specific actions that they want to achieve, typically in very simple terms, such as a bridge or swap. Actual execution of the actions is then performed on the user's behalf by third parties known as solvers/relayers.">intent</abbr> centric bridging system that connects bridging users to a network of relayers.
+Synapse Intent Network (SIN) is an RFQ (Request-For-Quote) based <abbr title="'Intent' refers to a user authorizing specific actions that they want to achieve, typically in very simple terms, such as a bridge or swap. Actual execution of the actions is then performed on the user's behalf by third parties known as solvers/relayers.">intent</abbr> centric bridging system that connects bridging users to a network of relayers.
 
 These relayers compete to provide the optimal bridge execution (eg: the best price) for the user's specific request.
 
@@ -122,14 +122,14 @@ These relayers compete to provide the optimal bridge execution (eg: the best pri
     <blockquote>
         Validates proofs during the [Dispute Period] and submits [dispute] transactions for any discrepancies found.
         <div></div>
-        Currently, Synapse itself is the sole Guard operator of the Synapse RFQ system.
+        Currently, Synapse itself is the sole Guard operator of the Synapse Intent Network (SIN) system.
     </blockquote><br />
 
 <b>Cancelers</b> <span style={{color: 'darkgray'}}><i>(Permissioned Role)</i></span>
     <blockquote>
         Able to manually pre-emptively cancel bridge requests which have been deposited, have not yet been relayed, and are past their relay deadline.
         <div></div>
-        Currently, Synapse itself is the sole Canceler operator of the Synapse RFQ system.
+        Currently, Synapse itself is the sole Canceler operator of the Synapse Intent Network (SIN) system.
         <div></div>
         <span style={{color: 'darkgray', fontSize: '0.9em'}}><i>Note: Incomplete bridge requests can also be canceled permissionlessly (without any involvement from a Canceler) after a longer cancellation window has passed.</i></span>
     </blockquote>
@@ -206,5 +206,5 @@ If any discrepancies are found, the guards will [dispute] the proof
 <blockquote>
 Once the [Dispute Period] has passed without incident, a [claim] transaction can be executed by the [Relayer] on the origin chain.
 
-This wil release the deposit funds from escrow and deliver them to the rightful [Relayer] as a reimbursement for the liquidity they provided on the [relay].
+This willrelease the deposit funds from escrow and deliver them to the rightful [Relayer] as a reimbursement for the liquidity they provided on the [relay].
 </blockquote>


### PR DESCRIPTION
addtl relabeling to Synapse Intent Network from Synapse RFQ.

Various typo fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Rebranded "Synapse RFQ system" to "Synapse Intent Network (SIN)" across multiple documents for consistency.
	- Enhanced clarity in sections detailing API integration, quoting methods, relaying processes, and security measures.
	- Minor typographical corrections made to improve readability and professionalism.
	- Maintained existing functionality while ensuring updated terminology aligns with the new branding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
77cfead96520eecc8665162a90755644f53092a1: [docs preview link ](https://bridge-docs-hpvw2639s-synapsecns.vercel.app)