### PR TITLE
typo

### DIFF
--- a/docs/bridge/docs/03-RFQ/index.md
+++ b/docs/bridge/docs/03-RFQ/index.md
@@ -206,5 +206,5 @@ If any discrepancies are found, the guards will [dispute] the proof
 <blockquote>
 Once the [Dispute Period] has passed without incident, a [claim] transaction can be executed by the [Relayer] on the origin chain.
 
-This willrelease the deposit funds from escrow and deliver them to the rightful [Relayer] as a reimbursement for the liquidity they provided on the [relay].
+This will release the deposit funds from escrow and deliver them to the rightful [Relayer] as a reimbursement for the liquidity they provided on the [relay].
 </blockquote>


### PR DESCRIPTION
doc typo not stopped on CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected a typographical error in the RFQ process documentation for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
2aeeb94d18511448633b5ecc4a984dada87dd2d4: [docs preview link ](https://bridge-docs-r0md1muv5-synapsecns.vercel.app)