### PR TITLE
fix(contracts-rfq): FastBridge V2 prove race condition

### DIFF
--- a/packages/contracts-rfq/contracts/AdminV2.sol
+++ b/packages/contracts-rfq/contracts/AdminV2.sol
@@ -18,6 +18,16 @@ import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 contract AdminV2 is AccessControlEnumerable, IAdminV2, IAdminV2Errors {
     using SafeERC20 for IERC20;
 
+    /// @notice Struct for storing information about a prover.
+    /// @param id                   The ID of the prover: its position in `_allProvers` plus one,
+    ///                             or zero if the prover has never been added.
+    /// @param activeFromTimestamp  The timestamp at which the prover becomes active,
+    ///                             or zero if the prover has never been added or is no longer active.
+    struct ProverInfo {
+        uint16 id;
+        uint240 activeFromTimestamp;
+    }
+
     /// @notice The address reserved for the native gas token (ETH on Ethereum and most L2s, AVAX on Avalanche, etc.).
     address public constant NATIVE_GAS_TOKEN = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
 
@@ -60,6 +70,11 @@ contract AdminV2 is AccessControlEnumerable, IAdminV2, IAdminV2Errors {
     /// @notice The delay period after which a transaction can be permissionlessly cancelled.
     uint256 public cancelDelay;
 
+    /// @notice A list of all provers ever added to the contract. Can hold up to 2^16-1 provers.
+    address[] private _allProvers;
+    /// @notice A mapping of provers to their information: id and activeFromTimestamp.
+    mapping(address => ProverInfo) private _proverInfos;
+
     /// @notice This variable is deprecated and should not be used.
     /// @dev Use ZapNative V2 requests instead.
     uint256 public immutable chainGasAmount = 0;
@@ -67,6 +82,16 @@ contract AdminV2 is AccessControlEnumerable, IAdminV2, IAdminV2Errors {
     constructor(address defaultAdmin) {
         _grantRole(DEFAULT_ADMIN_ROLE, defaultAdmin);
         _setCancelDelay(DEFAULT_CANCEL_DELAY);
+    }
+
+    /// @inheritdoc IAdminV2
+    function addProver(address prover) external onlyRole(GOVERNOR_ROLE) {
+        // TODO: implement
+    }
+
+    /// @inheritdoc IAdminV2
+    function removeProver(address prover) external onlyRole(GOVERNOR_ROLE) {
+        // TODO: implement
     }
 
     /// @inheritdoc IAdminV2
@@ -96,6 +121,16 @@ contract AdminV2 is AccessControlEnumerable, IAdminV2, IAdminV2Errors {
         } else {
             IERC20(token).safeTransfer(recipient, feeAmount);
         }
+    }
+
+    /// @inheritdoc IAdminV2
+    function getActiveProverID(address prover) external view returns (uint16) {
+        // TODO: implement
+    }
+
+    /// @inheritdoc IAdminV2
+    function getProvers() external view returns (address[] memory) {
+        // TODO: implement
     }
 
     /// @notice Internal logic to set the cancel delay. Security checks are performed outside of this function.

--- a/packages/contracts-rfq/contracts/AdminV2.sol
+++ b/packages/contracts-rfq/contracts/AdminV2.sol
@@ -90,7 +90,7 @@ contract AdminV2 is AccessControlEnumerable, IAdminV2, IAdminV2Errors {
     }
 
     /// @inheritdoc IAdminV2
-    function addProver(address prover) external onlyRole(GOVERNOR_ROLE) {
+    function addProver(address prover) external onlyRole(DEFAULT_ADMIN_ROLE) {
         if (getActiveProverID(prover) != 0) revert ProverAlreadyActive();
         ProverInfo storage $ = _proverInfos[prover];
         // Add the prover to the list of all provers and record its id (its position + 1),
@@ -109,7 +109,7 @@ contract AdminV2 is AccessControlEnumerable, IAdminV2, IAdminV2Errors {
     }
 
     /// @inheritdoc IAdminV2
-    function removeProver(address prover) external onlyRole(GOVERNOR_ROLE) {
+    function removeProver(address prover) external onlyRole(DEFAULT_ADMIN_ROLE) {
         if (getActiveProverID(prover) == 0) revert ProverNotActive();
         // We never remove provers from the list of all provers to preserve their IDs,
         // so we just need to reset the activeFrom timestamp.

--- a/packages/contracts-rfq/contracts/AdminV2.sol
+++ b/packages/contracts-rfq/contracts/AdminV2.sol
@@ -159,6 +159,19 @@ contract AdminV2 is AccessControlEnumerable, IAdminV2, IAdminV2Errors {
     }
 
     /// @inheritdoc IAdminV2
+    function getProverInfo(address prover) external view returns (uint16 proverID, uint256 activeFromTimestamp) {
+        proverID = _proverInfos[prover].id;
+        activeFromTimestamp = _proverInfos[prover].activeFromTimestamp;
+    }
+
+    /// @inheritdoc IAdminV2
+    function getProverInfoByID(uint16 proverID) external view returns (address prover, uint256 activeFromTimestamp) {
+        if (proverID == 0 || proverID > _allProvers.length) return (address(0), 0);
+        prover = _allProvers[proverID - 1];
+        activeFromTimestamp = _proverInfos[prover].activeFromTimestamp;
+    }
+
+    /// @inheritdoc IAdminV2
     function getActiveProverID(address prover) public view returns (uint16) {
         // Aggregate the read operations from the same storage slot.
         uint16 id = _proverInfos[prover].id;

--- a/packages/contracts-rfq/contracts/AdminV2.sol
+++ b/packages/contracts-rfq/contracts/AdminV2.sol
@@ -35,10 +35,6 @@ contract AdminV2 is AccessControlEnumerable, IAdminV2, IAdminV2Errors {
     /// @dev Only addresses with this role can post FastBridge quotes to the API.
     bytes32 public constant QUOTER_ROLE = keccak256("QUOTER_ROLE");
 
-    /// @notice The role identifier for the Prover's on-chain authentication in FastBridge.
-    /// @dev Only addresses with this role can provide proofs that a FastBridge request has been relayed.
-    bytes32 public constant PROVER_ROLE = keccak256("PROVER_ROLE");
-
     /// @notice The role identifier for the Guard's on-chain authentication in FastBridge.
     /// @dev Only addresses with this role can dispute submitted relay proofs during the dispute period.
     bytes32 public constant GUARD_ROLE = keccak256("GUARD_ROLE");

--- a/packages/contracts-rfq/contracts/FastBridgeV2.sol
+++ b/packages/contracts-rfq/contracts/FastBridgeV2.sol
@@ -121,7 +121,7 @@ contract FastBridgeV2 is AdminV2, MulticallTarget, IFastBridgeV2, IFastBridgeV2E
 
         // Apply the timeout penalty to the prover that submitted the proof.
         // Note: this is a no-op if the prover has already been removed.
-        _applyTimeoutPenalty(proverID);
+        _applyDisputePenaltyTime(proverID);
 
         // Update status to REQUESTED and delete the disputed proof details.
         // Note: these are storage writes.

--- a/packages/contracts-rfq/contracts/FastBridgeV2.sol
+++ b/packages/contracts-rfq/contracts/FastBridgeV2.sol
@@ -347,7 +347,9 @@ contract FastBridgeV2 is AdminV2, MulticallTarget, IFastBridgeV2, IFastBridgeV2E
     }
 
     /// @inheritdoc IFastBridgeV2
-    function proveV2(bytes32 transactionId, bytes32 destTxHash, address relayer) public onlyRole(PROVER_ROLE) {
+    function proveV2(bytes32 transactionId, bytes32 destTxHash, address relayer) public {
+        uint16 proverID = getActiveProverID(msg.sender);
+        if (proverID == 0) revert ProverNotActive();
         // Can only prove a REQUESTED transaction.
         BridgeTxDetails storage $ = bridgeTxDetails[transactionId];
         if ($.status != BridgeStatus.REQUESTED) revert StatusIncorrect();

--- a/packages/contracts-rfq/contracts/interfaces/IAdminV2.sol
+++ b/packages/contracts-rfq/contracts/interfaces/IAdminV2.sol
@@ -31,6 +31,16 @@ interface IAdminV2 {
     /// @notice Returns the ID of the active prover, or zero if the prover is not currently active.
     function getActiveProverID(address prover) external view returns (uint16);
 
+    /// @notice Returns the information about the prover with the provided address.
+    /// @return proverID            The ID of the prover if it has been added before, or zero otherwise.
+    /// @return activeFromTimestamp The timestamp when the prover becomes active, or zero if the prover isn't active.
+    function getProverInfo(address prover) external view returns (uint16 proverID, uint256 activeFromTimestamp);
+
+    /// @notice Returns the information about the prover with the provided ID.
+    /// @return prover              The address of the prover with the provided ID, or zero the ID does not exist.
+    /// @return activeFromTimestamp The timestamp when the prover becomes active, or zero if the prover isn't active.
+    function getProverInfoByID(uint16 proverID) external view returns (address prover, uint256 activeFromTimestamp);
+
     /// @notice Returns the list of the active provers.
     function getProvers() external view returns (address[] memory);
 }

--- a/packages/contracts-rfq/contracts/interfaces/IAdminV2.sol
+++ b/packages/contracts-rfq/contracts/interfaces/IAdminV2.sol
@@ -11,10 +11,10 @@ interface IAdminV2 {
     event ProverRemoved(address prover);
     event ProverTimeoutApplied(address prover, uint256 inactiveUntilTimestamp);
 
-    /// @notice Allows the governor to add a new prover to the contract.
+    /// @notice Allows the role admin to add a new prover to the contract.
     function addProver(address prover) external;
 
-    /// @notice Allows the governor to remove a prover from the contract.
+    /// @notice Allows the role admin to remove a prover from the contract.
     function removeProver(address prover) external;
 
     /// @notice Allows the governor to set the cancel delay. The cancel delay is the time period after the transaction

--- a/packages/contracts-rfq/contracts/interfaces/IAdminV2.sol
+++ b/packages/contracts-rfq/contracts/interfaces/IAdminV2.sol
@@ -9,6 +9,7 @@ interface IAdminV2 {
 
     event ProverAdded(address prover);
     event ProverRemoved(address prover);
+    event ProverTimeoutApplied(address prover, uint256 inactiveUntilTimestamp);
 
     /// @notice Allows the governor to add a new prover to the contract.
     function addProver(address prover) external;

--- a/packages/contracts-rfq/contracts/interfaces/IAdminV2.sol
+++ b/packages/contracts-rfq/contracts/interfaces/IAdminV2.sol
@@ -6,6 +6,15 @@ interface IAdminV2 {
     event FeeRateUpdated(uint256 oldFeeRate, uint256 newFeeRate);
     event FeesSwept(address token, address recipient, uint256 amount);
 
+    event ProverAdded(address prover);
+    event ProverRemoved(address prover);
+
+    /// @notice Allows the governor to add a new prover to the contract.
+    function addProver(address prover) external;
+
+    /// @notice Allows the governor to remove a prover from the contract.
+    function removeProver(address prover) external;
+
     /// @notice Allows the governor to set the cancel delay. The cancel delay is the time period after the transaction
     /// deadline during which a transaction can be permissionlessly cancelled if it hasn't been proven by any Relayer.
     function setCancelDelay(uint256 newCancelDelay) external;
@@ -18,4 +27,10 @@ interface IAdminV2 {
 
     /// @notice Allows the governor to withdraw the accumulated protocol fees from the contract.
     function sweepProtocolFees(address token, address recipient) external;
+
+    /// @notice Returns the ID of the active prover, or zero if the prover is not currently active.
+    function getActiveProverID(address prover) external view returns (uint16);
+
+    /// @notice Returns the list of the active provers.
+    function getProvers() external view returns (address[] memory);
 }

--- a/packages/contracts-rfq/contracts/interfaces/IAdminV2.sol
+++ b/packages/contracts-rfq/contracts/interfaces/IAdminV2.sol
@@ -3,13 +3,13 @@ pragma solidity ^0.8.4;
 
 interface IAdminV2 {
     event CancelDelayUpdated(uint256 oldCancelDelay, uint256 newCancelDelay);
-    event ProverTimeoutUpdated(uint256 oldProverTimeout, uint256 newProverTimeout);
+    event DisputePenaltyTimeUpdated(uint256 oldDisputePenaltyTime, uint256 newDisputePenaltyTime);
     event FeeRateUpdated(uint256 oldFeeRate, uint256 newFeeRate);
     event FeesSwept(address token, address recipient, uint256 amount);
 
     event ProverAdded(address prover);
     event ProverRemoved(address prover);
-    event ProverTimeoutApplied(address prover, uint256 inactiveUntilTimestamp);
+    event DisputePenaltyTimeApplied(address prover, uint256 inactiveUntilTimestamp);
 
     /// @notice Allows the role admin to add a new prover to the contract.
     function addProver(address prover) external;
@@ -21,10 +21,10 @@ interface IAdminV2 {
     /// deadline during which a transaction can be permissionlessly cancelled if it hasn't been proven by any Relayer.
     function setCancelDelay(uint256 newCancelDelay) external;
 
-    /// @notice Allows the governor to set the prover timeout. The prover timeout is the time period used to
-    /// temporarily deactivate a prover if its proof is disputed: prover will be inactive for the prover timeout
+    /// @notice Allows the governor to set the dispute penalty time. The dispute penalty time is the time period used to
+    /// temporarily deactivate a prover if its proof is disputed: prover will be inactive for the dispute penalty time
     /// after the dispute is submitted.
-    function setProverTimeout(uint256 newProverTimeout) external;
+    function setDisputePenaltyTime(uint256 newDisputePenaltyTime) external;
 
     /// @notice Allows the governor to set the protocol fee rate. The protocol fee is taken from the origin
     /// amount and is only applied to completed and claimed transactions.

--- a/packages/contracts-rfq/contracts/interfaces/IAdminV2.sol
+++ b/packages/contracts-rfq/contracts/interfaces/IAdminV2.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.4;
 
 interface IAdminV2 {
     event CancelDelayUpdated(uint256 oldCancelDelay, uint256 newCancelDelay);
+    event ProverTimeoutUpdated(uint256 oldProverTimeout, uint256 newProverTimeout);
     event FeeRateUpdated(uint256 oldFeeRate, uint256 newFeeRate);
     event FeesSwept(address token, address recipient, uint256 amount);
 
@@ -18,6 +19,11 @@ interface IAdminV2 {
     /// @notice Allows the governor to set the cancel delay. The cancel delay is the time period after the transaction
     /// deadline during which a transaction can be permissionlessly cancelled if it hasn't been proven by any Relayer.
     function setCancelDelay(uint256 newCancelDelay) external;
+
+    /// @notice Allows the governor to set the prover timeout. The prover timeout is the time period used to
+    /// temporarily deactivate a prover if its proof is disputed: prover will be inactive for the prover timeout
+    /// after the dispute is submitted.
+    function setProverTimeout(uint256 newProverTimeout) external;
 
     /// @notice Allows the governor to set the protocol fee rate. The protocol fee is taken from the origin
     /// amount and is only applied to completed and claimed transactions.

--- a/packages/contracts-rfq/contracts/interfaces/IAdminV2Errors.sol
+++ b/packages/contracts-rfq/contracts/interfaces/IAdminV2Errors.sol
@@ -4,4 +4,6 @@ pragma solidity ^0.8.4;
 interface IAdminV2Errors {
     error CancelDelayBelowMin();
     error FeeRateAboveMax();
+    error ProverAlreadyActive();
+    error ProverNotActive();
 }

--- a/packages/contracts-rfq/contracts/interfaces/IAdminV2Errors.sol
+++ b/packages/contracts-rfq/contracts/interfaces/IAdminV2Errors.sol
@@ -7,5 +7,5 @@ interface IAdminV2Errors {
     error ProverAlreadyActive();
     error ProverCapacityExceeded();
     error ProverNotActive();
-    error ProverTimeoutBelowMin();
+    error DisputePenaltyTimeBelowMin();
 }

--- a/packages/contracts-rfq/contracts/interfaces/IAdminV2Errors.sol
+++ b/packages/contracts-rfq/contracts/interfaces/IAdminV2Errors.sol
@@ -7,4 +7,5 @@ interface IAdminV2Errors {
     error ProverAlreadyActive();
     error ProverCapacityExceeded();
     error ProverNotActive();
+    error ProverTimeoutBelowMin();
 }

--- a/packages/contracts-rfq/contracts/interfaces/IAdminV2Errors.sol
+++ b/packages/contracts-rfq/contracts/interfaces/IAdminV2Errors.sol
@@ -5,5 +5,6 @@ interface IAdminV2Errors {
     error CancelDelayBelowMin();
     error FeeRateAboveMax();
     error ProverAlreadyActive();
+    error ProverCapacityExceeded();
     error ProverNotActive();
 }

--- a/packages/contracts-rfq/contracts/interfaces/IFastBridgeV2.sol
+++ b/packages/contracts-rfq/contracts/interfaces/IFastBridgeV2.sol
@@ -15,6 +15,7 @@ interface IFastBridgeV2 is IFastBridge {
     struct BridgeTxDetails {
         BridgeStatus status;
         uint32 destChainId;
+        uint16 proverID;
         uint56 proofBlockTimestamp;
         address proofRelayer;
     }

--- a/packages/contracts-rfq/contracts/interfaces/IFastBridgeV2.sol
+++ b/packages/contracts-rfq/contracts/interfaces/IFastBridgeV2.sol
@@ -16,7 +16,7 @@ interface IFastBridgeV2 is IFastBridge {
         BridgeStatus status;
         uint32 destChainId;
         uint16 proverID;
-        uint56 proofBlockTimestamp;
+        uint40 proofBlockTimestamp;
         address proofRelayer;
     }
 

--- a/packages/contracts-rfq/foundry.toml
+++ b/packages/contracts-rfq/foundry.toml
@@ -7,6 +7,7 @@ src = 'contracts'
 out = 'out'
 libs = ["lib", "node_modules"]
 ffi = true
+gas_limit = 9223372036854775807
 fs_permissions = [
     { access = "read", path = "./" },
     { access = "read-write", path = "./.deployments" }

--- a/packages/contracts-rfq/test/FastBridgeV2.Management.t.sol
+++ b/packages/contracts-rfq/test/FastBridgeV2.Management.t.sol
@@ -119,7 +119,7 @@ contract FastBridgeV2ManagementTest is FastBridgeV2Test {
         uint256 proverAtime = block.timestamp;
         vm.expectEmit(address(fastBridge));
         emit ProverAdded(proverA);
-        addProver(governor, proverA);
+        addProver(admin, proverA);
         assertEq(fastBridge.getActiveProverID(proverA), 1);
         assertEq(fastBridge.getActiveProverID(proverB), 0);
         address[] memory provers = fastBridge.getProvers();
@@ -136,7 +136,7 @@ contract FastBridgeV2ManagementTest is FastBridgeV2Test {
         uint256 proverBtime = block.timestamp;
         vm.expectEmit(address(fastBridge));
         emit ProverAdded(proverB);
-        addProver(governor, proverB);
+        addProver(admin, proverB);
         assertEq(fastBridge.getActiveProverID(proverA), 1);
         assertEq(fastBridge.getActiveProverID(proverB), 2);
         address[] memory provers = fastBridge.getProvers();
@@ -154,7 +154,7 @@ contract FastBridgeV2ManagementTest is FastBridgeV2Test {
         uint256 proverBtime = block.timestamp;
         vm.expectEmit(address(fastBridge));
         emit ProverAdded(proverB);
-        addProver(governor, proverB);
+        addProver(admin, proverB);
         assertEq(fastBridge.getActiveProverID(proverA), 0);
         assertEq(fastBridge.getActiveProverID(proverB), 2);
         address[] memory provers = fastBridge.getProvers();
@@ -167,7 +167,7 @@ contract FastBridgeV2ManagementTest is FastBridgeV2Test {
         uint256 proverAtime = block.timestamp;
         vm.expectEmit(address(fastBridge));
         emit ProverAdded(proverA);
-        addProver(governor, proverA);
+        addProver(admin, proverA);
         assertEq(fastBridge.getActiveProverID(proverA), 1);
         assertEq(fastBridge.getActiveProverID(proverB), 2);
         provers = fastBridge.getProvers();
@@ -178,24 +178,24 @@ contract FastBridgeV2ManagementTest is FastBridgeV2Test {
         checkProverInfo(proverB, 2, proverBtime);
     }
 
-    function test_addProver_revertNotGovernor(address caller) public {
-        vm.assume(caller != governor);
-        expectUnauthorized(caller, fastBridge.GOVERNOR_ROLE());
+    function test_addProver_revertNotAdmin(address caller) public {
+        vm.assume(caller != admin);
+        expectUnauthorized(caller, fastBridge.DEFAULT_ADMIN_ROLE());
         addProver(caller, proverA);
     }
 
     function test_addProver_revertAlreadyActive() public {
         test_addProver();
         vm.expectRevert(ProverAlreadyActive.selector);
-        addProver(governor, proverA);
+        addProver(admin, proverA);
     }
 
     function test_addProver_revertTooManyProvers() public {
         for (uint256 i = 0; i < type(uint16).max; i++) {
-            addProver(governor, address(uint160(i)));
+            addProver(admin, address(uint160(i)));
         }
         vm.expectRevert(ProverCapacityExceeded.selector);
-        addProver(governor, proverA);
+        addProver(admin, proverA);
     }
 
     // ═══════════════════════════════════════════════ REMOVE PROVER ═══════════════════════════════════════════════════
@@ -205,7 +205,7 @@ contract FastBridgeV2ManagementTest is FastBridgeV2Test {
         uint256 proverBtime = block.timestamp;
         vm.expectEmit(address(fastBridge));
         emit ProverRemoved(proverA);
-        removeProver(governor, proverA);
+        removeProver(admin, proverA);
         assertEq(fastBridge.getActiveProverID(proverA), 0);
         assertEq(fastBridge.getActiveProverID(proverB), 2);
         address[] memory provers = fastBridge.getProvers();
@@ -219,7 +219,7 @@ contract FastBridgeV2ManagementTest is FastBridgeV2Test {
         test_removeProver();
         vm.expectEmit(address(fastBridge));
         emit ProverRemoved(proverB);
-        removeProver(governor, proverB);
+        removeProver(admin, proverB);
         assertEq(fastBridge.getActiveProverID(proverA), 0);
         assertEq(fastBridge.getActiveProverID(proverB), 0);
         address[] memory provers = fastBridge.getProvers();
@@ -228,21 +228,21 @@ contract FastBridgeV2ManagementTest is FastBridgeV2Test {
         checkProverInfo(proverB, 2, 0);
     }
 
-    function test_removeProver_revertNotGovernor(address caller) public {
-        vm.assume(caller != governor);
-        expectUnauthorized(caller, fastBridge.GOVERNOR_ROLE());
+    function test_removeProver_revertNotAdmin(address caller) public {
+        vm.assume(caller != admin);
+        expectUnauthorized(caller, fastBridge.DEFAULT_ADMIN_ROLE());
         removeProver(caller, proverA);
     }
 
     function test_removeProver_revertNeverBeenActive() public {
         vm.expectRevert(ProverNotActive.selector);
-        removeProver(governor, proverA);
+        removeProver(admin, proverA);
     }
 
     function test_removeProver_revertNotActive() public {
         test_removeProver();
         vm.expectRevert(ProverNotActive.selector);
-        removeProver(governor, proverA);
+        removeProver(admin, proverA);
     }
 
     // ═════════════════════════════════════════════ SET CANCEL DELAY ══════════════════════════════════════════════════

--- a/packages/contracts-rfq/test/FastBridgeV2.Management.t.sol
+++ b/packages/contracts-rfq/test/FastBridgeV2.Management.t.sol
@@ -13,8 +13,8 @@ contract FastBridgeV2ManagementTest is FastBridgeV2Test {
     uint256 public constant MIN_CANCEL_DELAY = 1 hours;
     uint256 public constant DEFAULT_CANCEL_DELAY = 1 days;
 
-    uint256 public constant MIN_PROVER_TIMEOUT = 1 minutes;
-    uint256 public constant DEFAULT_PROVER_TIMEOUT = 30 minutes;
+    uint256 public constant MIN_DISPUTE_PENALTY_TIME = 1 minutes;
+    uint256 public constant DEFAULT_DISPUTE_PENALTY_TIME = 30 minutes;
 
     address public admin = makeAddr("Admin");
     address public governorA = makeAddr("Governor A");
@@ -26,7 +26,7 @@ contract FastBridgeV2ManagementTest is FastBridgeV2Test {
     event ProverRemoved(address prover);
 
     event CancelDelayUpdated(uint256 oldCancelDelay, uint256 newCancelDelay);
-    event ProverTimeoutUpdated(uint256 oldProverTimeout, uint256 newProverTimeout);
+    event DisputePenaltyTimeUpdated(uint256 oldDisputePenaltyTime, uint256 newDisputePenaltyTime);
     event FeeRateUpdated(uint256 oldFeeRate, uint256 newFeeRate);
     event FeesSwept(address token, address recipient, uint256 amount);
 
@@ -65,9 +65,9 @@ contract FastBridgeV2ManagementTest is FastBridgeV2Test {
         fastBridge.setCancelDelay(newCancelDelay);
     }
 
-    function setProverTimeout(address caller, uint256 newProverTimeout) public {
+    function setDisputePenaltyTime(address caller, uint256 newDisputePenaltyTime) public {
         vm.prank(caller);
-        fastBridge.setProverTimeout(newProverTimeout);
+        fastBridge.setDisputePenaltyTime(newDisputePenaltyTime);
     }
 
     function setProtocolFeeRate(address caller, uint256 newFeeRate) public {
@@ -94,7 +94,7 @@ contract FastBridgeV2ManagementTest is FastBridgeV2Test {
 
     function test_defaultValues() public view {
         assertEq(fastBridge.cancelDelay(), DEFAULT_CANCEL_DELAY);
-        assertEq(fastBridge.proverTimeout(), DEFAULT_PROVER_TIMEOUT);
+        assertEq(fastBridge.disputePenaltyTime(), DEFAULT_DISPUTE_PENALTY_TIME);
         assertEq(fastBridge.protocolFeeRate(), 0);
     }
 
@@ -273,32 +273,32 @@ contract FastBridgeV2ManagementTest is FastBridgeV2Test {
         setCancelDelay(caller, 4 days);
     }
 
-    // ════════════════════════════════════════════ SET PROVER TIMEOUT ═════════════════════════════════════════════════
+    // ═════════════════════════════════════════ SET DISPUTE PENALTY TIME ══════════════════════════════════════════════
 
-    function test_setProverTimeout() public {
+    function test_setDisputePenaltyTime() public {
         vm.expectEmit(address(fastBridge));
-        emit ProverTimeoutUpdated(DEFAULT_PROVER_TIMEOUT, 1 days);
-        setProverTimeout(governor, 1 days);
-        assertEq(fastBridge.proverTimeout(), 1 days);
+        emit DisputePenaltyTimeUpdated(DEFAULT_DISPUTE_PENALTY_TIME, 1 days);
+        setDisputePenaltyTime(governor, 1 days);
+        assertEq(fastBridge.disputePenaltyTime(), 1 days);
     }
 
-    function test_setProverTimeout_twice() public {
-        test_setProverTimeout();
+    function test_setDisputePenaltyTime_twice() public {
+        test_setDisputePenaltyTime();
         vm.expectEmit(address(fastBridge));
-        emit ProverTimeoutUpdated(1 days, 2 days);
-        setProverTimeout(governor, 2 days);
-        assertEq(fastBridge.proverTimeout(), 2 days);
+        emit DisputePenaltyTimeUpdated(1 days, 2 days);
+        setDisputePenaltyTime(governor, 2 days);
+        assertEq(fastBridge.disputePenaltyTime(), 2 days);
     }
 
-    function test_setProverTimeout_revertBelowMin() public {
-        vm.expectRevert(ProverTimeoutBelowMin.selector);
-        setProverTimeout(governor, MIN_PROVER_TIMEOUT - 1);
+    function test_setDisputePenaltyTime_revertBelowMin() public {
+        vm.expectRevert(DisputePenaltyTimeBelowMin.selector);
+        setDisputePenaltyTime(governor, MIN_DISPUTE_PENALTY_TIME - 1);
     }
 
-    function test_setProverTimeout_revertNotGovernor(address caller) public {
+    function test_setDisputePenaltyTime_revertNotGovernor(address caller) public {
         vm.assume(caller != governor);
         expectUnauthorized(caller, fastBridge.GOVERNOR_ROLE());
-        setProverTimeout(caller, 1 days);
+        setDisputePenaltyTime(caller, 1 days);
     }
 
     // ═══════════════════════════════════════════ SET PROTOCOL FEE RATE ═══════════════════════════════════════════════

--- a/packages/contracts-rfq/test/FastBridgeV2.Management.t.sol
+++ b/packages/contracts-rfq/test/FastBridgeV2.Management.t.sol
@@ -2,12 +2,11 @@
 pragma solidity ^0.8.20;
 
 import {IAdmin} from "../contracts/interfaces/IAdmin.sol";
-import {IAdminV2Errors} from "../contracts/interfaces/IAdminV2Errors.sol";
 
 import {FastBridgeV2, FastBridgeV2Test} from "./FastBridgeV2.t.sol";
 
 // solhint-disable func-name-mixedcase, ordering
-contract FastBridgeV2ManagementTest is FastBridgeV2Test, IAdminV2Errors {
+contract FastBridgeV2ManagementTest is FastBridgeV2Test {
     uint256 public constant FEE_RATE_MAX = 1e4; // 1%
     bytes32 public constant GOVERNOR_ROLE = keccak256("GOVERNOR_ROLE");
 

--- a/packages/contracts-rfq/test/FastBridgeV2.Src.Base.t.sol
+++ b/packages/contracts-rfq/test/FastBridgeV2.Src.Base.t.sol
@@ -27,12 +27,13 @@ abstract contract FastBridgeV2SrcBaseTest is FastBridgeV2Test {
     }
 
     function configureFastBridge() public virtual override {
+        fastBridge.addProver(relayerA);
+        fastBridge.addProver(relayerB);
+
         fastBridge.grantRole(fastBridge.GUARD_ROLE(), guard);
         fastBridge.grantRole(fastBridge.CANCELER_ROLE(), canceler);
 
         fastBridge.grantRole(fastBridge.GOVERNOR_ROLE(), address(this));
-        fastBridge.addProver(relayerA);
-        fastBridge.addProver(relayerB);
         fastBridge.setCancelDelay(PERMISSIONLESS_CANCEL_DELAY);
         fastBridge.setProverTimeout(PROVER_TIMEOUT);
     }

--- a/packages/contracts-rfq/test/FastBridgeV2.Src.Base.t.sol
+++ b/packages/contracts-rfq/test/FastBridgeV2.Src.Base.t.sol
@@ -26,12 +26,12 @@ abstract contract FastBridgeV2SrcBaseTest is FastBridgeV2Test {
     }
 
     function configureFastBridge() public virtual override {
-        fastBridge.grantRole(fastBridge.PROVER_ROLE(), relayerA);
-        fastBridge.grantRole(fastBridge.PROVER_ROLE(), relayerB);
         fastBridge.grantRole(fastBridge.GUARD_ROLE(), guard);
         fastBridge.grantRole(fastBridge.CANCELER_ROLE(), canceler);
 
         fastBridge.grantRole(fastBridge.GOVERNOR_ROLE(), address(this));
+        fastBridge.addProver(relayerA);
+        fastBridge.addProver(relayerB);
         fastBridge.setCancelDelay(PERMISSIONLESS_CANCEL_DELAY);
     }
 

--- a/packages/contracts-rfq/test/FastBridgeV2.Src.Base.t.sol
+++ b/packages/contracts-rfq/test/FastBridgeV2.Src.Base.t.sol
@@ -11,7 +11,7 @@ abstract contract FastBridgeV2SrcBaseTest is FastBridgeV2Test {
     uint256 public constant CLAIM_DELAY = 30 minutes;
     // Use values different from the default to ensure it's being set correctly.
     uint256 public constant PERMISSIONLESS_CANCEL_DELAY = 13.37 hours;
-    uint256 public constant PROVER_TIMEOUT = 4.2 minutes;
+    uint256 public constant DISPUTE_PENALTY_TIME = 4.2 minutes;
 
     uint256 public constant LEFTOVER_BALANCE = 10 ether;
     uint256 public constant INITIAL_PROTOCOL_FEES_TOKEN = 456_789;
@@ -35,7 +35,7 @@ abstract contract FastBridgeV2SrcBaseTest is FastBridgeV2Test {
 
         fastBridge.grantRole(fastBridge.GOVERNOR_ROLE(), address(this));
         fastBridge.setCancelDelay(PERMISSIONLESS_CANCEL_DELAY);
-        fastBridge.setProverTimeout(PROVER_TIMEOUT);
+        fastBridge.setDisputePenaltyTime(DISPUTE_PENALTY_TIME);
     }
 
     function mintTokens() public virtual override {

--- a/packages/contracts-rfq/test/FastBridgeV2.Src.Base.t.sol
+++ b/packages/contracts-rfq/test/FastBridgeV2.Src.Base.t.sol
@@ -9,8 +9,9 @@ import {FastBridgeV2, FastBridgeV2Test, IFastBridge, IFastBridgeV2} from "./Fast
 abstract contract FastBridgeV2SrcBaseTest is FastBridgeV2Test {
     uint256 public constant MIN_DEADLINE = 30 minutes;
     uint256 public constant CLAIM_DELAY = 30 minutes;
-    // Use a value different from the default to ensure it's being set correctly.
+    // Use values different from the default to ensure it's being set correctly.
     uint256 public constant PERMISSIONLESS_CANCEL_DELAY = 13.37 hours;
+    uint256 public constant PROVER_TIMEOUT = 4.2 minutes;
 
     uint256 public constant LEFTOVER_BALANCE = 10 ether;
     uint256 public constant INITIAL_PROTOCOL_FEES_TOKEN = 456_789;
@@ -33,6 +34,7 @@ abstract contract FastBridgeV2SrcBaseTest is FastBridgeV2Test {
         fastBridge.addProver(relayerA);
         fastBridge.addProver(relayerB);
         fastBridge.setCancelDelay(PERMISSIONLESS_CANCEL_DELAY);
+        fastBridge.setProverTimeout(PROVER_TIMEOUT);
     }
 
     function mintTokens() public virtual override {

--- a/packages/contracts-rfq/test/FastBridgeV2.Src.t.sol
+++ b/packages/contracts-rfq/test/FastBridgeV2.Src.t.sol
@@ -346,10 +346,10 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         prove({caller: relayerA, bridgeTx: tokenTx, destTxHash: hex"01"});
     }
 
-    function test_prove_revert_callerNotRelayer(address caller) public {
+    function test_prove_revert_callerNotProver(address caller) public {
         vm.assume(caller != relayerA && caller != relayerB);
         bridge({caller: userA, msgValue: 0, params: tokenParams});
-        expectUnauthorized(caller, fastBridge.PROVER_ROLE());
+        vm.expectRevert(ProverNotActive.selector);
         prove({caller: caller, bridgeTx: tokenTx, destTxHash: hex"01"});
     }
 
@@ -464,7 +464,7 @@ contract FastBridgeV2SrcTest is FastBridgeV2SrcBaseTest {
         bytes32 txId = getTxId(tokenTx);
         vm.assume(caller != relayerA && caller != relayerB);
         bridge({caller: userA, msgValue: 0, params: tokenParams});
-        expectUnauthorized(caller, fastBridge.PROVER_ROLE());
+        vm.expectRevert(ProverNotActive.selector);
         prove({caller: caller, transactionId: txId, destTxHash: hex"01", relayer: relayerA});
     }
 

--- a/packages/contracts-rfq/test/FastBridgeV2.t.sol
+++ b/packages/contracts-rfq/test/FastBridgeV2.t.sol
@@ -9,6 +9,7 @@ import {IFastBridge} from "../contracts/interfaces/IFastBridge.sol";
 import {IFastBridgeV2} from "../contracts/interfaces/IFastBridgeV2.sol";
 
 import {FastBridgeV2} from "../contracts/FastBridgeV2.sol";
+import {IAdminV2Errors} from "../contracts/interfaces/IAdminV2Errors.sol";
 import {IFastBridgeV2Errors} from "../contracts/interfaces/IFastBridgeV2Errors.sol";
 
 import {MockERC20} from "./MockERC20.sol";
@@ -18,7 +19,7 @@ import {Test} from "forge-std/Test.sol";
 import {StdStorage, stdStorage} from "forge-std/Test.sol";
 
 // solhint-disable no-empty-blocks, max-states-count, ordering
-abstract contract FastBridgeV2Test is Test, IFastBridgeV2Errors {
+abstract contract FastBridgeV2Test is Test, IAdminV2Errors, IFastBridgeV2Errors {
     using stdStorage for StdStorage;
 
     uint32 public constant SRC_CHAIN_ID = 1337;

--- a/packages/contracts-rfq/test/integration/FastBridgeV2.MulticallTarget.t.sol
+++ b/packages/contracts-rfq/test/integration/FastBridgeV2.MulticallTarget.t.sol
@@ -8,9 +8,10 @@ import {IFastBridge, MulticallTargetIntegrationTest} from "./MulticallTarget.t.s
 
 contract FastBridgeV2MulticallTargetTest is MulticallTargetIntegrationTest {
     function deployAndConfigureFastBridge() public override returns (address) {
-        FastBridgeV2 fastBridge = new FastBridgeV2(address(this));
-        fastBridge.grantRole(fastBridge.PROVER_ROLE(), relayer);
-        return address(fastBridge);
+        FastBridgeV2 fb = new FastBridgeV2(address(this));
+        fb.grantRole(fb.GOVERNOR_ROLE(), address(this));
+        fb.addProver(relayer);
+        return address(fb);
     }
 
     function getEncodedBridgeTx(IFastBridge.BridgeTransaction memory bridgeTx)

--- a/packages/contracts-rfq/test/integration/FastBridgeV2.MulticallTarget.t.sol
+++ b/packages/contracts-rfq/test/integration/FastBridgeV2.MulticallTarget.t.sol
@@ -9,7 +9,6 @@ import {IFastBridge, MulticallTargetIntegrationTest} from "./MulticallTarget.t.s
 contract FastBridgeV2MulticallTargetTest is MulticallTargetIntegrationTest {
     function deployAndConfigureFastBridge() public override returns (address) {
         FastBridgeV2 fb = new FastBridgeV2(address(this));
-        fb.grantRole(fb.GOVERNOR_ROLE(), address(this));
         fb.addProver(relayer);
         return address(fb);
     }

--- a/packages/contracts-rfq/test/integration/TokenZapV1.t.sol
+++ b/packages/contracts-rfq/test/integration/TokenZapV1.t.sol
@@ -45,7 +45,6 @@ abstract contract TokenZapV1IntegrationTest is Test {
 
     function setUp() public virtual {
         fastBridge = new FastBridgeV2(address(this));
-        fastBridge.grantRole(fastBridge.GOVERNOR_ROLE(), address(this));
         fastBridge.addProver(relayer);
 
         srcToken = new MockERC20("SRC", 18);

--- a/packages/contracts-rfq/test/integration/TokenZapV1.t.sol
+++ b/packages/contracts-rfq/test/integration/TokenZapV1.t.sol
@@ -45,7 +45,8 @@ abstract contract TokenZapV1IntegrationTest is Test {
 
     function setUp() public virtual {
         fastBridge = new FastBridgeV2(address(this));
-        fastBridge.grantRole(fastBridge.PROVER_ROLE(), relayer);
+        fastBridge.grantRole(fastBridge.GOVERNOR_ROLE(), address(this));
+        fastBridge.addProver(relayer);
 
         srcToken = new MockERC20("SRC", 18);
         dstToken = new MockERC20("DST", 18);


### PR DESCRIPTION
# Description
This PR adds the concept of "dispute penalty time":

- Whenever a bridge request is getting disputed, the prover that submitted the proof for it loses their prover privileges for a predetermined `disputePenaltyTime`.
  - This happens automatically does not require any additional actions from the Guard.
  - The edge case where the prover has already been removed by the time of dispute is handled gracefully.
- The dispute penalty time can be updated by the contract's governor.
- Additionally, the prover that provided the proof for a bridge transaction is now exposed as part of `BridgeTxDetails`
- Same as before, the contract's role admin is able to add and remove provers by using new exposed methods instead of `grantRole()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced prover management with new functions to add and remove provers.
  - Introduced new events for tracking prover activities and dispute penalties.
  - Added functionality for setting and querying prover timeouts.

- **Bug Fixes**
  - Improved error handling for prover management scenarios.

- **Documentation**
  - Updated interfaces to reflect new functions and events related to prover management.

- **Tests**
  - Expanded test coverage for prover management functionalities and timeout scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->