### PR TITLE
fix(contracts-rfq): add `forwardTo` to ZapData for Zap Actions that don't forward assets to the user

### DIFF
--- a/packages/contracts-rfq/contracts/interfaces/ISynapseIntentPreviewer.sol
+++ b/packages/contracts-rfq/contracts/interfaces/ISynapseIntentPreviewer.sol
@@ -8,6 +8,8 @@ interface ISynapseIntentPreviewer {
     /// @dev Will not revert if the intent cannot be completed, returns empty values instead.
     /// @dev Returns (amountIn, []) if the intent is a no-op (tokenIn == tokenOut).
     /// @param swapQuoter   Peripheral contract to use for swap quoting
+    /// @param forwardTo    The address to which the proceeds of the intent should be forwarded to.
+    ///                     Note: if no forwarding is required (or done within the intent), use address(0).
     /// @param tokenIn      Initial token for the intent
     /// @param tokenOut     Final token for the intent
     /// @param amountIn     Initial amount of tokens to use for the intent
@@ -16,6 +18,7 @@ interface ISynapseIntentPreviewer {
     ///                     Empty if the intent cannot be completed, or if intent is a no-op (tokenIn == tokenOut).
     function previewIntent(
         address swapQuoter,
+        address forwardTo,
         address tokenIn,
         address tokenOut,
         uint256 amountIn

--- a/packages/contracts-rfq/contracts/libs/ZapDataV1.sol
+++ b/packages/contracts-rfq/contracts/libs/ZapDataV1.sol
@@ -12,13 +12,17 @@ library ZapDataV1 {
     // Offsets of the fields in the packed ZapData struct
     // uint16   version                 [000 .. 002)
     // uint16   amountPosition          [002 .. 004)
-    // address  target                  [004 .. 024)
-    // bytes    payload                 [024 .. ***)
+    // address  finalToken              [004 .. 024)
+    // address  forwardTo               [024 .. 044)
+    // address  target                  [044 .. 064)
+    // bytes    payload                 [064 .. ***)
 
     // forgefmt: disable-start
     uint256 private constant OFFSET_AMOUNT_POSITION = 2;
-    uint256 private constant OFFSET_TARGET          = 4;
-    uint256 private constant OFFSET_PAYLOAD         = 24;
+    uint256 private constant OFFSET_FINAL_TOKEN     = 4;
+    uint256 private constant OFFSET_FORWARD_TO      = 24;
+    uint256 private constant OFFSET_TARGET          = 44;
+    uint256 private constant OFFSET_PAYLOAD         = 64;
     // forgefmt: disable-end
 
     error ZapDataV1__InvalidEncoding();
@@ -73,7 +77,7 @@ library ZapDataV1 {
         if (amountPosition_ != AMOUNT_NOT_PRESENT && (uint256(amountPosition_) + 32 > payload_.length)) {
             revert ZapDataV1__InvalidEncoding();
         }
-        return abi.encodePacked(VERSION, amountPosition_, target_, payload_);
+        return abi.encodePacked(VERSION, amountPosition_, finalToken_, forwardTo_, target_, payload_);
     }
 
     /// @notice Extracts the version from the encoded Zap Data.
@@ -86,12 +90,18 @@ library ZapDataV1 {
 
     /// @notice Extracts the finalToken address from the encoded Zap Data.
     function finalToken(bytes calldata encodedZapData) internal pure returns (address finalToken_) {
-        // TODO
+        // Load 32 bytes from the offset and shift it 96 bits to the right to get the highest 160 bits.
+        assembly {
+            finalToken_ := shr(96, calldataload(add(encodedZapData.offset, OFFSET_FINAL_TOKEN)))
+        }
     }
 
     /// @notice Extracts the forwardTo address from the encoded Zap Data.
     function forwardTo(bytes calldata encodedZapData) internal pure returns (address forwardTo_) {
-        // TODO
+        // Load 32 bytes from the offset and shift it 96 bits to the right to get the highest 160 bits.
+        assembly {
+            forwardTo_ := shr(96, calldataload(add(encodedZapData.offset, OFFSET_FORWARD_TO)))
+        }
     }
 
     /// @notice Extracts the target address from the encoded Zap Data.

--- a/packages/contracts-rfq/contracts/libs/ZapDataV1.sol
+++ b/packages/contracts-rfq/contracts/libs/ZapDataV1.sol
@@ -44,6 +44,14 @@ library ZapDataV1 {
     ///                         This will usually be `4 + 32 * n`, where `n` is the position of the token amount in
     ///                         the list of parameters of the target function (starting from 0).
     ///                         Or `AMOUNT_NOT_PRESENT` if the token amount is not encoded within `payload_`.
+    /// @param finalToken_      The token produced as a result of the Zap action (ERC20 or native gas token).
+    ///                         A zero address value signals that the Zap action doesn't result in any asset per se,
+    ///                         like bridging or depositing into a vault without an LP token.
+    ///                         Note: this parameter must be set to a non-zero value if the `forwardTo_` parameter is
+    ///                         set to a non-zero value.
+    /// @param forwardTo_       The address to which `finalToken` should be forwarded. This parameter is required only
+    ///                         if the Zap action does not automatically transfer the token to the intended recipient.
+    ///                         Otherwise, it must be set to address(0).
     /// @param target_          Address of the target contract.
     /// @param payload_         ABI-encoded calldata to be used for the `target_` contract call.
     ///                         If the target function has the token amount as an argument, any placeholder amount value
@@ -51,6 +59,8 @@ library ZapDataV1 {
     ///                         be replaced with the actual amount, when the Zap Data is decoded.
     function encodeV1(
         uint16 amountPosition_,
+        address finalToken_,
+        address forwardTo_,
         address target_,
         bytes memory payload_
     )
@@ -72,6 +82,16 @@ library ZapDataV1 {
         assembly {
             version_ := shr(240, calldataload(encodedZapData.offset))
         }
+    }
+
+    /// @notice Extracts the finalToken address from the encoded Zap Data.
+    function finalToken(bytes calldata encodedZapData) internal pure returns (address finalToken_) {
+        // TODO
+    }
+
+    /// @notice Extracts the forwardTo address from the encoded Zap Data.
+    function forwardTo(bytes calldata encodedZapData) internal pure returns (address forwardTo_) {
+        // TODO
     }
 
     /// @notice Extracts the target address from the encoded Zap Data.

--- a/packages/contracts-rfq/contracts/router/SynapseIntentPreviewer.sol
+++ b/packages/contracts-rfq/contracts/router/SynapseIntentPreviewer.sol
@@ -21,6 +21,7 @@ contract SynapseIntentPreviewer is ISynapseIntentPreviewer {
     /// @dev Amount value that signals that the Zap step should be performed using the full ZapRecipient balance.
     uint256 internal constant FULL_BALANCE = type(uint256).max;
 
+    error SIP__NoOpForwardNotSupported();
     error SIP__PoolTokenMismatch();
     error SIP__PoolZeroAddress();
     error SIP__RawParamsEmpty();
@@ -29,6 +30,7 @@ contract SynapseIntentPreviewer is ISynapseIntentPreviewer {
     /// @inheritdoc ISynapseIntentPreviewer
     function previewIntent(
         address swapQuoter,
+        address forwardTo,
         address tokenIn,
         address tokenOut,
         uint256 amountIn

--- a/packages/contracts-rfq/contracts/router/SynapseIntentPreviewer.sol
+++ b/packages/contracts-rfq/contracts/router/SynapseIntentPreviewer.sol
@@ -152,6 +152,9 @@ contract SynapseIntentPreviewer is ISynapseIntentPreviewer {
                 msgValue: 0,
                 zapData: ZapDataV1.encodeV1({
                     target_: pool,
+                    // TODO
+                    finalToken_: address(0),
+                    forwardTo_: address(0),
                     // addLiquidity(amounts, minToMint, deadline)
                     payload_: abi.encodeCall(IDefaultExtendedPool.addLiquidity, (amounts, 0, type(uint256).max)),
                     // amountIn is encoded within `amounts` at `TOKEN_IN_INDEX`, `amounts` is encoded after
@@ -185,6 +188,9 @@ contract SynapseIntentPreviewer is ISynapseIntentPreviewer {
                 msgValue: 0,
                 zapData: ZapDataV1.encodeV1({
                     target_: pool,
+                    // TODO
+                    finalToken_: address(0),
+                    forwardTo_: address(0),
                     // removeLiquidityOneToken(tokenAmount, tokenIndex, minAmount, deadline)
                     payload_: abi.encodeCall(
                         IDefaultExtendedPool.removeLiquidityOneToken, (0, params.tokenIndexTo, 0, type(uint256).max)
@@ -236,6 +242,9 @@ contract SynapseIntentPreviewer is ISynapseIntentPreviewer {
             msgValue: 0,
             zapData: ZapDataV1.encodeV1({
                 target_: params.pool,
+                // TODO
+                finalToken_: address(0),
+                forwardTo_: address(0),
                 // swap(tokenIndexFrom, tokenIndexTo, dx, minDy, deadline)
                 payload_: abi.encodeCall(
                     IDefaultPool.swap, (params.tokenIndexFrom, params.tokenIndexTo, 0, 0, type(uint256).max)
@@ -261,6 +270,9 @@ contract SynapseIntentPreviewer is ISynapseIntentPreviewer {
             msgValue: amountIn,
             zapData: ZapDataV1.encodeV1({
                 target_: wrappedNative,
+                // TODO
+                finalToken_: address(0),
+                forwardTo_: address(0),
                 // deposit()
                 payload_: abi.encodeCall(IWETH9.deposit, ()),
                 // amountIn is not encoded
@@ -281,6 +293,9 @@ contract SynapseIntentPreviewer is ISynapseIntentPreviewer {
             msgValue: 0,
             zapData: ZapDataV1.encodeV1({
                 target_: wrappedNative,
+                // TODO
+                finalToken_: address(0),
+                forwardTo_: address(0),
                 // withdraw(amount)
                 payload_: abi.encodeCall(IWETH9.withdraw, (0)),
                 // amountIn encoded as the first parameter

--- a/packages/contracts-rfq/contracts/zaps/TokenZapV1.sol
+++ b/packages/contracts-rfq/contracts/zaps/TokenZapV1.sol
@@ -26,6 +26,7 @@ contract TokenZapV1 is IZapRecipient {
 
     address public constant NATIVE_GAS_TOKEN = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
 
+    error TokenZapV1__FinalTokenBalanceZero();
     error TokenZapV1__PayloadLengthAboveMax();
     error TokenZapV1__TargetZeroAddress();
     error TokenZapV1__TokenZeroAddress();
@@ -82,6 +83,11 @@ contract TokenZapV1 is IZapRecipient {
             // Perform the Zap action, forwarding the requested native value to the target contract.
             // Note: this will bubble up any revert from the target contract, and revert if target is EOA.
             Address.functionCallWithValue({target: target, data: payload, value: msgValue});
+        }
+        // Forward the final token to the specified recipient, if required.
+        address forwardTo = zapData.forwardTo();
+        if (forwardTo != address(0)) {
+            _forwardToken(zapData.finalToken(), forwardTo);
         }
         // Return function selector to indicate successful execution
         return this.zap.selector;
@@ -159,5 +165,10 @@ contract TokenZapV1 is IZapRecipient {
         zapData.validateV1();
         target = zapData.target();
         payload = zapData.payload(amount);
+    }
+
+    /// @notice Forwards the proceeds of the Zap action to the specified recipient.
+    function _forwardToken(address token, address forwardTo) internal {
+        // TODO
     }
 }

--- a/packages/contracts-rfq/contracts/zaps/TokenZapV1.sol
+++ b/packages/contracts-rfq/contracts/zaps/TokenZapV1.sol
@@ -47,6 +47,7 @@ contract TokenZapV1 is IZapRecipient {
     /// @param zapData      Encoded Zap Data containing the target address and calldata for the Zap action.
     /// @return selector    Selector of this function to signal the caller about the success of the Zap action.
     function zap(address token, uint256 amount, bytes calldata zapData) external payable returns (bytes4) {
+        if (token == address(0)) revert TokenZapV1__TokenZeroAddress();
         // Validate the ZapData format and extract the target address.
         zapData.validateV1();
         address target = zapData.target();
@@ -122,6 +123,10 @@ contract TokenZapV1 is IZapRecipient {
     {
         if (payload.length > ZapDataV1.AMOUNT_NOT_PRESENT) {
             revert TokenZapV1__PayloadLengthAboveMax();
+        }
+        // Final token needs to be specified if forwarding is required.
+        if (forwardTo != address(0) && finalToken == address(0)) {
+            revert TokenZapV1__TokenZeroAddress();
         }
         // External integrations do not need to understand the specific `AMOUNT_NOT_PRESENT` semantics.
         // Therefore, they can specify any value greater than or equal to `payload.length` to indicate

--- a/packages/contracts-rfq/contracts/zaps/TokenZapV1.sol
+++ b/packages/contracts-rfq/contracts/zaps/TokenZapV1.sol
@@ -119,7 +119,8 @@ contract TokenZapV1 is IZapRecipient {
             amountPosition = ZapDataV1.AMOUNT_NOT_PRESENT;
         }
         // At this point, we have checked that both `amountPosition` and `payload.length` fit in uint16.
-        return ZapDataV1.encodeV1(uint16(amountPosition), target, payload);
+        // TODO
+        return ZapDataV1.encodeV1(uint16(amountPosition), address(0), address(0), target, payload);
     }
 
     /// @notice Decodes the ZapData for a Zap action. Replaces the placeholder amount with the actual amount,

--- a/packages/contracts-rfq/deployments/arbitrum/SynapseIntentPreviewer.json
+++ b/packages/contracts-rfq/deployments/arbitrum/SynapseIntentPreviewer.json
@@ -1,9 +1,9 @@
 {
-  "address": "0xE184826D4aBC2798134abE7e2Fd72156827Fc7EA",
+  "address": "0x9519E8D136d0a89d7e10D1a66C97249E0135544B",
   "constructorArgs": "0x",
   "receipt": {
-    "hash": "0xdee35d80aa7aa61e76d152e22676067769f2923c85ed5e96d55c807ac9418277",
-    "blockNumber": 281941808
+    "hash": "0xb34f3d918399ac6fa599ecedfdd4a47bd993f4f0e401698d6256dab2fd928ab9",
+    "blockNumber": 282619262
   },
   "abi": [
     {
@@ -25,6 +25,11 @@
       "inputs": [
         {
           "name": "swapQuoter",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "forwardTo",
           "type": "address",
           "internalType": "address"
         },
@@ -79,6 +84,11 @@
         }
       ],
       "stateMutability": "view"
+    },
+    {
+      "type": "error",
+      "name": "SIP__NoOpForwardNotSupported",
+      "inputs": []
     },
     {
       "type": "error",

--- a/packages/contracts-rfq/deployments/arbitrum/TokenZapV1.json
+++ b/packages/contracts-rfq/deployments/arbitrum/TokenZapV1.json
@@ -1,9 +1,9 @@
 {
-  "address": "0xcae5baD754dC99cDA1d58415C5eeeb92e1279F69",
+  "address": "0x6327797F149a75D506aFda46D5fCE6E74fC409D5",
   "constructorArgs": "0x",
   "receipt": {
-    "hash": "0x2a3ca21354283f25dd3e27358b642bc9d33e3a780afb99c98729b7697e903ff6",
-    "blockNumber": 281258026
+    "hash": "0x961a29a85c10275a0d1921ef606f3ed45a79e9106e379b5efd7ae14faa30b1fe",
+    "blockNumber": 282619267
   },
   "abi": [
     {
@@ -70,6 +70,16 @@
           "name": "amountPosition",
           "type": "uint256",
           "internalType": "uint256"
+        },
+        {
+          "name": "finalToken",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "forwardTo",
+          "type": "address",
+          "internalType": "address"
         }
       ],
       "outputs": [
@@ -150,12 +160,22 @@
     },
     {
       "type": "error",
+      "name": "TokenZapV1__FinalTokenBalanceZero",
+      "inputs": []
+    },
+    {
+      "type": "error",
       "name": "TokenZapV1__PayloadLengthAboveMax",
       "inputs": []
     },
     {
       "type": "error",
       "name": "TokenZapV1__TargetZeroAddress",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "TokenZapV1__TokenZeroAddress",
       "inputs": []
     },
     {

--- a/packages/contracts-rfq/deployments/optimism/SynapseIntentPreviewer.json
+++ b/packages/contracts-rfq/deployments/optimism/SynapseIntentPreviewer.json
@@ -1,9 +1,9 @@
 {
-  "address": "0xE184826D4aBC2798134abE7e2Fd72156827Fc7EA",
+  "address": "0x9519E8D136d0a89d7e10D1a66C97249E0135544B",
   "constructorArgs": "0x",
   "receipt": {
-    "hash": "0x57d5d445810008804844d57d54ab99ab5229e87a206996f9cafc67494bf7fd77",
-    "blockNumber": 128944965
+    "hash": "0x928a7db8741fb992934302f73e076f7630075151384529b538cb133e797c4bac",
+    "blockNumber": 129029951
   },
   "abi": [
     {
@@ -25,6 +25,11 @@
       "inputs": [
         {
           "name": "swapQuoter",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "forwardTo",
           "type": "address",
           "internalType": "address"
         },
@@ -79,6 +84,11 @@
         }
       ],
       "stateMutability": "view"
+    },
+    {
+      "type": "error",
+      "name": "SIP__NoOpForwardNotSupported",
+      "inputs": []
     },
     {
       "type": "error",

--- a/packages/contracts-rfq/deployments/optimism/TokenZapV1.json
+++ b/packages/contracts-rfq/deployments/optimism/TokenZapV1.json
@@ -1,9 +1,9 @@
 {
-  "address": "0xcae5baD754dC99cDA1d58415C5eeeb92e1279F69",
+  "address": "0x6327797F149a75D506aFda46D5fCE6E74fC409D5",
   "constructorArgs": "0x",
   "receipt": {
-    "hash": "0x9bba14716cfff19933c2d0c1e83fc1400df60909c49e27d633f03ee1f4740e92",
-    "blockNumber": 128859363
+    "hash": "0xc306e272b5daa98006c1d9009246fac697c258ed8fb6012ab19f5ef5376899b9",
+    "blockNumber": 129029951
   },
   "abi": [
     {
@@ -70,6 +70,16 @@
           "name": "amountPosition",
           "type": "uint256",
           "internalType": "uint256"
+        },
+        {
+          "name": "finalToken",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "forwardTo",
+          "type": "address",
+          "internalType": "address"
         }
       ],
       "outputs": [
@@ -150,12 +160,22 @@
     },
     {
       "type": "error",
+      "name": "TokenZapV1__FinalTokenBalanceZero",
+      "inputs": []
+    },
+    {
+      "type": "error",
       "name": "TokenZapV1__PayloadLengthAboveMax",
       "inputs": []
     },
     {
       "type": "error",
       "name": "TokenZapV1__TargetZeroAddress",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "TokenZapV1__TokenZeroAddress",
       "inputs": []
     },
     {

--- a/packages/contracts-rfq/test/harnesses/ZapDataV1Harness.sol
+++ b/packages/contracts-rfq/test/harnesses/ZapDataV1Harness.sol
@@ -13,6 +13,8 @@ contract ZapDataV1Harness {
 
     function encodeV1(
         uint16 amountPosition_,
+        address finalToken_,
+        address forwardTo_,
         address target_,
         bytes memory payload_
     )
@@ -20,11 +22,19 @@ contract ZapDataV1Harness {
         pure
         returns (bytes memory encodedZapData)
     {
-        return ZapDataV1.encodeV1(amountPosition_, target_, payload_);
+        return ZapDataV1.encodeV1(amountPosition_, finalToken_, forwardTo_, target_, payload_);
     }
 
     function version(bytes calldata encodedZapData) public pure returns (uint16) {
         return ZapDataV1.version(encodedZapData);
+    }
+
+    function finalToken(bytes calldata encodedZapData) public pure returns (address) {
+        return ZapDataV1.finalToken(encodedZapData);
+    }
+
+    function forwardTo(bytes calldata encodedZapData) public pure returns (address) {
+        return ZapDataV1.forwardTo(encodedZapData);
     }
 
     function target(bytes calldata encodedZapData) public pure returns (address) {

--- a/packages/contracts-rfq/test/integration/TokenZapV1.t.sol
+++ b/packages/contracts-rfq/test/integration/TokenZapV1.t.sol
@@ -84,7 +84,9 @@ abstract contract TokenZapV1IntegrationTest is Test {
         bytes memory zapData = dstZap.encodeZapData({
             target: address(dstVault),
             payload: getDepositPayload(address(dstToken)),
-            amountPosition: 4 + 32 * 2
+            amountPosition: 4 + 32 * 2,
+            finalToken: address(0),
+            forwardTo: address(0)
         });
         depositTokenParams.zapData = zapData;
         depositTokenWithZapNativeParams.zapData = zapData;
@@ -93,24 +95,32 @@ abstract contract TokenZapV1IntegrationTest is Test {
         depositNativeParams.zapData = dstZap.encodeZapData({
             target: address(dstVault),
             payload: getDepositPayload(NATIVE_GAS_TOKEN),
-            amountPosition: 4 + 32 * 2
+            amountPosition: 4 + 32 * 2,
+            finalToken: address(0),
+            forwardTo: address(0)
         });
         // Deposit no amount
         depositNativeNoAmountParams.zapData = dstZap.encodeZapData({
             target: address(dstVault),
             payload: getDepositNoAmountPayload(),
-            amountPosition: ZapDataV1.AMOUNT_NOT_PRESENT
+            amountPosition: ZapDataV1.AMOUNT_NOT_PRESENT,
+            finalToken: address(0),
+            forwardTo: address(0)
         });
         // Deposit revert
         depositTokenRevertParams.zapData = dstZap.encodeZapData({
             target: address(dstVault),
             payload: getDepositRevertPayload(),
-            amountPosition: ZapDataV1.AMOUNT_NOT_PRESENT
+            amountPosition: ZapDataV1.AMOUNT_NOT_PRESENT,
+            finalToken: address(0),
+            forwardTo: address(0)
         });
         depositNativeRevertParams.zapData = dstZap.encodeZapData({
             target: address(dstVault),
             payload: getDepositRevertPayload(),
-            amountPosition: ZapDataV1.AMOUNT_NOT_PRESENT
+            amountPosition: ZapDataV1.AMOUNT_NOT_PRESENT,
+            finalToken: address(0),
+            forwardTo: address(0)
         });
     }
 

--- a/packages/contracts-rfq/test/router/SynapseIntentPreviewer.t.sol
+++ b/packages/contracts-rfq/test/router/SynapseIntentPreviewer.t.sol
@@ -110,6 +110,9 @@ contract SynapseIntentPreviewerTest is Test {
     function getSwapZapData(uint8 indexIn, uint8 indexOut) public view returns (bytes memory) {
         return zapDataLib.encodeV1({
             target_: defaultPoolMock,
+            // TODO
+            finalToken_: address(0),
+            forwardTo_: address(0),
             // swap(tokenIndexFrom, tokenIndexTo, dx, minDy, deadline)
             payload_: abi.encodeCall(DefaultPoolMock.swap, (indexIn, indexOut, 0, 0, type(uint256).max)),
             // Amount (dx) is encoded as the third parameter
@@ -153,6 +156,9 @@ contract SynapseIntentPreviewerTest is Test {
         uint256[] memory amounts = new uint256[](TOKENS);
         return zapDataLib.encodeV1({
             target_: defaultPoolMock,
+            // TODO
+            finalToken_: address(0),
+            forwardTo_: address(0),
             // addLiquidity(amounts, minToMint, deadline)
             payload_: abi.encodeCall(IDefaultExtendedPool.addLiquidity, (amounts, 0, type(uint256).max)),
             // Amount is encoded within `amounts` at `TOKEN_IN_INDEX`, `amounts` is encoded after
@@ -196,6 +202,9 @@ contract SynapseIntentPreviewerTest is Test {
     function getRemoveLiquidityZapData(uint8 indexOut) public view returns (bytes memory) {
         return zapDataLib.encodeV1({
             target_: defaultPoolMock,
+            // TODO
+            finalToken_: address(0),
+            forwardTo_: address(0),
             // removeLiquidityOneToken(tokenAmount, tokenIndex, minAmount, deadline)
             payload_: abi.encodeCall(IDefaultExtendedPool.removeLiquidityOneToken, (0, indexOut, 0, type(uint256).max)),
             // Amount (tokenAmount) is encoded as the first parameter
@@ -235,6 +244,9 @@ contract SynapseIntentPreviewerTest is Test {
     function getWrapETHZapData() public view returns (bytes memory) {
         return zapDataLib.encodeV1({
             target_: weth,
+            // TODO
+            finalToken_: address(0),
+            forwardTo_: address(0),
             // deposit()
             payload_: abi.encodeCall(WETHMock.deposit, ()),
             // Amount is not encoded
@@ -269,6 +281,9 @@ contract SynapseIntentPreviewerTest is Test {
     function getUnwrapWETHZapData() public view returns (bytes memory) {
         return zapDataLib.encodeV1({
             target_: weth,
+            // TODO
+            finalToken_: address(0),
+            forwardTo_: address(0),
             // withdraw(amount)
             payload_: abi.encodeCall(WETHMock.withdraw, (0)),
             // Amount is encoded as the first parameter

--- a/packages/contracts-rfq/test/router/SynapseIntentRouter.BalanceChecks.t.sol
+++ b/packages/contracts-rfq/test/router/SynapseIntentRouter.BalanceChecks.t.sol
@@ -204,4 +204,55 @@ contract SynapseIntentRouterBalanceChecksTest is SynapseIntentRouterTest {
             steps: steps
         });
     }
+
+    function test_swapUnwrapForwardNative_exactAmounts_revert_unspentERC20() public {
+        uint256 amountSwap = AMOUNT / TOKEN_PRICE;
+        ISynapseIntentRouter.StepParams[] memory steps = getSwapUnwrapForwardNativeSteps(AMOUNT, amountSwap);
+        vm.expectRevert(SIR__UnspentFunds.selector);
+        completeUserIntent({
+            msgValue: 0,
+            amountIn: AMOUNT + 1,
+            minLastStepAmountIn: amountSwap,
+            deadline: block.timestamp,
+            steps: steps
+        });
+    }
+
+    function test_swapUnwrapForwardNative_exactAmounts_revert_unspentWETH() public {
+        uint256 amountReduced = AMOUNT / TOKEN_PRICE - 1;
+        ISynapseIntentRouter.StepParams[] memory steps = getSwapUnwrapForwardNativeSteps(AMOUNT, amountReduced);
+        vm.expectRevert(SIR__UnspentFunds.selector);
+        completeUserIntent({
+            msgValue: 0,
+            amountIn: AMOUNT,
+            minLastStepAmountIn: amountReduced,
+            deadline: block.timestamp,
+            steps: steps
+        });
+    }
+
+    function test_swapUnwrapForwardNative_exactAmounts_extraFunds_revert_unspentERC20() public withExtraFunds {
+        test_swapUnwrapForwardNative_exactAmounts_revert_unspentERC20();
+    }
+
+    function test_swapUnwrapForwardNative_exactAmounts_extraFunds_revert_unspentWETH() public withExtraFunds {
+        test_swapUnwrapForwardNative_exactAmounts_revert_unspentWETH();
+    }
+
+    function test_swapUnwrapForwardNative_exactAmount1_extraFunds_revertWithBalanceChecks()
+        public
+        override
+        withExtraFunds
+    {
+        uint256 amountSwap = AMOUNT / TOKEN_PRICE;
+        ISynapseIntentRouter.StepParams[] memory steps = getSwapUnwrapForwardNativeSteps(FULL_BALANCE, amountSwap);
+        vm.expectRevert(SIR__UnspentFunds.selector);
+        completeUserIntent({
+            msgValue: 0,
+            amountIn: AMOUNT,
+            minLastStepAmountIn: amountSwap,
+            deadline: block.timestamp,
+            steps: steps
+        });
+    }
 }

--- a/packages/contracts-rfq/test/zaps/TokenZapV1.GasBench.t.sol
+++ b/packages/contracts-rfq/test/zaps/TokenZapV1.GasBench.t.sol
@@ -42,7 +42,7 @@ contract TokenZapV1GasBenchmarkTest is Test {
 
     function getZapData(bytes memory originalPayload) public view returns (bytes memory) {
         // Amount is the second argument of the deposit function.
-        return tokenZap.encodeZapData(address(vault), originalPayload, 4 + 32);
+        return tokenZap.encodeZapData(address(vault), originalPayload, 4 + 32, address(0), address(0));
     }
 
     function test_deposit_erc20() public {

--- a/packages/contracts-rfq/test/zaps/TokenZapV1.t.sol
+++ b/packages/contracts-rfq/test/zaps/TokenZapV1.t.sol
@@ -375,7 +375,7 @@ contract TokenZapV1Test is Test {
 
     function getZeroTargetZapData(bytes memory payload, uint16 amountPosition) public pure returns (bytes memory) {
         // Encode manually as the library checks for zero address
-        return abi.encodePacked(ZapDataV1.VERSION, amountPosition, address(0), payload);
+        return abi.encodePacked(ZapDataV1.VERSION, amountPosition, address(0), address(0), address(0), payload);
     }
 
     function test_zap_erc20_revert_notEnoughTokens() public {


### PR DESCRIPTION
**Description**
This PR enhances `TokenZapV1` and `ZapDataV1` by adding an optional feature to transfer the proceeds of the Zap Action to the specified `forwardTo` address. This is useful for creating Zap Actions for contracts that send the funds back to `msg.sender` rather than the specified address, example being `IDefaultPool` pool contracts that are used as the source of liquidity on some of the chains.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for specifying a forwarding address in multiple functions, enhancing token transfer flexibility.
	- Introduced new error types for improved error handling in contracts.
	- Enhanced zap data functions to accommodate additional parameters for final token and forwarding address.

- **Bug Fixes**
	- Improved error handling for zero address tokens in various functions.

- **Tests**
	- Updated test cases to validate the new forwarding functionality and ensure correct behavior across different scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->