### PR TITLE
Making address (origin and dest) mandated in rest API 

### DIFF
--- a/docs/bridge/docs/02-Bridge/02-REST-API.md
+++ b/docs/bridge/docs/02-Bridge/02-REST-API.md
@@ -26,7 +26,8 @@ The API is available at [`https://api.synapseprotocol.com/`](https://api.synapse
 | Date                   | Description                                                                                                                                                        |
 | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | 2024&#8209;10&#8209;01 | [https://synapse-rest-api-v2.herokuapp.com/](https://synapse-rest-api-v2.herokuapp.com/) is no longer maintained and has been fully deprecated as of October 2024. |
-| 2024&#8209;11&#8209;19 | [https://api.synapseprotocol.com/](https://api.synapseprotocol.com/) the /bridgeTxInfo endpoint has been consolidated into the /bridge endpoint, which now returns call data                   |
+| 2024&#8209;11&#8209;19 | [https://api.synapseprotocol.com/](https://api.synapseprotocol.com/) the /bridgeTxInfo endpoint has been consolidated into the /bridge endpoint, which now returns call data                 |
+| 2024&#8209;12&#8209;12 | [https://api.synapseprotocol.com/](https://api.synapseprotocol.com/bridge) the /bridge endpoint now requires both `originUserAddress` and `destAddress` to generate call data.                   |
 
 ## Support
 

--- a/packages/rest-api/src/controllers/bridgeController.ts
+++ b/packages/rest-api/src/controllers/bridgeController.ts
@@ -53,18 +53,19 @@ export const bridgeController = async (req, res) => {
           quote.originQuery.tokenOut
         )
 
-        const callData = destAddress
-          ? await Synapse.bridge(
-              destAddress,
-              quote.routerAddress,
-              Number(fromChain),
-              Number(toChain),
-              fromToken,
-              amountInWei,
-              quote.originQuery,
-              quote.destQuery
-            )
-          : null
+        const callData =
+          destAddress && originUserAddress
+            ? await Synapse.bridge(
+                destAddress,
+                quote.routerAddress,
+                Number(fromChain),
+                Number(toChain),
+                fromToken,
+                amountInWei,
+                quote.originQuery,
+                quote.destQuery
+              )
+            : null
 
         return {
           ...quote,

--- a/packages/rest-api/src/routes/bridgeRoute.ts
+++ b/packages/rest-api/src/routes/bridgeRoute.ts
@@ -56,13 +56,13 @@ const router: express.Router = express.Router()
  *         required: false
  *         schema:
  *           type: string
- *         description: The address of the user on the origin chain
+ *         description: The address of the user on the origin chain (required to generate callData)
  *       - in: query
  *         name: destAddress
  *         required: false
  *         schema:
  *           type: string
- *         description: The destination address for the bridge transaction
+ *         description: The destination address for the bridge transaction (required to generate callData)
  *     responses:
  *       200:
  *         description: Successful response

--- a/packages/rest-api/src/tests/bridgeRoute.test.ts
+++ b/packages/rest-api/src/tests/bridgeRoute.test.ts
@@ -210,6 +210,22 @@ describe('Bridge Route with Real Synapse Service', () => {
     expect(response.body[0].callData).toBeNull()
   }, 15000)
 
+  it('should return bridge quotes without callData when originUserAddress is not provided', async () => {
+    const response = await request(app).get('/bridge').query({
+      fromChain: '1',
+      toChain: '10',
+      fromToken: USDC.addresses[1],
+      toToken: USDC.addresses[10],
+      amount: '1000',
+      destAddress: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+    })
+
+    expect(response.status).toBe(200)
+    expect(Array.isArray(response.body)).toBe(true)
+    expect(response.body.length).toBeGreaterThan(0)
+    expect(response.body[0].callData).toBeNull()
+  }, 15000)
+
   it('should return 400 for invalid destAddress', async () => {
     const response = await request(app).get('/bridge').query({
       fromChain: '1',

--- a/packages/rest-api/src/tests/bridgeRoute.test.ts
+++ b/packages/rest-api/src/tests/bridgeRoute.test.ts
@@ -174,7 +174,7 @@ describe('Bridge Route with Real Synapse Service', () => {
     expect(response.body.error).toHaveProperty('field', 'amount')
   })
 
-  it('should return bridge quotes with callData when destAddress is provided', async () => {
+  it('should return bridge quotes with callData when originUserAddress and destAddress are provided', async () => {
     const response = await request(app).get('/bridge').query({
       fromChain: '1',
       toChain: '10',
@@ -182,6 +182,7 @@ describe('Bridge Route with Real Synapse Service', () => {
       toToken: USDC.addresses[10],
       amount: '1000',
       destAddress: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+      originUserAddress: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
     })
 
     expect(response.status).toBe(200)
@@ -200,6 +201,7 @@ describe('Bridge Route with Real Synapse Service', () => {
       fromToken: USDC.addresses[1],
       toToken: USDC.addresses[10],
       amount: '1000',
+      originUserAddress: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
     })
 
     expect(response.status).toBe(200)

--- a/packages/rest-api/swagger.json
+++ b/packages/rest-api/swagger.json
@@ -201,7 +201,7 @@
           {
             "in": "query",
             "name": "destAddress",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string"
             },


### PR DESCRIPTION
Change was made to mandate origin and dest addresses in /bridge requests (if call data is to be returned). This is in advance of some of the SIN changes (complex destination chain actions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new API endpoints: `/destinationTokens`, `/destinationTx`, and `/synapseTxId`.

- **Improvements**
  - Updated documentation for the `/bridge` endpoint to clarify parameter requirements.
  - Enhanced error handling for invalid addresses in the bridge route.
  - Standardized error responses across several endpoints.

- **Bug Fixes**
  - Adjusted logic to require both `originUserAddress` and `destAddress` for bridge operations.

- **Documentation**
  - Updated OpenAPI documentation for clarity and consistency across endpoints.
  - Marked `/bridgeTxInfo` and `/swapTxInfo` endpoints as deprecated.
  - Updated Synapse REST API documentation to reflect changes in parameter requirements for the `/bridge` endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
c46ada8e0b334aaa4f3053e60920aa1b7cc08612: [docs preview link ](https://bridge-docs-qoz9u6uwx-synapsecns.vercel.app)
770d6d9f92007f4036fd2e06be80b27876b9708c: [docs preview link ](https://bridge-docs-1rrhwqyia-synapsecns.vercel.app)