### PR TITLE
link out to staking in announcement message

### DIFF
--- a/packages/synapse-interface/components/layouts/LandingPageWrapper/index.tsx
+++ b/packages/synapse-interface/components/layouts/LandingPageWrapper/index.tsx
@@ -21,6 +21,7 @@ import {
   LANDING_PATH,
   TELEGRAM_URL,
   TWITTER_URL,
+  STAKE_SYN_FOR_CX_URL,
 } from '@/constants/urls'
 import { NAVIGATION } from '@/constants/routes'
 import { MoreButton } from './MoreButton'
@@ -51,6 +52,22 @@ const TODO_REMOVE_wrapperStyle = {
   backgroundRepeat: 'no-repeat',
 }
 
+const StakingBannerContent = () => {
+  return (
+    <div>
+      Stake your SYN to receieve CX (Cortex Protocol) tokens{' '}
+      <a
+        href={STAKE_SYN_FOR_CX_URL}
+        target="blank"
+        className="underline hover:cursor hover:text-white/65"
+      >
+        here
+      </a>
+      !
+    </div>
+  )
+}
+
 export function LandingPageWrapper({ children }: { children: any }) {
   return (
     <div className="dark">
@@ -60,9 +77,10 @@ export function LandingPageWrapper({ children }: { children: any }) {
       >
         <AnnouncementBanner
           bannerId="2024-12-18-cortex-staking"
-          bannerContent="Stake your SYN to receive CX (Cortex Protocol) tokens!"
+          bannerContent={<StakingBannerContent />}
+          // bannerContent="Stake your SYN to receive CX (Cortex Protocol) tokens!"
           startDate={new Date('2024-12-17T18:45:09+00:00')}
-          endDate={new Date('2025-01-25T18:45:09+00:00')}
+          endDate={new Date('2025-02-25T18:45:09+00:00')}
         />
         <MaintenanceBanners />
         <LandingNav />

--- a/packages/synapse-interface/components/layouts/LandingPageWrapper/index.tsx
+++ b/packages/synapse-interface/components/layouts/LandingPageWrapper/index.tsx
@@ -55,7 +55,7 @@ const TODO_REMOVE_wrapperStyle = {
 const StakingBannerContent = () => {
   return (
     <div>
-      Stake your SYN to receieve CX (Cortex Protocol) tokens{' '}
+      Stake your SYN to receive CX (Cortex Protocol) tokens{' '}
       <a
         href={STAKE_SYN_FOR_CX_URL}
         target="blank"


### PR DESCRIPTION
null
49974939169272549865dfc5f09336b95593f9aa: [synapse-interface preview link ](https://sanguine-synapse-interface-ec9jcs648-synapsecns.vercel.app)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a staking banner to the landing page
  - Updated announcement banner with new content about staking SYN tokens for CX tokens

- **Improvements**
  - Extended announcement banner end date to February 25, 2025

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
870eb085b80146d104339b89f8f8714bcc8d83f1: [synapse-interface preview link ](https://sanguine-synapse-interface-6966eoqzz-synapsecns.vercel.app)