### PR TITLE
reduced origin min gas balance when quoting a route w/ origin gas token

### DIFF
--- a/services/rfq/relayer/inventory/mocks/manager.go
+++ b/services/rfq/relayer/inventory/mocks/manager.go
@@ -136,6 +136,28 @@ func (_m *Manager) HasSufficientGas(ctx context.Context, chainID int, gasValue *
 	return r0, r1
 }
 
+
+// HasSufficientGasWithMult provides a mock function with given fields: ctx, chainID, gasValue, thresholdMultiplier
+func (_m *Manager) HasSufficientGasWithMult(ctx context.Context, chainID int, gasValue *big.Int, thresholdMultiplier *float64) (bool, error) {
+	ret := _m.Called(ctx, chainID, gasValue, thresholdMultiplier)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(context.Context, int, *big.Int, *float64) bool); ok {
+		r0 = rf(ctx, chainID, gasValue, thresholdMultiplier)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, int, *big.Int, *float64) error); ok {
+		r1 = rf(ctx, chainID, gasValue, thresholdMultiplier)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Rebalance provides a mock function with given fields: ctx
 func (_m *Manager) Rebalance(ctx context.Context) error {
 	ret := _m.Called(ctx)


### PR DESCRIPTION
as origin chain gets critically low on gas, this change should discourage the relayer from quoting most routes involving that chain *except* those that will replenish the deficit gas

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced gas sufficiency checks with a flexible threshold multiplier
  - Improved handling of native gas tokens in quote generation

- **Bug Fixes**
  - Refined gas calculation logic to better support route quoting
  - Added validation for threshold multiplier range

- **Improvements**
  - More nuanced approach to gas management across different token types
  - Streamlined error messaging for gas-related checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->