### PR TITLE
fix(synapse-interface): remove RFQ output amount check

### DIFF
--- a/packages/synapse-interface/components/StateManagedBridge/BridgeTransactionButton.tsx
+++ b/packages/synapse-interface/components/StateManagedBridge/BridgeTransactionButton.tsx
@@ -72,7 +72,6 @@ export const BridgeTransactionButton = ({
     hasSufficientBalance,
     doesBridgeStateMatchQuote,
     isBridgeFeeGreaterThanInput,
-    isBridgeQuoteAmountGreaterThanInputForRfq,
     onSelectedChain,
   } = useBridgeValidations()
 
@@ -83,7 +82,6 @@ export const BridgeTransactionButton = ({
     isWalletPending ||
     !hasValidInput ||
     !doesBridgeStateMatchQuote ||
-    isBridgeQuoteAmountGreaterThanInputForRfq ||
     (isConnected && !hasValidQuote) ||
     (isConnected && !hasSufficientBalance) ||
     (isConnected && isQuoteStale) ||
@@ -175,15 +173,6 @@ export const BridgeTransactionButton = ({
       destinationTokenAddressForState: toToken.addresses[toChainId],
       bridgeQuote,
     })
-  } else if (
-    !isLoading &&
-    isBridgeQuoteAmountGreaterThanInputForRfq &&
-    hasValidInput
-  ) {
-    buttonProperties = {
-      label: t('Invalid bridge quote'),
-      onClick: null,
-    }
   } else if (destinationAddress && !isAddress(destinationAddress)) {
     buttonProperties = {
       label: t('Invalid Destination address'),

--- a/packages/synapse-interface/components/StateManagedBridge/hooks/useBridgeValidations.ts
+++ b/packages/synapse-interface/components/StateManagedBridge/hooks/useBridgeValidations.ts
@@ -76,17 +76,6 @@ export const useBridgeValidations = () => {
     return stringifiedBridgeQuote === stringifiedBridgeState
   }, [stringifiedBridgeQuote, stringifiedBridgeState])
 
-  const isBridgeQuoteAmountGreaterThanInputForRfq = useMemo(() => {
-    return (
-      bridgeQuote.bridgeModuleName === 'SynapseRFQ' &&
-      bridgeQuote.outputAmount > debouncedFromValueBigInt
-    )
-  }, [
-    bridgeQuote.outputAmount,
-    bridgeQuote.bridgeModuleName,
-    debouncedFromValueBigInt,
-  ])
-
   const isBridgeFeeGreaterThanInput = useMemo(() => {
     return (
       bridgeQuote.bridgeModuleName !== null &&
@@ -107,7 +96,6 @@ export const useBridgeValidations = () => {
     hasSufficientBalance,
     doesBridgeStateMatchQuote,
     isBridgeFeeGreaterThanInput,
-    isBridgeQuoteAmountGreaterThanInputForRfq,
     onSelectedChain,
   }
 }


### PR DESCRIPTION
**Description**
Enables the RFQ quotes that have output amount greater than the amount sent on the origin chain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Simplified bridge transaction button logic
  - Removed specific validation for bridge quote amount
  - Enabled more flexible button interaction for bridge transactions

The changes modify how the bridge transaction button works, removing previous restrictions on quote amount validation and providing users with more straightforward transaction capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
47b020293e493214768494a870d4eb8a67b69ae8: [synapse-interface preview link ](https://sanguine-synapse-interface-qy27gtsxx-synapsecns.vercel.app)