### PR TITLE
fix getFee calculation bug. Add pricer test for more exotic non-nativ…

### DIFF
--- a/services/rfq/relayer/pricer/fee_pricer.go
+++ b/services/rfq/relayer/pricer/fee_pricer.go
@@ -222,21 +222,28 @@ func (f *feePricer) getFee(parentCtx context.Context, gasChain, denomChain uint3
 
 	// Compute the fee.
 	var feeDenom *big.Float
-	feeWei := new(big.Float).Mul(new(big.Float).SetInt(gasPrice), new(big.Float).SetFloat64(float64(gasEstimate)))
+
+	feeNativeWei := new(big.Float).Mul(new(big.Float).SetInt(gasPrice), new(big.Float).SetFloat64(float64(gasEstimate)))
 	if denomToken == nativeToken {
 		// Denomination token is native token, so no need for unit conversion.
-		feeDenom = feeWei
+		feeDenom = feeNativeWei
 	} else {
-		// Convert the fee from ETH to denomToken terms.
-		feeEth := new(big.Float).Quo(feeWei, new(big.Float).SetInt(nativeDecimalsFactor))
-		feeUSD := new(big.Float).Mul(feeEth, new(big.Float).SetFloat64(nativeTokenPrice))
-		feeUSDC := new(big.Float).Mul(feeUSD, new(big.Float).SetFloat64(denomTokenPrice))
-		feeDenom = new(big.Float).Mul(feeUSDC, new(big.Float).SetInt(denomDecimalsFactor))
+
+		// The steps below convert a raw/wei value of our native gas units (feeNativeWei EG: 1234500000000000) into an equivalent amount in the "denom" Token
+
+		// convert native gas fee raw/wei into units
+		feeNativeUnits := new(big.Float).Quo(feeNativeWei, new(big.Float).SetInt(nativeDecimalsFactor))
+		// convert native gas fee units into USD value which can then be utilized as a normalizer between our native input and denominated output.
+		feeUSD := new(big.Float).Mul(feeNativeUnits, new(big.Float).SetFloat64(nativeTokenPrice))
+		// convert USD value into "denomToken" units
+		feeDenomUnits := new(big.Float).Quo(feeUSD, new(big.Float).SetFloat64(denomTokenPrice))
+		// convert denominated units into "denomToken" raw/wei value
+		feeDenom = new(big.Float).Mul(feeDenomUnits, new(big.Float).SetInt(denomDecimalsFactor))
 		span.SetAttributes(
-			attribute.String("fee_wei", feeWei.String()),
-			attribute.String("fee_eth", feeEth.String()),
-			attribute.String("fee_usd", feeUSD.String()),
-			attribute.String("fee_usdc", feeUSDC.String()),
+			attribute.String("fee_native_wei", feeNativeWei.String()),
+			attribute.String("fee_native_units", feeNativeUnits.Text('f', -1)),
+			attribute.String("fee_usd", feeUSD.Text('f', -1)),
+			attribute.String("fee_denom_units", feeDenomUnits.Text('f', -1)),
 		)
 	}
 
@@ -263,8 +270,8 @@ func (f *feePricer) getFee(parentCtx context.Context, gasChain, denomChain uint3
 		attribute.Float64("denom_token_price", denomTokenPrice),
 		attribute.Float64("multplier", multiplier),
 		attribute.Int("denom_token_decimals", int(denomTokenDecimals)),
-		attribute.String("fee_wei", feeWei.String()),
-		attribute.String("fee_denom", feeDenom.String()),
+		attribute.String("fee_native_wei", feeNativeWei.String()),
+		attribute.String("fee_denom", feeDenom.Text('f', -1)),
 		attribute.String("fee_usdc_decimals_scaled", feeUSDCDecimalsScaled.String()),
 	)
 	return feeUSDCDecimalsScaled, nil

--- a/services/rfq/relayer/pricer/suite_test.go
+++ b/services/rfq/relayer/pricer/suite_test.go
@@ -53,6 +53,16 @@ func (c *PricerSuite) SetupTest() {
 						PriceUSD: 2000,
 						Decimals: 18,
 					},
+					"BNB": {
+						Address:  "",
+						PriceUSD: 600,
+						Decimals: 18,
+					},
+					"BTC": {
+						Address:  "",
+						PriceUSD: 95000,
+						Decimals: 8,
+					},
 				},
 				NativeToken: "ETH",
 			},
@@ -63,10 +73,20 @@ func (c *PricerSuite) SetupTest() {
 						PriceUSD: 1,
 						Decimals: 6,
 					},
-					"MATIC": {
+					"ETH": {
 						Address:  "",
-						PriceUSD: 0.5,
+						PriceUSD: 2000,
 						Decimals: 18,
+					},
+					"BNB": {
+						Address:  "",
+						PriceUSD: 600,
+						Decimals: 18,
+					},
+					"BTC": {
+						Address:  "",
+						PriceUSD: 95000,
+						Decimals: 8,
 					},
 				},
 				NativeToken: "MATIC",

--- a/services/rfq/relayer/pricer/suite_test.go
+++ b/services/rfq/relayer/pricer/suite_test.go
@@ -73,6 +73,11 @@ func (c *PricerSuite) SetupTest() {
 						PriceUSD: 1,
 						Decimals: 6,
 					},
+					"MATIC": {
+						Address:  "",
+						PriceUSD: 0.5,
+						Decimals: 18,
+					},
 					"ETH": {
 						Address:  "",
 						PriceUSD: 2000,

--- a/services/rfq/relayer/quoter/suite_test.go
+++ b/services/rfq/relayer/quoter/suite_test.go
@@ -55,9 +55,19 @@ func (s *QuoterSuite) SetupTest() {
 						Decimals: 6,
 					},
 					"ETH": {
-						Address:  util.EthAddress.String(),
+						Address:  "",
 						PriceUSD: 2000,
 						Decimals: 18,
+					},
+					"BNB": {
+						Address:  "",
+						PriceUSD: 600,
+						Decimals: 18,
+					},
+					"BTC": {
+						Address:  "",
+						PriceUSD: 95000,
+						Decimals: 8,
 					},
 				},
 				NativeToken: "ETH",
@@ -74,6 +84,21 @@ func (s *QuoterSuite) SetupTest() {
 						Address:  "",
 						PriceUSD: 0.5,
 						Decimals: 18,
+					},
+					"ETH": {
+						Address:  "",
+						PriceUSD: 2000,
+						Decimals: 18,
+					},
+					"BNB": {
+						Address:  "",
+						PriceUSD: 600,
+						Decimals: 18,
+					},
+					"BTC": {
+						Address:  "",
+						PriceUSD: 95000,
+						Decimals: 8,
 					},
 				},
 				NativeToken: "MATIC",


### PR DESCRIPTION
non-native-asset handling on getFee was confusingly labeled & had a bug on the "feeUSDC" calculation step (now relabeled to "feeDenomUnits")

USD value of the fee was attempting to convert into Denom Token's units via multiplication of the Denom Token's USD price -- however, a division is required here.

This happened to be an inconsequential bug in the past because USDC is the only asset we've priced in this way (which has a USD value of 1 and will calculate the same whether multiplied or divided)

Fixed the bug and relabeled variables & tags to be more clear/explicit.

Also added Pricer tests of MATIC, USDC, BNB, ETH, and BTC pricing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced fee calculation for more accurate estimates when using alternative tokens.
  - Expanded token support with additional cryptocurrencies (BNB and BTC) for broader fee coverage.

- **Tests**
  - Added comprehensive test cases to validate fee estimation across multiple tokens, including USDC, MATIC, ETH, BNB, and BTC.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->