### PR TITLE
indexer berachain weth decimals fix

### DIFF
--- a/packages/rfq-indexer/indexer/src/utils/formatAmount.ts
+++ b/packages/rfq-indexer/indexer/src/utils/formatAmount.ts
@@ -1,10 +1,12 @@
 import { formatUnits } from 'viem'
 
 const ADDRESSES_WITH_18_DECIMALS = [
-  '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE', // ETH
+  '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE', // native chain gas (eg: ETH)
   '0x2cFc85d8E48F8EAB294be644d9E25C3030863003', // WLD
   '0x163f8c2467924be0ae7b5347228cabf260318753', // WLD
   '0xdC6fF44d5d932Cbd77B52E5612Ba0529DC6226F1', // WLD
+  '0x2f6f07cdcf3588944bf4c42ac74ff24bf56e7590', // Berachain WETH
+  '0x2170Ed0880ac9A755fd29B2688956BD959F933F8', // BSC ETH
 ].map((address) => address.toLowerCase())
 
 export const formatAmount = (amount: bigint, tokenAddress: string): string => {


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**
A clear and concise description of the features you're adding in this pull request.

**Additional context**
Add any other context about the problem you're solving.

**Metadata**
- Fixes #[Link to Issue]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced token amount displays by providing clearer descriptions for native chain gas.
  - Added support for additional tokens, including Berachain WETH and BSC ETH, to ensure improved consistency in value formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->