### PR TITLE
fix(sdk-router): fixed fee calculation [SYN-49]

### DIFF
--- a/packages/sdk-router/src/rfq/quote.ts
+++ b/packages/sdk-router/src/rfq/quote.ts
@@ -74,16 +74,16 @@ export const applyQuote = (
   quote: FastBridgeQuote,
   originAmount: BigNumber
 ): BigNumber => {
-  // Check that the origin amount covers the fixed fee
-  if (originAmount.lte(quote.fixedFee)) {
+  if (originAmount.eq(Zero) || originAmount.gt(quote.maxOriginAmount)) {
     return Zero
   }
-  // Check that the Relayer is able to process the origin amount (post fixed fee)
-  const amountAfterFee = originAmount.sub(quote.fixedFee)
-  if (amountAfterFee.gt(quote.maxOriginAmount)) {
+  // After these checks: 0 < originAmount <= quote.maxOriginAmount
+  const destAmount = originAmount
+    .mul(quote.destAmount)
+    .div(quote.maxOriginAmount)
+  // Check that the destination amount is greater than the fixed fee
+  if (destAmount.lt(quote.fixedFee)) {
     return Zero
   }
-  // After these checks: 0 < amountAfterFee <= quote.maxOriginAmount
-  // Solve (amountAfterFee -> ?) using (maxOriginAmount -> destAmount) pricing ratio
-  return amountAfterFee.mul(quote.destAmount).div(quote.maxOriginAmount)
+  return destAmount.sub(quote.fixedFee)
 }

--- a/packages/sdk-router/src/rfq/quote.ts
+++ b/packages/sdk-router/src/rfq/quote.ts
@@ -85,7 +85,5 @@ export const applyQuote = (
   if (destAmount.lt(quote.fixedFee)) {
     return Zero
   }
-  const result = destAmount.sub(quote.fixedFee)
-  console.log({ quote, originAmount, result }, 'Applied quote')
-  return result
+  return destAmount.sub(quote.fixedFee)
 }

--- a/packages/sdk-router/src/rfq/quote.ts
+++ b/packages/sdk-router/src/rfq/quote.ts
@@ -85,5 +85,7 @@ export const applyQuote = (
   if (destAmount.lt(quote.fixedFee)) {
     return Zero
   }
-  return destAmount.sub(quote.fixedFee)
+  const result = destAmount.sub(quote.fixedFee)
+  console.log({ quote, originAmount, result }, 'Applied quote')
+  return result
 }


### PR DESCRIPTION
**Description**
This PR changes the way that the flat fixed fee is applied for the RFQ quote calculation. It was previously applied to the origin amount, as if the fixed fee is denominated in the origin asset,

In reality, the fixed fee is denominated in the destination asset, and is applied only after the origin/destination price is applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced processing of transaction quotes with improved validation and fee calculation.
- **Bug Fixes**
  - Adjusted conditions to correctly handle cases where transaction amounts exceed limits or fall below fee thresholds.
- **Tests**
  - Introduced new utility functions for comparing `BigNumber` values and refined test scenarios for improved clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->