### PR TITLE
fix(contracts-rfq): mockCallRevert internal revert in tests

### DIFF
--- a/packages/contracts-rfq/test/libs/UniversalTokenLib.t.sol
+++ b/packages/contracts-rfq/test/libs/UniversalTokenLib.t.sol
@@ -29,6 +29,7 @@ contract UniversalTokenLibraryTest is Test {
         assertEq(token.balanceOf(address(recipient)), amount);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testUniversalTransferTokenNoopWhenSameRecipient() public {
         uint256 amount = 12_345;
         token.mint(address(libHarness), amount);


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**
A clear and concise description of the features you're adding in this pull request.

**Additional context**
Add any other context about the problem you're solving.

**Metadata**
- Fixes #[Link to Issue]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated test configuration to correctly handle internal revert expectations during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->