### PR TITLE
fix: hide slippage between different type of assets for now [SYN-39]

### DIFF
--- a/packages/synapse-interface/components/StateManagedBridge/BridgeExchangeRateInfo.tsx
+++ b/packages/synapse-interface/components/StateManagedBridge/BridgeExchangeRateInfo.tsx
@@ -65,15 +65,17 @@ const Slippage = () => {
   const t = useTranslations('Bridge')
   // TODO: handle slippage between different types of assets
   const {
-    bridgeQuote: { exchangeRate, bridgeModuleName },
+    bridgeQuote: { exchangeRate, originTokenForQuote, destTokenForQuote },
   } = useBridgeQuoteState()
+  const areSameAssets =
+    originTokenForQuote?.swapableType === destTokenForQuote?.swapableType
 
   const { formattedPercentSlippage, safeFromAmount, underFee, textColor } =
     useExchangeRateInfo(debouncedFromValue, exchangeRate)
   return (
     <div className="flex justify-between">
       <span className="text-zinc-500 dark:text-zinc-400">{t('Slippage')}</span>
-      {safeFromAmount !== '0' && !underFee && bridgeModuleName !== 'Gas.zip' ? (
+      {safeFromAmount !== '0' && !underFee && areSameAssets ? (
         <span className={textColor}>{formattedPercentSlippage}</span>
       ) : (
         <span className="">−</span>


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**
A clear and concise description of the features you're adding in this pull request.

**Additional context**
Add any other context about the problem you're solving.

**Metadata**
- Fixes #[Link to Issue]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the slippage display logic so that the component now shows a formatted percentage only when the input amount is valid, fees are not applied, and the token types match. Otherwise, a placeholder is shown for a more consistent user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
991f5c265e9959a429cbf142264b5585f6f15f83: [synapse-interface preview link ](https://sanguine-synapse-interface-og5jvlebp-synapsecns.vercel.app)