### PR TITLE
[DI-48] fix: replace vulnerable tj-actions actions with dorny/paths-filter

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -53,29 +53,31 @@ jobs:
 
       - name: Check For Solidity Changes
         id: filter_solidity
-        uses: tj-actions/changed-files@v26.1
+        uses: dorny/paths-filter@v2
         with:
-          files: |
-            **/*.sol
+          filters: |
+            sol:
+              - '**/*.sol'
 
       - name: Check For GolangCI Changes
         id: golangci_changed
-        uses: tj-actions/changed-files@v26.1
+        uses: dorny/paths-filter@v2
         with:
           # note: without building a yaml tree of our workflow, we won't be able to tell if golangci version changed so any ci change triggers full lint.
-          files: |
-           .golangci.yml
-           .golangci-version
-           .github/workflows/go.yml
+          filters: |
+            config:
+              - '.golangci.yml'
+              - '.golangci-version'
+              - '.github/workflows/go.yml'
 
 
       - name: Run step if any of the listed files above change
-        if: steps.filter_solidity.outputs.any_changed == 'true'
+        if: steps.filter_solidity.outputs.sol == 'true'
         run: |
           echo "One or more files listed above has changed."
 
       - name: Golangci changed
-        if: steps.golangci_changed.outputs.any_changed == 'true'
+        if: steps.golangci_changed.outputs.config == 'true'
         run: |
           echo "Golangci has changed."
 
@@ -458,28 +460,29 @@ jobs:
           GOMEMLIMIT: 6GiB
           GOGC: -1
 
-      - name: Verify Changed files
-        uses: tj-actions/verify-changed-files@v11.1
-        id: verify-changed-files
+      - name: Filter Changed files
+        uses: dorny/paths-filter@v2
+        id: filter-changed-files
         with:
-          files: |
-            *.go
+          filters: |
+            go:
+              - '*.go'
 
-      - name: List all changed files tracked and untracked files
-        if: steps.verify-changed-files.outputs.files_changed == 'true'
+      - name: List changed files
+        if: steps.filter-changed-files.outputs.go == 'true'
         run: |
-          echo "Changed files: ${{ steps.verify-changed-files.outputs.changed_files }}"
+          echo "Go files have been changed"
 
         # Fail if files need regeneration
         # TODO: this can run into a bit of a race condition if any other label is removed/added while this is run, look into fixing this by dispatching another workflow
       - name: Add Label
-        if: ${{ !contains(fromJson(needs.pr_metadata.outputs.labels), format('needs-go-generate-{0}', matrix.package)) && steps.verify-changed-files.outputs.files_changed == 'true' }}
+        if: ${{ !contains(fromJson(needs.pr_metadata.outputs.labels), format('needs-go-generate-{0}', matrix.package)) && steps.filter-changed-files.outputs.go == 'true' }}
         uses: ./.github/actions/add-label
         with:
           label: 'needs-go-generate-${{matrix.package}}'
 
       - name: Remove Label
-        if: ${{ contains(fromJson(needs.pr_metadata.outputs.labels), format('needs-go-generate-{0}', matrix.package)) && steps.verify-changed-files.outputs.files_changed != 'true' }}
+        if: ${{ contains(fromJson(needs.pr_metadata.outputs.labels), format('needs-go-generate-{0}', matrix.package)) && steps.filter-changed-files.outputs.go != 'true' }}
         uses: ./.github/actions/remove-label
         with:
           label: 'needs-go-generate-${{matrix.package}}'
@@ -613,28 +616,29 @@ jobs:
           GOMEMLIMIT: 6GiB
           GOGC: -1
 
-      - name: Verify Changed files
-        uses: tj-actions/verify-changed-files@v11
-        id: verify-changed-files
+      - name: Filter Changed files
+        uses: dorny/paths-filter@v2
+        id: filter-changed-files
         with:
-          files: |
-            *.go
+          filters: |
+            go:
+              - '*.go'
 
-      - name: List all changed files tracked and untracked files
-        if: steps.verify-changed-files.outputs.files_changed == 'true'
+      - name: List changed files
+        if: steps.filter-changed-files.outputs.go == 'true'
         run: |
-          echo "Changed files: ${{ steps.verify-changed-files.outputs.changed_files }}"
+          echo "Go files have been changed"
 
         # Fail if files need regeneration
         # TODO: this can run into a bit of a race condition if any other label is removed/added while this is run, look into fixing this by dispatching another workflow
       - name: Add Label
-        if: ${{ !contains(fromJson(needs.pr_metadata.outputs.labels), format('needs-go-generate-{0}', matrix.package)) && steps.verify-changed-files.outputs.files_changed == 'true' }}
+        if: ${{ !contains(fromJson(needs.pr_metadata.outputs.labels), format('needs-go-generate-{0}', matrix.package)) && steps.filter-changed-files.outputs.go == 'true' }}
         uses: ./.github/actions/add-label
         with:
           label: 'needs-go-generate-${{matrix.package}}'
 
       - name: Remove Label
-        if: ${{ contains(fromJson(needs.pr_metadata.outputs.labels), format('needs-go-generate-{0}', matrix.package)) && steps.verify-changed-files.outputs.files_changed != 'true' }}
+        if: ${{ contains(fromJson(needs.pr_metadata.outputs.labels), format('needs-go-generate-{0}', matrix.package)) && steps.filter-changed-files.outputs.go != 'true' }}
         uses: ./.github/actions/remove-label
         with:
           label: 'needs-go-generate-${{matrix.package}}'

--- a/.github/workflows/goreleaser-actions.yml
+++ b/.github/workflows/goreleaser-actions.yml
@@ -159,7 +159,9 @@ jobs:
 
       - name: Get branch name
         id: branch-name
-        uses: tj-actions/branch-names@v6
+        run: |
+          echo "is_default=$([ "$GITHUB_REF" == "refs/heads/${{ github.event.repository.default_branch }}" ] && echo 'true' || echo 'false')" >> $GITHUB_OUTPUT
+          echo "current_branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
 
       - name: Bump version and push tag
         id: tag_version

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -66,29 +66,30 @@ jobs:
           with:
             version: nightly
 
-        - name: Verify Changed files
-          uses: tj-actions/verify-changed-files@v11.1
-          id: verify-yarn-lock
+        - name: Filter changed files
+          uses: dorny/paths-filter@v2
+          id: filter-yarn-lock
           with:
-            files: |
-              yarn.lock
+            filters: |
+              yarn:
+                - 'yarn.lock'
 
         - name: Add Label
-          if: ${{ steps.verify-yarn-lock.outputs.files_changed == 'true' && github.event_name != 'push' }}
+          if: ${{ steps.filter-yarn-lock.outputs.yarn == 'true' && github.event_name != 'push' }}
           uses: ./.github/actions/add-label
           with:
             label: 'needs-yarn-install'
 
         - name: Remove Label
-          if: ${{ steps.verify-yarn-lock.outputs.files_changed != 'true' && github.event_name != 'push' }}
+          if: ${{ steps.filter-yarn-lock.outputs.yarn != 'true' && github.event_name != 'push' }}
           uses: ./.github/actions/remove-label
           with:
             label: 'needs-yarn-install'
 
-        - name: List all changed files tracked and untracked files
-          if: steps.verify-changed-files.outputs.files_changed == 'true'
+        - name: List changed files
+          if: steps.filter-yarn-lock.outputs.yarn == 'true'
           run: |
-            echo "Changed files: ${{ steps.verify-changed-files.outputs.changed_files }}"
+            echo "Changed files: yarn.lock"
 
         - name: Run tests # Run tests of all packages
           run: yarn test:coverage


### PR DESCRIPTION
Replace all tj-actions actions (changed-files, verify-changed-files, branch-names) with secure alternatives to mitigate the security vulnerability. Used dorny/paths-filter for file checking and bash scripts for branch name detection.

🤖 Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude <noreply@anthropic.com>

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**
A clear and concise description of the features you're adding in this pull request.

**Additional context**
Add any other context about the problem you're solving.

**Metadata**
- Fixes #[Link to Issue]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Streamlined automation workflows with an enhanced mechanism for detecting file and dependency changes.
	- Improved branch name and release condition handling for more reliable and efficient deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->