### PR TITLE
fix(sdk-router): add nativeFee to IntentStep

### DIFF
--- a/packages/sdk-router/src/operations/intent.ts
+++ b/packages/sdk-router/src/operations/intent.ts
@@ -60,6 +60,7 @@ async function _getSameChainIntentQuotes(
     routerAddress: swapQuote.routerAddress,
     moduleNames: swapQuote.moduleNames,
     gasDropAmount: '0',
+    nativeFee: '0',
     tx: swapQuote.tx,
   }
 
@@ -124,6 +125,7 @@ async function _getCrossChainIntentQuotes(
         estimatedTime: bridgeQuote.estimatedTime,
         moduleNames: bridgeQuote.moduleNames,
         gasDropAmount: bridgeQuote.gasDropAmount,
+        nativeFee: bridgeQuote.nativeFee,
         tx: bridgeQuote.tx,
       }
       // Check if the token out is the same as the requested token out.

--- a/packages/sdk-router/src/types/intent.ts
+++ b/packages/sdk-router/src/types/intent.ts
@@ -70,6 +70,7 @@ export type IntentQuote = {
  * @property {number} estimatedTime - Estimated time for the operation to complete in seconds.
  * @property {string[]} moduleNames - Names of the modules used for the operation.
  * @property {string} gasDropAmount - Amount of gas to be dropped after the operation alongside `toToken`.
+ * @property {string} nativeFee - Native fee to be paid for the operation (if any).
  * @property {PopulatedTx} [tx] - Optional populated transaction for the operation (returned only if `fromSender` is provided).
  */
 export type IntentStep = {
@@ -86,5 +87,6 @@ export type IntentStep = {
   estimatedTime: number
   moduleNames: string[]
   gasDropAmount: string
+  nativeFee: string
   tx?: PopulatedTx
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new field displaying native fee information for each intent step, including both same-chain and cross-chain operations. This allows users to view the native fee required for each step in the process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->