### PR TITLE
fix(solidity-devops): bump forge-std to 1.9.7

### DIFF
--- a/packages/solidity-devops/package.json
+++ b/packages/solidity-devops/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "chalk": "^4.1.2",
     "dotenv": "^16.4.5",
-    "forge-std": "github:foundry-rs/forge-std#v1.9.6"
+    "forge-std": "github:foundry-rs/forge-std#v1.9.7"
   },
   "bin": {
     "fsr": "js/forgeScriptRun.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19341,9 +19341,9 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==
 
-"forge-std@github:foundry-rs/forge-std#v1.9.6":
-  version "1.9.6"
-  resolved "https://codeload.github.com/foundry-rs/forge-std/tar.gz/3b20d60d14b343ee4f908cb8079495c07f5e8981"
+"forge-std@github:foundry-rs/forge-std#v1.9.7":
+  version "1.9.7"
+  resolved "https://codeload.github.com/foundry-rs/forge-std/tar.gz/77041d2ce690e692d6e03cc812b57d1ddaa4d505"
 
 fork-ts-checker-webpack-plugin@^4.1.6:
   version "4.1.6"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the "forge-std" dependency to version v1.9.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->