### PR TITLE
build: update checkout action to v5

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup NodeJS
         uses: ./.github/actions/setup-nodejs

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         language: ['go', 'javascript']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 2
       - name: Install Go

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -21,7 +21,7 @@ jobs:
       contents: read
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       -
         name: Set up Docker Buildx

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -40,7 +40,7 @@ jobs:
       golangci_changed: ${{ steps.golangci_changed.outputs.any_changed }}
       all_packages: ${{ steps.filter_go.outputs.all_modules }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -125,7 +125,7 @@ jobs:
       run:
         working-directory: ${{ matrix.package }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 2
           submodules: 'recursive'
@@ -285,7 +285,7 @@ jobs:
         go-version:
           - 1.22.x
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 2
       - name: Install Go
@@ -331,7 +331,7 @@ jobs:
         with:
           go-version: 1.23.x
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -404,7 +404,7 @@ jobs:
         # only do on agents for now. Anything that relies on solidity in a package should do this
         package: ['agents', 'services/rfq']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 2
           submodules: 'recursive'
@@ -499,7 +499,7 @@ jobs:
         package: ${{ fromJSON(needs.changes.outputs.unchanged_deps) }}
     steps:
       # needed for remove label action
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: ${{ contains(fromJson(needs.pr_metadata.outputs.labels), format('needs-go-generate-{0}', matrix.package)) }}
         with:
           fetch-depth: 2
@@ -522,7 +522,7 @@ jobs:
         # only do on agents for now. Anything that relies on solidity in a package should do this
         package: ${{ fromJSON(needs.changes.outputs.packages_deps) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 2
           submodules: 'recursive'

--- a/.github/workflows/goreleaser-actions.yml
+++ b/.github/workflows/goreleaser-actions.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0 # needed if using new-from-rev (see: https://golangci-lint.run/usage/configuration/#issues-configuration)
 
@@ -92,7 +92,7 @@ jobs:
       packages: ${{ steps.filter_go.outputs.changed_modules_deps }}
       package_count: ${{ steps.length.outputs.FILTER_LENGTH }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -136,7 +136,7 @@ jobs:
 
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: ${{ github.ref == 'refs/heads/master' && '0' || '1' }}
 

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -30,7 +30,7 @@ jobs:
         chart: [ 'agents_embedded', 'agents_remote', 'scribe', 'explorer', 'omnirpc' ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/hyperliquid-node.yml
+++ b/.github/workflows/hyperliquid-node.yml
@@ -21,10 +21,10 @@ jobs:
       contents: read
     steps:
       - name: Git Checkout (Sanguine)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Git Checkout (Hyperliquid)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: 'hyperliquid-dex/node'
           ref: 'main'
@@ -71,10 +71,10 @@ jobs:
       contents: read
     steps:
       - name: Git Checkout (Sanguine)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Git Checkout (Hyperliquid)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: 'hyperliquid-dex/node'
           ref: 'main'

--- a/.github/workflows/jaeger-ui.yml
+++ b/.github/workflows/jaeger-ui.yml
@@ -18,7 +18,7 @@ jobs:
       contents: read
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cache Docker images.
         uses: ScribeMD/docker-cache@0.3.6

--- a/.github/workflows/label-statuses.yml
+++ b/.github/workflows/label-statuses.yml
@@ -9,7 +9,7 @@ jobs:
   label-statuses:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: master
 

--- a/.github/workflows/lerna.yaml
+++ b/.github/workflows/lerna.yaml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           submodules: 'recursive'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
   general-linters:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: mszostok/codeowners-validator@v0.7.4
         with:
           checks: 'files,duppatterns,syntax'

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 2
           submodules: 'recursive'
@@ -52,7 +52,7 @@ jobs:
 
       steps:
         - name: 'Checkout'
-          uses: actions/checkout@v4
+          uses: actions/checkout@v5
           with:
             fetch-depth: 2
             submodules: 'recursive'

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -19,7 +19,7 @@ jobs:
 #      pull-requests: write
 #      checks: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: SonarCloud Scan

--- a/.github/workflows/solidity.yml
+++ b/.github/workflows/solidity.yml
@@ -28,7 +28,7 @@ jobs:
       packages: ${{ steps.filter_solidity.outputs.changes }}
       package_count: ${{ steps.length.outputs.FILTER_LENGTH }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           # if any of these packages use submodules in the future, please uncomment this line
@@ -65,7 +65,7 @@ jobs:
       VERCEL_ORG_ID: '${{ secrets.VERCEL_ORG_ID }}'
       NODE_ENV: 'production'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup NodeJS
         uses: ./.github/actions/setup-nodejs
         with:
@@ -147,7 +147,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 2
           submodules: 'recursive'
@@ -202,7 +202,7 @@ jobs:
       matrix:
         package: ${{ fromJson(needs.changes.outputs.packages) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -266,7 +266,7 @@ jobs:
         exclude:
           - package: solidity-devops
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -319,7 +319,7 @@ jobs:
         exclude:
           - package: solidity-devops
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 

--- a/.github/workflows/ui-preview.yaml
+++ b/.github/workflows/ui-preview.yaml
@@ -17,7 +17,7 @@ jobs:
       packages: ${{ steps.filter_ui.outputs.changes }}
       package_count: ${{ steps.length.outputs.FILTER_LENGTH }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           # if any of these packages use submodules in the future, please uncomment this line
@@ -56,7 +56,7 @@ jobs:
       VERCEL_ORG_ID: '${{ secrets.VERCEL_ORG_ID }}'
       NODE_ENV: 'production'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup NodeJS
         uses: ./.github/actions/setup-nodejs
         with:


### PR DESCRIPTION
Maintenance update to actions/checkout@v5 to align with the current runner stack (Node 24); nothing else modified.

Release notes: https://github.com/actions/checkout/releases/tag/v5.0.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Upgraded GitHub Actions checkout to v5 across all CI workflows, including build, test, lint, release, security analysis, and preview pipelines.
  * Ensures consistent checkout behavior across multi-repo and multi-job workflows without altering existing parameters or logic.
  * No changes to product features, APIs, or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->