### PR TITLE
fix(rest-api): error when no routes found

### DIFF
--- a/packages/rest-api/src/controllers/bridgeController.ts
+++ b/packages/rest-api/src/controllers/bridgeController.ts
@@ -46,6 +46,14 @@ export const bridgeController = async (req, res) => {
         : {}
     )
 
+    // Check if no bridge quotes were found
+    if (!resp || resp.length === 0) {
+      logger.info(`No bridge routes found`, {
+        query: req.query,
+      })
+      return res.status(404).json({ error: 'No bridge routes found' })
+    }
+
     const payload = await Promise.all(
       resp.map(async (quote) => {
         const originQueryTokenOutInfo = tokenAddressToToken(

--- a/packages/rest-api/src/controllers/intentController.ts
+++ b/packages/rest-api/src/controllers/intentController.ts
@@ -45,6 +45,14 @@ export const intentController = async (req, res) => {
       allowMultipleTxs,
     })
 
+    // Check if no intent quotes were found
+    if (!intentQuotes || intentQuotes.length === 0) {
+      logger.info(`No intent quotes found`, {
+        query: req.query,
+      })
+      return res.status(404).json({ error: 'No intent quotes found' })
+    }
+
     // Include callData only if both fromSender and toRecipient are provided.
     const payload = intentQuotes.map((quote) => ({
       ...quote,

--- a/packages/rest-api/src/tests/bridgeRoute.test.ts
+++ b/packages/rest-api/src/tests/bridgeRoute.test.ts
@@ -240,4 +240,17 @@ describe('Bridge Route with Real Synapse Service', () => {
     expect(response.status).toBe(400)
     expect(response.body.error).toHaveProperty('message', 'Invalid destAddress')
   }, 15000)
+
+  it('should return 404 when no bridge routes found for small amount (0.001 USDC from Arbitrum to Ethereum)', async () => {
+    const response = await request(app).get('/bridge').query({
+      fromChain: '42161', // Arbitrum
+      toChain: '1', // Ethereum
+      fromToken: USDC.addresses[42161],
+      toToken: USDC.addresses[1],
+      amount: '0.001',
+    })
+
+    expect(response.status).toBe(404)
+    expect(response.body).toHaveProperty('error', 'No bridge routes found')
+  }, 15000)
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Clear 404 response with error message when no bridge routes are available.
  - Clear 404 response with error message when no intent quotes are available.
- Bug Fixes
  - Prevents proceeding with empty results, avoiding confusing or partial responses.
- Tests
  - Added test to verify 404 response and error message when no bridge routes exist for very small amounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->