### PR TITLE
chore(sdk-router): cleanup unused dependencies

### DIFF
--- a/packages/sdk-router/package.json
+++ b/packages/sdk-router/package.json
@@ -45,13 +45,14 @@
   },
   "module": "dist/sdk-v2.esm.js",
   "devDependencies": {
+    "@babel/core": "^7.20.12",
+    "@babel/plugin-transform-modules-commonjs": "^7.24.8",
     "@codecov/rollup-plugin": "^0.0.1-beta.10",
-    "@ethersproject/providers": "^5.7.0",
-    "@types/big.js": "^4.0.5",
     "@types/jest": "^24.0.25",
+    "babel-jest": "^25.2.6",
     "cspell": "^8.15.4",
     "dotenv": "^16.3.1",
-    "husky": "^8.0.1",
+    "jest": "^29.7.0",
     "jest-fetch-mock": "^3.0.3",
     "jest-mock-extended": "^3.0.5",
     "node-fetch": "^2.0.0",
@@ -62,8 +63,6 @@
     "typescript": "^4.8.3"
   },
   "dependencies": {
-    "@babel/core": "^7.20.12",
-    "@babel/plugin-transform-modules-commonjs": "^7.24.8",
     "@ethersproject/abi": "^5.7.0",
     "@ethersproject/abstract-provider": "^5.7.0",
     "@ethersproject/address": "^5.7.0",
@@ -71,15 +70,10 @@
     "@ethersproject/bytes": "^5.7.0",
     "@ethersproject/constants": "^5.7.0",
     "@ethersproject/contracts": "^5.7.0",
-    "babel-jest": "^25.2.6",
-    "big.js": "^5.2.2",
-    "decimal.js-light": "^2.5.1",
+    "@ethersproject/providers": "^5.7.0",
     "ethers": "^5.7.2",
-    "jest": "^29.7.0",
-    "jsbi": "^4.3.0",
     "node-cache": "^5.1.2",
     "tiny-invariant": "^1.2.0",
-    "toformat": "^2.0.0",
     "ts-xor": "^1.1.0",
     "uuidv7": "^1.0.1"
   }

--- a/packages/sdk-router/src/declarations.d.ts
+++ b/packages/sdk-router/src/declarations.d.ts
@@ -1,1 +1,0 @@
-declare module 'toformat'

--- a/yarn.lock
+++ b/yarn.lock
@@ -9516,11 +9516,6 @@
   dependencies:
     "@babel/types" "^7.20.7"
 
-"@types/big.js@^4.0.5":
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/@types/big.js/-/big.js-4.0.5.tgz#62c61697646269e39191f24e55e8272f05f21fc0"
-  integrity sha512-D9KFrAt05FDSqLo7PU9TDHfDgkarlwdkuwFsg7Zm4xl62tTNaz+zN+Tkcdx2wGLBbSMf8BnoMhOVeUGUaJfLKg==
-
 "@types/bn.js@^4.11.3":
   version "4.11.6"
   resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-4.11.6.tgz#c306c70d9358aaea33cd4eda092a742b9505967c"
@@ -16078,7 +16073,7 @@ decamelize@^4.0.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-4.0.0.tgz#aa472d7bf660eb15f3494efd531cab7f2a709837"
   integrity sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==
 
-decimal.js-light@^2.4.1, decimal.js-light@^2.5.1:
+decimal.js-light@^2.4.1:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/decimal.js-light/-/decimal.js-light-2.5.1.tgz#134fd32508f19e208f4fb2f8dac0d2626a867934"
   integrity sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==
@@ -21381,11 +21376,6 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-husky@^8.0.1:
-  version "8.0.3"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.3.tgz#4936d7212e46d1dea28fef29bb3a108872cd9184"
-  integrity sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==
-
 i18next-browser-languagedetector@7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/i18next-browser-languagedetector/-/i18next-browser-languagedetector-7.1.0.tgz#01876fac51f86b78975e79b48ccb62e2313a2d7d"
@@ -23593,11 +23583,6 @@ js-yaml@4.1.0, js-yaml@^4.0.0, js-yaml@^4.1.0:
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
   dependencies:
     argparse "^2.0.1"
-
-jsbi@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/jsbi/-/jsbi-4.3.0.tgz#b54ee074fb6fcbc00619559305c8f7e912b04741"
-  integrity sha512-SnZNcinB4RIcnEyZqFPdGPVgrg2AcnykiBy0sHVJQKHYeaLUvi3Exj+iaPpLnFVkDPZIV4U0yvgC9/R4uEAZ9g==
 
 jsbn@1.1.0:
   version "1.1.0"
@@ -34623,11 +34608,6 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
-
-toformat@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/toformat/-/toformat-2.0.0.tgz#7a043fd2dfbe9021a4e36e508835ba32056739d8"
-  integrity sha512-03SWBVop6nU8bpyZCx7SodpYznbZF5R4ljwNLBcTQzKOD9xuihRo/psX58llS1BMFhhAI08H3luot5GoXJz2pQ==
 
 toidentifier@1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Remove unused packages and reorganize dependencies to correctly distinguish between runtime and development dependencies.

- Remove: big.js, decimal.js-light, jsbi, toformat
- Move to devDeps: @babel/core, @babel/plugin-transform-modules-commonjs, babel-jest, jest
- Move to deps: @ethersproject/providers (used in runtime code)
- Remove from devDeps: husky, @types/big.js
- Delete src/declarations.d.ts (unused toformat declaration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies and package configuration in the SDK router module.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->