### PR TITLE
fix(synapse-interface): use tx submission time for bridge timer

### DIFF
--- a/packages/synapse-interface/components/_Transaction/_Transaction.tsx
+++ b/packages/synapse-interface/components/_Transaction/_Transaction.tsx
@@ -35,6 +35,7 @@ interface _TransactionProps {
   routerAddress: string
   estimatedTime: number // in seconds
   timestamp: number
+  submittedAt?: number
   currentTime: number
   kappa?: string
   status: 'pending' | 'completed' | 'reverted' | 'refunded'
@@ -55,12 +56,15 @@ export const _Transaction = ({
   routerAddress,
   estimatedTime,
   timestamp,
+  submittedAt,
   currentTime,
   kappa,
   status,
   disabled,
 }: _TransactionProps) => {
   const dispatch = useAppDispatch()
+
+  const startTime = submittedAt ?? timestamp
 
   const t = useTranslations('Time')
 
@@ -85,7 +89,7 @@ export const _Transaction = ({
     isCheckTxStatus,
     isCheckTxForRevert,
     isCheckTxForRefund,
-  } = calculateEstimatedTimeStatus(currentTime, timestamp, estimatedTime)
+  } = calculateEstimatedTimeStatus(currentTime, startTime, estimatedTime)
   if (bridgeModuleName === 'Gas.zip') {
     isCheckTxForRefund = isEstimatedTimeReached
   }
@@ -174,7 +178,7 @@ export const _Transaction = ({
           >
             <div className="p-2 mt-1 text-xs cursor-default text-zinc-300">
               {t('Began')}{' '}
-              {new Date(timestamp * 1000).toLocaleString('en-US', {
+              {new Date(startTime * 1000).toLocaleString('en-US', {
                 month: 'short',
                 day: 'numeric',
                 hour: '2-digit',
@@ -221,7 +225,7 @@ export const _Transaction = ({
       <div className="px-1">
         <AnimatedProgressBar
           id={originTxHash}
-          startTime={timestamp}
+          startTime={startTime}
           estDuration={estimatedTime * 2} // 2x buffer
           status={status}
         />

--- a/packages/synapse-interface/components/_Transaction/_Transactions.tsx
+++ b/packages/synapse-interface/components/_Transaction/_Transactions.tsx
@@ -61,6 +61,7 @@ export const _Transactions = ({
               estimatedTime={tx.estimatedTime}
               kappa={tx?.kappa}
               timestamp={tx.timestamp}
+              submittedAt={tx.submittedAt}
               currentTime={currentTime}
               status={
                 tx.destinationChain.id === HYPERLIQUID.id

--- a/packages/synapse-interface/pages/state-managed-bridge/index.tsx
+++ b/packages/synapse-interface/pages/state-managed-bridge/index.tsx
@@ -378,7 +378,7 @@ const StateManagedBridge = () => {
       dispatch(
         updatePendingBridgeTransaction({
           id: currentTimestamp,
-          timestamp: undefined,
+          timestamp: getUnixTimeMinutesFromNow(0),
           transactionHash: tx,
           isSubmitted: false,
         })

--- a/packages/synapse-interface/slices/_transactions/reducer.ts
+++ b/packages/synapse-interface/slices/_transactions/reducer.ts
@@ -17,6 +17,7 @@ export interface _TransactionDetails {
   routerAddress: string
   estimatedTime: number
   timestamp: number
+  submittedAt?: number
   kappa?: string
   status: 'pending' | 'completed' | 'reverted' | 'refunded'
 }

--- a/packages/synapse-interface/utils/hooks/use_TransactionsListener.ts
+++ b/packages/synapse-interface/utils/hooks/use_TransactionsListener.ts
@@ -53,6 +53,7 @@ export const use_TransactionsListener = () => {
               routerAddress: tx.routerAddress,
               estimatedTime: tx.estimatedTime,
               timestamp: tx.id,
+              submittedAt: tx.timestamp ?? tx.id,
               status: 'pending',
             })
           )


### PR DESCRIPTION
Track `submittedAt` timestamp separately from user initiation time. Timer now starts from when the transaction was submitted to the network, not when the user clicked Bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced transaction submission time tracking for improved accuracy in time-based calculations and timestamp displays.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
b04d9a586a07eebc56321a6da531d1dc1276eff1: [synapse-interface preview link ](https://sanguine-synapse-interface-jc68shj34-synapsecns.vercel.app)