### PR TITLE
fix(synapse-interface): fix navigation menu error

### DIFF
--- a/packages/synapse-interface/components/layouts/LandingPageWrapper/index.tsx
+++ b/packages/synapse-interface/components/layouts/LandingPageWrapper/index.tsx
@@ -232,12 +232,6 @@ function MoreInfoButtons() {
   return (
     <>
       <MoreInfoItem
-        className="mdl:hidden"
-        to={NAVIGATION.Analytics.path}
-        labelText={NAVIGATION.Analytics.text}
-        description="See preliminary analytics of the bridge"
-      />
-      <MoreInfoItem
         to={NAVIGATION.SYN.path}
         labelText={NAVIGATION.SYN.text}
         description="View $SYN related information such as contract addresses"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the Analytics link from the landing page information buttons. The information section now displays only the SYN link and its description.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
43fc13a15be4b7ea83a0c438c6217514baac7141: [synapse-interface preview link ](https://sanguine-synapse-interface-9pncuu5ua-synapsecns.vercel.app)