### PR TITLE
[codex] update Synapse website Discord link for fe-release

### DIFF
--- a/packages/synapse-interface/components/_Transaction/_Transaction.tsx
+++ b/packages/synapse-interface/components/_Transaction/_Transaction.tsx
@@ -21,6 +21,7 @@ import { Address } from 'viem'
 import { useIsTxReverted } from './helpers/useIsTxReverted'
 import { useTxRefundStatus } from './helpers/useTxRefundStatus'
 import { HYPERLIQUID } from '@/constants/chains/master'
+import { DISCORD_URL } from '@/constants/urls'
 
 interface _TransactionProps {
   connectedAddress: string
@@ -200,7 +201,7 @@ export const _Transaction = ({
               )}
             <MenuItem
               text={t('Contact Support (Discord)')}
-              link="https://discord.gg/4rMzuEnKqe"
+              link={DISCORD_URL}
             />
             {status !== 'pending' && (
               <MenuItem

--- a/packages/synapse-interface/constants/urls/index.tsx
+++ b/packages/synapse-interface/constants/urls/index.tsx
@@ -36,7 +36,7 @@ export const JOBS_URL = 'https://jobs.ashbyhq.com/Synapse%20Labs'
 export const STAKE_SYN_FOR_CX_URL = 'https://cortexprotocol.com/agents/convert'
 
 /** Synapse Social Links */
-export const DISCORD_URL = 'https://discord.gg/4rMzuEnKqe'
+export const DISCORD_URL = 'https://discord.gg/Z2K8yNzfE'
 export const TELEGRAM_URL = 'https://t.me/synapseprotocol'
 export const FORUM_URL = 'https://common.xyz/cortex-dao'
 export const TWITTER_URL = 'https://twitter.com/SynapseProtocol'


### PR DESCRIPTION
## What changed
- updated the shared `DISCORD_URL` used by the Synapse interface on `fe-release` to the new invite
- replaced a remaining hardcoded Discord invite in the transaction support dropdown with the shared constant

## Why
`fe-release` still points to the old Discord invite in two interface code paths.

## Impact
Users clicking Discord links from the website and transaction support menu on the release branch will be sent to the current invite.

## Root cause
The invite URL had drifted on `fe-release`: the shared constant was outdated and one transaction UI path bypassed the constant entirely.

## Validation
- verified the diff against `origin/fe-release` is only these two intended file changes
- previously attempted targeted linting in this checkout, but the package ESLint setup failed to parse existing TypeScript files and did not provide usable validation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated the Discord support link to direct users to a new server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
9ef41652536072549c41d7904bd706da254bba5b: [synapse-interface preview link ](https://sanguine-synapse-interface-einbqli6d-synapsecns.vercel.app)