### PR TITLE
fix(synapse-interface): validate RPC chain id

### DIFF
--- a/packages/synapse-interface/pages/api/rpc/[chainId].ts
+++ b/packages/synapse-interface/pages/api/rpc/[chainId].ts
@@ -52,18 +52,25 @@ const handler = async (req: Request) => {
     return new Response('RPC proxy not configured', { status: 500 })
   }
 
-  const chainId = new URL(req.url).pathname.split('/').pop()
+  const requestUrl = new URL(req.url)
+  const safeChainId = requestUrl.pathname.split('/').pop()
+  if (!safeChainId || !/^[0-9]+$/.test(safeChainId)) {
+    return new Response('Invalid chainId', { status: 400 })
+  }
 
   const body = await req.text()
 
-  const resp = await fetch(`https://edge.goldsky.com/standard/evm/${chainId}`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-ERPC-Secret-Token': secret,
-    },
-    body,
-  })
+  const resp = await fetch(
+    `https://edge.goldsky.com/standard/evm/${safeChainId}`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-ERPC-Secret-Token': secret,
+      },
+      body,
+    }
+  )
 
   return new Response(resp.body, {
     status: resp.status,

--- a/packages/synapse-interface/pages/api/rpc/[chainId].ts
+++ b/packages/synapse-interface/pages/api/rpc/[chainId].ts
@@ -54,7 +54,7 @@ const handler = async (req: Request) => {
 
   const requestUrl = new URL(req.url)
   const safeChainId = requestUrl.pathname.split('/').pop()
-  if (!safeChainId || !/^[0-9]+$/.test(safeChainId)) {
+  if (!safeChainId || !/^\d+$/.test(safeChainId)) {
     return new Response('Invalid chainId', { status: 400 })
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of chain ID parameters for RPC requests; missing or non-numeric chain IDs are rejected with a 400 error.
  * Upstream RPC calls now use the validated chain ID to ensure requests target the intended chain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
10942d356e16e75b534eac978557aa1b334b29f9: [synapse-interface preview link ](https://sanguine-synapse-interface-o4bn25rxl-synapsecns.vercel.app)
6e54ca1ecca0c26a260c7fbb67c978703f79cf33: [synapse-interface preview link ](https://sanguine-synapse-interface-dvuvj2897-synapsecns.vercel.app)