### PR TITLE
fix(synapse-interface): bridge pauses

### DIFF
--- a/packages/synapse-interface/README.md
+++ b/packages/synapse-interface/README.md
@@ -79,7 +79,7 @@ The shared artifacts are:
 Current repository state:
 
 - `paused-chains.json` is intentionally shipped as an empty array. This repository no longer maintains chain-specific pause records in the shared artifacts.
-- `paused-bridge-modules.json` remains the maintained pause artifact for bridge module filtering. Records must stay chain-scoped; do not add a global `ALL` pause record.
+- `paused-bridge-modules.json` remains the maintained pause artifact for bridge module filtering. Records must stay chain-scoped with `chainId`, `toChainId`, or both; do not add a global `ALL` pause record.
 - Example files under `public/pauses/v1/examples/` are intentionally empty arrays so they do not advertise removed chain-specific or global configs.
 
 When a shared pause artifact changes, the production webapp picks it up after:
@@ -100,7 +100,10 @@ Use `paused-bridge-modules.json` to pause a specific bridge module on a specific
 ### Bridge Module Pause Props
 
 `chainId`
-Chain ID of the chain where the bridge module should be paused.
+Origin chain ID where the bridge module should be paused.
+
+`toChainId`
+Destination chain ID where the bridge module should be paused.
 
 `bridgeModuleName`
 Accepts `SynapseRFQ`, `SynapseBridge`, or `SynapseCCTP`.

--- a/packages/synapse-interface/README.md
+++ b/packages/synapse-interface/README.md
@@ -69,17 +69,19 @@ The interface renders maintenance UI from shared pause artifacts:
 2. Countdown Progress Bar at the top of Bridge / Swap cards.
 3. Warning Message below the input UI in Bridge / Swap cards.
 
-The widget still depends on these same pause artifact files and repository paths for its maintenance state, even though it fetches them through different remote URLs. Keep both files present at their current paths even when they are empty, because the widget is coupled to those artifact locations.
+The widget still depends on these same pause artifact files and repository paths for its maintenance state, even though it fetches them through different remote URLs. Keep shared artifact files present at their current paths even when they are empty, because consumers may be coupled to those artifact locations.
 
 The shared artifacts are:
 
 - [Pause Chains JSON](https://github.com/synapsecns/sanguine/blob/master/packages/synapse-interface/public/pauses/v1/paused-chains.json)
 - [Pause Bridge Modules JSON](https://github.com/synapsecns/sanguine/blob/master/packages/synapse-interface/public/pauses/v1/paused-bridge-modules.json)
+- [Pause Bridge Modules To Chain JSON](https://github.com/synapsecns/sanguine/blob/master/packages/synapse-interface/public/pauses/v1/paused-bridge-modules-to-chain.json)
 
 Current repository state:
 
 - `paused-chains.json` is intentionally shipped as an empty array. This repository no longer maintains chain-specific pause records in the shared artifacts.
-- `paused-bridge-modules.json` remains the maintained pause artifact for bridge module filtering. Records must stay chain-scoped with `chainId`, `toChainId`, or both; do not add a global `ALL` pause record.
+- `paused-bridge-modules.json` remains the maintained pause artifact for origin chain bridge module filtering. Records must stay chain-scoped with `chainId`; do not add a global `ALL` pause record.
+- `paused-bridge-modules-to-chain.json` remains the maintained pause artifact for destination chain bridge module filtering. Records must stay chain-scoped with `toChainId`; do not add a global `ALL` pause record.
 - Example files under `public/pauses/v1/examples/` are intentionally empty arrays so they do not advertise removed chain-specific or global configs.
 
 When a shared pause artifact changes, the production webapp picks it up after:
@@ -91,7 +93,7 @@ This deployment flow applies to the interface only. After Step 1, the [Github Pa
 
 ## Bridge Module Pause
 
-Use `paused-bridge-modules.json` to pause a specific bridge module on a specific chain. Supported bridge modules are:
+Use `paused-bridge-modules.json` to pause a specific bridge module from a specific chain. Use `paused-bridge-modules-to-chain.json` to pause a specific bridge module to a specific chain. Supported bridge modules are:
 
 - `SynapseRFQ`
 - `SynapseCCTP`
@@ -100,10 +102,10 @@ Use `paused-bridge-modules.json` to pause a specific bridge module on a specific
 ### Bridge Module Pause Props
 
 `chainId`
-Origin chain ID where the bridge module should be paused.
+Origin chain ID where the bridge module should be paused. Use only in `paused-bridge-modules.json`.
 
 `toChainId`
-Destination chain ID where the bridge module should be paused.
+Destination chain ID where the bridge module should be paused. Use only in `paused-bridge-modules-to-chain.json`.
 
 `bridgeModuleName`
 Accepts `SynapseRFQ`, `SynapseBridge`, or `SynapseCCTP`.

--- a/packages/synapse-interface/components/Maintenance/Maintenance.tsx
+++ b/packages/synapse-interface/components/Maintenance/Maintenance.tsx
@@ -28,7 +28,8 @@ interface ChainPause {
 }
 
 export interface BridgeModulePause {
-  chainId?: number // If undefined, pause bridge module for all chains.
+  chainId?: number // Origin chain ID. If undefined, match any origin chain.
+  toChainId?: number // Destination chain ID. If undefined, match any destination chain.
   bridgeModuleName: 'SynapseBridge' | 'SynapseRFQ' | 'SynapseCCTP' | 'ALL'
 }
 

--- a/packages/synapse-interface/components/Maintenance/hooks/useSynapsePauseData.ts
+++ b/packages/synapse-interface/components/Maintenance/hooks/useSynapsePauseData.ts
@@ -8,11 +8,14 @@ import {
 import { fetchJsonData } from '../functions/fetchJsonData'
 import pausedChains from '@/public/pauses/v1/paused-chains.json'
 import pausedBridgeModules from '@/public/pauses/v1/paused-bridge-modules.json'
+import pausedBridgeModulesToChain from '@/public/pauses/v1/paused-bridge-modules-to-chain.json'
 
 const PAUSED_CHAINS_URL =
   'https://synapsecns.github.io/sanguine/packages/synapse-interface/public/pauses/v1/paused-chains.json'
 const PAUSED_MODULES_URL =
   'https://synapsecns.github.io/sanguine/packages/synapse-interface/public/pauses/v1/paused-bridge-modules.json'
+const PAUSED_MODULES_TO_CHAIN_URL =
+  'https://synapsecns.github.io/sanguine/packages/synapse-interface/public/pauses/v1/paused-bridge-modules-to-chain.json'
 
 export const useSynapsePauseData = () => {
   const dispatch = useAppDispatch()
@@ -25,9 +28,17 @@ export const useSynapsePauseData = () => {
     try {
       const pausedChainsData = await fetchJsonData(PAUSED_CHAINS_URL)
       const pausedModulesData = await fetchJsonData(PAUSED_MODULES_URL)
+      const pausedModulesToChainData = await fetchJsonData(
+        PAUSED_MODULES_TO_CHAIN_URL
+      )
 
       dispatch(setPausedChainsData(pausedChainsData))
-      dispatch(setPausedModulesData(pausedModulesData))
+      dispatch(
+        setPausedModulesData([
+          ...pausedModulesData,
+          ...pausedModulesToChainData,
+        ])
+      )
     } catch (error) {
       console.error(
         'Using local source, failed to fetch paused chains/modules: ',
@@ -36,7 +47,12 @@ export const useSynapsePauseData = () => {
 
       /** Read local source if fetch fails as backup */
       dispatch(setPausedChainsData(pausedChains))
-      dispatch(setPausedModulesData(pausedBridgeModules))
+      dispatch(
+        setPausedModulesData([
+          ...pausedBridgeModules,
+          ...pausedBridgeModulesToChain,
+        ])
+      )
     } finally {
       setTimeout(() => {
         setIsFetching(false)

--- a/packages/synapse-interface/components/StateManagedBridge/BridgeModulePausedWarning.tsx
+++ b/packages/synapse-interface/components/StateManagedBridge/BridgeModulePausedWarning.tsx
@@ -29,12 +29,10 @@ export const BridgeModulePausedWarning = ({
     return null
   }
 
-  const moduleNames = pausedModuleNames.join(', ')
-
   return (
     <WarningMessage
       twClassName="mb-2 border border-amber-500/30 !bg-amber-50 !text-amber-950 dark:!bg-amber-950/30 dark:!text-amber-100"
-      message={t('BridgeModulePauseWarningMessage', { moduleNames })}
+      message={t('BridgeModulePauseWarningMessage')}
     />
   )
 }

--- a/packages/synapse-interface/components/StateManagedBridge/BridgeModulePausedWarning.tsx
+++ b/packages/synapse-interface/components/StateManagedBridge/BridgeModulePausedWarning.tsx
@@ -1,0 +1,40 @@
+import { useMemo } from 'react'
+import { useTranslations } from 'next-intl'
+
+import type { BridgeModulePause } from '@/components/Maintenance/Maintenance'
+import { WarningMessage } from '@/components/Warning'
+import { getPausedBridgeModuleNamesForRoute } from '@/utils/getPausedBridgeModuleNamesForRoute'
+
+export const BridgeModulePausedWarning = ({
+  fromChainId,
+  toChainId,
+  pausedModulesList,
+}: {
+  fromChainId: number
+  toChainId: number
+  pausedModulesList: BridgeModulePause[]
+}) => {
+  const t = useTranslations('Bridge')
+  const pausedModuleNames = useMemo(
+    () =>
+      getPausedBridgeModuleNamesForRoute({
+        pausedModules: pausedModulesList,
+        fromChainId,
+        toChainId,
+      }),
+    [fromChainId, toChainId, pausedModulesList]
+  )
+
+  if (!fromChainId || !toChainId || pausedModuleNames.length === 0) {
+    return null
+  }
+
+  const moduleNames = pausedModuleNames.join(', ')
+
+  return (
+    <WarningMessage
+      twClassName="mb-2 border border-amber-500/30 !bg-amber-50 !text-amber-950 dark:!bg-amber-950/30 dark:!text-amber-100"
+      message={t('BridgeModulePauseWarningMessage', { moduleNames })}
+    />
+  )
+}

--- a/packages/synapse-interface/messages/ar.json
+++ b/packages/synapse-interface/messages/ar.json
@@ -14,6 +14,7 @@
     "Bridge": "الجسر",
     "Send your assets across chains": "أرسل أصولك عبر السلاسل.",
     "Bridge paused": "الجسر متوقف مؤقتًا",
+    "BridgeModulePauseWarningMessage": "{moduleNames} متوقف مؤقتًا لهذا المسار. قد تكون عروض الأسعار محدودة أو أقل ملاءمة من المتوقع.",
     "Please select Origin Network": "يرجى اختيار شبكة المصدر",
     "Please select Destination network": "يرجى اختيار شبكة الوجهة",
     "Please select an Origin token": "يرجى اختيار رمز المصدر",

--- a/packages/synapse-interface/messages/ar.json
+++ b/packages/synapse-interface/messages/ar.json
@@ -14,7 +14,7 @@
     "Bridge": "الجسر",
     "Send your assets across chains": "أرسل أصولك عبر السلاسل.",
     "Bridge paused": "الجسر متوقف مؤقتًا",
-    "BridgeModulePauseWarningMessage": "{moduleNames} متوقف مؤقتًا لهذا المسار. قد تكون عروض الأسعار محدودة أو أقل ملاءمة من المتوقع.",
+    "BridgeModulePauseWarningMessage": "الجسر متوقف مؤقتًا لهذا المسار. قد تكون عروض الأسعار أقل ملاءمة.",
     "Please select Origin Network": "يرجى اختيار شبكة المصدر",
     "Please select Destination network": "يرجى اختيار شبكة الوجهة",
     "Please select an Origin token": "يرجى اختيار رمز المصدر",

--- a/packages/synapse-interface/messages/en-US.json
+++ b/packages/synapse-interface/messages/en-US.json
@@ -14,6 +14,7 @@
     "Bridge": "Bridge",
     "Send your assets across chains": "Send your assets across chains.",
     "Bridge paused": "Bridge paused",
+    "BridgeModulePauseWarningMessage": "{moduleNames} is paused for this route. Quotes may be limited or less favorable than expected.",
     "Please select Origin Network": "Please select Origin Network",
     "Please select Destination network": "Please select Destination network",
     "Please select an Origin token": "Please select an Origin token",

--- a/packages/synapse-interface/messages/en-US.json
+++ b/packages/synapse-interface/messages/en-US.json
@@ -14,7 +14,7 @@
     "Bridge": "Bridge",
     "Send your assets across chains": "Send your assets across chains.",
     "Bridge paused": "Bridge paused",
-    "BridgeModulePauseWarningMessage": "{moduleNames} is paused for this route. Quotes may be limited or less favorable than expected.",
+    "BridgeModulePauseWarningMessage": "Bridge is paused for this route. Quotes may be less favorable.",
     "Please select Origin Network": "Please select Origin Network",
     "Please select Destination network": "Please select Destination network",
     "Please select an Origin token": "Please select an Origin token",

--- a/packages/synapse-interface/messages/es.json
+++ b/packages/synapse-interface/messages/es.json
@@ -14,6 +14,7 @@
     "Bridge": "Puente",
     "Send your assets across chains": "Envía tus activos entre cadenas.",
     "Bridge paused": "Puente en pausa",
+    "BridgeModulePauseWarningMessage": "{moduleNames} está en pausa para esta ruta. Las cotizaciones pueden ser limitadas o menos favorables de lo esperado.",
     "Please select Origin Network": "Por favor, selecciona la Red de Origen",
     "Please select Destination network": "Por favor, selecciona la red de Destino",
     "Please select an Origin token": "Por favor, selecciona un token de Origen",

--- a/packages/synapse-interface/messages/es.json
+++ b/packages/synapse-interface/messages/es.json
@@ -14,7 +14,7 @@
     "Bridge": "Puente",
     "Send your assets across chains": "Envía tus activos entre cadenas.",
     "Bridge paused": "Puente en pausa",
-    "BridgeModulePauseWarningMessage": "{moduleNames} está en pausa para esta ruta. Las cotizaciones pueden ser limitadas o menos favorables de lo esperado.",
+    "BridgeModulePauseWarningMessage": "El puente está en pausa para esta ruta. Las cotizaciones pueden ser menos favorables.",
     "Please select Origin Network": "Por favor, selecciona la Red de Origen",
     "Please select Destination network": "Por favor, selecciona la red de Destino",
     "Please select an Origin token": "Por favor, selecciona un token de Origen",

--- a/packages/synapse-interface/messages/fr.json
+++ b/packages/synapse-interface/messages/fr.json
@@ -14,6 +14,7 @@
     "Bridge": "Bridge",
     "Send your assets across chains": "Envoyez vos actifs à travers les chaînes.",
     "Bridge paused": "Bridge en pause",
+    "BridgeModulePauseWarningMessage": "{moduleNames} est en pause pour cette route. Les offres peuvent être limitées ou moins favorables que prévu.",
     "Please select Origin Network": "Veuillez sélectionner le réseau d'origine",
     "Please select Destination network": "Veuillez sélectionner le réseau de destination",
     "Please select an Origin token": "Veuillez sélectionner un jeton d'origine",

--- a/packages/synapse-interface/messages/fr.json
+++ b/packages/synapse-interface/messages/fr.json
@@ -14,7 +14,7 @@
     "Bridge": "Bridge",
     "Send your assets across chains": "Envoyez vos actifs à travers les chaînes.",
     "Bridge paused": "Bridge en pause",
-    "BridgeModulePauseWarningMessage": "{moduleNames} est en pause pour cette route. Les offres peuvent être limitées ou moins favorables que prévu.",
+    "BridgeModulePauseWarningMessage": "Le bridge est en pause pour cette route. Les offres peuvent être moins favorables.",
     "Please select Origin Network": "Veuillez sélectionner le réseau d'origine",
     "Please select Destination network": "Veuillez sélectionner le réseau de destination",
     "Please select an Origin token": "Veuillez sélectionner un jeton d'origine",

--- a/packages/synapse-interface/messages/jp.json
+++ b/packages/synapse-interface/messages/jp.json
@@ -14,6 +14,7 @@
     "Bridge": "ブリッジ",
     "Send your assets across chains": "チェーン間でアセットを送信します。",
     "Bridge paused": "ブリッジ一時停止中",
+    "BridgeModulePauseWarningMessage": "{moduleNames} はこのルートで一時停止中です。見積もりが限られるか、想定より不利になる場合があります。",
     "Please select Origin Network": "オリジンネットワークを選択してください",
     "Please select Destination network": "宛先ネットワークを選択してください",
     "Please select an Origin token": "オリジントークンを選択してください",

--- a/packages/synapse-interface/messages/jp.json
+++ b/packages/synapse-interface/messages/jp.json
@@ -14,7 +14,7 @@
     "Bridge": "ブリッジ",
     "Send your assets across chains": "チェーン間でアセットを送信します。",
     "Bridge paused": "ブリッジ一時停止中",
-    "BridgeModulePauseWarningMessage": "{moduleNames} はこのルートで一時停止中です。見積もりが限られるか、想定より不利になる場合があります。",
+    "BridgeModulePauseWarningMessage": "このルートではブリッジが一時停止中です。見積もりが不利になる場合があります。",
     "Please select Origin Network": "オリジンネットワークを選択してください",
     "Please select Destination network": "宛先ネットワークを選択してください",
     "Please select an Origin token": "オリジントークンを選択してください",

--- a/packages/synapse-interface/messages/tr.json
+++ b/packages/synapse-interface/messages/tr.json
@@ -14,6 +14,7 @@
     "Bridge": "Köprü",
     "Send your assets across chains": "Varlıklarınızı zincirler arasında gönderin.",
     "Bridge paused": "Köprü duraklatıldı",
+    "BridgeModulePauseWarningMessage": "{moduleNames} bu rota için duraklatıldı. Teklifler sınırlı veya beklenenden daha az avantajlı olabilir.",
     "Please select Origin Network": "Lütfen Kaynak Ağı seçin",
     "Please select Destination network": "Lütfen Hedef ağı seçin",
     "Please select an Origin token": "Lütfen bir Kaynak token seçin",

--- a/packages/synapse-interface/messages/tr.json
+++ b/packages/synapse-interface/messages/tr.json
@@ -14,7 +14,7 @@
     "Bridge": "Köprü",
     "Send your assets across chains": "Varlıklarınızı zincirler arasında gönderin.",
     "Bridge paused": "Köprü duraklatıldı",
-    "BridgeModulePauseWarningMessage": "{moduleNames} bu rota için duraklatıldı. Teklifler sınırlı veya beklenenden daha az avantajlı olabilir.",
+    "BridgeModulePauseWarningMessage": "Köprü bu rota için duraklatıldı. Teklifler daha az avantajlı olabilir.",
     "Please select Origin Network": "Lütfen Kaynak Ağı seçin",
     "Please select Destination network": "Lütfen Hedef ağı seçin",
     "Please select an Origin token": "Lütfen bir Kaynak token seçin",

--- a/packages/synapse-interface/messages/zh-CN.json
+++ b/packages/synapse-interface/messages/zh-CN.json
@@ -14,7 +14,7 @@
     "Bridge": "桥接",
     "Send your assets across chains": "跨链发送您的资产。",
     "Bridge paused": "桥接已暂停",
-    "BridgeModulePauseWarningMessage": "{moduleNames} 已针对此路线暂停。报价可能有限，或不如预期优惠。",
+    "BridgeModulePauseWarningMessage": "此路线的桥接已暂停。报价可能不够优惠。",
     "Please select Origin Network": "请选择来源网络",
     "Please select Destination network": "请选择目标网络",
     "Please select an Origin token": "请选择来源代币",

--- a/packages/synapse-interface/messages/zh-CN.json
+++ b/packages/synapse-interface/messages/zh-CN.json
@@ -14,6 +14,7 @@
     "Bridge": "桥接",
     "Send your assets across chains": "跨链发送您的资产。",
     "Bridge paused": "桥接已暂停",
+    "BridgeModulePauseWarningMessage": "{moduleNames} 已针对此路线暂停。报价可能有限，或不如预期优惠。",
     "Please select Origin Network": "请选择来源网络",
     "Please select Destination network": "请选择目标网络",
     "Please select an Origin token": "请选择来源代币",

--- a/packages/synapse-interface/pages/state-managed-bridge/index.tsx
+++ b/packages/synapse-interface/pages/state-managed-bridge/index.tsx
@@ -17,6 +17,7 @@ import { InputContainer } from '@/components/StateManagedBridge/InputContainer'
 import { OutputContainer } from '@/components/StateManagedBridge/OutputContainer'
 import { BridgeExchangeRateInfo } from '@/components/StateManagedBridge/BridgeExchangeRateInfo'
 import { BridgeTransactionButton } from '@/components/StateManagedBridge/BridgeTransactionButton'
+import { BridgeModulePausedWarning } from '@/components/StateManagedBridge/BridgeModulePausedWarning'
 import ExplorerToastLink from '@/components/ExplorerToastLink'
 import { SwitchButton } from '@/components/buttons/SwitchButton'
 import { PageHeader } from '@/components/PageHeader'
@@ -520,6 +521,13 @@ const StateManagedBridge = () => {
               {!(
                 fromChainId === ARBITRUM.id && toChainId === HYPERLIQUID.id
               ) && <BridgeExchangeRateInfo />}
+              <BridgeModulePausedWarning
+                fromChainId={fromChainId}
+                toChainId={
+                  toChainId === HYPERLIQUID.id ? ARBITRUM.id : toChainId
+                }
+                pausedModulesList={pausedModulesList}
+              />
               {toChainId === HYPERLIQUID.id && (
                 <HyperliquidDepositInfo
                   fromChainId={fromChainId}

--- a/packages/synapse-interface/pages/state-managed-bridge/index.tsx
+++ b/packages/synapse-interface/pages/state-managed-bridge/index.tsx
@@ -1,5 +1,5 @@
 import toast from 'react-hot-toast'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Address, zeroAddress, isAddress } from 'viem'
 import { polygon } from 'viem/chains'
 import { useAccount } from 'wagmi'
@@ -126,6 +126,10 @@ const StateManagedBridge = () => {
     BridgeMaintenanceProgressBar,
     BridgeMaintenanceWarningMessage,
   } = useMaintenance()
+  const pausedModulesKey = useMemo(
+    () => JSON.stringify(pausedModulesList),
+    [pausedModulesList]
+  )
 
   useEffect(() => {
     segmentAnalyticsEvent(
@@ -151,7 +155,16 @@ const StateManagedBridge = () => {
     } else {
       dispatch(resetBridgeQuote())
     }
-  }, [fromChainId, toChainId, fromToken, toToken, debouncedFromValue, address, destinationAddress])
+  }, [
+    fromChainId,
+    toChainId,
+    fromToken,
+    toToken,
+    debouncedFromValue,
+    address,
+    destinationAddress,
+    pausedModulesKey,
+  ])
 
   const getAndSetBridgeQuote = async () => {
     currentSDKRequestID.current += 1

--- a/packages/synapse-interface/public/pauses/v1/paused-bridge-modules-to-chain.json
+++ b/packages/synapse-interface/public/pauses/v1/paused-bridge-modules-to-chain.json
@@ -1,0 +1,46 @@
+[
+  {
+    "toChainId": 1,
+    "bridgeModuleName": "SynapseBridge"
+  },
+  {
+    "toChainId": 25,
+    "bridgeModuleName": "SynapseBridge"
+  },
+  {
+    "toChainId": 250,
+    "bridgeModuleName": "SynapseBridge"
+  },
+  {
+    "toChainId": 288,
+    "bridgeModuleName": "SynapseBridge"
+  },
+  {
+    "toChainId": 1284,
+    "bridgeModuleName": "SynapseBridge"
+  },
+  {
+    "toChainId": 1285,
+    "bridgeModuleName": "SynapseBridge"
+  },
+  {
+    "toChainId": 2000,
+    "bridgeModuleName": "SynapseBridge"
+  },
+  {
+    "toChainId": 7700,
+    "bridgeModuleName": "SynapseBridge"
+  },
+  {
+    "toChainId": 53935,
+    "bridgeModuleName": "SynapseBridge"
+  },
+  {
+    "toChainId": 81457,
+    "bridgeModuleName": "SynapseBridge"
+  },
+  {
+    "toChainId": 1313161554,
+    "bridgeModuleName": "SynapseBridge"
+  }
+]

--- a/packages/synapse-interface/public/pauses/v1/paused-bridge-modules.json
+++ b/packages/synapse-interface/public/pauses/v1/paused-bridge-modules.json
@@ -10,49 +10,5 @@
   {
     "chainId": 53935,
     "bridgeModuleName": "SynapseBridge"
-  },
-  {
-    "toChainId": 1,
-    "bridgeModuleName": "SynapseBridge"
-  },
-  {
-    "toChainId": 25,
-    "bridgeModuleName": "SynapseBridge"
-  },
-  {
-    "toChainId": 250,
-    "bridgeModuleName": "SynapseBridge"
-  },
-  {
-    "toChainId": 288,
-    "bridgeModuleName": "SynapseBridge"
-  },
-  {
-    "toChainId": 1284,
-    "bridgeModuleName": "SynapseBridge"
-  },
-  {
-    "toChainId": 1285,
-    "bridgeModuleName": "SynapseBridge"
-  },
-  {
-    "toChainId": 2000,
-    "bridgeModuleName": "SynapseBridge"
-  },
-  {
-    "toChainId": 7700,
-    "bridgeModuleName": "SynapseBridge"
-  },
-  {
-    "toChainId": 53935,
-    "bridgeModuleName": "SynapseBridge"
-  },
-  {
-    "toChainId": 81457,
-    "bridgeModuleName": "SynapseBridge"
-  },
-  {
-    "toChainId": 1313161554,
-    "bridgeModuleName": "SynapseBridge"
   }
 ]

--- a/packages/synapse-interface/public/pauses/v1/paused-bridge-modules.json
+++ b/packages/synapse-interface/public/pauses/v1/paused-bridge-modules.json
@@ -1,1 +1,58 @@
-[]
+[
+  {
+    "chainId": 288,
+    "bridgeModuleName": "SynapseBridge"
+  },
+  {
+    "chainId": 2000,
+    "bridgeModuleName": "SynapseBridge"
+  },
+  {
+    "chainId": 53935,
+    "bridgeModuleName": "SynapseBridge"
+  },
+  {
+    "toChainId": 1,
+    "bridgeModuleName": "SynapseBridge"
+  },
+  {
+    "toChainId": 25,
+    "bridgeModuleName": "SynapseBridge"
+  },
+  {
+    "toChainId": 250,
+    "bridgeModuleName": "SynapseBridge"
+  },
+  {
+    "toChainId": 288,
+    "bridgeModuleName": "SynapseBridge"
+  },
+  {
+    "toChainId": 1284,
+    "bridgeModuleName": "SynapseBridge"
+  },
+  {
+    "toChainId": 1285,
+    "bridgeModuleName": "SynapseBridge"
+  },
+  {
+    "toChainId": 2000,
+    "bridgeModuleName": "SynapseBridge"
+  },
+  {
+    "toChainId": 7700,
+    "bridgeModuleName": "SynapseBridge"
+  },
+  {
+    "toChainId": 53935,
+    "bridgeModuleName": "SynapseBridge"
+  },
+  {
+    "toChainId": 81457,
+    "bridgeModuleName": "SynapseBridge"
+  },
+  {
+    "toChainId": 1313161554,
+    "bridgeModuleName": "SynapseBridge"
+  }
+]

--- a/packages/synapse-interface/slices/bridgeQuote/thunks.ts
+++ b/packages/synapse-interface/slices/bridgeQuote/thunks.ts
@@ -63,8 +63,10 @@ export const fetchBridgeQuote = createAsyncThunk(
 
     const pausedBridgeModules = new Set(
       pausedModulesList
-        .filter((module) =>
-          module.chainId ? module.chainId === fromChainId : true
+        .filter(
+          (module) =>
+            (module.chainId ? module.chainId === fromChainId : true) &&
+            (module.toChainId ? module.toChainId === toChainId : true)
         )
         .flatMap(getBridgeModuleNames)
     )

--- a/packages/synapse-interface/slices/bridgeQuote/thunks.ts
+++ b/packages/synapse-interface/slices/bridgeQuote/thunks.ts
@@ -7,7 +7,7 @@ import { AcceptedChainId, CHAINS_BY_ID } from '@/constants/chains'
 import { segmentAnalyticsEvent } from '@/contexts/SegmentAnalyticsProvider'
 import { stringToBigInt, formatBigIntToString } from '@/utils/bigint/format'
 import { calculateExchangeRate } from '@/utils/calculateExchangeRate'
-import { getBridgeModuleNames } from '@/utils/getBridgeModuleNames'
+import { getPausedBridgeModuleNamesForRoute } from '@/utils/getPausedBridgeModuleNamesForRoute'
 import { Token } from '@/utils/types'
 import { BridgeModulePause } from '@/components/Maintenance/Maintenance'
 import { HYPERLIQUID } from '@/constants/chains/master'
@@ -62,13 +62,11 @@ export const fetchBridgeQuote = createAsyncThunk(
     })
 
     const pausedBridgeModules = new Set(
-      pausedModulesList
-        .filter(
-          (module) =>
-            (module.chainId ? module.chainId === fromChainId : true) &&
-            (module.toChainId ? module.toChainId === toChainId : true)
-        )
-        .flatMap(getBridgeModuleNames)
+      getPausedBridgeModuleNamesForRoute({
+        pausedModules: pausedModulesList,
+        fromChainId,
+        toChainId,
+      })
     )
     const activeQuotes = allQuotes.filter(
       (quote) => !quote.moduleNames.some((m) => pausedBridgeModules.has(m))

--- a/packages/synapse-interface/utils/getPausedBridgeModuleNamesForRoute.ts
+++ b/packages/synapse-interface/utils/getPausedBridgeModuleNamesForRoute.ts
@@ -25,5 +25,5 @@ export const getPausedBridgeModuleNamesForRoute = ({
         )
         .flatMap(getBridgeModuleNames)
     )
-  ).sort()
+  ).sort((a, b) => a.localeCompare(b))
 }

--- a/packages/synapse-interface/utils/getPausedBridgeModuleNamesForRoute.ts
+++ b/packages/synapse-interface/utils/getPausedBridgeModuleNamesForRoute.ts
@@ -1,0 +1,29 @@
+import { getBridgeModuleNames } from '@/utils/getBridgeModuleNames'
+
+type BridgeModulePauseLike = {
+  chainId?: number
+  toChainId?: number
+  bridgeModuleName: string
+}
+
+export const getPausedBridgeModuleNamesForRoute = ({
+  pausedModules,
+  fromChainId,
+  toChainId,
+}: {
+  pausedModules: BridgeModulePauseLike[]
+  fromChainId: number
+  toChainId: number
+}) => {
+  return Array.from(
+    new Set(
+      pausedModules
+        .filter(
+          (module) =>
+            (module.chainId ? module.chainId === fromChainId : true) &&
+            (module.toChainId ? module.toChainId === toChainId : true)
+        )
+        .flatMap(getBridgeModuleNames)
+    )
+  ).sort()
+}

--- a/packages/widget/src/components/Maintenance/Maintenance.tsx
+++ b/packages/widget/src/components/Maintenance/Maintenance.tsx
@@ -20,6 +20,7 @@ interface ChainPause {
 
 interface BridgeModulePause {
   chainId: number | undefined
+  toChainId?: number
   bridgeModuleName: 'SynapseBridge' | 'SynapseRFQ' | 'SynapseCCTP' | 'ALL'
 }
 

--- a/packages/widget/src/hooks/useNativeSafeMax.ts
+++ b/packages/widget/src/hooks/useNativeSafeMax.ts
@@ -11,6 +11,7 @@ type BigIntLike = bigint | { toString(): string }
 
 type BridgeModulePauseLike = {
   chainId?: number
+  toChainId?: number
   bridgeModuleName: string
 }
 
@@ -381,6 +382,7 @@ export const useNativeSafeMax = ({
       const selectedQuote = selectBridgeQuote<BridgeQuoteLike>({
         quotes,
         originChainId,
+        destinationChainId,
         pausedModules: stablePausedModules,
       })
 

--- a/packages/widget/src/state/slices/bridgeQuote/hooks.test.ts
+++ b/packages/widget/src/state/slices/bridgeQuote/hooks.test.ts
@@ -198,4 +198,30 @@ describe('fetchBridgeQuote quote filtering', () => {
     expect(state.bridgeQuote.bridgeModuleName).toBe('SynapseBridge')
     expect(state.bridgeQuote.nativeFee).toBe(12n)
   })
+
+  it('filters destination chain-specific paused bridge modules', async () => {
+    const { action, state } = await runFetchBridgeQuote({
+      nativeFee: '12',
+      pausedModules: [
+        {
+          bridgeModuleName: 'SynapseRFQ',
+          toChainId: 2,
+        },
+      ],
+      quotes: [
+        createSdkQuote({
+          moduleNames: ['SynapseRFQ'],
+          nativeFee: '77',
+        }),
+        createSdkQuote({
+          moduleNames: ['SynapseBridge'],
+          nativeFee: '12',
+        }),
+      ],
+    })
+
+    expect(fetchBridgeQuote.fulfilled.match(action)).toBe(true)
+    expect(state.bridgeQuote.bridgeModuleName).toBe('SynapseBridge')
+    expect(state.bridgeQuote.nativeFee).toBe(12n)
+  })
 })

--- a/packages/widget/src/state/slices/bridgeQuote/hooks.ts
+++ b/packages/widget/src/state/slices/bridgeQuote/hooks.ts
@@ -98,6 +98,7 @@ export const fetchBridgeQuote = createAsyncThunk(
     const quote = selectBridgeQuote<SelectedBridgeQuote>({
       quotes: validQuotes,
       originChainId,
+      destinationChainId,
       pausedModules,
     })
 

--- a/packages/widget/src/utils/selectBridgeQuote.test.ts
+++ b/packages/widget/src/utils/selectBridgeQuote.test.ts
@@ -13,6 +13,7 @@ describe('selectBridgeQuote', () => {
         createQuote('rfq', ['SynapseRFQ']),
       ],
       originChainId: 1,
+      destinationChainId: 10,
       pausedModules: [],
     })
 
@@ -26,6 +27,7 @@ describe('selectBridgeQuote', () => {
         createQuote('rfq', ['SynapseRFQ']),
       ],
       originChainId: 1,
+      destinationChainId: 10,
       pausedModules: [
         { bridgeModuleName: 'SynapseBridge', chainId: 1 },
         { bridgeModuleName: 'ALL' },
@@ -33,5 +35,33 @@ describe('selectBridgeQuote', () => {
     })
 
     expect(quote).toBeNull()
+  })
+
+  it('respects destination chain-specific paused-module entries', () => {
+    const quote = selectBridgeQuote({
+      quotes: [
+        createQuote('bridge', ['SynapseBridge']),
+        createQuote('rfq', ['SynapseRFQ']),
+      ],
+      originChainId: 1,
+      destinationChainId: 10,
+      pausedModules: [{ bridgeModuleName: 'SynapseRFQ', toChainId: 10 }],
+    })
+
+    expect(quote?.id).toBe('bridge')
+  })
+
+  it('does not apply destination chain-specific entries to other destinations', () => {
+    const quote = selectBridgeQuote({
+      quotes: [
+        createQuote('bridge', ['SynapseBridge']),
+        createQuote('rfq', ['SynapseRFQ']),
+      ],
+      originChainId: 1,
+      destinationChainId: 42161,
+      pausedModules: [{ bridgeModuleName: 'SynapseRFQ', toChainId: 10 }],
+    })
+
+    expect(quote?.id).toBe('rfq')
   })
 })

--- a/packages/widget/src/utils/selectBridgeQuote.ts
+++ b/packages/widget/src/utils/selectBridgeQuote.ts
@@ -2,6 +2,7 @@ import { getBridgeModuleNames } from '@/utils/getBridgeModuleNames'
 
 type BridgeModulePauseLike = {
   chainId?: number
+  toChainId?: number
   bridgeModuleName: string
 }
 
@@ -12,16 +13,20 @@ type BridgeQuoteLike = {
 export const selectBridgeQuote = <T extends BridgeQuoteLike>({
   quotes,
   originChainId,
+  destinationChainId,
   pausedModules,
 }: {
   quotes: T[]
   originChainId: number
+  destinationChainId: number
   pausedModules: BridgeModulePauseLike[]
 }): T | null => {
   const pausedBridgeModules = new Set(
     pausedModules
-      .filter((module) =>
-        module.chainId ? module.chainId === originChainId : true
+      .filter(
+        (module) =>
+          (module.chainId ? module.chainId === originChainId : true) &&
+          (module.toChainId ? module.toChainId === destinationChainId : true)
       )
       .flatMap(getBridgeModuleNames)
   )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual warning notifications when attempting to bridge on paused routes to inform users of potential service disruptions.

* **Documentation**
  * Updated maintenance guide to document destination-chain-specific pause controls alongside existing origin-chain pause settings.

* **Localization**
  * Added pause warning message translations in Arabic, English, Spanish, French, Japanese, Turkish, and Simplified Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
b1ba236858be506fe7a02e590576e826515783d1: [synapse-interface preview link ](https://sanguine-synapse-interface-4gra8zuha-synapsecns.vercel.app)
5fb735f0b52909bc510e6a2f1c55e5bbe02b1ede: [synapse-interface preview link ](https://sanguine-synapse-interface-ewxf33nd7-synapsecns.vercel.app)