### PR TITLE
ci(goreleaser): fix provider release publishing

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -15,8 +15,33 @@ env:
   CODEQL_EXTRACTOR_GO_BUILD_TRACING: 'on'
 
 jobs:
+  changes:
+    name: Change Detection
+    runs-on: ubuntu-latest
+    outputs:
+      packages: ${{ steps.filter_go.outputs.changed_modules_deps }}
+      package_count: ${{ steps.length.outputs.FILTER_LENGTH }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: docker://ghcr.io/synapsecns/sanguine/git-changes-action:latest
+        id: filter_go
+        with:
+          github_token: ${{ secrets.WORKFLOW_PAT || secrets.GITHUB_TOKEN }}
+          timeout: '10m'
+
+      - id: length
+        run: |
+          export FILTER_LENGTH=$(echo $FILTERED_PATHS | jq '. | length')
+          echo "FILTER_LENGTH=$FILTER_LENGTH" >> "$GITHUB_OUTPUT"
+        env:
+          FILTERED_PATHS: ${{ steps.filter_go.outputs.changed_modules_deps }}
+
   analyze:
     name: Analyze ${{ matrix.language }}
+    needs: changes
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -33,12 +58,16 @@ jobs:
           go-version-file: 'go.work'
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
 
-      - uses: github/codeql-action/autobuild@v2
+      - uses: github/codeql-action/autobuild@v3
         if: ${{ matrix.language != 'go' }}
+
+      - name: Autobuild (Go)
+        uses: github/codeql-action/autobuild@v3
+        if: ${{ matrix.language == 'go' && needs.changes.outputs.package_count == 0 }}
 
       - name: Go modules cache
         if: ${{ matrix.language == 'go' }}
@@ -54,17 +83,22 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - name: Build (Go)
-        if: ${{ matrix.language == 'go' }}
-        # go build all workspaces
-        run: go build $(go work edit -json | jq -c -r '[.Use[].DiskPath] | map_values(. + "/...")[]')
+        if: ${{ matrix.language == 'go' && needs.changes.outputs.package_count > 0 }}
+        run: |
+          echo "$CODEQL_GO_PACKAGES" | jq -r '.[]' | while read -r package; do
+            echo "::group::Build ${package}"
+            (cd "$package" && GOWORK=off go build ./...)
+            echo "::endgroup::"
+          done
         # see: https://www.reddit.com/r/golang/comments/476pae/how_to_speed_up_go_compiler_and_many_other_go/
         # this cannot use gomemlimit because we are running multiple builds in paralell
         env:
+          CODEQL_GO_PACKAGES: ${{ needs.changes.outputs.packages }}
           GOGC: 2000
           GOMEMLIMIT: 6GiB
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
         with:
           upload: false # disable the upload here - we will upload in a different action
           output: sarif-results
@@ -82,6 +116,6 @@ jobs:
           output: sarif-results/${{ matrix.language }}.sarif
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: sarif-results/${{ matrix.language }}.sarif

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -51,13 +51,19 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2
+
+      - name: Skip Go analysis
+        if: ${{ matrix.language == 'go' && needs.changes.outputs.package_count == 0 }}
+        run: echo "No changed Go modules detected; skipping Go CodeQL build and analysis."
+
       - name: Install Go
-        if: ${{ matrix.language == 'go' }}
+        if: ${{ matrix.language == 'go' && needs.changes.outputs.package_count > 0 }}
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.work'
 
       - name: Initialize CodeQL
+        if: ${{ matrix.language != 'go' || needs.changes.outputs.package_count > 0 }}
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
@@ -65,12 +71,8 @@ jobs:
       - uses: github/codeql-action/autobuild@v3
         if: ${{ matrix.language != 'go' }}
 
-      - name: Autobuild (Go)
-        uses: github/codeql-action/autobuild@v3
-        if: ${{ matrix.language == 'go' && needs.changes.outputs.package_count == 0 }}
-
       - name: Go modules cache
-        if: ${{ matrix.language == 'go' }}
+        if: ${{ matrix.language == 'go' && needs.changes.outputs.package_count > 0 }}
         uses: actions/cache@v4
         with:
           # see https://github.com/mvdan/github-actions-golang
@@ -98,12 +100,14 @@ jobs:
           GOMEMLIMIT: 6GiB
 
       - name: Perform CodeQL Analysis
+        if: ${{ matrix.language != 'go' || needs.changes.outputs.package_count > 0 }}
         uses: github/codeql-action/analyze@v3
         with:
           upload: false # disable the upload here - we will upload in a different action
           output: sarif-results
 
       - name: filter-sarif
+        if: ${{ matrix.language != 'go' || needs.changes.outputs.package_count > 0 }}
         uses: advanced-security/filter-sarif@v1
         with:
           # filter out all test files unless they contain a sql-injection vulnerability
@@ -116,6 +120,7 @@ jobs:
           output: sarif-results/${{ matrix.language }}.sarif
 
       - name: Upload SARIF
+        if: ${{ matrix.language != 'go' || needs.changes.outputs.package_count > 0 }}
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: sarif-results/${{ matrix.language }}.sarif

--- a/.github/workflows/goreleaser-actions.yml
+++ b/.github/workflows/goreleaser-actions.yml
@@ -1,5 +1,12 @@
 name: Go Releaser
-on: [push]
+on:
+  push:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: 'Go module path to release, for example contrib/terraform-provider-grafanaamg'
+        required: true
+        type: string
 
 jobs:
   # build the goreleaser container cgo cross compiler container. Note: this wil not be applied  until
@@ -86,10 +93,10 @@ jobs:
     name: Change Detection
     runs-on: ubuntu-latest
     # see: https://stackoverflow.com/a/68414395
-    if: ${{ format('refs/heads/{0}', github.event.repository.default_branch) == github.ref || contains(github.event.head_commit.message, '[goreleaser]') }}
+    if: ${{ github.event_name == 'workflow_dispatch' || format('refs/heads/{0}', github.event.repository.default_branch) == github.ref || contains(github.event.head_commit.message, '[goreleaser]') }}
     outputs:
       # Expose matched filters as job 'packages' output variable
-      packages: ${{ steps.filter_go.outputs.changed_modules_deps }}
+      packages: ${{ steps.length.outputs.PACKAGES }}
       package_count: ${{ steps.length.outputs.FILTER_LENGTH }}
     steps:
       - uses: actions/checkout@v4
@@ -103,10 +110,18 @@ jobs:
 
       - id: length
         run: |
-          export FILTER_LENGTH=$(echo $FILTERED_PATHS | jq '. | length')
-          echo "##[set-output name=FILTER_LENGTH;]$(echo $FILTER_LENGTH)"
+          if [ -n "$DISPATCH_PACKAGE" ]; then
+            PACKAGES=$(jq -cn --arg package "$DISPATCH_PACKAGE" '[$package]')
+          else
+            PACKAGES=$FILTERED_PATHS
+          fi
+
+          FILTER_LENGTH=$(echo "$PACKAGES" | jq '. | length')
+          echo "PACKAGES=$PACKAGES" >> "$GITHUB_OUTPUT"
+          echo "FILTER_LENGTH=$FILTER_LENGTH" >> "$GITHUB_OUTPUT"
         env:
           FILTERED_PATHS: ${{ steps.filter_go.outputs.changed_modules_deps }}
+          DISPATCH_PACKAGE: ${{ inputs.package }}
 
   run-goreleaser:
     runs-on:
@@ -160,7 +175,7 @@ jobs:
       - name: Get branch name
         id: branch-name
         run: |
-          echo "is_default=$([ "$GITHUB_REF" == "refs/heads/${{ github.event.repository.default_branch }}" ] && echo 'true' || echo 'false')" >> $GITHUB_OUTPUT
+          echo "is_default=$([ "$GITHUB_REF" = "refs/heads/${{ github.event.repository.default_branch }}" ] && echo 'true' || echo 'false')" >> $GITHUB_OUTPUT
           echo "current_branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
 
       - name: Bump version and push tag


### PR DESCRIPTION
## Summary
- update the repo CodeQL workflow to use CodeQL action v3
- reuse module change detection before CodeQL Go analysis
- build changed Go modules with `GOWORK=off` instead of building every module in `go.work`
- skip Go CodeQL explicitly when no Go modules changed
- fix GoReleaser default-branch detection under `sh` (`=` instead of Bash-only `==`)
- add manual GoReleaser dispatch for a specific package so missed releases can be recovered without fake code changes

## Why
The post-merge `Codeql` push workflow for #4054 failed because the Go build step built every module in the workspace. That re-triggered unrelated stale module failures in old workspace modules even though the provider module build, lint, tests, and dynamic CodeQL run were green.

The post-merge GoReleaser job also appeared green but did not create a usable provider release: the `Get branch name` step ran under `sh` while using Bash `==`, so `is_default` was not set to true on `master`; the tag bump and release steps were skipped.

## Validation
- parsed `.github/workflows/codeql.yaml` and `.github/workflows/goreleaser-actions.yml` locally with Ruby YAML
- manually dispatched `codeql.yaml` on this branch and confirmed it passed
- inspected the failed master CodeQL log: failure was the all-workspace `go build`, not `contrib/terraform-provider-grafanaamg`
- inspected the master GoReleaser log: release steps were skipped after `/bin/sh: unexpected operator` in branch detection

## Recovery after merge
Run `Go Releaser` manually on `master` with package `contrib/terraform-provider-grafanaamg`. That should create the provider tag and GitHub release assets.
