### PR TITLE
ci(goreleaser): skip change detection on manual dispatch

### DIFF
--- a/.github/workflows/goreleaser-actions.yml
+++ b/.github/workflows/goreleaser-actions.yml
@@ -104,6 +104,7 @@ jobs:
           fetch-depth: 0
 
       - uses: docker://ghcr.io/synapsecns/sanguine/git-changes-action:latest
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         id: filter_go
         with:
           github_token: ${{ secrets.WORKFLOW_PAT || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- skip `git-changes-action` when GoReleaser is manually dispatched
- keep the manual `package` input as the source of truth for recovery releases

## Why
The recovery dispatch for `contrib/terraform-provider-grafanaamg` failed in Change Detection before it could use the package input, because the workflow still ran `git-changes-action` first. Manual dispatch does not need module diff detection.

## Validation
- parsed `.github/workflows/goreleaser-actions.yml` locally with Ruby YAML
