### PR TITLE
fix(sdk-router): enable ETH as SBA bridge destination

### DIFF
--- a/packages/sdk-router/src/sba/synapseBridgeAdapterModuleSet.ts
+++ b/packages/sdk-router/src/sba/synapseBridgeAdapterModuleSet.ts
@@ -38,6 +38,7 @@ const SBA_BRIDGE_ENABLED_DESTINATION_CHAINS = new Set<SupportedChainId>([
   // SupportedChainId.CANTO,
   // SupportedChainId.CRONOS,
   SupportedChainId.DFK,
+  SupportedChainId.ETH,
   SupportedChainId.HARMONY,
   SupportedChainId.KLAYTN,
   SupportedChainId.METIS,


### PR DESCRIPTION
## Summary
- Adds `SupportedChainId.ETH` to `SBA_BRIDGE_ENABLED_DESTINATION_CHAINS`
- The SBA adapter is deployed on ETH (`0x5Ba000Bb06230E0582e111F08e1f2F2F200005BA`, lzEid 30101) and tokens like HIGH are already configured in `supportedTokens.ts`, but ETH was excluded from the enabled destinations set
- This caused all SBA bridge routes to Ethereum to return empty — HIGH BSC→ETH had zero quotes

## Context
After the ETH bridge upgrade (multisig), the legacy SynapseRouter is no longer in `allModuleSets`. HIGH can only route through SBA, but SBA had ETH excluded from its destination chains. The adapter metadata and token configs were already present — just the enablement gate was missing.

## Test plan
- [ ] Verify `api.synapseprotocol.com/bridge` returns quotes for HIGH BSC→ETH after deploy
- [ ] Verify https://bridge.synapseprotocol.com/?fromChainId=56&fromToken=HIGH&toChainId=1&toToken=HIGH shows active quotes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where bridge token candidates could not be returned for Ethereum as a destination chain. Ethereum is now properly supported as a destination for token bridging operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/synapsecns/sanguine/pull/4063?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->