### PR TITLE
fix(terraform-provider-grafanaamg): sweep expired provider tokens before minting

### DIFF
--- a/contrib/terraform-provider-grafanaamg/README.md
+++ b/contrib/terraform-provider-grafanaamg/README.md
@@ -34,7 +34,7 @@ export GRAFANA_AMG_SERVICE_ACCOUNT_ID="sa-000000000000000000000"
 export GRAFANA_AMG_REGION="us-east-1"
 ```
 
-The provider uses the default AWS SDK credential chain. The AWS principal must be allowed to call `grafana:CreateWorkspaceServiceAccountToken` and `grafana:DeleteWorkspaceServiceAccountToken` for the configured workspace and service account.
+The provider uses the default AWS SDK credential chain. The AWS principal must be allowed to call `grafana:CreateWorkspaceServiceAccountToken`, `grafana:DeleteWorkspaceServiceAccountToken`, and `grafana:ListWorkspaceServiceAccountTokens` for the configured workspace and service account.
 
 If `GRAFANA_AUTH` is already set, the wrapper does not create an AMG token and delegates directly to the upstream Grafana provider.
 
@@ -48,6 +48,7 @@ If `GRAFANA_AUTH` is already set, the wrapper does not create an AMG token and d
 | `GRAFANA_AMG_TOKEN_TTL_SECONDS` | No | `3600` | Lifetime for each generated service account token. |
 | `GRAFANA_AMG_TOKEN_NAME_PREFIX` | No | `terraform-provider-grafanaamg` | Prefix for generated token names. |
 | `GRAFANA_AMG_DELETE_TOKEN_ON_STOP` | No | `true` | Delete generated tokens when Terraform stops the provider. Tokens still expire by TTL if cleanup is interrupted. |
+| `GRAFANA_AMG_SWEEP_EXPIRED_TOKENS` | No | `true` | Before minting, delete **expired** tokens whose name matches the token name prefix. AMG counts expired tokens against the workspace service-account token quota until they are deleted, so tokens leaked by interrupted runs otherwise accumulate until every run fails with `ServiceQuotaExceededException`. The sweep never touches unexpired tokens or tokens without the prefix, and a sweep failure is logged but never fails the run. |
 
 ## Release
 

--- a/contrib/terraform-provider-grafanaamg/provider/wrapper.go
+++ b/contrib/terraform-provider-grafanaamg/provider/wrapper.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/grafana"
+	"github.com/aws/aws-sdk-go-v2/service/grafana/types"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 )
 
@@ -26,6 +27,7 @@ const (
 	envTokenTTLSeconds  = "GRAFANA_AMG_TOKEN_TTL_SECONDS"    // #nosec G101 -- environment variable name, not a credential.
 	envTokenNamePrefix  = "GRAFANA_AMG_TOKEN_NAME_PREFIX"    // #nosec G101 -- environment variable name, not a credential.
 	envDeleteToken      = "GRAFANA_AMG_DELETE_TOKEN_ON_STOP" // #nosec G101 -- environment variable name, not a credential.
+	envSweepExpired     = "GRAFANA_AMG_SWEEP_EXPIRED_TOKENS" // #nosec G101 -- environment variable name, not a credential.
 
 	defaultTokenTTLSeconds = int32(3600)
 	defaultTokenNamePrefix = "terraform-provider-grafanaamg" // #nosec G101 -- token name prefix, not a credential.
@@ -53,11 +55,13 @@ type amgConfig struct {
 	tokenTTLSeconds  int32
 	tokenNamePrefix  string
 	deleteToken      bool
+	sweepExpired     bool
 }
 
 type grafanaAPI interface {
 	CreateWorkspaceServiceAccountToken(ctx context.Context, input *grafana.CreateWorkspaceServiceAccountTokenInput, optFns ...func(*grafana.Options)) (*grafana.CreateWorkspaceServiceAccountTokenOutput, error)
 	DeleteWorkspaceServiceAccountToken(ctx context.Context, input *grafana.DeleteWorkspaceServiceAccountTokenInput, optFns ...func(*grafana.Options)) (*grafana.DeleteWorkspaceServiceAccountTokenOutput, error)
+	ListWorkspaceServiceAccountTokens(ctx context.Context, input *grafana.ListWorkspaceServiceAccountTokensInput, optFns ...func(*grafana.Options)) (*grafana.ListWorkspaceServiceAccountTokensOutput, error)
 }
 
 var newGrafanaClient = grafanaClient
@@ -81,6 +85,10 @@ func (s *Server) ConfigureProvider(ctx context.Context, req *tfprotov5.Configure
 		}
 
 		return resp, nil
+	}
+
+	if cfg.sweepExpired {
+		sweepExpiredTokens(ctx, cfg)
 	}
 
 	token, err := s.createToken(ctx, cfg)
@@ -194,6 +202,80 @@ func (s *Server) createToken(ctx context.Context, cfg amgConfig) (mintedToken, e
 	}, nil
 }
 
+// sweepExpiredTokens best-effort deletes expired tokens previously minted by
+// this provider (matched by the configured name prefix). AMG counts expired
+// tokens against the workspace's service-account token quota until they are
+// explicitly deleted, so tokens leaked by interrupted runs (a crash or kill
+// between ConfigureProvider and StopProvider) accumulate until every
+// subsequent run fails token creation with ServiceQuotaExceededException.
+// Sweeping before each mint keeps the account at one live token per
+// concurrent run. Failures are logged, never fatal: the sweep must not break
+// a run that would otherwise succeed.
+func sweepExpiredTokens(ctx context.Context, cfg amgConfig) {
+	client, err := newGrafanaClient(ctx, cfg.region)
+	if err != nil {
+		log.Printf("skipping expired AMG token sweep: %v", err)
+		return
+	}
+
+	now := time.Now()
+	swept := 0
+
+	var nextToken *string
+	for {
+		out, listErr := client.ListWorkspaceServiceAccountTokens(ctx, &grafana.ListWorkspaceServiceAccountTokensInput{
+			ServiceAccountId: aws.String(cfg.serviceAccountID),
+			WorkspaceId:      aws.String(cfg.workspaceID),
+			NextToken:        nextToken,
+		})
+		if listErr != nil {
+			log.Printf("skipping expired AMG token sweep: list tokens: %v", listErr)
+			return
+		}
+
+		for _, token := range out.ServiceAccountTokens {
+			if !isSweepable(token, cfg.tokenNamePrefix, now) {
+				continue
+			}
+
+			_, deleteErr := client.DeleteWorkspaceServiceAccountToken(ctx, &grafana.DeleteWorkspaceServiceAccountTokenInput{
+				ServiceAccountId: aws.String(cfg.serviceAccountID),
+				TokenId:          token.Id,
+				WorkspaceId:      aws.String(cfg.workspaceID),
+			})
+			if deleteErr != nil {
+				log.Printf("failed to sweep expired AMG token %s: %v", aws.ToString(token.Id), deleteErr)
+				continue
+			}
+			swept++
+		}
+
+		if aws.ToString(out.NextToken) == "" {
+			break
+		}
+		nextToken = out.NextToken
+	}
+
+	if swept > 0 {
+		log.Printf("swept %d expired AMG service account token(s) minted by this provider", swept)
+	}
+}
+
+// isSweepable reports whether a token is an expired leftover minted by this
+// provider. Only prefix-matched tokens are considered so other tokens on a
+// shared service account (human-created, other tooling) are never touched.
+func isSweepable(token types.ServiceAccountTokenSummary, namePrefix string, now time.Time) bool {
+	if token.Id == nil || token.ExpiresAt == nil {
+		return false
+	}
+
+	if !token.ExpiresAt.Before(now) {
+		return false
+	}
+
+	return strings.HasPrefix(aws.ToString(token.Name), namePrefix)
+}
+
 func deleteToken(ctx context.Context, token createdToken) error {
 	client, err := newGrafanaClient(ctx, token.region)
 	if err != nil {
@@ -243,7 +325,12 @@ func loadAMGConfig() (amgConfig, bool, error) {
 		return amgConfig{}, false, err
 	}
 
-	deleteOnStop, err := parseDeleteOnStop()
+	deleteOnStop, err := parseBoolEnv(envDeleteToken, true)
+	if err != nil {
+		return amgConfig{}, false, err
+	}
+
+	sweepExpired, err := parseBoolEnv(envSweepExpired, true)
 	if err != nil {
 		return amgConfig{}, false, err
 	}
@@ -260,6 +347,7 @@ func loadAMGConfig() (amgConfig, bool, error) {
 		tokenTTLSeconds:  ttl,
 		tokenNamePrefix:  prefix,
 		deleteToken:      deleteOnStop,
+		sweepExpired:     sweepExpired,
 	}, true, nil
 }
 
@@ -277,18 +365,18 @@ func parseTokenTTL() (int32, error) {
 	return int32(parsedTTL), nil
 }
 
-func parseDeleteOnStop() (bool, error) {
-	rawDelete := strings.TrimSpace(os.Getenv(envDeleteToken))
-	if rawDelete == "" {
-		return true, nil
+func parseBoolEnv(name string, defaultValue bool) (bool, error) {
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return defaultValue, nil
 	}
 
-	parsedDelete, err := strconv.ParseBool(rawDelete)
+	parsed, err := strconv.ParseBool(raw)
 	if err != nil {
-		return false, fmt.Errorf("%s must be a boolean", envDeleteToken)
+		return false, fmt.Errorf("%s must be a boolean", name)
 	}
 
-	return parsedDelete, nil
+	return parsed, nil
 }
 
 func diagnosticResponse(summary string, err string) *tfprotov5.ConfigureProviderResponse {

--- a/contrib/terraform-provider-grafanaamg/provider/wrapper_test.go
+++ b/contrib/terraform-provider-grafanaamg/provider/wrapper_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/grafana"
@@ -41,6 +42,14 @@ type fakeGrafanaClient struct {
 	createErr   error
 	deleteInput *grafana.DeleteWorkspaceServiceAccountTokenInput
 	deleteErr   error
+	// deletedTokenIDs records every delete, in order (deleteInput only
+	// keeps the last one).
+	deletedTokenIDs []string
+	// listOuts are returned in order, one per ListWorkspaceServiceAccountTokens
+	// call, so tests can exercise pagination.
+	listOuts  []*grafana.ListWorkspaceServiceAccountTokensOutput
+	listErr   error
+	listCalls int
 }
 
 func (f *fakeGrafanaClient) CreateWorkspaceServiceAccountToken(_ context.Context, input *grafana.CreateWorkspaceServiceAccountTokenInput, _ ...func(*grafana.Options)) (*grafana.CreateWorkspaceServiceAccountTokenOutput, error) {
@@ -51,8 +60,25 @@ func (f *fakeGrafanaClient) CreateWorkspaceServiceAccountToken(_ context.Context
 
 func (f *fakeGrafanaClient) DeleteWorkspaceServiceAccountToken(_ context.Context, input *grafana.DeleteWorkspaceServiceAccountTokenInput, _ ...func(*grafana.Options)) (*grafana.DeleteWorkspaceServiceAccountTokenOutput, error) {
 	f.deleteInput = input
+	f.deletedTokenIDs = append(f.deletedTokenIDs, aws.ToString(input.TokenId))
 
 	return &grafana.DeleteWorkspaceServiceAccountTokenOutput{}, f.deleteErr
+}
+
+func (f *fakeGrafanaClient) ListWorkspaceServiceAccountTokens(_ context.Context, _ *grafana.ListWorkspaceServiceAccountTokensInput, _ ...func(*grafana.Options)) (*grafana.ListWorkspaceServiceAccountTokensOutput, error) {
+	f.listCalls++
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+
+	if len(f.listOuts) == 0 {
+		return &grafana.ListWorkspaceServiceAccountTokensOutput{}, nil
+	}
+
+	out := f.listOuts[0]
+	f.listOuts = f.listOuts[1:]
+
+	return out, nil
 }
 
 func withGrafanaClient(t *testing.T, client grafanaAPI) {
@@ -122,6 +148,129 @@ func TestConfigureProviderCreatesTokenAndDelegates(t *testing.T) {
 	}
 	if os.Getenv(envGrafanaAuth) != "" {
 		t.Fatal("expected GRAFANA_AUTH to be restored after configure")
+	}
+}
+
+func TestSweepDeletesOnlyExpiredPrefixMatchedTokens(t *testing.T) {
+	past := time.Now().Add(-time.Hour)
+	future := time.Now().Add(time.Hour)
+	client := &fakeGrafanaClient{
+		listOuts: []*grafana.ListWorkspaceServiceAccountTokensOutput{{
+			ServiceAccountTokens: []types.ServiceAccountTokenSummary{
+				// Expired + prefix match: swept.
+				{Id: aws.String("expired-ours"), Name: aws.String("terraform-provider-grafanaamg-1"), ExpiresAt: &past},
+				// Expired but foreign name: never touched.
+				{Id: aws.String("expired-foreign"), Name: aws.String("human-created"), ExpiresAt: &past},
+				// Prefix match but still live (e.g. a concurrent run): kept.
+				{Id: aws.String("live-ours"), Name: aws.String("terraform-provider-grafanaamg-2"), ExpiresAt: &future},
+				// Defensive: no expiry recorded -> kept.
+				{Id: aws.String("no-expiry"), Name: aws.String("terraform-provider-grafanaamg-3")},
+			},
+		}},
+	}
+	withGrafanaClient(t, client)
+
+	sweepExpiredTokens(context.Background(), amgConfig{
+		workspaceID:      "g-123",
+		serviceAccountID: "sa-123",
+		tokenNamePrefix:  defaultTokenNamePrefix,
+		sweepExpired:     true,
+	})
+
+	if len(client.deletedTokenIDs) != 1 || client.deletedTokenIDs[0] != "expired-ours" {
+		t.Fatalf("expected exactly [expired-ours] deleted, got %v", client.deletedTokenIDs)
+	}
+}
+
+func TestSweepFollowsPagination(t *testing.T) {
+	past := time.Now().Add(-time.Hour)
+	client := &fakeGrafanaClient{
+		listOuts: []*grafana.ListWorkspaceServiceAccountTokensOutput{
+			{
+				ServiceAccountTokens: []types.ServiceAccountTokenSummary{
+					{Id: aws.String("page1"), Name: aws.String("terraform-provider-grafanaamg-1"), ExpiresAt: &past},
+				},
+				NextToken: aws.String("more"),
+			},
+			{
+				ServiceAccountTokens: []types.ServiceAccountTokenSummary{
+					{Id: aws.String("page2"), Name: aws.String("terraform-provider-grafanaamg-2"), ExpiresAt: &past},
+				},
+			},
+		},
+	}
+	withGrafanaClient(t, client)
+
+	sweepExpiredTokens(context.Background(), amgConfig{
+		workspaceID:      "g-123",
+		serviceAccountID: "sa-123",
+		tokenNamePrefix:  defaultTokenNamePrefix,
+		sweepExpired:     true,
+	})
+
+	if client.listCalls != 2 {
+		t.Fatalf("expected 2 list calls, got %d", client.listCalls)
+	}
+	if len(client.deletedTokenIDs) != 2 {
+		t.Fatalf("expected 2 deletions across pages, got %v", client.deletedTokenIDs)
+	}
+}
+
+func TestConfigureProviderSweepFailureDoesNotFailRun(t *testing.T) {
+	t.Setenv(envWorkspaceID, "g-123")
+	t.Setenv(envServiceAccountID, "sa-123")
+	t.Setenv(envGrafanaAuth, "")
+
+	client := &fakeGrafanaClient{
+		listErr: errors.New("list boom"),
+		createOut: &grafana.CreateWorkspaceServiceAccountTokenOutput{
+			ServiceAccountToken: &types.ServiceAccountTokenSummaryWithKey{
+				Id:  aws.String("token-123"),
+				Key: aws.String("secret"),
+			},
+		},
+	}
+	withGrafanaClient(t, client)
+
+	upstream := &fakeProviderServer{configureResp: &tfprotov5.ConfigureProviderResponse{}}
+	resp, err := New(upstream).ConfigureProvider(context.Background(), &tfprotov5.ConfigureProviderRequest{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if hasErrors(resp) {
+		t.Fatal("a failed sweep must not fail provider configuration")
+	}
+	if client.listCalls != 1 {
+		t.Fatalf("expected the sweep to have been attempted, got %d list calls", client.listCalls)
+	}
+	if upstream.configureCalls != 1 {
+		t.Fatalf("expected one configure call, got %d", upstream.configureCalls)
+	}
+}
+
+func TestConfigureProviderSweepDisabled(t *testing.T) {
+	t.Setenv(envWorkspaceID, "g-123")
+	t.Setenv(envServiceAccountID, "sa-123")
+	t.Setenv(envGrafanaAuth, "")
+	t.Setenv(envSweepExpired, "false")
+
+	client := &fakeGrafanaClient{
+		createOut: &grafana.CreateWorkspaceServiceAccountTokenOutput{
+			ServiceAccountToken: &types.ServiceAccountTokenSummaryWithKey{
+				Id:  aws.String("token-123"),
+				Key: aws.String("secret"),
+			},
+		},
+	}
+	withGrafanaClient(t, client)
+
+	upstream := &fakeProviderServer{configureResp: &tfprotov5.ConfigureProviderResponse{}}
+	_, err := New(upstream).ConfigureProvider(context.Background(), &tfprotov5.ConfigureProviderRequest{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if client.listCalls != 0 {
+		t.Fatalf("expected no list calls with sweep disabled, got %d", client.listCalls)
 	}
 }
 
@@ -242,6 +391,7 @@ func TestLoadAMGConfigDefaults(t *testing.T) {
 	t.Setenv(envTokenTTLSeconds, "")
 	t.Setenv(envTokenNamePrefix, "")
 	t.Setenv(envDeleteToken, "")
+	t.Setenv(envSweepExpired, "")
 
 	cfg, enabled, err := loadAMGConfig()
 	if err != nil {
@@ -265,6 +415,9 @@ func TestLoadAMGConfigDefaults(t *testing.T) {
 	if !cfg.deleteToken {
 		t.Fatal("expected token cleanup to default to true")
 	}
+	if !cfg.sweepExpired {
+		t.Fatal("expected expired-token sweep to default to true")
+	}
 }
 
 func TestLoadAMGConfigOverrides(t *testing.T) {
@@ -274,6 +427,7 @@ func TestLoadAMGConfigOverrides(t *testing.T) {
 	t.Setenv(envTokenTTLSeconds, "120")
 	t.Setenv(envTokenNamePrefix, "ci")
 	t.Setenv(envDeleteToken, "false")
+	t.Setenv(envSweepExpired, "false")
 
 	cfg, enabled, err := loadAMGConfig()
 	if err != nil {
@@ -293,6 +447,23 @@ func TestLoadAMGConfigOverrides(t *testing.T) {
 	}
 	if cfg.deleteToken {
 		t.Fatal("expected token cleanup override to be false")
+	}
+	if cfg.sweepExpired {
+		t.Fatal("expected expired-token sweep override to be false")
+	}
+}
+
+func TestLoadAMGConfigRejectsInvalidSweepExpired(t *testing.T) {
+	t.Setenv(envWorkspaceID, "g-123")
+	t.Setenv(envServiceAccountID, "sa-123")
+	t.Setenv(envSweepExpired, "not-bool")
+
+	_, enabled, err := loadAMGConfig()
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if enabled {
+		t.Fatal("expected AMG config to be disabled on invalid input")
 	}
 }
 


### PR DESCRIPTION
## Problem

AMG counts **expired** service-account tokens against the workspace token quota until they are explicitly deleted. The provider deletes its per-run token on `StopProvider`, but any interrupted run (crash/kill between Configure and Stop) leaks its token permanently. At ~1 token per plan/apply, an active workspace fills the quota (100) within days, after which **every** run fails provider init:

```
Error: Failed to create Amazon Managed Grafana token.
ServiceQuotaExceededException: Service Account Token quota has been reached (402)
```

We've hit this twice in nine days on our TFC workspaces (103 leaked tokens on the first occurrence, 100/100 — all expired — on the second), each time requiring a manual AWS CLI reap to unblock.

## Fix

Before minting, list the service account's tokens and delete the ones that are **both expired and name-prefix-matched** (the provider's own `<prefix>-<unixnano>` naming). This reclaims tokens leaked by interrupted runs on the next successful run, keeping the account at ~1 live token per concurrent run.

Safety properties:
- **Never touches unexpired tokens** (a concurrent run's live token survives) or tokens without the configured name prefix (human-created / other tooling on a shared service account).
- **Best-effort, never fatal**: any list/delete failure is logged and the mint proceeds — the sweep can only remove dead weight, never break a run that would otherwise succeed (including when the principal lacks the new List permission: it degrades to current behavior).
- Follows `NextToken` pagination.
- Opt-out: `GRAFANA_AMG_SWEEP_EXPIRED_TOKENS=false` (default `true`).

## Notes for review

- The AWS principal now additionally needs `grafana:ListWorkspaceServiceAccountTokens`; README permission list + env-var table updated.
- `parseDeleteOnStop` generalized into `parseBoolEnv` (shared by the new flag, same validation semantics).
- Unit tests cover: prefix/expiry selection matrix, pagination, sweep-failure-doesn't-fail-configure, opt-out, and the new config parsing (defaults/override/invalid).
- Verified with `go build`, `go vet`, `go test`, `goimports` (module-local, `GOWORK=off`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional cleanup of expired service-account tokens before creating new tokens.
  * Cleanup targets only expired tokens matching the configured token-name prefix.
  * Added `GRAFANA_AMG_SWEEP_EXPIRED_TOKENS` configuration, enabled by default.
  * Cleanup continues across multiple pages and logs failures without stopping provider configuration.

* **Documentation**
  * Updated AWS permissions requirements and documented the new environment variable.

* **Bug Fixes**
  * Added validation for invalid sweep configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->