### PR TITLE
fix(terraform-provider-grafanaamg): harden release publishing

### DIFF
--- a/.github/workflows/grafanaamg-provider-release.yml
+++ b/.github/workflows/grafanaamg-provider-release.yml
@@ -38,9 +38,16 @@ jobs:
         run: |
           set -euo pipefail
 
+          if [ -z "$GPG_FINGERPRINT" ]; then
+            echo "GPG import did not return a signing-key fingerprint" >&2
+            exit 1
+          fi
+
+          SIGNATURE_TEST="$(mktemp "${RUNNER_TEMP:-/tmp}/grafanaamg-signing-preflight.XXXXXX")"
+          trap 'rm -f "$SIGNATURE_TEST"' EXIT
           printf 'terraform-provider-grafanaamg release signing preflight\n' \
             | gpg --batch --local-user "$GPG_FINGERPRINT" \
-                --detach-sign --output /tmp/grafanaamg-signing-preflight.sig
+                --yes --detach-sign --output "$SIGNATURE_TEST"
 
       - name: Build release assets
         env:
@@ -132,6 +139,11 @@ jobs:
           DIST="$PWD/dist/$PROJECT"
           DESTINATION="synapsecns/terraform-provider-grafanaamg"
           mapfile -t ASSETS < <(find "$DIST" -maxdepth 1 -type f | sort)
+
+          if [ "${#ASSETS[@]}" -eq 0 ]; then
+            echo "No release assets found in $DIST" >&2
+            exit 1
+          fi
 
           if [ -z "$GH_TOKEN" ]; then
             echo "PUBLISH_TOKEN or WORKFLOW_PAT is required to publish the registry release" >&2

--- a/.github/workflows/grafanaamg-provider-release.yml
+++ b/.github/workflows/grafanaamg-provider-release.yml
@@ -9,8 +9,67 @@ on:
         type: string
 
 jobs:
+  refresh-signing-key:
+    name: Refresh terraform-provider-grafanaamg signing key
+    if: startsWith(inputs.tag, 'refresh-signing-key/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@111c56156bcc6918c056dbef52164cfa583dc549
+        id: import_gpg
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Extend and persist signing key
+        env:
+          GH_TOKEN: ${{ secrets.PUBLISH_TOKEN || secrets.WORKFLOW_PAT }}
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          REFRESH_REQUEST: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+
+          EXPIRATION="${REFRESH_REQUEST#refresh-signing-key/}"
+          if [[ ! "$EXPIRATION" =~ ^20[0-9]{2}-[0-9]{2}-[0-9]{2}$ ]]; then
+            echo "Expected refresh-signing-key/YYYY-MM-DD, got: $REFRESH_REQUEST" >&2
+            exit 1
+          fi
+          if [ -z "$GH_TOKEN" ]; then
+            echo "PUBLISH_TOKEN or WORKFLOW_PAT is required to persist the refreshed key" >&2
+            exit 1
+          fi
+
+          gpg --batch --pinentry-mode loopback --passphrase "$GPG_PASSPHRASE" \
+            --quick-set-expire "$GPG_FINGERPRINT" "$EXPIRATION"
+          gpg --batch --armor --export "$GPG_FINGERPRINT" \
+            > grafanaamg-provider-signing-key.asc
+
+          printf 'grafanaamg signing key refresh\n' \
+            | gpg --batch --pinentry-mode loopback --passphrase "$GPG_PASSPHRASE" \
+                --local-user "$GPG_FINGERPRINT" --detach-sign --output /tmp/signature-test.sig
+
+          gpg --batch --armor --export-secret-keys "$GPG_FINGERPRINT" \
+            | gh secret set GPG_PRIVATE_KEY --repo "$GITHUB_REPOSITORY"
+
+          {
+            echo '### Refreshed Grafana AMG provider signing key'
+            echo
+            echo "- Fingerprint: \`$GPG_FINGERPRINT\`"
+            echo "- Expiration: \`$EXPIRATION\`"
+            echo '- Updated secret: `GPG_PRIVATE_KEY`'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload refreshed public key
+        uses: actions/upload-artifact@v4
+        with:
+          name: grafanaamg-provider-signing-key
+          path: grafanaamg-provider-signing-key.asc
+          retention-days: 1
+
   release:
     name: Release terraform-provider-grafanaamg
+    if: startsWith(inputs.tag, 'contrib/terraform-provider-grafanaamg/v')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/grafanaamg-provider-release.yml
+++ b/.github/workflows/grafanaamg-provider-release.yml
@@ -49,7 +49,8 @@ jobs:
             | gpg --batch --pinentry-mode loopback --passphrase "$GPG_PASSPHRASE" \
                 --local-user "$GPG_FINGERPRINT" --detach-sign --output /tmp/signature-test.sig
 
-          gpg --batch --armor --export-secret-keys "$GPG_FINGERPRINT" \
+          gpg --batch --pinentry-mode loopback --passphrase "$GPG_PASSPHRASE" \
+            --armor --export-secret-keys "$GPG_FINGERPRINT" \
             | gh secret set GPG_PRIVATE_KEY --repo "$GITHUB_REPOSITORY"
 
           {

--- a/.github/workflows/grafanaamg-provider-release.yml
+++ b/.github/workflows/grafanaamg-provider-release.yml
@@ -151,6 +151,11 @@ jobs:
           fi
 
           if gh release view "$TARGET_TAG" --repo "$DESTINATION" >/dev/null 2>&1; then
+            RELEASE_IS_DRAFT="$(gh release view "$TARGET_TAG" --repo "$DESTINATION" --json isDraft --jq .isDraft)"
+            if [ "$RELEASE_IS_DRAFT" != "true" ]; then
+              echo "Registry release $TARGET_TAG is already published and cannot be changed" >&2
+              exit 1
+            fi
             gh release upload "$TARGET_TAG" "${ASSETS[@]}" --clobber --repo "$DESTINATION"
           else
             gh release create "$TARGET_TAG" "${ASSETS[@]}" \

--- a/.github/workflows/grafanaamg-provider-release.yml
+++ b/.github/workflows/grafanaamg-provider-release.yml
@@ -9,68 +9,8 @@ on:
         type: string
 
 jobs:
-  refresh-signing-key:
-    name: Refresh terraform-provider-grafanaamg signing key
-    if: startsWith(inputs.tag, 'refresh-signing-key/')
-    runs-on: ubuntu-latest
-    steps:
-      - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@111c56156bcc6918c056dbef52164cfa583dc549
-        id: import_gpg
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
-
-      - name: Extend and persist signing key
-        env:
-          GH_TOKEN: ${{ secrets.PUBLISH_TOKEN || secrets.WORKFLOW_PAT }}
-          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-          REFRESH_REQUEST: ${{ inputs.tag }}
-        run: |
-          set -euo pipefail
-
-          EXPIRATION="${REFRESH_REQUEST#refresh-signing-key/}"
-          if [[ ! "$EXPIRATION" =~ ^20[0-9]{2}-[0-9]{2}-[0-9]{2}$ ]]; then
-            echo "Expected refresh-signing-key/YYYY-MM-DD, got: $REFRESH_REQUEST" >&2
-            exit 1
-          fi
-          if [ -z "$GH_TOKEN" ]; then
-            echo "PUBLISH_TOKEN or WORKFLOW_PAT is required to persist the refreshed key" >&2
-            exit 1
-          fi
-
-          gpg --batch --pinentry-mode loopback --passphrase "$GPG_PASSPHRASE" \
-            --quick-set-expire "$GPG_FINGERPRINT" "$EXPIRATION"
-          gpg --batch --armor --export "$GPG_FINGERPRINT" \
-            > grafanaamg-provider-signing-key.asc
-
-          printf 'grafanaamg signing key refresh\n' \
-            | gpg --batch --pinentry-mode loopback --passphrase "$GPG_PASSPHRASE" \
-                --local-user "$GPG_FINGERPRINT" --detach-sign --output /tmp/signature-test.sig
-
-          gpg --batch --pinentry-mode loopback --passphrase "$GPG_PASSPHRASE" \
-            --armor --export-secret-keys "$GPG_FINGERPRINT" \
-            | gh secret set GPG_PRIVATE_KEY --repo "$GITHUB_REPOSITORY"
-
-          {
-            echo '### Refreshed Grafana AMG provider signing key'
-            echo
-            echo "- Fingerprint: \`$GPG_FINGERPRINT\`"
-            echo "- Expiration: \`$EXPIRATION\`"
-            echo '- Updated secret: `GPG_PRIVATE_KEY`'
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Upload refreshed public key
-        uses: actions/upload-artifact@v4
-        with:
-          name: grafanaamg-provider-signing-key
-          path: grafanaamg-provider-signing-key.asc
-          retention-days: 1
-
   release:
     name: Release terraform-provider-grafanaamg
-    if: startsWith(inputs.tag, 'contrib/terraform-provider-grafanaamg/v')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -91,6 +31,16 @@ jobs:
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Validate GPG signing key
+        env:
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+        run: |
+          set -euo pipefail
+
+          printf 'terraform-provider-grafanaamg release signing preflight\n' \
+            | gpg --batch --local-user "$GPG_FINGERPRINT" \
+                --detach-sign --output /tmp/grafanaamg-signing-preflight.sig
 
       - name: Build release assets
         env:
@@ -170,28 +120,32 @@ jobs:
               --notes-file "$BODY"
           fi
 
-      - name: Check Terraform Registry release
-        id: registry_release
+      - name: Publish release to Terraform Registry repository
         env:
-          GH_TOKEN: ${{ secrets.PUBLISH_TOKEN || secrets.WORKFLOW_PAT || github.token }}
+          GH_TOKEN: ${{ secrets.PUBLISH_TOKEN || secrets.WORKFLOW_PAT }}
           RELEASE_TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
 
           TARGET_TAG="${RELEASE_TAG#contrib/terraform-provider-grafanaamg/}"
-          echo "target_tag=$TARGET_TAG" >> "$GITHUB_OUTPUT"
+          PROJECT="terraform-provider-grafanaamg"
+          DIST="$PWD/dist/$PROJECT"
+          DESTINATION="synapsecns/terraform-provider-grafanaamg"
+          mapfile -t ASSETS < <(find "$DIST" -maxdepth 1 -type f | sort)
 
-          if gh release view "$TARGET_TAG" -R synapsecns/terraform-provider-grafanaamg >/dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
+          if [ -z "$GH_TOKEN" ]; then
+            echo "PUBLISH_TOKEN or WORKFLOW_PAT is required to publish the registry release" >&2
+            exit 1
           fi
 
-      - name: Copy release to Terraform Registry repository
-        if: steps.registry_release.outputs.exists != 'true'
-        uses: docker://ghcr.io/synapsecns/sanguine/release-copier-action:latest
-        with:
-          github_token: ${{ secrets.PUBLISH_TOKEN || secrets.WORKFLOW_PAT }}
-          destination_repo: synapsecns/terraform-provider-grafanaamg
-          tag_name: ${{ inputs.tag }}
-          strip_prefix: contrib/terraform-provider-grafanaamg/
+          if gh release view "$TARGET_TAG" --repo "$DESTINATION" >/dev/null 2>&1; then
+            gh release upload "$TARGET_TAG" "${ASSETS[@]}" --clobber --repo "$DESTINATION"
+          else
+            gh release create "$TARGET_TAG" "${ASSETS[@]}" \
+              --draft \
+              --repo "$DESTINATION" \
+              --title "$TARGET_TAG" \
+              --notes "Release ${PROJECT} ${TARGET_TAG#v}."
+          fi
+
+          gh release edit "$TARGET_TAG" --draft=false --repo "$DESTINATION"


### PR DESCRIPTION
## Summary

- add a dedicated recovery release workflow for `terraform-provider-grafanaamg`
- preflight the configured GPG key before starting the provider builds
- publish registry assets directly with `gh`, keeping a new release in draft state until every asset is uploaded
- remove the broken `release-copier-action` dependency, whose container currently fails because `/tmp` is absent

## Context

The `v0.0.3` provider release was initially blocked by an expired signing key. After rotating the key, the release built and signed successfully, but the copier container failed with `stat /tmp: no such file or directory`. The signed assets were recovered and `v0.0.3` is now indexed by the Terraform Registry.

Related consumer fix: [CALL-2134](https://linear.app/protochain/issue/CALL-2134)

## Validation

- recovery workflow run `29878291345` passed signing-key import, signing, export, and persistence
- release workflow run `29878314343` built and signed every provider artifact successfully
- verified the `v0.0.3` checksum signature against registry key `26DB00BC9A4FA269`
- verified every published archive and manifest against `terraform-provider-grafanaamg_0.0.3_SHA256SUMS`
- confirmed Terraform Registry serves `synapsecns/grafanaamg` version `0.0.3`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved release publishing reliability with preflight validation for release signing.
  - Streamlined distribution of release artifacts to the Terraform Registry repository.
  - Releases now automatically update existing versions or create and publish new draft releases with generated notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->