### PR TITLE
test(rfq-relayer): cover retry with unknown chain ID

### DIFF
--- a/services/rfq/relayer/relapi/handler_unknown_chain_test.go
+++ b/services/rfq/relayer/relapi/handler_unknown_chain_test.go
@@ -1,0 +1,60 @@
+package relapi_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/synapsecns/sanguine/core/metrics"
+	"github.com/synapsecns/sanguine/services/rfq/contracts/fastbridge"
+	"github.com/synapsecns/sanguine/services/rfq/relayer/chain"
+	"github.com/synapsecns/sanguine/services/rfq/relayer/relapi"
+	"github.com/synapsecns/sanguine/services/rfq/relayer/relconfig"
+	"github.com/synapsecns/sanguine/services/rfq/relayer/reldb"
+)
+
+type quoteRequestDB struct {
+	reldb.Service
+	quoteRequest *reldb.QuoteRequest
+}
+
+func (d quoteRequestDB) GetQuoteRequestByOriginTxHash(_ context.Context, _ common.Hash) (*reldb.QuoteRequest, error) {
+	return d.quoteRequest, nil
+}
+
+func TestGetTxRetryUnknownChainID(t *testing.T) {
+	const chainID uint32 = 999999
+
+	db := quoteRequestDB{
+		quoteRequest: &reldb.QuoteRequest{
+			Transaction: fastbridge.IFastBridgeBridgeTransaction{
+				DestChainId: chainID,
+			},
+		},
+	}
+	handler := relapi.NewHandler(
+		metrics.NewNullHandler(),
+		db,
+		map[uint32]*chain.Chain{},
+		relconfig.Config{},
+		nil,
+	)
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodGet, "/retry?hash=0x01", nil)
+
+	handler.GetTxRetry(ctx)
+
+	require.Equal(t, http.StatusInternalServerError, recorder.Code)
+	require.JSONEq(
+		t,
+		fmt.Sprintf(`{"error":"No contract found for chain: %d"}`, chainID),
+		recorder.Body.String(),
+	)
+}


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**

Add a focused test for the RFQ relayer retry handler when a quote references an unknown destination chain.

The test verifies that the handler returns HTTP 500 with the expected error message instead of attempting to submit the relay.

Closes #3006



**Additional context**

testing by the following cmd:

- `CI=true GOWORK=off GOTOOLCHAIN=go1.22.4 go test ./relayer/relapi -run '^TestGetTxRetryUnknownChainID$' -count=1`
- `GOWORK=off GOTOOLCHAIN=go1.22.4 go vet ./relayer/relapi`

**Metadata**
- Fixes #[Link to Issue]




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for retry requests targeting an unknown blockchain network.
  * Requests with an unsupported chain ID now return a clear server error indicating that no matching contract was found.

* **Tests**
  * Added coverage to verify the expected error response for unknown chain IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->