### PR TITLE
docs(omnirpc): note deprecated endpoints and add benchmark reference

### DIFF
--- a/docs/bridge/docs/07-Services/02-Omnirpc.md
+++ b/docs/bridge/docs/07-Services/02-Omnirpc.md
@@ -60,6 +60,8 @@ refreshInterval: 60
 
 In this example, any request to ethereum (chain id: 1) will need at least 5 rpcs to agree on the data before it is considered valid, but op will only need 1.
 
+Note: several public endpoints in the example above (including `gateway.pokt.network` and `linkpool.io` paths) are now deprecated. For live health status and latency measurements of alternative public RPC endpoints across chains, see [OpenChainBench](https://openchainbench.com/rpc), an independent open-source project probing endpoints every minute from three regions under a CC BY 4.0 license.
+
 Data can be fetched like so, where the last character is the chain id:
 
 ```bash


### PR DESCRIPTION
Adds one short note after the OmniRPC configuration example in `docs/bridge/docs/07-Services/02-Omnirpc.md`.

**Why this fits:**
- The example YAML config lists several public RPC endpoints that are now deprecated (e.g. `gateway.pokt.network` after Pocket sunset the free gateway, `main-light.eth.linkpool.io` after LinkPool deprecation)
- Adding a note helps future readers pick working endpoints instead of copying dead ones
- OpenChainBench provides live health status of alternative public RPC endpoints

**What's added:**
- One sentence note below the example config
- Single external link to https://openchainbench.com/rpc
- The example YAML itself is left untouched (preserves the "OmniRPC config shape" tutorial intent)

**About OpenChainBench:** independent open-source project measuring public RPC endpoint latency across 22+ chains every minute from three regions. Data published under CC BY 4.0, harness open sourced on GitHub, no affiliation with any RPC provider.

**Disclosure:** I contribute to OpenChainBench. Happy to reword or drop entirely if this doesn't fit editorial guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the OmniRPC configuration guide to note that several example public RPC endpoints are deprecated.
  * Added guidance to consult OpenChainBench for current endpoint health and latency information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->