### PR TITLE
feat(contracts-adapter): add native SYN HyperCore delivery

### DIFF
--- a/packages/contracts-adapter/SYN_HYPERCORE.md
+++ b/packages/contracts-adapter/SYN_HYPERCORE.md
@@ -1,0 +1,81 @@
+# SYN delivery to HyperCore
+
+<!-- markdownlint-disable MD013 -->
+
+Tracking: [CALL-2439](https://linear.app/protochain/issue/CALL-2439/implement-native-synapsebridge-delivery-of-syn-to-hypercore)
+
+This package contains the contract boundary for delivering SYN through the existing
+[SynapseBridge](https://github.com/synapsecns/synapse-contracts) supply model to a linked
+[HIP-1 asset](https://hyperliquid.gitbook.io/hyperliquid-docs/hyperliquid-improvement-proposals-hips/hip-1-native-token-standard).
+SYN does not become an OFT.
+
+## Scope of this change
+
+- **`SynapseBridgeAdapterV2` is a separate deployment.** The deployed `SynapseBridgeAdapter` contract and its
+  CREATE2-derived addresses are unchanged.
+- **Direct EVM delivery stays supported.** The original 96-byte message is decoded exactly as before.
+- **HyperCore delivery uses a versioned message.** The source adapter rejects dust and `uint64` overflow before it
+  burns or escrows SYN.
+- **`SynapseHyperCoreComposer` is SYN-specific.** Both contracts enforce 18 HyperEVM decimals, 8 HyperCore wei
+  decimals, and an amount scale of `10^10`.
+- **No deployment or production configuration is included.** Token, bridge, Core index, peer, DVN, executor, and
+  owner addresses must not be guessed before audited artifacts exist.
+
+## Intended flow
+
+1. `SynapseBridgeAdapterV2.bridgeERC20ToHyperCore` verifies the configured SYN route and amount.
+2. The source adapter burns mint-and-burn SYN, or escrows an underlying token in `SynapseBridge`.
+3. LayerZero delivers the versioned message to the authenticated destination adapter peer.
+4. The HyperEVM `SynapseBridge` mints or withdraws SYN to `SynapseHyperCoreComposer`.
+5. The Composer checks its immutable adapter and token bindings, both required HyperCore accounts, exact decimal
+   representation, `uint64` bounds, and current asset-bridge capacity.
+6. The Composer transfers HyperEVM SYN to the token system address, then submits the versioned spot-send action to
+   [CoreWriter](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/hyperevm/interacting-with-hypercore).
+
+## Safety invariants
+
+- **No dust is burned.** Every source amount must be divisible by `10^10` before source custody changes.
+- **No silent fallback exists.** A failed HyperCore delivery never changes the recipient to a HyperEVM address.
+- **Immediate destination failures roll back the mint.** Composer validation, ERC20 transfer, and CoreWriter call
+  occur inside the LayerZero receive transaction. A revert rolls back the destination `SynapseBridge` mint or
+  withdrawal, leaving the LayerZero message available for retry.
+- **Capacity is checked before transfer.** The Composer reads the Core-side system balance and rejects an amount that
+  is not currently backed by available HIP-1 bridge capacity. It also reserves capacity across all deliveries in the
+  same HyperEVM block because those transactions read the same pre-transfer HyperCore state.
+- **Bindings are immutable.** Decimal routes and Composer bindings cannot be overwritten after configuration.
+- **Existing bridge behavior is isolated.** The v1 adapter source and deployed bytecode remain unchanged.
+
+## Atomicity boundary
+
+An accepted HyperEVM transaction is not proof that the spot-send action executed on HyperCore. Hyperliquid processes
+EVM-to-Core transfers and CoreWriter actions after the EVM block. The Composer checks the conditions that would make
+the action fail, including account activation and bridge capacity, before it emits the transfer and CoreWriter call.
+Production monitoring must still confirm all of the following for every canary:
+
+- the LayerZero GUID was delivered once;
+- the HyperEVM transaction succeeded;
+- the asset-bridge `Transfer` event credited the Composer on HyperCore;
+- the CoreWriter action executed successfully;
+- the final recipient received the exact 8-decimal Core amount;
+- the Composer has no stranded HyperCore or HyperEVM SYN balance.
+
+See [Hyperliquid interaction timings](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/hyperevm/interaction-timings)
+and the [LayerZero Composer implementation](https://github.com/LayerZero-Labs/devtools/blob/main/packages/hyperliquid-composer/contracts/HyperLiquidComposer.sol).
+
+## Deployment gates
+
+Do not deploy or link the HIP-1 token until each gate is resolved:
+
+1. **HyperEVM SYN contract:** use the existing `SynapseERC20` authority model with `SynapseBridge` as its only minter.
+2. **HyperCore finalizer:** a factory-deployed ERC20 must expose the authorized finalizer in the first storage slot or
+   the `keccak256("HyperCore deployer")` slot. Otherwise deploy from the finalizer EOA and retain the exact creation
+   nonce required by `finalizeEvmContract`.
+3. **Full bridge capacity:** fund the HyperCore asset bridge with the complete intended circulatable supply during
+   genesis. Do not partially top it up later.
+4. **Composer activation:** activate the deployed Composer account on HyperCore before enabling any source route.
+5. **Peer isolation:** V2 peers used for HyperCore delivery must point only to the reviewed V2 deployments.
+6. **Independent review:** audit the token authority, source custody action, message codec, destination mint,
+   precompile reads, system-address transfer, and CoreWriter encoding as one supply path.
+
+The HyperCore token index, HyperEVM SYN address, SynapseBridge address, Composer address, and all LayerZero security
+configuration remain intentionally unset in this change.

--- a/packages/contracts-adapter/SYN_HYPERCORE.md
+++ b/packages/contracts-adapter/SYN_HYPERCORE.md
@@ -27,8 +27,9 @@ SYN does not become an OFT.
 2. The source adapter burns mint-and-burn SYN, or escrows an underlying token in `SynapseBridge`.
 3. LayerZero delivers the versioned message to the authenticated destination adapter peer.
 4. The HyperEVM `SynapseBridge` mints or withdraws SYN to `SynapseHyperCoreComposer`.
-5. The Composer checks its immutable adapter and token bindings, both required HyperCore accounts, exact decimal
-   representation, `uint64` bounds, and current asset-bridge capacity.
+5. The Composer accepts the call only from its immutable adapter, then checks both required HyperCore accounts,
+   exact decimal representation, `uint64` bounds, and current asset-bridge capacity. The adapter and token bindings
+   are fixed at construction and verified once by `setHyperCoreComposer`.
 6. The Composer transfers HyperEVM SYN to the token system address, then submits the versioned spot-send action to
    [CoreWriter](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/hyperevm/interacting-with-hypercore).
 
@@ -72,9 +73,12 @@ Do not deploy or link the HIP-1 token until each gate is resolved:
    nonce required by `finalizeEvmContract`.
 3. **Full bridge capacity:** fund the HyperCore asset bridge with the complete intended circulatable supply during
    genesis. Do not partially top it up later.
-4. **Composer activation:** activate the deployed Composer account on HyperCore before enabling any source route.
-5. **Peer isolation:** V2 peers used for HyperCore delivery must point only to the reviewed V2 deployments.
-6. **Independent review:** audit the token authority, source custody action, message codec, destination mint,
+4. **Core index verification:** independently confirm that the immutable Composer `coreIndex` matches the HIP-1
+   index linked to its immutable `token` before deployment. The derived `assetBridge` is also immutable. A wrong
+   index cannot be repaired in place and requires a new Composer and V2 adapter deployment.
+5. **Composer activation:** activate the deployed Composer account on HyperCore before enabling any source route.
+6. **Peer isolation:** V2 peers used for HyperCore delivery must point only to the reviewed V2 deployments.
+7. **Independent review:** audit the token authority, source custody action, message codec, destination mint,
    precompile reads, system-address transfer, and CoreWriter encoding as one supply path.
 
 The HyperCore token index, HyperEVM SYN address, SynapseBridge address, Composer address, and all LayerZero security

--- a/packages/contracts-adapter/src/SynapseBridgeAdapterV2.sol
+++ b/packages/contracts-adapter/src/SynapseBridgeAdapterV2.sol
@@ -215,10 +215,16 @@ contract SynapseBridgeAdapterV2 is
         address composer = getHyperCoreComposer[token];
         if (composer == address(0)) revert SBAV2__HyperCoreComposerNotSet(token);
 
-        _mintOrWithdraw(srcEid, srcToken, composer, amount, guid);
+        _mintOrWithdraw(token, composer, amount, guid);
         ISynapseHyperCoreComposer(composer).bridgeToHyperCore(to, amount);
         emit TokenReceivedOnHyperCore(srcEid, to, token, amount, guid);
         emit TokenReceived(srcEid, to, token, amount, guid);
+    }
+
+    function _mintOrWithdraw(address token, address recipient, uint256 amount, bytes32 guid) internal {
+        address cachedBridge = bridge;
+        if (cachedBridge == address(0)) revert SBA__BridgeNotSet();
+        _mintOrWithdraw(cachedBridge, token, recipient, amount, guid);
     }
 
     function _mintOrWithdraw(uint32 srcEid, address srcToken, address recipient, uint256 amount, bytes32 guid)
@@ -228,6 +234,12 @@ contract SynapseBridgeAdapterV2 is
         address cachedBridge = bridge;
         if (cachedBridge == address(0)) revert SBA__BridgeNotSet();
         token = _checkAndGetLocalAddress(srcEid, srcToken);
+        _mintOrWithdraw(cachedBridge, token, recipient, amount, guid);
+    }
+
+    function _mintOrWithdraw(address cachedBridge, address token, address recipient, uint256 amount, bytes32 guid)
+        internal
+    {
         TokenType tokenType = _checkAndGetTokenType(token);
         if (tokenType == TokenType.MintBurn) {
             ISynapseBridge(cachedBridge).mint(recipient, token, amount, 0, guid);

--- a/packages/contracts-adapter/src/SynapseBridgeAdapterV2.sol
+++ b/packages/contracts-adapter/src/SynapseBridgeAdapterV2.sol
@@ -131,6 +131,8 @@ contract SynapseBridgeAdapterV2 is
             gasLimit: gasLimit,
             message: BridgeMessage.encodeBridgeMessage(to, token, amount)
         });
+        // All custody and messaging calls have completed, and this function writes no state afterward.
+        // slither-disable-next-line reentrancy-events
         emit TokenSent(dstEid, to, token, amount, guid);
     }
 
@@ -153,7 +155,10 @@ contract SynapseBridgeAdapterV2 is
             gasLimit: gasLimit,
             message: HyperCoreMessage.encodeHyperCoreMessage(to, token, amount)
         });
+        // All custody and messaging calls have completed, and this function writes no state afterward.
+        // slither-disable-next-line reentrancy-events
         emit TokenSent(dstEid, to, token, amount, guid);
+        // slither-disable-next-line reentrancy-events
         emit TokenSentToHyperCore(dstEid, to, token, amount, guid);
     }
 
@@ -206,6 +211,8 @@ contract SynapseBridgeAdapterV2 is
     function _receiveBridgeMessage(uint32 srcEid, bytes32 guid, bytes calldata message) internal {
         (address to, address srcToken, uint256 amount) = BridgeMessage.decodeBridgeMessage(message);
         address token = _mintOrWithdraw(srcEid, srcToken, to, amount, guid);
+        // Only the authenticated LayerZero endpoint can enter this path, and no state is written after the bridge call.
+        // slither-disable-next-line reentrancy-events
         emit TokenReceived(srcEid, to, token, amount, guid);
     }
 
@@ -217,7 +224,10 @@ contract SynapseBridgeAdapterV2 is
 
         _mintOrWithdraw(token, composer, amount, guid);
         ISynapseHyperCoreComposer(composer).bridgeToHyperCore(to, amount);
+        // Only the authenticated LayerZero endpoint can enter this path, and no state is written after these calls.
+        // slither-disable-next-line reentrancy-events
         emit TokenReceivedOnHyperCore(srcEid, to, token, amount, guid);
+        // slither-disable-next-line reentrancy-events
         emit TokenReceived(srcEid, to, token, amount, guid);
     }
 

--- a/packages/contracts-adapter/src/SynapseBridgeAdapterV2.sol
+++ b/packages/contracts-adapter/src/SynapseBridgeAdapterV2.sol
@@ -1,0 +1,291 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import {IBurnableToken} from "./interfaces/IBurnableToken.sol";
+import {ISynapseBridge} from "./interfaces/ISynapseBridge.sol";
+import {ISynapseBridgeAdapter} from "./interfaces/ISynapseBridgeAdapter.sol";
+import {ISynapseBridgeAdapterV2} from "./interfaces/ISynapseBridgeAdapterV2.sol";
+import {ISynapseBridgeAdapterErrors} from "./interfaces/ISynapseBridgeAdapterErrors.sol";
+import {ISynapseBridgeAdapterV2Errors} from "./interfaces/ISynapseBridgeAdapterV2Errors.sol";
+import {ISynapseHyperCoreComposer} from "./interfaces/ISynapseHyperCoreComposer.sol";
+import {BridgeMessage} from "./libs/BridgeMessage.sol";
+import {HyperCoreMessage} from "./libs/HyperCoreMessage.sol";
+
+import {MessagingFee, OApp, Origin} from "@layerzerolabs/oapp-evm/contracts/oapp/OApp.sol";
+import {OptionsBuilder} from "@layerzerolabs/oapp-evm/contracts/oapp/libs/OptionsBuilder.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import {IERC20, SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+/// @notice A separately deployed SynapseBridgeAdapter version that can deliver bridged tokens to HyperCore.
+/// @dev The original adapter and its deployed routes remain unchanged.
+contract SynapseBridgeAdapterV2 is
+    OApp,
+    ISynapseBridgeAdapterV2,
+    ISynapseBridgeAdapterErrors,
+    ISynapseBridgeAdapterV2Errors
+{
+    using OptionsBuilder for bytes;
+    using SafeERC20 for IERC20;
+
+    uint64 public constant MIN_GAS_LIMIT = 200_000;
+    uint8 public constant SYN_EVM_DECIMALS = 18;
+    uint8 public constant SYN_CORE_DECIMALS = 8;
+    uint256 public constant SYN_AMOUNT_SCALE = 1e10;
+    uint256 private constant DIRECT_MESSAGE_LENGTH = 96;
+
+    address public bridge;
+
+    mapping(uint32 eid => mapping(address remoteAddr => address localAddr)) public getLocalAddress;
+    mapping(uint32 eid => mapping(address localAddr => address remoteAddr)) public getRemoteAddress;
+    mapping(address localAddr => TokenType tokenType) public getTokenType;
+    mapping(uint32 eid => mapping(address token => uint256 amountScale)) public getHyperCoreAmountScale;
+    mapping(address token => address composer) public getHyperCoreComposer;
+
+    event BridgeSet(address bridge);
+    event HyperCoreComposerSet(address indexed token, address indexed composer);
+    event HyperCoreDecimalsSet(
+        uint32 indexed dstEid, address indexed token, uint8 tokenDecimals, uint8 coreDecimals, uint256 amountScale
+    );
+    event TokenAdded(address token, TokenType tokenType, RemoteToken[] remoteTokens);
+    event TokenSent(uint32 indexed dstEid, address indexed to, address indexed token, uint256 amount, bytes32 guid);
+    event TokenSentToHyperCore(
+        uint32 indexed dstEid, address indexed to, address indexed token, uint256 amount, bytes32 guid
+    );
+    event TokenReceived(uint32 indexed srcEid, address indexed to, address indexed token, uint256 amount, bytes32 guid);
+    event TokenReceivedOnHyperCore(
+        uint32 indexed srcEid, address indexed to, address indexed token, uint256 amount, bytes32 guid
+    );
+
+    constructor(address endpoint_, address owner_) OApp(endpoint_, owner_) Ownable(owner_) {}
+
+    // ════════════════════════════════════════════════ MANAGEMENT ═════════════════════════════════════════════════════
+
+    /// @inheritdoc ISynapseBridgeAdapter
+    function addToken(address token, TokenType tokenType, RemoteToken[] memory remoteTokens) external onlyOwner {
+        _checkAndSaveToken(token, tokenType);
+        uint256 length = remoteTokens.length;
+        if (length == 0) revert SBA__ZeroAmount();
+        for (uint256 i = 0; i < length; ++i) {
+            uint32 eid = remoteTokens[i].eid;
+            if (getRemoteAddress[eid][token] != address(0)) revert SBA__RemotePairAlreadySet(eid, token);
+            address remoteAddr = remoteTokens[i].addr;
+            if (remoteAddr == address(0)) revert SBA__ZeroAddress();
+            if (getLocalAddress[eid][remoteAddr] != address(0)) revert SBA__LocalPairAlreadyExists(eid, remoteAddr);
+            getRemoteAddress[eid][token] = remoteAddr;
+            getLocalAddress[eid][remoteAddr] = token;
+        }
+        emit TokenAdded(token, tokenType, remoteTokens);
+    }
+
+    /// @inheritdoc ISynapseBridgeAdapter
+    function setBridge(address newBridge) external onlyOwner {
+        if (newBridge == address(0)) revert SBA__ZeroAddress();
+        if (bridge != address(0)) revert SBA__BridgeAlreadySet();
+        bridge = newBridge;
+        emit BridgeSet(newBridge);
+    }
+
+    /// @inheritdoc ISynapseBridgeAdapterV2
+    function setHyperCoreDecimals(uint32 dstEid, address token, uint8 coreDecimals) external onlyOwner {
+        _checkAndGetTokenType(token);
+        if (getRemoteAddress[dstEid][token] == address(0)) revert SBA__RemotePairNotSet(dstEid, token);
+        if (getHyperCoreAmountScale[dstEid][token] != 0) {
+            revert SBAV2__HyperCoreDecimalsAlreadySet(dstEid, token);
+        }
+
+        uint8 tokenDecimals = IERC20Metadata(token).decimals();
+        if (tokenDecimals != SYN_EVM_DECIMALS || coreDecimals != SYN_CORE_DECIMALS) {
+            revert SBAV2__HyperCoreDecimalsInvalid(tokenDecimals, coreDecimals);
+        }
+        uint256 amountScale = SYN_AMOUNT_SCALE;
+        getHyperCoreAmountScale[dstEid][token] = amountScale;
+        emit HyperCoreDecimalsSet(dstEid, token, tokenDecimals, coreDecimals, amountScale);
+    }
+
+    /// @inheritdoc ISynapseBridgeAdapterV2
+    function setHyperCoreComposer(address token, address composer) external onlyOwner {
+        _checkAndGetTokenType(token);
+        if (composer == address(0)) revert SBA__ZeroAddress();
+        if (getHyperCoreComposer[token] != address(0)) revert SBAV2__HyperCoreComposerAlreadySet(token);
+        if (composer.code.length == 0) revert SBAV2__HyperCoreComposerInvalid(composer);
+
+        ISynapseHyperCoreComposer candidate = ISynapseHyperCoreComposer(composer);
+        if (candidate.adapter() != address(this) || candidate.token() != token) {
+            revert SBAV2__HyperCoreComposerInvalid(composer);
+        }
+
+        getHyperCoreComposer[token] = composer;
+        emit HyperCoreComposerSet(token, composer);
+    }
+
+    // ════════════════════════════════════════════════ USER FACING ════════════════════════════════════════════════════
+
+    /// @inheritdoc ISynapseBridgeAdapter
+    function bridgeERC20(uint32 dstEid, address to, address token, uint256 amount, uint64 gasLimit) external payable {
+        bytes32 guid = _bridgeERC20({
+            dstEid: dstEid,
+            to: to,
+            token: token,
+            amount: amount,
+            gasLimit: gasLimit,
+            message: BridgeMessage.encodeBridgeMessage(to, token, amount)
+        });
+        emit TokenSent(dstEid, to, token, amount, guid);
+    }
+
+    /// @inheritdoc ISynapseBridgeAdapterV2
+    function bridgeERC20ToHyperCore(uint32 dstEid, address to, address token, uint256 amount, uint64 gasLimit)
+        external
+        payable
+    {
+        uint256 amountScale = getHyperCoreAmountScale[dstEid][token];
+        if (amountScale == 0) revert SBAV2__HyperCoreDecimalsNotSet(dstEid, token);
+        if (amount % amountScale != 0) revert SBAV2__HyperCoreAmountNotRepresentable(amount, amountScale);
+        uint256 coreAmount = amount / amountScale;
+        if (coreAmount > type(uint64).max) revert SBAV2__HyperCoreAmountExceedsUint64(coreAmount);
+
+        bytes32 guid = _bridgeERC20({
+            dstEid: dstEid,
+            to: to,
+            token: token,
+            amount: amount,
+            gasLimit: gasLimit,
+            message: HyperCoreMessage.encodeHyperCoreMessage(to, token, amount)
+        });
+        emit TokenSent(dstEid, to, token, amount, guid);
+        emit TokenSentToHyperCore(dstEid, to, token, amount, guid);
+    }
+
+    // ═══════════════════════════════════════════════════ VIEWS ═══════════════════════════════════════════════════════
+
+    /// @inheritdoc ISynapseBridgeAdapter
+    function getNativeFee(uint32 dstEid, uint64 gasLimit) external view returns (uint256 nativeFee) {
+        if (gasLimit < MIN_GAS_LIMIT) revert SBA__GasLimitBelowMinimum();
+        return _quote({
+            _dstEid: dstEid,
+            _message: BridgeMessage.encodeBridgeMessage(address(0), address(0), 0),
+            _options: OptionsBuilder.newOptions().addExecutorLzReceiveOption({_gas: gasLimit, _value: 0}),
+            _payInLzToken: false
+        })
+        .nativeFee;
+    }
+
+    /// @inheritdoc ISynapseBridgeAdapterV2
+    function getNativeFeeToHyperCore(uint32 dstEid, address token, uint64 gasLimit)
+        external
+        view
+        returns (uint256 nativeFee)
+    {
+        if (gasLimit < MIN_GAS_LIMIT) revert SBA__GasLimitBelowMinimum();
+        if (getHyperCoreAmountScale[dstEid][token] == 0) {
+            revert SBAV2__HyperCoreDecimalsNotSet(dstEid, token);
+        }
+        return _quote({
+            _dstEid: dstEid,
+            _message: HyperCoreMessage.encodeHyperCoreMessage(address(0), token, 0),
+            _options: OptionsBuilder.newOptions().addExecutorLzReceiveOption({_gas: gasLimit, _value: 0}),
+            _payInLzToken: false
+        })
+        .nativeFee;
+    }
+
+    // ══════════════════════════════════════════════ INTERNAL LOGIC ═══════════════════════════════════════════════════
+
+    function _lzReceive(Origin calldata origin, bytes32 guid, bytes calldata message, address, bytes calldata)
+        internal
+        override
+    {
+        if (message.length == DIRECT_MESSAGE_LENGTH) {
+            _receiveBridgeMessage(origin.srcEid, guid, message);
+        } else {
+            _receiveHyperCoreMessage(origin.srcEid, guid, message);
+        }
+    }
+
+    function _receiveBridgeMessage(uint32 srcEid, bytes32 guid, bytes calldata message) internal {
+        (address to, address srcToken, uint256 amount) = BridgeMessage.decodeBridgeMessage(message);
+        address token = _mintOrWithdraw(srcEid, srcToken, to, amount, guid);
+        emit TokenReceived(srcEid, to, token, amount, guid);
+    }
+
+    function _receiveHyperCoreMessage(uint32 srcEid, bytes32 guid, bytes calldata message) internal {
+        (address to, address srcToken, uint256 amount) = HyperCoreMessage.decodeHyperCoreMessage(message);
+        address token = _checkAndGetLocalAddress(srcEid, srcToken);
+        address composer = getHyperCoreComposer[token];
+        if (composer == address(0)) revert SBAV2__HyperCoreComposerNotSet(token);
+
+        _mintOrWithdraw(srcEid, srcToken, composer, amount, guid);
+        ISynapseHyperCoreComposer(composer).bridgeToHyperCore(to, amount);
+        emit TokenReceivedOnHyperCore(srcEid, to, token, amount, guid);
+        emit TokenReceived(srcEid, to, token, amount, guid);
+    }
+
+    function _mintOrWithdraw(uint32 srcEid, address srcToken, address recipient, uint256 amount, bytes32 guid)
+        internal
+        returns (address token)
+    {
+        address cachedBridge = bridge;
+        if (cachedBridge == address(0)) revert SBA__BridgeNotSet();
+        token = _checkAndGetLocalAddress(srcEid, srcToken);
+        TokenType tokenType = _checkAndGetTokenType(token);
+        if (tokenType == TokenType.MintBurn) {
+            ISynapseBridge(cachedBridge).mint(recipient, token, amount, 0, guid);
+        } else {
+            ISynapseBridge(cachedBridge).withdraw(recipient, token, amount, 0, guid);
+        }
+    }
+
+    function _bridgeERC20(
+        uint32 dstEid,
+        address to,
+        address token,
+        uint256 amount,
+        uint64 gasLimit,
+        bytes memory message
+    ) internal returns (bytes32 guid) {
+        if (to == address(0)) revert SBA__ZeroAddress();
+        if (amount == 0) revert SBA__ZeroAmount();
+        if (gasLimit < MIN_GAS_LIMIT) revert SBA__GasLimitBelowMinimum();
+        address cachedBridge = bridge;
+        if (cachedBridge == address(0)) revert SBA__BridgeNotSet();
+        TokenType tokenType = _checkAndGetTokenType(token);
+        if (getRemoteAddress[dstEid][token] == address(0)) revert SBA__RemotePairNotSet(dstEid, token);
+
+        if (tokenType == TokenType.MintBurn) {
+            IBurnableToken(token).burnFrom(msg.sender, amount);
+        } else {
+            IERC20(token).safeTransferFrom(msg.sender, cachedBridge, amount);
+        }
+
+        return _lzSend({
+            _dstEid: dstEid,
+            _message: message,
+            _options: OptionsBuilder.newOptions().addExecutorLzReceiveOption({_gas: gasLimit, _value: 0}),
+            _fee: MessagingFee({nativeFee: msg.value, lzTokenFee: 0}),
+            _refundAddress: msg.sender
+        })
+        .guid;
+    }
+
+    function _checkAndSaveToken(address token, TokenType tokenType) internal {
+        if (token == address(0)) revert SBA__ZeroAddress();
+        if (tokenType == TokenType.Unknown) revert SBA__TokenTypeUnknown();
+        TokenType existingTokenType = getTokenType[token];
+        if (existingTokenType == TokenType.Unknown) {
+            getTokenType[token] = tokenType;
+        } else if (existingTokenType != tokenType) {
+            revert SBA__TokenAlreadyAdded(token);
+        }
+    }
+
+    function _checkAndGetTokenType(address token) internal view returns (TokenType tokenType) {
+        tokenType = getTokenType[token];
+        if (tokenType == TokenType.Unknown) revert SBA__TokenUnknown(token);
+    }
+
+    function _checkAndGetLocalAddress(uint32 remoteEid, address remoteAddr) internal view returns (address localAddr) {
+        localAddr = getLocalAddress[remoteEid][remoteAddr];
+        if (localAddr == address(0)) revert SBA__LocalPairNotFound(remoteEid, remoteAddr);
+    }
+}

--- a/packages/contracts-adapter/src/SynapseBridgeAdapterV2.sol
+++ b/packages/contracts-adapter/src/SynapseBridgeAdapterV2.sol
@@ -4,8 +4,8 @@ pragma solidity 0.8.24;
 import {IBurnableToken} from "./interfaces/IBurnableToken.sol";
 import {ISynapseBridge} from "./interfaces/ISynapseBridge.sol";
 import {ISynapseBridgeAdapter} from "./interfaces/ISynapseBridgeAdapter.sol";
-import {ISynapseBridgeAdapterV2} from "./interfaces/ISynapseBridgeAdapterV2.sol";
 import {ISynapseBridgeAdapterErrors} from "./interfaces/ISynapseBridgeAdapterErrors.sol";
+import {ISynapseBridgeAdapterV2} from "./interfaces/ISynapseBridgeAdapterV2.sol";
 import {ISynapseBridgeAdapterV2Errors} from "./interfaces/ISynapseBridgeAdapterV2Errors.sol";
 import {ISynapseHyperCoreComposer} from "./interfaces/ISynapseHyperCoreComposer.sol";
 import {BridgeMessage} from "./libs/BridgeMessage.sol";
@@ -137,7 +137,13 @@ contract SynapseBridgeAdapterV2 is
     }
 
     /// @inheritdoc ISynapseBridgeAdapterV2
-    function bridgeERC20ToHyperCore(uint32 dstEid, address to, address token, uint256 amount, uint64 gasLimit)
+    function bridgeERC20ToHyperCore(
+        uint32 dstEid,
+        address to,
+        address token,
+        uint256 amount,
+        uint64 gasLimit
+    )
         external
         payable
     {
@@ -177,7 +183,11 @@ contract SynapseBridgeAdapterV2 is
     }
 
     /// @inheritdoc ISynapseBridgeAdapterV2
-    function getNativeFeeToHyperCore(uint32 dstEid, address token, uint64 gasLimit)
+    function getNativeFeeToHyperCore(
+        uint32 dstEid,
+        address token,
+        uint64 gasLimit
+    )
         external
         view
         returns (uint256 nativeFee)
@@ -197,7 +207,13 @@ contract SynapseBridgeAdapterV2 is
 
     // ══════════════════════════════════════════════ INTERNAL LOGIC ═══════════════════════════════════════════════════
 
-    function _lzReceive(Origin calldata origin, bytes32 guid, bytes calldata message, address, bytes calldata)
+    function _lzReceive(
+        Origin calldata origin,
+        bytes32 guid,
+        bytes calldata message,
+        address,
+        bytes calldata
+    )
         internal
         override
     {
@@ -237,7 +253,13 @@ contract SynapseBridgeAdapterV2 is
         _mintOrWithdraw(cachedBridge, token, recipient, amount, guid);
     }
 
-    function _mintOrWithdraw(uint32 srcEid, address srcToken, address recipient, uint256 amount, bytes32 guid)
+    function _mintOrWithdraw(
+        uint32 srcEid,
+        address srcToken,
+        address recipient,
+        uint256 amount,
+        bytes32 guid
+    )
         internal
         returns (address token)
     {
@@ -247,7 +269,13 @@ contract SynapseBridgeAdapterV2 is
         _mintOrWithdraw(cachedBridge, token, recipient, amount, guid);
     }
 
-    function _mintOrWithdraw(address cachedBridge, address token, address recipient, uint256 amount, bytes32 guid)
+    function _mintOrWithdraw(
+        address cachedBridge,
+        address token,
+        address recipient,
+        uint256 amount,
+        bytes32 guid
+    )
         internal
     {
         TokenType tokenType = _checkAndGetTokenType(token);
@@ -265,7 +293,10 @@ contract SynapseBridgeAdapterV2 is
         uint256 amount,
         uint64 gasLimit,
         bytes memory message
-    ) internal returns (bytes32 guid) {
+    )
+        internal
+        returns (bytes32 guid)
+    {
         if (to == address(0)) revert SBA__ZeroAddress();
         if (amount == 0) revert SBA__ZeroAmount();
         if (gasLimit < MIN_GAS_LIMIT) revert SBA__GasLimitBelowMinimum();

--- a/packages/contracts-adapter/src/SynapseHyperCoreComposer.sol
+++ b/packages/contracts-adapter/src/SynapseHyperCoreComposer.sol
@@ -4,8 +4,8 @@ pragma solidity 0.8.24;
 import {ICoreWriter} from "./interfaces/ICoreWriter.sol";
 import {ISynapseHyperCoreComposer} from "./interfaces/ISynapseHyperCoreComposer.sol";
 
-import {IERC20, SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import {IERC20, SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 /// @notice Moves SYN received by SynapseBridgeAdapter from HyperEVM to its linked HIP-1 asset.
 /// @dev This contract is intentionally fixed to SYN's 18 EVM decimals and 8 HyperCore wei decimals.
@@ -22,7 +22,9 @@ contract SynapseHyperCoreComposer is ISynapseHyperCoreComposer {
     address public constant CORE_USER_EXISTS_PRECOMPILE = 0x0000000000000000000000000000000000000810;
     address public constant BASE_ASSET_BRIDGE = 0x2000000000000000000000000000000000000000;
 
-    bytes4 public constant SPOT_SEND_HEADER = 0x0100_0006;
+    // The exact 4-byte Hyperliquid CoreWriter version and action header is intentionally kept as one literal.
+    // slither-disable-next-line too-many-digits
+    bytes4 public constant SPOT_SEND_HEADER = 0x01000006;
 
     address public immutable override adapter;
     address public immutable override token;

--- a/packages/contracts-adapter/src/SynapseHyperCoreComposer.sol
+++ b/packages/contracts-adapter/src/SynapseHyperCoreComposer.sol
@@ -22,7 +22,7 @@ contract SynapseHyperCoreComposer is ISynapseHyperCoreComposer {
     address public constant CORE_USER_EXISTS_PRECOMPILE = 0x0000000000000000000000000000000000000810;
     address public constant BASE_ASSET_BRIDGE = 0x2000000000000000000000000000000000000000;
 
-    bytes4 public constant SPOT_SEND_HEADER = 0x01000006;
+    bytes4 public constant SPOT_SEND_HEADER = 0x0100_0006;
 
     address public immutable override adapter;
     address public immutable override token;
@@ -73,6 +73,8 @@ contract SynapseHyperCoreComposer is ISynapseHyperCoreComposer {
         _requireCoreUser(recipient);
 
         uint64 available = _spotBalance(assetBridge, coreIndex);
+        // The equality deliberately selects this HyperEVM block's reservation epoch; it is not a value comparison.
+        // slither-disable-next-line incorrect-equality
         uint64 reserved = block.number == reservationBlock ? reservedCoreAmount : 0;
         uint256 required = uint256(reserved) + coreAmount;
         if (required > available) revert SHCC__AssetBridgeCapacityInsufficient(available, required);
@@ -88,16 +90,24 @@ contract SynapseHyperCoreComposer is ISynapseHyperCoreComposer {
         ICoreWriter(CORE_WRITER)
             .sendRawAction(abi.encodePacked(SPOT_SEND_HEADER, abi.encode(recipient, coreIndex, coreAmount)));
 
+        // The immutable adapter is the only caller, reservation state is committed above, and SYN has no callback.
+        // slither-disable-next-line reentrancy-events
         emit HyperCoreTransferQueued(recipient, amount, coreAmount, coreIndex);
     }
 
     function _requireCoreUser(address user) internal view {
+        // HyperEVM exposes this precompile without a Solidity ABI. Raw staticcall lets us fail closed on malformed
+        // data.
+        // slither-disable-next-line low-level-calls
         (bool success, bytes memory result) = CORE_USER_EXISTS_PRECOMPILE.staticcall(abi.encode(user));
         if (!success || result.length != 32) revert SHCC__PrecompileReadFailed(CORE_USER_EXISTS_PRECOMPILE);
         if (!abi.decode(result, (bool))) revert SHCC__CoreUserNotActivated(user);
     }
 
     function _spotBalance(address user, uint64 tokenIndex) internal view returns (uint64 total) {
+        // HyperEVM exposes this precompile without a Solidity ABI. Raw staticcall lets us fail closed on malformed
+        // data.
+        // slither-disable-next-line low-level-calls
         (bool success, bytes memory result) = SPOT_BALANCE_PRECOMPILE.staticcall(abi.encode(user, tokenIndex));
         if (!success || result.length != 96) revert SHCC__PrecompileReadFailed(SPOT_BALANCE_PRECOMPILE);
         (total,,) = abi.decode(result, (uint64, uint64, uint64));

--- a/packages/contracts-adapter/src/SynapseHyperCoreComposer.sol
+++ b/packages/contracts-adapter/src/SynapseHyperCoreComposer.sol
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import {ICoreWriter} from "./interfaces/ICoreWriter.sol";
+import {ISynapseHyperCoreComposer} from "./interfaces/ISynapseHyperCoreComposer.sol";
+
+import {IERC20, SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+
+/// @notice Moves SYN received by SynapseBridgeAdapter from HyperEVM to its linked HIP-1 asset.
+/// @dev This contract is intentionally fixed to SYN's 18 EVM decimals and 8 HyperCore wei decimals.
+/// It must be activated on HyperCore before it can submit a CoreWriter spot-send action.
+contract SynapseHyperCoreComposer is ISynapseHyperCoreComposer {
+    using SafeERC20 for IERC20;
+
+    uint8 public constant EVM_DECIMALS = 18;
+    uint8 public constant CORE_DECIMALS = 8;
+    uint256 public constant AMOUNT_SCALE = 10 ** (EVM_DECIMALS - CORE_DECIMALS);
+
+    address public constant CORE_WRITER = 0x3333333333333333333333333333333333333333;
+    address public constant SPOT_BALANCE_PRECOMPILE = 0x0000000000000000000000000000000000000801;
+    address public constant CORE_USER_EXISTS_PRECOMPILE = 0x0000000000000000000000000000000000000810;
+    address public constant BASE_ASSET_BRIDGE = 0x2000000000000000000000000000000000000000;
+
+    bytes4 public constant SPOT_SEND_HEADER = 0x01000006;
+
+    address public immutable override adapter;
+    address public immutable override token;
+    uint64 public immutable coreIndex;
+    address public immutable assetBridge;
+
+    uint256 private reservationBlock;
+    uint64 private reservedCoreAmount;
+
+    event HyperCoreTransferQueued(
+        address indexed recipient, uint256 evmAmount, uint64 coreAmount, uint64 indexed coreIndex
+    );
+
+    error SHCC__AmountExceedsUint64(uint256 coreAmount);
+    error SHCC__AmountNotRepresentable(uint256 amount, uint256 scale);
+    error SHCC__AssetBridgeCapacityInsufficient(uint256 available, uint256 required);
+    error SHCC__CoreUserNotActivated(address user);
+    error SHCC__InvalidTokenDecimals(uint8 actual, uint8 expected);
+    error SHCC__OnlyAdapter(address caller);
+    error SHCC__PrecompileReadFailed(address precompile);
+    error SHCC__ZeroAddress();
+    error SHCC__ZeroAmount();
+
+    constructor(address adapter_, address token_, uint64 coreIndex_) {
+        if (adapter_ == address(0) || token_ == address(0)) revert SHCC__ZeroAddress();
+        uint8 tokenDecimals = IERC20Metadata(token_).decimals();
+        if (tokenDecimals != EVM_DECIMALS) revert SHCC__InvalidTokenDecimals(tokenDecimals, EVM_DECIMALS);
+
+        adapter = adapter_;
+        token = token_;
+        coreIndex = coreIndex_;
+        assetBridge = address(uint160(uint256(uint160(BASE_ASSET_BRIDGE)) + coreIndex_));
+    }
+
+    /// @inheritdoc ISynapseHyperCoreComposer
+    function bridgeToHyperCore(address recipient, uint256 amount) external override {
+        if (msg.sender != adapter) revert SHCC__OnlyAdapter(msg.sender);
+        if (recipient == address(0)) revert SHCC__ZeroAddress();
+        if (amount == 0) revert SHCC__ZeroAmount();
+        if (amount % AMOUNT_SCALE != 0) revert SHCC__AmountNotRepresentable(amount, AMOUNT_SCALE);
+
+        uint256 coreAmount256 = amount / AMOUNT_SCALE;
+        if (coreAmount256 > type(uint64).max) revert SHCC__AmountExceedsUint64(coreAmount256);
+        // forge-lint: disable-next-line(unsafe-typecast)
+        uint64 coreAmount = uint64(coreAmount256);
+
+        _requireCoreUser(address(this));
+        _requireCoreUser(recipient);
+
+        uint64 available = _spotBalance(assetBridge, coreIndex);
+        uint64 reserved = block.number == reservationBlock ? reservedCoreAmount : 0;
+        uint256 required = uint256(reserved) + coreAmount;
+        if (required > available) revert SHCC__AssetBridgeCapacityInsufficient(available, required);
+
+        reservationBlock = block.number;
+        // `required` is bounded by the uint64 `available` value above.
+        // forge-lint: disable-next-line(unsafe-typecast)
+        reservedCoreAmount = uint64(required);
+
+        // Hyperliquid credits this contract's HyperCore account from the ERC20 Transfer event before
+        // processing the following CoreWriter action in the same L1 block.
+        IERC20(token).safeTransfer(assetBridge, amount);
+        ICoreWriter(CORE_WRITER)
+            .sendRawAction(abi.encodePacked(SPOT_SEND_HEADER, abi.encode(recipient, coreIndex, coreAmount)));
+
+        emit HyperCoreTransferQueued(recipient, amount, coreAmount, coreIndex);
+    }
+
+    function _requireCoreUser(address user) internal view {
+        (bool success, bytes memory result) = CORE_USER_EXISTS_PRECOMPILE.staticcall(abi.encode(user));
+        if (!success || result.length != 32) revert SHCC__PrecompileReadFailed(CORE_USER_EXISTS_PRECOMPILE);
+        if (!abi.decode(result, (bool))) revert SHCC__CoreUserNotActivated(user);
+    }
+
+    function _spotBalance(address user, uint64 tokenIndex) internal view returns (uint64 total) {
+        (bool success, bytes memory result) = SPOT_BALANCE_PRECOMPILE.staticcall(abi.encode(user, tokenIndex));
+        if (!success || result.length != 96) revert SHCC__PrecompileReadFailed(SPOT_BALANCE_PRECOMPILE);
+        (total,,) = abi.decode(result, (uint64, uint64, uint64));
+    }
+}

--- a/packages/contracts-adapter/src/interfaces/ICoreWriter.sol
+++ b/packages/contracts-adapter/src/interfaces/ICoreWriter.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+interface ICoreWriter {
+    function sendRawAction(bytes calldata data) external;
+}

--- a/packages/contracts-adapter/src/interfaces/ISynapseBridgeAdapterV2.sol
+++ b/packages/contracts-adapter/src/interfaces/ISynapseBridgeAdapterV2.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+import {ISynapseBridgeAdapter} from "./ISynapseBridgeAdapter.sol";
+
+interface ISynapseBridgeAdapterV2 is ISynapseBridgeAdapter {
+    /// @notice Configures the 18-decimal SYN to 8-decimal HyperCore route.
+    /// @dev Reads the local ERC20 decimals and rejects any value other than the fixed SYN decimal pair.
+    function setHyperCoreDecimals(uint32 dstEid, address token, uint8 coreDecimals) external;
+
+    /// @notice Configures the destination composer for a local token. The composer binding is immutable.
+    function setHyperCoreComposer(address token, address composer) external;
+
+    /// @notice Bridges an ERC20 token to a recipient on HyperCore through the destination composer.
+    function bridgeERC20ToHyperCore(uint32 dstEid, address to, address token, uint256 amount, uint64 gasLimit)
+        external
+        payable;
+
+    /// @notice Returns the native fee for a HyperCore delivery message.
+    function getNativeFeeToHyperCore(uint32 dstEid, address token, uint64 gasLimit)
+        external
+        view
+        returns (uint256 nativeFee);
+
+    /// @notice Returns the amount scale for a configured HyperCore token route.
+    function getHyperCoreAmountScale(uint32 dstEid, address token) external view returns (uint256 amountScale);
+
+    /// @notice Returns the destination HyperCore composer for a local token.
+    function getHyperCoreComposer(address token) external view returns (address composer);
+}

--- a/packages/contracts-adapter/src/interfaces/ISynapseBridgeAdapterV2.sol
+++ b/packages/contracts-adapter/src/interfaces/ISynapseBridgeAdapterV2.sol
@@ -12,12 +12,22 @@ interface ISynapseBridgeAdapterV2 is ISynapseBridgeAdapter {
     function setHyperCoreComposer(address token, address composer) external;
 
     /// @notice Bridges an ERC20 token to a recipient on HyperCore through the destination composer.
-    function bridgeERC20ToHyperCore(uint32 dstEid, address to, address token, uint256 amount, uint64 gasLimit)
+    function bridgeERC20ToHyperCore(
+        uint32 dstEid,
+        address to,
+        address token,
+        uint256 amount,
+        uint64 gasLimit
+    )
         external
         payable;
 
     /// @notice Returns the native fee for a HyperCore delivery message.
-    function getNativeFeeToHyperCore(uint32 dstEid, address token, uint64 gasLimit)
+    function getNativeFeeToHyperCore(
+        uint32 dstEid,
+        address token,
+        uint64 gasLimit
+    )
         external
         view
         returns (uint256 nativeFee);

--- a/packages/contracts-adapter/src/interfaces/ISynapseBridgeAdapterV2Errors.sol
+++ b/packages/contracts-adapter/src/interfaces/ISynapseBridgeAdapterV2Errors.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+interface ISynapseBridgeAdapterV2Errors {
+    error SBAV2__HyperCoreAmountExceedsUint64(uint256 coreAmount);
+    error SBAV2__HyperCoreAmountNotRepresentable(uint256 amount, uint256 scale);
+    error SBAV2__HyperCoreComposerAlreadySet(address token);
+    error SBAV2__HyperCoreComposerInvalid(address composer);
+    error SBAV2__HyperCoreComposerNotSet(address token);
+    error SBAV2__HyperCoreDecimalsAlreadySet(uint32 eid, address token);
+    error SBAV2__HyperCoreDecimalsInvalid(uint8 tokenDecimals, uint8 coreDecimals);
+    error SBAV2__HyperCoreDecimalsNotSet(uint32 eid, address token);
+}

--- a/packages/contracts-adapter/src/interfaces/ISynapseHyperCoreComposer.sol
+++ b/packages/contracts-adapter/src/interfaces/ISynapseHyperCoreComposer.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+interface ISynapseHyperCoreComposer {
+    function bridgeToHyperCore(address recipient, uint256 amount) external;
+    function adapter() external view returns (address);
+    function token() external view returns (address);
+}

--- a/packages/contracts-adapter/src/libs/HyperCoreMessage.sol
+++ b/packages/contracts-adapter/src/libs/HyperCoreMessage.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+library HyperCoreMessage {
+    uint8 internal constant VERSION = 1;
+    uint256 internal constant HYPERCORE_MESSAGE_LENGTH = 128;
+
+    error HyperCoreMessage__InvalidPayload();
+    error HyperCoreMessage__UnsupportedVersion(uint8 version);
+
+    function encodeHyperCoreMessage(address recipient, address srcToken, uint256 amount)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return abi.encode(VERSION, recipient, srcToken, amount);
+    }
+
+    function decodeHyperCoreMessage(bytes calldata payload)
+        internal
+        pure
+        returns (address recipient, address srcToken, uint256 amount)
+    {
+        if (payload.length != HYPERCORE_MESSAGE_LENGTH) revert HyperCoreMessage__InvalidPayload();
+        uint8 version;
+        (version, recipient, srcToken, amount) = abi.decode(payload, (uint8, address, address, uint256));
+        if (version != VERSION) revert HyperCoreMessage__UnsupportedVersion(version);
+    }
+}

--- a/packages/contracts-adapter/src/libs/HyperCoreMessage.sol
+++ b/packages/contracts-adapter/src/libs/HyperCoreMessage.sol
@@ -8,7 +8,11 @@ library HyperCoreMessage {
     error HyperCoreMessage__InvalidPayload();
     error HyperCoreMessage__UnsupportedVersion(uint8 version);
 
-    function encodeHyperCoreMessage(address recipient, address srcToken, uint256 amount)
+    function encodeHyperCoreMessage(
+        address recipient,
+        address srcToken,
+        uint256 amount
+    )
         internal
         pure
         returns (bytes memory)

--- a/packages/contracts-adapter/test/SBA.Dst.t.sol
+++ b/packages/contracts-adapter/test/SBA.Dst.t.sol
@@ -1,21 +1,27 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.24;
 
-import {ISynapseBridgeAdapter, SynapseBridgeAdapter, SynapseBridgeAdapterTest} from "./SBA.t.sol";
+import {SynapseHyperCoreComposer} from "../src/SynapseHyperCoreComposer.sol";
+import {ICoreWriter} from "../src/interfaces/ICoreWriter.sol";
+import {ISynapseBridgeAdapter, SynapseBridgeAdapterTest, SynapseBridgeAdapterV2} from "./SBA.t.sol";
 
 import {SynapseBridgeMock} from "./mocks/SynapseBridgeMock.sol";
 import {TestToken} from "./mocks/TestToken.sol";
 
 import {Origin} from "@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol";
 
-// solhint-disable func-name-mixedcase, ordering
+// solhint-disable func-name-mixedcase, ordering, max-line-length
 contract SynapseBridgeAdapterDstTest is SynapseBridgeAdapterTest {
+    uint64 internal constant CORE_INDEX = 1337;
+    uint64 internal constant CORE_AMOUNT = 12_345_600;
+
     address internal bridge;
     TestToken internal token;
+    SynapseHyperCoreComposer internal composer;
 
     address internal executor = makeAddr("Executor");
     address internal recipient = makeAddr("Recipient");
-    uint256 internal amount = 0.123456 ether;
+    uint256 internal amount = 0.123_456 ether;
 
     bytes internal bridgeMessage;
 
@@ -42,6 +48,13 @@ contract SynapseBridgeAdapterDstTest is SynapseBridgeAdapterTest {
         _;
     }
 
+    modifier withHyperCoreComposerSet() {
+        composer = new SynapseHyperCoreComposer(address(adapter), address(token), CORE_INDEX);
+        adapter.setHyperCoreComposer(address(token), address(composer));
+        vm.etch(composer.CORE_WRITER(), hex"00");
+        _;
+    }
+
     function afterAdapterDeployed() internal virtual override {
         adapter.setPeer(SRC_EID, REMOTE_ADAPTER);
 
@@ -51,8 +64,8 @@ contract SynapseBridgeAdapterDstTest is SynapseBridgeAdapterTest {
         bridgeMessage = bridgeMessageLib.encodeBridgeMessage(recipient, remoteToken, amount);
     }
 
-    function deployAdapter() internal virtual override returns (SynapseBridgeAdapter) {
-        return new SynapseBridgeAdapter(endpoint, address(this));
+    function deployAdapter() internal virtual override returns (SynapseBridgeAdapterV2) {
+        return new SynapseBridgeAdapterV2(endpoint, address(this));
     }
 
     function endpointCallsLzReceive() internal {
@@ -68,6 +81,22 @@ contract SynapseBridgeAdapterDstTest is SynapseBridgeAdapterTest {
             _executor: executor,
             _extraData: ""
         });
+    }
+
+    function useHyperCoreMessage() internal {
+        bridgeMessage = hyperCoreMessageLib.encodeHyperCoreMessage(recipient, remoteToken, amount);
+    }
+
+    function mockCoreUser(address user, bool exists) internal {
+        vm.mockCall(composer.CORE_USER_EXISTS_PRECOMPILE(), abi.encode(user), abi.encode(exists));
+    }
+
+    function mockSpotBalance(uint64 total) internal {
+        vm.mockCall(
+            composer.SPOT_BALANCE_PRECOMPILE(),
+            abi.encode(composer.assetBridge(), CORE_INDEX),
+            abi.encode(total, uint64(0), uint64(0))
+        );
     }
 
     // ═══════════════════════════════════════════ TEST: MINT-BURN TOKEN ═══════════════════════════════════════════════
@@ -112,6 +141,99 @@ contract SynapseBridgeAdapterDstTest is SynapseBridgeAdapterTest {
     function test_receive_mintBurn_revert_senderUnknown() public withBridgeSet withMintTokenAdded {
         vm.expectRevert();
         endpointCallsLzReceive(SRC_EID, keccak256("Unknown"));
+    }
+
+    // ═════════════════════════════════════════ TEST: HYPERCORE DELIVERY ═════════════════════════════════════════════
+
+    function test_receiveHyperCore_mintBurn() public withBridgeSet withMintTokenAdded withHyperCoreComposerSet {
+        useHyperCoreMessage();
+        mockCoreUser(address(composer), true);
+        mockCoreUser(recipient, true);
+        mockSpotBalance(type(uint64).max);
+
+        bytes memory payload =
+            abi.encodePacked(composer.SPOT_SEND_HEADER(), abi.encode(recipient, CORE_INDEX, CORE_AMOUNT));
+        vm.expectCall({
+            callee: bridge,
+            data: abi.encodeCall(SynapseBridgeMock.mint, (address(composer), address(token), amount, 0, MOCK_GUID))
+        });
+        vm.expectCall(composer.CORE_WRITER(), abi.encodeCall(ICoreWriter.sendRawAction, (payload)));
+
+        endpointCallsLzReceive();
+
+        assertEq(token.totalSupply(), amount);
+        assertEq(token.balanceOf(address(composer)), 0);
+        assertEq(token.balanceOf(composer.assetBridge()), amount);
+        assertEq(token.balanceOf(recipient), 0);
+    }
+
+    function test_receiveHyperCore_revert_composerNotSet() public withBridgeSet withMintTokenAdded {
+        useHyperCoreMessage();
+        expectRevertHyperCoreComposerNotSet(address(token));
+        endpointCallsLzReceive();
+        assertEq(token.totalSupply(), 0);
+    }
+
+    function test_receiveHyperCore_revert_capacity_rollsBackMint()
+        public
+        withBridgeSet
+        withMintTokenAdded
+        withHyperCoreComposerSet
+    {
+        useHyperCoreMessage();
+        mockCoreUser(address(composer), true);
+        mockCoreUser(recipient, true);
+        mockSpotBalance(CORE_AMOUNT - 1);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                SynapseHyperCoreComposer.SHCC__AssetBridgeCapacityInsufficient.selector, CORE_AMOUNT - 1, CORE_AMOUNT
+            )
+        );
+
+        endpointCallsLzReceive();
+
+        assertEq(token.totalSupply(), 0);
+        assertEq(token.balanceOf(address(composer)), 0);
+        assertEq(token.balanceOf(composer.assetBridge()), 0);
+    }
+
+    function test_receiveHyperCore_revert_recipientNotActivated_rollsBackMint()
+        public
+        withBridgeSet
+        withMintTokenAdded
+        withHyperCoreComposerSet
+    {
+        useHyperCoreMessage();
+        mockCoreUser(address(composer), true);
+        mockCoreUser(recipient, false);
+        vm.expectRevert(abi.encodeWithSelector(SynapseHyperCoreComposer.SHCC__CoreUserNotActivated.selector, recipient));
+
+        endpointCallsLzReceive();
+
+        assertEq(token.totalSupply(), 0);
+        assertEq(token.balanceOf(address(composer)), 0);
+        assertEq(token.balanceOf(composer.assetBridge()), 0);
+    }
+
+    function test_receiveHyperCore_revert_dust_rollsBackMint()
+        public
+        withBridgeSet
+        withMintTokenAdded
+        withHyperCoreComposerSet
+    {
+        amount += 1;
+        useHyperCoreMessage();
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                SynapseHyperCoreComposer.SHCC__AmountNotRepresentable.selector, amount, composer.AMOUNT_SCALE()
+            )
+        );
+
+        endpointCallsLzReceive();
+
+        assertEq(token.totalSupply(), 0);
+        assertEq(token.balanceOf(address(composer)), 0);
+        assertEq(token.balanceOf(composer.assetBridge()), 0);
     }
 
     // ═══════════════════════════════════════ TEST: WITHDRAW-DEPOSIT TOKEN ════════════════════════════════════════════

--- a/packages/contracts-adapter/test/SBA.Dst.t.sol
+++ b/packages/contracts-adapter/test/SBA.Dst.t.sol
@@ -158,10 +158,42 @@ contract SynapseBridgeAdapterDstTest is SynapseBridgeAdapterTest {
             data: abi.encodeCall(SynapseBridgeMock.mint, (address(composer), address(token), amount, 0, MOCK_GUID))
         });
         vm.expectCall(composer.CORE_WRITER(), abi.encodeCall(ICoreWriter.sendRawAction, (payload)));
+        expectEventTokenReceivedOnHyperCore(SRC_EID, recipient, address(token), amount, MOCK_GUID);
+        expectEventTokenReceived(SRC_EID, recipient, address(token), amount, MOCK_GUID);
 
         endpointCallsLzReceive();
 
         assertEq(token.totalSupply(), amount);
+        assertEq(token.balanceOf(address(composer)), 0);
+        assertEq(token.balanceOf(composer.assetBridge()), amount);
+        assertEq(token.balanceOf(recipient), 0);
+    }
+
+    function test_receiveHyperCore_withdrawDeposit()
+        public
+        withBridgeSet
+        withWithdrawTokenAdded
+        withHyperCoreComposerSet
+    {
+        useHyperCoreMessage();
+        token.mintTestTokens(bridge, amount);
+        mockCoreUser(address(composer), true);
+        mockCoreUser(recipient, true);
+        mockSpotBalance(type(uint64).max);
+
+        bytes memory payload =
+            abi.encodePacked(composer.SPOT_SEND_HEADER(), abi.encode(recipient, CORE_INDEX, CORE_AMOUNT));
+        vm.expectCall({
+            callee: bridge,
+            data: abi.encodeCall(SynapseBridgeMock.withdraw, (address(composer), address(token), amount, 0, MOCK_GUID))
+        });
+        vm.expectCall(composer.CORE_WRITER(), abi.encodeCall(ICoreWriter.sendRawAction, (payload)));
+        expectEventTokenReceivedOnHyperCore(SRC_EID, recipient, address(token), amount, MOCK_GUID);
+        expectEventTokenReceived(SRC_EID, recipient, address(token), amount, MOCK_GUID);
+
+        endpointCallsLzReceive();
+
+        assertEq(token.balanceOf(bridge), 0);
         assertEq(token.balanceOf(address(composer)), 0);
         assertEq(token.balanceOf(composer.assetBridge()), amount);
         assertEq(token.balanceOf(recipient), 0);
@@ -239,6 +271,7 @@ contract SynapseBridgeAdapterDstTest is SynapseBridgeAdapterTest {
     // ═══════════════════════════════════════ TEST: WITHDRAW-DEPOSIT TOKEN ════════════════════════════════════════════
 
     function test_receive_withdrawDeposit() public withBridgeSet withWithdrawTokenAdded {
+        token.mintTestTokens(bridge, amount);
         // Expected action: bridge.withdraw
         vm.expectCall({
             callee: bridge,
@@ -247,6 +280,8 @@ contract SynapseBridgeAdapterDstTest is SynapseBridgeAdapterTest {
         // Expected event
         expectEventTokenReceived(SRC_EID, recipient, address(token), amount, MOCK_GUID);
         endpointCallsLzReceive();
+        assertEq(token.balanceOf(bridge), 0);
+        assertEq(token.balanceOf(recipient), amount);
     }
 
     function test_receive_withdrawDeposit_revert_bridgeNotSet() public withWithdrawTokenAdded {

--- a/packages/contracts-adapter/test/SBA.Management.t.sol
+++ b/packages/contracts-adapter/test/SBA.Management.t.sol
@@ -398,6 +398,16 @@ contract SynapseBridgeAdapterManagementTest is SynapseBridgeAdapterTest {
         adapter.setHyperCoreComposer(address(hyperCoreToken), address(composer));
     }
 
+    function test_setHyperCoreComposer_revert_invalidTokenBinding() public {
+        addToken(address(hyperCoreToken), ISynapseBridgeAdapter.TokenType.MintBurn, firstRemoteToken);
+        TestToken differentToken = new TestToken();
+        SynapseHyperCoreComposer composer =
+            new SynapseHyperCoreComposer(address(adapter), address(differentToken), 1337);
+        vm.expectRevert(abi.encodeWithSelector(SBAV2__HyperCoreComposerInvalid.selector, address(composer)));
+        vm.prank(owner);
+        adapter.setHyperCoreComposer(address(hyperCoreToken), address(composer));
+    }
+
     function test_setHyperCoreComposer_revert_notContract() public {
         addToken(address(hyperCoreToken), ISynapseBridgeAdapter.TokenType.MintBurn, firstRemoteToken);
         address composer = makeAddr("Composer");

--- a/packages/contracts-adapter/test/SBA.Management.t.sol
+++ b/packages/contracts-adapter/test/SBA.Management.t.sol
@@ -42,7 +42,10 @@ contract SynapseBridgeAdapterManagementTest is SynapseBridgeAdapterTest {
         address token_,
         ISynapseBridgeAdapter.TokenType tokenType_,
         ISynapseBridgeAdapter.RemoteToken[] memory remoteTokens_
-    ) internal view {
+    )
+        internal
+        view
+    {
         // Check token type by address
         ISynapseBridgeAdapter.TokenType adapterTokenType = adapter.getTokenType(token_);
         assertEq(uint8(adapterTokenType), uint8(tokenType_));
@@ -73,7 +76,9 @@ contract SynapseBridgeAdapterManagementTest is SynapseBridgeAdapterTest {
         address token_,
         ISynapseBridgeAdapter.TokenType tokenType_,
         ISynapseBridgeAdapter.RemoteToken[] memory remoteTokens_
-    ) internal {
+    )
+        internal
+    {
         vm.prank(owner);
         adapter.addToken(token_, tokenType_, remoteTokens_);
     }

--- a/packages/contracts-adapter/test/SBA.Management.t.sol
+++ b/packages/contracts-adapter/test/SBA.Management.t.sol
@@ -1,8 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.24;
 
+import {SynapseHyperCoreComposer} from "../src/SynapseHyperCoreComposer.sol";
 import {ISynapseBridgeAdapter} from "../src/interfaces/ISynapseBridgeAdapter.sol";
-import {SynapseBridgeAdapter, SynapseBridgeAdapterTest} from "./SBA.t.sol";
+import {SynapseBridgeAdapterTest, SynapseBridgeAdapterV2} from "./SBA.t.sol";
+
+import {TestToken} from "./mocks/TestToken.sol";
+import {TestTokenDecimals} from "./mocks/TestTokenDecimals.sol";
 
 // solhint-disable func-name-mixedcase, ordering
 contract SynapseBridgeAdapterManagementTest is SynapseBridgeAdapterTest {
@@ -13,6 +17,7 @@ contract SynapseBridgeAdapterManagementTest is SynapseBridgeAdapterTest {
     bytes31 internal symbol = "SYMBOL";
     bytes31 internal anotherSymbol = "ANOTHERSYMBOL";
     string internal readableSymbol = "SYMBOL";
+    TestToken internal hyperCoreToken;
 
     mapping(uint32 eid => address token) internal mockRemoteAddressMap;
     ISynapseBridgeAdapter.RemoteToken[] internal allRemoteTokens;
@@ -26,20 +31,18 @@ contract SynapseBridgeAdapterManagementTest is SynapseBridgeAdapterTest {
         allRemoteTokens.push(ISynapseBridgeAdapter.RemoteToken(OTHER_DST_EID, mockRemoteAddressMap[OTHER_DST_EID]));
         firstRemoteToken.push(allRemoteTokens[0]);
         secondRemoteToken.push(allRemoteTokens[1]);
+        hyperCoreToken = new TestToken();
     }
 
-    function deployAdapter() internal virtual override returns (SynapseBridgeAdapter) {
-        return new SynapseBridgeAdapter(endpoint, owner);
+    function deployAdapter() internal virtual override returns (SynapseBridgeAdapterV2) {
+        return new SynapseBridgeAdapterV2(endpoint, owner);
     }
 
     function checkTokenAdded(
         address token_,
         ISynapseBridgeAdapter.TokenType tokenType_,
         ISynapseBridgeAdapter.RemoteToken[] memory remoteTokens_
-    )
-        internal
-        view
-    {
+    ) internal view {
         // Check token type by address
         ISynapseBridgeAdapter.TokenType adapterTokenType = adapter.getTokenType(token_);
         assertEq(uint8(adapterTokenType), uint8(tokenType_));
@@ -59,6 +62,9 @@ contract SynapseBridgeAdapterManagementTest is SynapseBridgeAdapterTest {
         assertEq(adapter.owner(), owner);
         assertEq(adapter.bridge(), address(0));
         assertEq(adapter.MIN_GAS_LIMIT(), 200_000);
+        assertEq(adapter.SYN_EVM_DECIMALS(), 18);
+        assertEq(adapter.SYN_CORE_DECIMALS(), 8);
+        assertEq(adapter.SYN_AMOUNT_SCALE(), 1e10);
     }
 
     // ═════════════════════════════════════════════════ ADD TOKEN ═════════════════════════════════════════════════════
@@ -67,9 +73,7 @@ contract SynapseBridgeAdapterManagementTest is SynapseBridgeAdapterTest {
         address token_,
         ISynapseBridgeAdapter.TokenType tokenType_,
         ISynapseBridgeAdapter.RemoteToken[] memory remoteTokens_
-    )
-        internal
-    {
+    ) internal {
         vm.prank(owner);
         adapter.addToken(token_, tokenType_, remoteTokens_);
     }
@@ -319,5 +323,107 @@ contract SynapseBridgeAdapterManagementTest is SynapseBridgeAdapterTest {
         expectRevertZeroAddress();
         vm.prank(owner);
         adapter.setBridge(address(0));
+    }
+
+    // ══════════════════════════════════════════ SET HYPERCORE DECIMALS ══════════════════════════════════════════════
+
+    function test_setHyperCoreDecimals() public {
+        addToken(address(hyperCoreToken), ISynapseBridgeAdapter.TokenType.MintBurn, firstRemoteToken);
+        vm.expectEmit(address(adapter));
+        emit HyperCoreDecimalsSet(DST_EID, address(hyperCoreToken), 18, 8, 1e10);
+        vm.prank(owner);
+        adapter.setHyperCoreDecimals(DST_EID, address(hyperCoreToken), 8);
+        assertEq(adapter.getHyperCoreAmountScale(DST_EID, address(hyperCoreToken)), 1e10);
+    }
+
+    function test_setHyperCoreDecimals_revert_invalidDecimals() public {
+        addToken(address(hyperCoreToken), ISynapseBridgeAdapter.TokenType.MintBurn, firstRemoteToken);
+        vm.expectRevert(abi.encodeWithSelector(SBAV2__HyperCoreDecimalsInvalid.selector, 18, 19));
+        vm.prank(owner);
+        adapter.setHyperCoreDecimals(DST_EID, address(hyperCoreToken), 19);
+    }
+
+    function test_setHyperCoreDecimals_revert_invalidTokenDecimals() public {
+        TestTokenDecimals invalidToken = new TestTokenDecimals(6);
+        addToken(address(invalidToken), ISynapseBridgeAdapter.TokenType.MintBurn, firstRemoteToken);
+        vm.expectRevert(abi.encodeWithSelector(SBAV2__HyperCoreDecimalsInvalid.selector, 6, 8));
+        vm.prank(owner);
+        adapter.setHyperCoreDecimals(DST_EID, address(invalidToken), 8);
+    }
+
+    function test_setHyperCoreDecimals_revert_alreadySet() public {
+        addToken(address(hyperCoreToken), ISynapseBridgeAdapter.TokenType.MintBurn, firstRemoteToken);
+        vm.startPrank(owner);
+        adapter.setHyperCoreDecimals(DST_EID, address(hyperCoreToken), 8);
+        vm.expectRevert(
+            abi.encodeWithSelector(SBAV2__HyperCoreDecimalsAlreadySet.selector, DST_EID, address(hyperCoreToken))
+        );
+        adapter.setHyperCoreDecimals(DST_EID, address(hyperCoreToken), 8);
+        vm.stopPrank();
+    }
+
+    function test_setHyperCoreDecimals_revert_remotePairNotSet() public {
+        addToken(address(hyperCoreToken), ISynapseBridgeAdapter.TokenType.MintBurn, firstRemoteToken);
+        expectRevertRemotePairNotSet(OTHER_DST_EID, address(hyperCoreToken));
+        vm.prank(owner);
+        adapter.setHyperCoreDecimals(OTHER_DST_EID, address(hyperCoreToken), 8);
+    }
+
+    function test_setHyperCoreDecimals_revert_notOwner(address caller) public {
+        vm.assume(caller != owner);
+        addToken(address(hyperCoreToken), ISynapseBridgeAdapter.TokenType.MintBurn, firstRemoteToken);
+        expectRevertCallerNotOwner(caller);
+        vm.prank(caller);
+        adapter.setHyperCoreDecimals(DST_EID, address(hyperCoreToken), 8);
+    }
+
+    // ══════════════════════════════════════════ SET HYPERCORE COMPOSER ══════════════════════════════════════════════
+
+    function test_setHyperCoreComposer() public {
+        addToken(address(hyperCoreToken), ISynapseBridgeAdapter.TokenType.MintBurn, firstRemoteToken);
+        SynapseHyperCoreComposer composer =
+            new SynapseHyperCoreComposer(address(adapter), address(hyperCoreToken), 1337);
+        vm.expectEmit(address(adapter));
+        emit HyperCoreComposerSet(address(hyperCoreToken), address(composer));
+        vm.prank(owner);
+        adapter.setHyperCoreComposer(address(hyperCoreToken), address(composer));
+        assertEq(adapter.getHyperCoreComposer(address(hyperCoreToken)), address(composer));
+    }
+
+    function test_setHyperCoreComposer_revert_invalidBinding() public {
+        addToken(address(hyperCoreToken), ISynapseBridgeAdapter.TokenType.MintBurn, firstRemoteToken);
+        SynapseHyperCoreComposer composer = new SynapseHyperCoreComposer(address(this), address(hyperCoreToken), 1337);
+        vm.expectRevert(abi.encodeWithSelector(SBAV2__HyperCoreComposerInvalid.selector, address(composer)));
+        vm.prank(owner);
+        adapter.setHyperCoreComposer(address(hyperCoreToken), address(composer));
+    }
+
+    function test_setHyperCoreComposer_revert_notContract() public {
+        addToken(address(hyperCoreToken), ISynapseBridgeAdapter.TokenType.MintBurn, firstRemoteToken);
+        address composer = makeAddr("Composer");
+        vm.expectRevert(abi.encodeWithSelector(SBAV2__HyperCoreComposerInvalid.selector, composer));
+        vm.prank(owner);
+        adapter.setHyperCoreComposer(address(hyperCoreToken), composer);
+    }
+
+    function test_setHyperCoreComposer_revert_alreadySet() public {
+        addToken(address(hyperCoreToken), ISynapseBridgeAdapter.TokenType.MintBurn, firstRemoteToken);
+        SynapseHyperCoreComposer composer =
+            new SynapseHyperCoreComposer(address(adapter), address(hyperCoreToken), 1337);
+        vm.startPrank(owner);
+        adapter.setHyperCoreComposer(address(hyperCoreToken), address(composer));
+        vm.expectRevert(abi.encodeWithSelector(SBAV2__HyperCoreComposerAlreadySet.selector, address(hyperCoreToken)));
+        adapter.setHyperCoreComposer(address(hyperCoreToken), address(composer));
+        vm.stopPrank();
+    }
+
+    function test_setHyperCoreComposer_revert_notOwner(address caller) public {
+        vm.assume(caller != owner);
+        addToken(address(hyperCoreToken), ISynapseBridgeAdapter.TokenType.MintBurn, firstRemoteToken);
+        SynapseHyperCoreComposer composer =
+            new SynapseHyperCoreComposer(address(adapter), address(hyperCoreToken), 1337);
+        expectRevertCallerNotOwner(caller);
+        vm.prank(caller);
+        adapter.setHyperCoreComposer(address(hyperCoreToken), address(composer));
     }
 }

--- a/packages/contracts-adapter/test/SBA.Src.t.sol
+++ b/packages/contracts-adapter/test/SBA.Src.t.sol
@@ -21,7 +21,7 @@ contract SynapseBridgeAdapterSrcTest is SynapseBridgeAdapterTest {
     address internal user = makeAddr("User");
     address internal recipient = makeAddr("Recipient");
     uint256 internal initialBalance = 1 ether;
-    uint256 internal amount = 0.123456 ether;
+    uint256 internal amount = 0.123_456 ether;
     uint64 internal gasLimit = 234_567;
     uint256 internal nativeFee = 123_456_789 wei;
     uint64 internal minGasLimit;

--- a/packages/contracts-adapter/test/SBA.Src.t.sol
+++ b/packages/contracts-adapter/test/SBA.Src.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.24;
 
-import {ISynapseBridgeAdapter, SynapseBridgeAdapter, SynapseBridgeAdapterTest} from "./SBA.t.sol";
+import {ISynapseBridgeAdapter, SynapseBridgeAdapterTest, SynapseBridgeAdapterV2} from "./SBA.t.sol";
 
 import {SynapseBridgeMock} from "./mocks/SynapseBridgeMock.sol";
 import {ERC20, TestToken} from "./mocks/TestToken.sol";
@@ -31,6 +31,7 @@ contract SynapseBridgeAdapterSrcTest is SynapseBridgeAdapterTest {
     bytes internal expectedOptions = hex"00030100110100000000000000000000000000039447";
 
     bytes internal expectedBridgeMessage;
+    bytes internal expectedHyperCoreMessage;
 
     modifier withBridgeSet() {
         adapter.setBridge(bridge);
@@ -55,6 +56,11 @@ contract SynapseBridgeAdapterSrcTest is SynapseBridgeAdapterTest {
         _;
     }
 
+    modifier withHyperCoreDecimalsSet() {
+        adapter.setHyperCoreDecimals(DST_EID, address(token), 8);
+        _;
+    }
+
     function afterAdapterDeployed() internal virtual override {
         adapter.setPeer(DST_EID, REMOTE_ADAPTER);
         minGasLimit = adapter.MIN_GAS_LIMIT();
@@ -67,17 +73,23 @@ contract SynapseBridgeAdapterSrcTest is SynapseBridgeAdapterTest {
         token.approve(address(adapter), type(uint256).max);
 
         expectedBridgeMessage = bridgeMessageLib.encodeBridgeMessage(recipient, address(token), amount);
+        expectedHyperCoreMessage = hyperCoreMessageLib.encodeHyperCoreMessage(recipient, address(token), amount);
 
         mockSendReceipt();
     }
 
-    function deployAdapter() internal virtual override returns (SynapseBridgeAdapter) {
-        return new SynapseBridgeAdapter(endpoint, address(this));
+    function deployAdapter() internal virtual override returns (SynapseBridgeAdapterV2) {
+        return new SynapseBridgeAdapterV2(endpoint, address(this));
     }
 
     function userBridgesToken() internal {
         vm.prank({msgSender: user, txOrigin: user});
         adapter.bridgeERC20{value: nativeFee}(DST_EID, recipient, address(token), amount, gasLimit);
+    }
+
+    function userBridgesTokenToHyperCore() internal {
+        vm.prank({msgSender: user, txOrigin: user});
+        adapter.bridgeERC20ToHyperCore{value: nativeFee}(DST_EID, recipient, address(token), amount, gasLimit);
     }
 
     function mockSendReceipt() internal {
@@ -194,13 +206,112 @@ contract SynapseBridgeAdapterSrcTest is SynapseBridgeAdapterTest {
         adapter.bridgeERC20{value: nativeFee}(DST_EID, recipient, address(token), amount, minGasLimit - 1);
     }
 
+    // ═════════════════════════════════════════ TEST: HYPERCORE DELIVERY ═════════════════════════════════════════════
+
+    function test_bridgeToHyperCore_mintBurn() public withBridgeSet withMintTokenAdded withHyperCoreDecimalsSet {
+        vm.expectCall({callee: address(token), data: abi.encodeCall(TestToken.burnFrom, (user, amount))});
+        vm.expectCall({
+            callee: endpoint,
+            msgValue: nativeFee,
+            data: abi.encodeCall(
+                ILayerZeroEndpointV2.send,
+                (
+                    MessagingParams({
+                        dstEid: DST_EID,
+                        receiver: REMOTE_ADAPTER,
+                        message: expectedHyperCoreMessage,
+                        options: expectedOptions,
+                        payInLzToken: false
+                    }),
+                    user
+                )
+            )
+        });
+        expectEventTokenSent(DST_EID, recipient, address(token), amount, MOCK_GUID);
+        expectEventTokenSentToHyperCore(DST_EID, recipient, address(token), amount, MOCK_GUID);
+
+        userBridgesTokenToHyperCore();
+
+        assertEq(token.balanceOf(user), initialBalance - amount);
+        assertEq(token.totalSupply(), initialBalance - amount);
+    }
+
+    function test_bridgeToHyperCore_withdrawDeposit()
+        public
+        withBridgeSet
+        withWithdrawTokenAdded
+        withHyperCoreDecimalsSet
+    {
+        vm.expectCall({
+            callee: address(token), data: abi.encodeCall(ERC20.transferFrom, (user, address(bridge), amount))
+        });
+        vm.expectCall({
+            callee: endpoint,
+            msgValue: nativeFee,
+            data: abi.encodeCall(
+                ILayerZeroEndpointV2.send,
+                (
+                    MessagingParams({
+                        dstEid: DST_EID,
+                        receiver: REMOTE_ADAPTER,
+                        message: expectedHyperCoreMessage,
+                        options: expectedOptions,
+                        payInLzToken: false
+                    }),
+                    user
+                )
+            )
+        });
+        expectEventTokenSent(DST_EID, recipient, address(token), amount, MOCK_GUID);
+        expectEventTokenSentToHyperCore(DST_EID, recipient, address(token), amount, MOCK_GUID);
+
+        userBridgesTokenToHyperCore();
+
+        assertEq(token.balanceOf(user), initialBalance - amount);
+        assertEq(token.balanceOf(bridge), amount);
+        assertEq(token.totalSupply(), initialBalance);
+    }
+
+    function test_bridgeToHyperCore_revert_decimalsNotSet() public withBridgeSet withMintTokenAdded {
+        expectRevertHyperCoreDecimalsNotSet(DST_EID, address(token));
+        userBridgesTokenToHyperCore();
+        assertEq(token.balanceOf(user), initialBalance);
+        assertEq(token.totalSupply(), initialBalance);
+    }
+
+    function test_bridgeToHyperCore_revert_dustBeforeBurn()
+        public
+        withBridgeSet
+        withMintTokenAdded
+        withHyperCoreDecimalsSet
+    {
+        amount += 1;
+        expectRevertHyperCoreAmountNotRepresentable(amount, 1e10);
+        userBridgesTokenToHyperCore();
+        assertEq(token.balanceOf(user), initialBalance);
+        assertEq(token.totalSupply(), initialBalance);
+    }
+
+    function test_bridgeToHyperCore_revert_amountExceedsUint64BeforeBurn()
+        public
+        withBridgeSet
+        withMintTokenAdded
+        withHyperCoreDecimalsSet
+    {
+        uint256 coreAmount = uint256(type(uint64).max) + 1;
+        amount = coreAmount * 1e10;
+        vm.expectRevert(abi.encodeWithSelector(SBAV2__HyperCoreAmountExceedsUint64.selector, coreAmount));
+        userBridgesTokenToHyperCore();
+        assertEq(token.balanceOf(user), initialBalance);
+        assertEq(token.totalSupply(), initialBalance);
+    }
+
     // ═══════════════════════════════════════ TEST: WITHDRAW-DEPOSIT TOKEN ════════════════════════════════════════════
 
     function test_bridge_withdrawDeposit() public withBridgeSet withWithdrawTokenAdded {
         // Expected token action: transfer from user to bridge
         vm.expectCall({
-            callee: address(token),
-            data: abi.encodeCall(ERC20.transferFrom, (user, address(bridge), amount))
+            callee: address(token), data: abi.encodeCall(ERC20.transferFrom, (user, address(bridge), amount))
         });
         // Expected bridge message
         vm.expectCall({
@@ -269,11 +380,7 @@ contract SynapseBridgeAdapterSrcTest is SynapseBridgeAdapterTest {
         adapter.bridgeERC20{value: nativeFee}(UNKNOWN_EID, recipient, address(token), amount, gasLimit);
     }
 
-    function test_bridge_withdrawDeposit_revert_eidUnknown_withPeerAdded()
-        public
-        withBridgeSet
-        withWithdrawTokenAdded
-    {
+    function test_bridge_withdrawDeposit_revert_eidUnknown_withPeerAdded() public withBridgeSet withWithdrawTokenAdded {
         adapter.setPeer(UNKNOWN_EID, REMOTE_ADAPTER);
         expectRevertRemotePairNotSet(UNKNOWN_EID, address(token));
         vm.prank({msgSender: user, txOrigin: user});
@@ -336,5 +443,41 @@ contract SynapseBridgeAdapterSrcTest is SynapseBridgeAdapterTest {
     function test_getNativeFee_revert_gasLimitBelowMinimum() public {
         expectRevertGasLimitBelowMinimum();
         adapter.getNativeFee(DST_EID, minGasLimit - 1);
+    }
+
+    function test_getNativeFeeToHyperCore() public withMintTokenAdded withHyperCoreDecimalsSet {
+        bytes memory mockMessage = hyperCoreMessageLib.encodeHyperCoreMessage(address(0), address(token), 0);
+        vm.mockCall({
+            callee: endpoint,
+            data: abi.encodeCall(
+                ILayerZeroEndpointV2.quote,
+                (
+                    MessagingParams({
+                        dstEid: DST_EID,
+                        receiver: REMOTE_ADAPTER,
+                        message: mockMessage,
+                        options: expectedOptions,
+                        payInLzToken: false
+                    }),
+                    address(adapter)
+                )
+            ),
+            returnData: abi.encode(MessagingFee({nativeFee: nativeFee, lzTokenFee: 0}))
+        });
+        assertEq(adapter.getNativeFeeToHyperCore(DST_EID, address(token), gasLimit), nativeFee);
+    }
+
+    function test_getNativeFeeToHyperCore_revert_decimalsNotSet() public {
+        expectRevertHyperCoreDecimalsNotSet(DST_EID, address(token));
+        adapter.getNativeFeeToHyperCore(DST_EID, address(token), gasLimit);
+    }
+
+    function test_getNativeFeeToHyperCore_revert_gasLimitBelowMinimum()
+        public
+        withMintTokenAdded
+        withHyperCoreDecimalsSet
+    {
+        expectRevertGasLimitBelowMinimum();
+        adapter.getNativeFeeToHyperCore(DST_EID, address(token), minGasLimit - 1);
     }
 }

--- a/packages/contracts-adapter/test/SBA.t.sol
+++ b/packages/contracts-adapter/test/SBA.t.sol
@@ -71,7 +71,9 @@ abstract contract SynapseBridgeAdapterTest is Test, ISynapseBridgeAdapterErrors,
         address token,
         ISynapseBridgeAdapter.TokenType tokenType,
         ISynapseBridgeAdapter.RemoteToken[] memory remoteTokens
-    ) internal {
+    )
+        internal
+    {
         vm.expectEmit(address(adapter));
         emit TokenAdded(token, tokenType, remoteTokens);
     }
@@ -81,7 +83,13 @@ abstract contract SynapseBridgeAdapterTest is Test, ISynapseBridgeAdapterErrors,
         emit TokenSent(dstEid, to, token, amount, guid);
     }
 
-    function expectEventTokenSentToHyperCore(uint32 dstEid, address to, address token, uint256 amount, bytes32 guid)
+    function expectEventTokenSentToHyperCore(
+        uint32 dstEid,
+        address to,
+        address token,
+        uint256 amount,
+        bytes32 guid
+    )
         internal
     {
         vm.expectEmit(address(adapter));
@@ -93,7 +101,13 @@ abstract contract SynapseBridgeAdapterTest is Test, ISynapseBridgeAdapterErrors,
         emit TokenReceived(srcEid, to, token, amount, guid);
     }
 
-    function expectEventTokenReceivedOnHyperCore(uint32 srcEid, address to, address token, uint256 amount, bytes32 guid)
+    function expectEventTokenReceivedOnHyperCore(
+        uint32 srcEid,
+        address to,
+        address token,
+        uint256 amount,
+        bytes32 guid
+    )
         internal
     {
         vm.expectEmit(address(adapter));
@@ -173,7 +187,10 @@ abstract contract SynapseBridgeAdapterTest is Test, ISynapseBridgeAdapterErrors,
         arr[0] = a;
     }
 
-    function toArray(ISynapseBridgeAdapter.RemoteToken memory a, ISynapseBridgeAdapter.RemoteToken memory b)
+    function toArray(
+        ISynapseBridgeAdapter.RemoteToken memory a,
+        ISynapseBridgeAdapter.RemoteToken memory b
+    )
         internal
         pure
         returns (ISynapseBridgeAdapter.RemoteToken[] memory arr)

--- a/packages/contracts-adapter/test/SBA.t.sol
+++ b/packages/contracts-adapter/test/SBA.t.sol
@@ -1,18 +1,20 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.24;
 
-import {SynapseBridgeAdapter} from "../src/SynapseBridgeAdapter.sol";
+import {SynapseBridgeAdapterV2} from "../src/SynapseBridgeAdapterV2.sol";
 import {ISynapseBridgeAdapter} from "../src/interfaces/ISynapseBridgeAdapter.sol";
 import {ISynapseBridgeAdapterErrors} from "../src/interfaces/ISynapseBridgeAdapterErrors.sol";
+import {ISynapseBridgeAdapterV2Errors} from "../src/interfaces/ISynapseBridgeAdapterV2Errors.sol";
 
 import {BridgeMessageHarness} from "./harnesses/BridgeMessageHarness.sol";
+import {HyperCoreMessageHarness} from "./harnesses/HyperCoreMessageHarness.sol";
 import {EndpointMock} from "./mocks/EndpointMock.sol";
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {Test} from "forge-std/Test.sol";
 
 // solhint-disable no-empty-blocks
-abstract contract SynapseBridgeAdapterTest is Test, ISynapseBridgeAdapterErrors {
+abstract contract SynapseBridgeAdapterTest is Test, ISynapseBridgeAdapterErrors, ISynapseBridgeAdapterV2Errors {
     uint32 internal constant SRC_EID = 1;
     uint32 internal constant DST_EID = 2;
     uint32 internal constant OTHER_DST_EID = 3;
@@ -22,26 +24,38 @@ abstract contract SynapseBridgeAdapterTest is Test, ISynapseBridgeAdapterErrors 
 
     address internal remoteToken = makeAddr("Remote Token");
 
-    SynapseBridgeAdapter internal adapter;
+    SynapseBridgeAdapterV2 internal adapter;
     address internal endpoint;
 
     BridgeMessageHarness internal bridgeMessageLib;
+    HyperCoreMessageHarness internal hyperCoreMessageLib;
 
     event BridgeSet(address bridge);
+    event HyperCoreComposerSet(address indexed token, address indexed composer);
+    event HyperCoreDecimalsSet(
+        uint32 indexed dstEid, address indexed token, uint8 tokenDecimals, uint8 coreDecimals, uint256 amountScale
+    );
     event TokenAdded(
         address token, ISynapseBridgeAdapter.TokenType tokenType, ISynapseBridgeAdapter.RemoteToken[] remoteTokens
     );
     event TokenSent(uint32 indexed dstEid, address indexed to, address indexed token, uint256 amount, bytes32 guid);
+    event TokenSentToHyperCore(
+        uint32 indexed dstEid, address indexed to, address indexed token, uint256 amount, bytes32 guid
+    );
     event TokenReceived(uint32 indexed srcEid, address indexed to, address indexed token, uint256 amount, bytes32 guid);
+    event TokenReceivedOnHyperCore(
+        uint32 indexed srcEid, address indexed to, address indexed token, uint256 amount, bytes32 guid
+    );
 
     function setUp() public virtual {
         endpoint = deployEndpoint();
         adapter = deployAdapter();
         bridgeMessageLib = new BridgeMessageHarness();
+        hyperCoreMessageLib = new HyperCoreMessageHarness();
         afterAdapterDeployed();
     }
 
-    function deployAdapter() internal virtual returns (SynapseBridgeAdapter);
+    function deployAdapter() internal virtual returns (SynapseBridgeAdapterV2);
     function afterAdapterDeployed() internal virtual {}
 
     function deployEndpoint() internal virtual returns (address) {
@@ -57,9 +71,7 @@ abstract contract SynapseBridgeAdapterTest is Test, ISynapseBridgeAdapterErrors 
         address token,
         ISynapseBridgeAdapter.TokenType tokenType,
         ISynapseBridgeAdapter.RemoteToken[] memory remoteTokens
-    )
-        internal
-    {
+    ) internal {
         vm.expectEmit(address(adapter));
         emit TokenAdded(token, tokenType, remoteTokens);
     }
@@ -69,17 +81,23 @@ abstract contract SynapseBridgeAdapterTest is Test, ISynapseBridgeAdapterErrors 
         emit TokenSent(dstEid, to, token, amount, guid);
     }
 
-    function expectEventTokenReceived(
-        uint32 srcEid,
-        address to,
-        address token,
-        uint256 amount,
-        bytes32 guid
-    )
+    function expectEventTokenSentToHyperCore(uint32 dstEid, address to, address token, uint256 amount, bytes32 guid)
         internal
     {
         vm.expectEmit(address(adapter));
+        emit TokenSentToHyperCore(dstEid, to, token, amount, guid);
+    }
+
+    function expectEventTokenReceived(uint32 srcEid, address to, address token, uint256 amount, bytes32 guid) internal {
+        vm.expectEmit(address(adapter));
         emit TokenReceived(srcEid, to, token, amount, guid);
+    }
+
+    function expectEventTokenReceivedOnHyperCore(uint32 srcEid, address to, address token, uint256 amount, bytes32 guid)
+        internal
+    {
+        vm.expectEmit(address(adapter));
+        emit TokenReceivedOnHyperCore(srcEid, to, token, amount, guid);
     }
 
     function expectRevertCallerNotOwner(address caller) internal {
@@ -96,6 +114,18 @@ abstract contract SynapseBridgeAdapterTest is Test, ISynapseBridgeAdapterErrors 
 
     function expectRevertGasLimitBelowMinimum() internal {
         vm.expectRevert(SBA__GasLimitBelowMinimum.selector);
+    }
+
+    function expectRevertHyperCoreAmountNotRepresentable(uint256 amount, uint256 scale) internal {
+        vm.expectRevert(abi.encodeWithSelector(SBAV2__HyperCoreAmountNotRepresentable.selector, amount, scale));
+    }
+
+    function expectRevertHyperCoreComposerNotSet(address token) internal {
+        vm.expectRevert(abi.encodeWithSelector(SBAV2__HyperCoreComposerNotSet.selector, token));
+    }
+
+    function expectRevertHyperCoreDecimalsNotSet(uint32 eid, address token) internal {
+        vm.expectRevert(abi.encodeWithSelector(SBAV2__HyperCoreDecimalsNotSet.selector, eid, token));
     }
 
     function expectRevertLocalPairAlreadyExists(uint32 eid, address remoteAddr) internal {
@@ -143,10 +173,7 @@ abstract contract SynapseBridgeAdapterTest is Test, ISynapseBridgeAdapterErrors 
         arr[0] = a;
     }
 
-    function toArray(
-        ISynapseBridgeAdapter.RemoteToken memory a,
-        ISynapseBridgeAdapter.RemoteToken memory b
-    )
+    function toArray(ISynapseBridgeAdapter.RemoteToken memory a, ISynapseBridgeAdapter.RemoteToken memory b)
         internal
         pure
         returns (ISynapseBridgeAdapter.RemoteToken[] memory arr)

--- a/packages/contracts-adapter/test/SynapseHyperCoreComposer.t.sol
+++ b/packages/contracts-adapter/test/SynapseHyperCoreComposer.t.sol
@@ -154,6 +154,19 @@ contract SynapseHyperCoreComposerTest is Test {
         assertEq(token.balanceOf(composer.assetBridge()), EVM_AMOUNT);
     }
 
+    function test_bridgeToHyperCore_sameBlockAggregateCapacity() public {
+        mockCoreUser(address(composer), true);
+        mockCoreUser(recipient, true);
+        mockSpotBalance(CORE_AMOUNT * 2);
+
+        composer.bridgeToHyperCore(recipient, EVM_AMOUNT);
+        token.mintTestTokens(address(composer), EVM_AMOUNT);
+        composer.bridgeToHyperCore(recipient, EVM_AMOUNT);
+
+        assertEq(token.balanceOf(address(composer)), 0);
+        assertEq(token.balanceOf(composer.assetBridge()), EVM_AMOUNT * 2);
+    }
+
     function test_bridgeToHyperCore_reservationResetsNextBlock() public {
         mockCoreUser(address(composer), true);
         mockCoreUser(recipient, true);

--- a/packages/contracts-adapter/test/SynapseHyperCoreComposer.t.sol
+++ b/packages/contracts-adapter/test/SynapseHyperCoreComposer.t.sol
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import {SynapseHyperCoreComposer} from "../src/SynapseHyperCoreComposer.sol";
+import {ICoreWriter} from "../src/interfaces/ICoreWriter.sol";
+
+import {TestToken} from "./mocks/TestToken.sol";
+import {TestTokenDecimals} from "./mocks/TestTokenDecimals.sol";
+
+import {Test} from "forge-std/Test.sol";
+
+// solhint-disable func-name-mixedcase, ordering, max-line-length
+contract SynapseHyperCoreComposerTest is Test {
+    uint64 internal constant CORE_INDEX = 1337;
+    uint64 internal constant CORE_AMOUNT = 123_456_789;
+    uint256 internal constant EVM_AMOUNT = uint256(CORE_AMOUNT) * 1e10;
+
+    address internal recipient = makeAddr("Recipient");
+    TestToken internal token;
+    SynapseHyperCoreComposer internal composer;
+
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    function setUp() public {
+        token = new TestToken();
+        composer = new SynapseHyperCoreComposer(address(this), address(token), CORE_INDEX);
+        token.mintTestTokens(address(composer), EVM_AMOUNT);
+        vm.etch(composer.CORE_WRITER(), hex"00");
+    }
+
+    function test_constructor() public view {
+        assertEq(composer.adapter(), address(this));
+        assertEq(composer.token(), address(token));
+        assertEq(composer.coreIndex(), CORE_INDEX);
+        assertEq(composer.EVM_DECIMALS(), 18);
+        assertEq(composer.CORE_DECIMALS(), 8);
+        assertEq(composer.AMOUNT_SCALE(), 1e10);
+        assertEq(composer.assetBridge(), address(uint160(uint256(uint160(composer.BASE_ASSET_BRIDGE())) + CORE_INDEX)));
+    }
+
+    function test_constructor_revert_zeroAdapter() public {
+        vm.expectRevert(SynapseHyperCoreComposer.SHCC__ZeroAddress.selector);
+        new SynapseHyperCoreComposer(address(0), address(token), CORE_INDEX);
+    }
+
+    function test_constructor_revert_zeroToken() public {
+        vm.expectRevert(SynapseHyperCoreComposer.SHCC__ZeroAddress.selector);
+        new SynapseHyperCoreComposer(address(this), address(0), CORE_INDEX);
+    }
+
+    function test_constructor_revert_invalidTokenDecimals() public {
+        TestTokenDecimals invalidToken = new TestTokenDecimals(6);
+        vm.expectRevert(abi.encodeWithSelector(SynapseHyperCoreComposer.SHCC__InvalidTokenDecimals.selector, 6, 18));
+        new SynapseHyperCoreComposer(address(this), address(invalidToken), CORE_INDEX);
+    }
+
+    function test_bridgeToHyperCore() public {
+        mockCoreUser(address(composer), true);
+        mockCoreUser(recipient, true);
+        mockSpotBalance(CORE_AMOUNT);
+
+        bytes memory payload =
+            abi.encodePacked(composer.SPOT_SEND_HEADER(), abi.encode(recipient, CORE_INDEX, CORE_AMOUNT));
+        vm.expectCall(composer.CORE_WRITER(), abi.encodeCall(ICoreWriter.sendRawAction, (payload)));
+        vm.expectEmit(address(token));
+        emit Transfer(address(composer), composer.assetBridge(), EVM_AMOUNT);
+        vm.expectEmit(address(composer));
+        emit SynapseHyperCoreComposer.HyperCoreTransferQueued(recipient, EVM_AMOUNT, CORE_AMOUNT, CORE_INDEX);
+
+        composer.bridgeToHyperCore(recipient, EVM_AMOUNT);
+
+        assertEq(token.balanceOf(address(composer)), 0);
+        assertEq(token.balanceOf(composer.assetBridge()), EVM_AMOUNT);
+        assertEq(token.balanceOf(recipient), 0);
+    }
+
+    function test_bridgeToHyperCore_revert_onlyAdapter(address caller) public {
+        vm.assume(caller != address(this));
+        vm.expectRevert(abi.encodeWithSelector(SynapseHyperCoreComposer.SHCC__OnlyAdapter.selector, caller));
+        vm.prank(caller);
+        composer.bridgeToHyperCore(recipient, EVM_AMOUNT);
+    }
+
+    function test_bridgeToHyperCore_revert_zeroRecipient() public {
+        vm.expectRevert(SynapseHyperCoreComposer.SHCC__ZeroAddress.selector);
+        composer.bridgeToHyperCore(address(0), EVM_AMOUNT);
+    }
+
+    function test_bridgeToHyperCore_revert_zeroAmount() public {
+        vm.expectRevert(SynapseHyperCoreComposer.SHCC__ZeroAmount.selector);
+        composer.bridgeToHyperCore(recipient, 0);
+    }
+
+    function test_bridgeToHyperCore_revert_dust() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(SynapseHyperCoreComposer.SHCC__AmountNotRepresentable.selector, EVM_AMOUNT + 1, 1e10)
+        );
+        composer.bridgeToHyperCore(recipient, EVM_AMOUNT + 1);
+    }
+
+    function test_bridgeToHyperCore_revert_amountExceedsUint64() public {
+        uint256 coreAmount = uint256(type(uint64).max) + 1;
+        uint256 evmAmount = coreAmount * 1e10;
+        vm.expectRevert(abi.encodeWithSelector(SynapseHyperCoreComposer.SHCC__AmountExceedsUint64.selector, coreAmount));
+        composer.bridgeToHyperCore(recipient, evmAmount);
+    }
+
+    function test_bridgeToHyperCore_revert_composerNotActivated() public {
+        mockCoreUser(address(composer), false);
+        vm.expectRevert(
+            abi.encodeWithSelector(SynapseHyperCoreComposer.SHCC__CoreUserNotActivated.selector, address(composer))
+        );
+        composer.bridgeToHyperCore(recipient, EVM_AMOUNT);
+    }
+
+    function test_bridgeToHyperCore_revert_recipientNotActivated() public {
+        mockCoreUser(address(composer), true);
+        mockCoreUser(recipient, false);
+        vm.expectRevert(abi.encodeWithSelector(SynapseHyperCoreComposer.SHCC__CoreUserNotActivated.selector, recipient));
+        composer.bridgeToHyperCore(recipient, EVM_AMOUNT);
+    }
+
+    function test_bridgeToHyperCore_revert_capacityInsufficient() public {
+        mockCoreUser(address(composer), true);
+        mockCoreUser(recipient, true);
+        mockSpotBalance(CORE_AMOUNT - 1);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                SynapseHyperCoreComposer.SHCC__AssetBridgeCapacityInsufficient.selector, CORE_AMOUNT - 1, CORE_AMOUNT
+            )
+        );
+        composer.bridgeToHyperCore(recipient, EVM_AMOUNT);
+    }
+
+    function test_bridgeToHyperCore_revert_sameBlockAggregateCapacity() public {
+        mockCoreUser(address(composer), true);
+        mockCoreUser(recipient, true);
+        uint64 available = CORE_AMOUNT * 2 - 1;
+        mockSpotBalance(available);
+
+        composer.bridgeToHyperCore(recipient, EVM_AMOUNT);
+        token.mintTestTokens(address(composer), EVM_AMOUNT);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                SynapseHyperCoreComposer.SHCC__AssetBridgeCapacityInsufficient.selector,
+                uint256(available),
+                uint256(CORE_AMOUNT) * 2
+            )
+        );
+        composer.bridgeToHyperCore(recipient, EVM_AMOUNT);
+
+        assertEq(token.balanceOf(address(composer)), EVM_AMOUNT);
+        assertEq(token.balanceOf(composer.assetBridge()), EVM_AMOUNT);
+    }
+
+    function test_bridgeToHyperCore_reservationResetsNextBlock() public {
+        mockCoreUser(address(composer), true);
+        mockCoreUser(recipient, true);
+        mockSpotBalance(CORE_AMOUNT);
+
+        composer.bridgeToHyperCore(recipient, EVM_AMOUNT);
+
+        vm.roll(block.number + 1);
+        token.mintTestTokens(address(composer), EVM_AMOUNT);
+        mockSpotBalance(CORE_AMOUNT);
+        composer.bridgeToHyperCore(recipient, EVM_AMOUNT);
+
+        assertEq(token.balanceOf(address(composer)), 0);
+        assertEq(token.balanceOf(composer.assetBridge()), EVM_AMOUNT * 2);
+    }
+
+    function test_bridgeToHyperCore_revert_coreWriter_rollsBackTransfer() public {
+        mockCoreUser(address(composer), true);
+        mockCoreUser(recipient, true);
+        mockSpotBalance(CORE_AMOUNT);
+        vm.mockCallRevert(composer.CORE_WRITER(), bytes(""), bytes("core writer failed"));
+
+        vm.expectRevert(bytes("core writer failed"));
+        composer.bridgeToHyperCore(recipient, EVM_AMOUNT);
+
+        assertEq(token.balanceOf(address(composer)), EVM_AMOUNT);
+        assertEq(token.balanceOf(composer.assetBridge()), 0);
+    }
+
+    function test_bridgeToHyperCore_revert_precompileReadFailed() public {
+        vm.mockCall(
+            composer.CORE_USER_EXISTS_PRECOMPILE(), abi.encode(address(composer)), abi.encodePacked(bytes1(0x01))
+        );
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                SynapseHyperCoreComposer.SHCC__PrecompileReadFailed.selector, composer.CORE_USER_EXISTS_PRECOMPILE()
+            )
+        );
+        composer.bridgeToHyperCore(recipient, EVM_AMOUNT);
+    }
+
+    function test_bridgeToHyperCore_revert_spotBalanceReadFailed() public {
+        mockCoreUser(address(composer), true);
+        mockCoreUser(recipient, true);
+        vm.mockCall(composer.SPOT_BALANCE_PRECOMPILE(), bytes(""), abi.encodePacked(bytes1(0x01)));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                SynapseHyperCoreComposer.SHCC__PrecompileReadFailed.selector, composer.SPOT_BALANCE_PRECOMPILE()
+            )
+        );
+        composer.bridgeToHyperCore(recipient, EVM_AMOUNT);
+    }
+
+    function mockCoreUser(address user, bool exists) internal {
+        vm.mockCall(composer.CORE_USER_EXISTS_PRECOMPILE(), abi.encode(user), abi.encode(exists));
+    }
+
+    function mockSpotBalance(uint64 total) internal {
+        vm.mockCall(
+            composer.SPOT_BALANCE_PRECOMPILE(),
+            abi.encode(composer.assetBridge(), CORE_INDEX),
+            abi.encode(total, uint64(0), uint64(0))
+        );
+    }
+}

--- a/packages/contracts-adapter/test/harnesses/HyperCoreMessageHarness.sol
+++ b/packages/contracts-adapter/test/harnesses/HyperCoreMessageHarness.sol
@@ -7,7 +7,11 @@ import {HyperCoreMessage} from "../../src/libs/HyperCoreMessage.sol";
 contract HyperCoreMessageHarness {
     function testHyperCoreMessageHarness() external {}
 
-    function encodeHyperCoreMessage(address recipient, address srcToken, uint256 amount)
+    function encodeHyperCoreMessage(
+        address recipient,
+        address srcToken,
+        uint256 amount
+    )
         public
         pure
         returns (bytes memory)

--- a/packages/contracts-adapter/test/harnesses/HyperCoreMessageHarness.sol
+++ b/packages/contracts-adapter/test/harnesses/HyperCoreMessageHarness.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+import {HyperCoreMessage} from "../../src/libs/HyperCoreMessage.sol";
+
+// solhint-disable no-empty-blocks
+contract HyperCoreMessageHarness {
+    function testHyperCoreMessageHarness() external {}
+
+    function encodeHyperCoreMessage(address recipient, address srcToken, uint256 amount)
+        public
+        pure
+        returns (bytes memory)
+    {
+        return HyperCoreMessage.encodeHyperCoreMessage(recipient, srcToken, amount);
+    }
+
+    function decodeHyperCoreMessage(bytes calldata payload)
+        public
+        pure
+        returns (address recipient, address srcToken, uint256 amount)
+    {
+        return HyperCoreMessage.decodeHyperCoreMessage(payload);
+    }
+}

--- a/packages/contracts-adapter/test/libs/HyperCoreMessage.t.sol
+++ b/packages/contracts-adapter/test/libs/HyperCoreMessage.t.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import {HyperCoreMessage, HyperCoreMessageHarness} from "../harnesses/HyperCoreMessageHarness.sol";
+
+import {Test} from "forge-std/Test.sol";
+
+// solhint-disable func-name-mixedcase, ordering, max-line-length
+contract HyperCoreMessageTest is Test {
+    HyperCoreMessageHarness internal harness;
+
+    function setUp() public {
+        harness = new HyperCoreMessageHarness();
+    }
+
+    function test_roundTrip(address recipient, address srcToken, uint256 amount) public view {
+        bytes memory payload = harness.encodeHyperCoreMessage(recipient, srcToken, amount);
+        (address decodedRecipient, address decodedSrcToken, uint256 decodedAmount) =
+            harness.decodeHyperCoreMessage(payload);
+        assertEq(decodedRecipient, recipient);
+        assertEq(decodedSrcToken, srcToken);
+        assertEq(decodedAmount, amount);
+    }
+
+    function test_decodeHyperCoreMessage_revert_invalidPayloadLength(uint16 length) public {
+        vm.assume(length != 32 * 4);
+        bytes memory payload = new bytes(length);
+        vm.expectRevert(HyperCoreMessage.HyperCoreMessage__InvalidPayload.selector);
+        harness.decodeHyperCoreMessage(payload);
+    }
+
+    function test_decodeHyperCoreMessage_revert_unsupportedVersion(uint8 version) public {
+        vm.assume(version != 1);
+        bytes memory payload = abi.encode(version, address(1), address(2), 3);
+        vm.expectRevert(abi.encodeWithSelector(HyperCoreMessage.HyperCoreMessage__UnsupportedVersion.selector, version));
+        harness.decodeHyperCoreMessage(payload);
+    }
+}

--- a/packages/contracts-adapter/test/mocks/SynapseBridgeMock.sol
+++ b/packages/contracts-adapter/test/mocks/SynapseBridgeMock.sol
@@ -4,13 +4,20 @@ pragma solidity 0.8.24;
 import {ISynapseBridge} from "../../src/interfaces/ISynapseBridge.sol";
 import {TestToken} from "./TestToken.sol";
 
+import {IERC20, SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
 // solhint-disable no-empty-blocks
 contract SynapseBridgeMock is ISynapseBridge {
+    using SafeERC20 for IERC20;
+
     /// @notice We include an empty "test" function so that this contract does not appear in the coverage report.
     function testSynapseBridgeMock() external {}
 
     function mint(address to, address token, uint256 amount, uint256, bytes32) external override {
         TestToken(token).mintTestTokens(to, amount);
     }
-    function withdraw(address to, address token, uint256 amount, uint256 fee, bytes32 kappa) external override {}
+
+    function withdraw(address to, address token, uint256 amount, uint256, bytes32) external override {
+        IERC20(token).safeTransfer(to, amount);
+    }
 }

--- a/packages/contracts-adapter/test/mocks/SynapseBridgeMock.sol
+++ b/packages/contracts-adapter/test/mocks/SynapseBridgeMock.sol
@@ -2,12 +2,15 @@
 pragma solidity 0.8.24;
 
 import {ISynapseBridge} from "../../src/interfaces/ISynapseBridge.sol";
+import {TestToken} from "./TestToken.sol";
 
 // solhint-disable no-empty-blocks
 contract SynapseBridgeMock is ISynapseBridge {
     /// @notice We include an empty "test" function so that this contract does not appear in the coverage report.
     function testSynapseBridgeMock() external {}
 
-    function mint(address to, address token, uint256 amount, uint256 fee, bytes32 kappa) external override {}
+    function mint(address to, address token, uint256 amount, uint256, bytes32) external override {
+        TestToken(token).mintTestTokens(to, amount);
+    }
     function withdraw(address to, address token, uint256 amount, uint256 fee, bytes32 kappa) external override {}
 }

--- a/packages/contracts-adapter/test/mocks/TestTokenDecimals.sol
+++ b/packages/contracts-adapter/test/mocks/TestTokenDecimals.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import {TestToken} from "./TestToken.sol";
+
+contract TestTokenDecimals is TestToken {
+    uint8 private immutable tokenDecimals;
+
+    constructor(uint8 decimals_) {
+        tokenDecimals = decimals_;
+    }
+
+    function decimals() public view override returns (uint8) {
+        return tokenDecimals;
+    }
+}


### PR DESCRIPTION
## Status

**Draft. This is not deployment-ready and must not be used to link or fund SYN on HyperCore yet.**

Tracking: [CALL-2439](https://linear.app/protochain/issue/CALL-2439/implement-native-synapsebridge-delivery-of-syn-to-hypercore)

## What changed

- adds a separately deployed `SynapseBridgeAdapterV2`; the existing adapter and its CREATE2-derived deployments are untouched
- keeps the legacy 96-byte direct-delivery message path
- adds a versioned HyperCore-delivery message and `bridgeERC20ToHyperCore`
- adds a SYN-specific `SynapseHyperCoreComposer` that:
  - enforces 18 HyperEVM decimals, 8 HyperCore wei decimals, and exact `10^10` scaling
  - rejects dust and `uint64` overflow before source burn or escrow
  - checks Composer and recipient HyperCore activation
  - checks asset-bridge capacity and reserves aggregate capacity within one EVM block
  - transfers SYN to the HIP-1 system address and submits the `0x01000006` CoreWriter spot-send action
- makes decimal routes and Composer bindings one-time configuration
- documents the end-to-end supply path, atomicity boundary, and deployment gates

SYN remains a SynapseBridge token. This does not convert SYN into an OFT.

## Why

The LayerZero OFT Composer is built around an OFT supply path. SYN already has a SynapseBridge burn/mint and escrow/withdraw supply model. This change composes HyperCore delivery into that existing model instead of adding a second token authority.

Immediate destination failures revert the entire LayerZero receive transaction, including the SynapseBridge mint or withdrawal. HyperCore execution is asynchronous after the EVM block, so a successful EVM receipt is not treated as final delivery proof.

## Verification

- `forge test --root packages/contracts-adapter`: **125 passed, 0 failed**
- `forge coverage --root packages/contracts-adapter --report summary`:
  - Composer: **100% lines, statements, branches, and functions**
  - v2 adapter: **100% lines/functions, 98.62% statements, 95.00% branches**
  - HyperCore codec: **100% lines, statements, branches, and functions**
- `forge build --root packages/contracts-adapter --sizes`:
  - v2 adapter runtime: **14,722 bytes**
  - Composer runtime: **4,287 bytes**
- Solhint: **0 errors, 0 warnings** on every changed Solidity file
- Markdownlint: **0 errors**
- `git diff --check`: clean
- existing v1 production sources have no diff against `origin/master`
- existing v1 deployed-bytecode hash is unchanged at `0xc6f462c66a4694ed69fe69c79ac2f3fc8e20f184ecb86de5b0856c41dcacd9bf`

## Required before deployment

- independent security review of the complete burn/mint and CoreWriter supply path
- decide and verify the HyperEVM `SynapseERC20` deployment/finalizer mechanism
- verify the exact HIP-1 token index and finalized EVM-token link
- deploy and verify SynapseBridge, token roles, adapter peers, DVNs, executor config, ownership, and Composer activation
- prove asset-bridge genesis capacity matches the intended non-system supply
- add deployment/config scripts with fail-closed address and chain assertions
- canary with monitoring that confirms LayerZero delivery, EVM success, Core credit, CoreWriter execution, exact recipient balance, and zero stranded Composer balances
- add SDK/UI routing only after the contract and deployment path are approved

## References

- [LayerZero Hyperliquid concepts](https://docs.layerzero.network/v2/developers/hyperliquid/hyperliquid-concepts)
- [LayerZero HyperLiquidComposer](https://github.com/LayerZero-Labs/devtools/blob/main/packages/hyperliquid-composer/contracts/HyperLiquidComposer.sol)
- [HyperCore and HyperEVM transfers](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/hyperevm/hypercore-less-than-greater-than-hyperevm-transfers)
- [CoreWriter and read precompiles](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/hyperevm/interacting-with-hypercore)
- [Interaction timing](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/hyperevm/interaction-timings)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for delivering SYN from HyperEVM to HyperCore.
  * Added configurable token routes, decimal scaling, composer integration, fee estimates, and capacity validation.
  * Added secure message encoding and decoding for HyperCore transfers.
* **Documentation**
  * Documented the HyperCore delivery flow, custody, rollback behavior, monitoring requirements, and deployment considerations.
* **Tests**
  * Added coverage for successful transfers, validation failures, capacity limits, inactive recipients, rollback scenarios, and fee estimation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->