### PR TITLE
fix(screener-api): enforce HMAC timestamp freshness on /api/data/sync

### DIFF
--- a/contrib/screener-api/screener/auth_middleware_test.go
+++ b/contrib/screener-api/screener/auth_middleware_test.go
@@ -1,0 +1,36 @@
+package screener
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSignatureTimestampFresh(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(1_700_000_000, 0)
+	maxSkew := 5 * time.Minute
+
+	tests := []struct {
+		name      string
+		timestamp string
+		want      bool
+	}{
+		{name: "exact now", timestamp: "1700000000", want: true},
+		{name: "within skew past", timestamp: "1699999900", want: true},
+		{name: "within skew future", timestamp: "1700000100", want: true},
+		{name: "stale past hour", timestamp: "1699996400", want: false},
+		{name: "far future", timestamp: "1700003600", want: false},
+		{name: "non numeric", timestamp: "not-a-unix-ts", want: false},
+		{name: "empty", timestamp: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := signatureTimestampFresh(tt.timestamp, now, maxSkew); got != tt.want {
+				t.Fatalf("signatureTimestampFresh(%q) = %v, want %v", tt.timestamp, got, tt.want)
+			}
+		})
+	}
+}

--- a/contrib/screener-api/screener/screener.go
+++ b/contrib/screener-api/screener/screener.go
@@ -4,11 +4,13 @@ package screener
 import (
 	"bytes"
 	"context"
+	"crypto/hmac"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -42,6 +44,10 @@ const (
 	okResponse  = "OK"
 	errResponse = "ERROR"
 	meterName   = "github.com/synapsecns/sanguine/contrib/screener-api"
+	// maxSignatureSkew is how far X-Signature-timestamp may drift from server time.
+	// Timestamp and nonce are part of the signed message; without a freshness check
+	// a captured sync request can be replayed indefinitely.
+	maxSignatureSkew = 5 * time.Minute
 )
 
 // Screener is the interface for the screener.
@@ -363,6 +369,19 @@ func (s *screenerImpl) blacklistAddress(c *gin.Context) {
 	}
 }
 
+// signatureTimestampFresh reports whether timestamp (unix seconds) is within maxSkew of now.
+func signatureTimestampFresh(timestamp string, now time.Time, maxSkew time.Duration) bool {
+	ts, err := strconv.ParseInt(timestamp, 10, 64)
+	if err != nil {
+		return false
+	}
+	skew := now.Sub(time.Unix(ts, 0))
+	if skew < 0 {
+		skew = -skew
+	}
+	return skew <= maxSkew
+}
+
 // This function takes the HTTP headers and the body of the request and reconstructs the signature to
 // compare it with the signature provided. If they match, the request is allowed to pass through.
 // nolint: canonicalheader
@@ -376,6 +395,20 @@ func (s *screenerImpl) authMiddleware(cfg config.Config) gin.HandlerFunc {
 		nonce := c.Request.Header.Get("X-Signature-nonce")
 		signature := c.Request.Header.Get("X-Signature-signature")
 		queryString := c.Request.URL.RawQuery
+
+		if appID == "" || appID != cfg.AppID {
+			span.AddEvent("error", trace.WithAttributes(attribute.String("error", "Invalid app id")))
+			c.JSON(http.StatusUnauthorized, gin.H{"error": errResponse})
+			c.Abort()
+			return
+		}
+
+		if !signatureTimestampFresh(timestamp, time.Now(), maxSignatureSkew) {
+			span.AddEvent("error", trace.WithAttributes(attribute.String("error", "Stale or invalid signature timestamp")))
+			c.JSON(http.StatusUnauthorized, gin.H{"error": errResponse})
+			c.Abort()
+			return
+		}
 
 		bodyBz, err := io.ReadAll(c.Request.Body)
 		if err != nil {
@@ -419,7 +452,7 @@ func (s *screenerImpl) authMiddleware(cfg config.Config) gin.HandlerFunc {
 			attribute.String("message", message),
 		)
 
-		if expectedSignature != signature {
+		if !hmac.Equal([]byte(expectedSignature), []byte(signature)) {
 			span.AddEvent(
 				"error",
 				trace.WithAttributes(attribute.String("error", "Invalid signature"+expectedSignature)),


### PR DESCRIPTION
## Summary

`POST /api/data/sync` HMAC auth folds `X-Signature-timestamp` and `X-Signature-nonce` into the signed message, but the server never enforced timestamp freshness (or app id binding). A captured valid request could be replayed indefinitely against blacklist create/update/delete.

## Change

- Reject requests whose `X-Signature-timestamp` is outside a 5-minute skew window (or non-numeric).
- Require `X-Signature-appid` to match configured `AppID`.
- Compare signatures with `hmac.Equal`.

Nonce uniqueness is not persisted here (would need shared storage); freshness closes indefinite replay of old captures.

## Test plan

- [x] `GOWORK=off go test ./screener/ -run TestSignatureTimestampFresh` → ok
- [ ] CI green

Tip: `ef5f972c4be446b74daf781b6a90b6198b7a4486`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Added validation to reject requests with missing, invalid, stale, or future authentication timestamps.
  * Improved signature verification to help prevent timing-based attacks.
* **Tests**
  * Added coverage for valid, expired, future, empty, and non-numeric timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->