### PR TITLE
fix(rfq): reject far-future EIP-191 auth timestamps

### DIFF
--- a/services/rfq/api/rest/auth.go
+++ b/services/rfq/api/rest/auth.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -19,6 +20,10 @@ import (
 // i.e. signature (hex encoded) = keccak(bytes.concat("\x19Ethereum Signed Message:\n", len(strconv.Itoa(time.Now().Unix()), strconv.Itoa(time.Now().Unix())))
 // so that full auth header string: auth = strconv.Itoa(time.Now().Unix()) + ":" + signature
 // see: https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_sign
+//
+// deadline is the earliest accepted timestamp (typically now - authAge). Timestamps
+// newer than now + (now - deadline) are rejected so far-future signed auths cannot
+// remain valid for years.
 func EIP191Auth(c *gin.Context, deadline int64) (accountRecovered common.Address, err error) {
 	auth := c.Request.Header.Get(AuthorizationHeader)
 
@@ -30,16 +35,29 @@ func EIP191Auth(c *gin.Context, deadline int64) (accountRecovered common.Address
 		return common.Address{}, err
 	}
 
-	// check timestamp is not older than given deadline
+	// check timestamp is within [deadline, now+(now-deadline)] of wall clock.
+	// Callers pass deadline = now - authAge (e.g. 1000s). Without an upper bound,
+	// a far-future signed timestamp remains valid until that future time ages in.
 	var timestamp int64
 	timestamp, err = strconv.ParseInt(s[0], 10, 64)
 	if err != nil {
 		err = fmt.Errorf("invalid timestamp in authorization")
 		c.JSON(http.StatusBadRequest, gin.H{"msg": err})
 		return common.Address{}, err
-	} else if timestamp < deadline {
+	}
+	now := time.Now().Unix()
+	maxAge := now - deadline
+	if maxAge < 0 {
+		maxAge = 0
+	}
+	if timestamp < deadline {
 		err = fmt.Errorf("authorization too old")
 		c.JSON(http.StatusUnauthorized, gin.H{"msg": err}) // Unauthorized
+		return common.Address{}, err
+	}
+	if timestamp > now+maxAge {
+		err = fmt.Errorf("authorization timestamp too far in the future")
+		c.JSON(http.StatusUnauthorized, gin.H{"msg": err})
 		return common.Address{}, err
 	}
 

--- a/services/rfq/api/rest/auth_test.go
+++ b/services/rfq/api/rest/auth_test.go
@@ -1,0 +1,64 @@
+package rest
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEIP191AuthRejectsFutureTimestamp(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	farFuture := strconv.FormatInt(time.Now().Unix()+365*24*60*60, 10)
+	data := "\x19Ethereum Signed Message:\n" + strconv.Itoa(len(farFuture)) + farFuture
+	digest := crypto.Keccak256([]byte(data))
+	sig, err := crypto.Sign(digest, key)
+	require.NoError(t, err)
+
+	auth := farFuture + ":" + hexutil.Encode(sig)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPut, "/quotes", nil)
+	c.Request.Header.Set(AuthorizationHeader, auth)
+
+	deadline := time.Now().Unix() - 1000
+	_, err = EIP191Auth(c, deadline)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "future")
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestEIP191AuthAcceptsFreshTimestamp(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	now := strconv.FormatInt(time.Now().Unix(), 10)
+	data := "\x19Ethereum Signed Message:\n" + strconv.Itoa(len(now)) + now
+	digest := crypto.Keccak256([]byte(data))
+	sig, err := crypto.Sign(digest, key)
+	require.NoError(t, err)
+
+	auth := fmt.Sprintf("%s:%s", now, hexutil.Encode(sig))
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPut, "/quotes", nil)
+	c.Request.Header.Set(AuthorizationHeader, auth)
+
+	deadline := time.Now().Unix() - 1000
+	addr, err := EIP191Auth(c, deadline)
+	require.NoError(t, err)
+	require.Equal(t, crypto.PubkeyToAddress(key.PublicKey), addr)
+}


### PR DESCRIPTION
## Summary

RFQ quoter `EIP191Auth` checked only that the signed unix timestamp was not older than `now - 1000`. There was no upper bound, so a far-future timestamp (e.g. `now + 10y`) produced an `Authorization` header that remained valid until that future time entered the acceptance window.

Affects relayer-authenticated quote/ack paths that call `checkRole` → `EIP191Auth`.

## Change

- Reject timestamps newer than `now + (now - deadline)` (symmetric with the existing staleness window).
- Unit tests for fresh accept + far-future reject.

## Test plan

- [x] Added `TestEIP191AuthRejectsFutureTimestamp` / `TestEIP191AuthAcceptsFreshTimestamp`
- [ ] CI `go test` for `services/rfq/api/rest` green (local Go 1.26 cannot build this module tree; CI uses module toolchain)

Tip: `ef5f972c4be446b74daf781b6a90b6198b7a4486`

Related: #4078 (screener HMAC freshness; different surface)


Made with [Cursor](https://cursor.com)