### PR TITLE
docs(rfq): fix Quoter API wording

### DIFF
--- a/docs/bridge/docs/04-RFQ/10-Quoting/Quoter API/index.md
+++ b/docs/bridge/docs/04-RFQ/10-Quoting/Quoter API/index.md
@@ -175,7 +175,7 @@ Once the message has been authenticated, the authorization of the sender/signer 
 
 ## Running the API:
 
-Users and relayers **are not** expected to run their own version of the Quoter API. Rather, they are expected to use a Quoter API that is hosted by the the interface they are quoting for. For example, the Quoter API used by the Synapse bridge interface is hosted at the URL above.
+Users and relayers **are not** expected to run their own version of the Quoter API. Rather, they are expected to use a Quoter API that is hosted by the interface they are quoting for. For example, the Quoter API used by the Synapse bridge interface is hosted at the URL above.
 
 
 ### Configuration


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.
-->

**Description**

Remove a duplicated article from the RFQ Quoter API documentation. The change is editorial only; API endpoints, examples, parameters, and behavior remain unchanged.



**Additional context**
Add any other context about the problem you're solving.

**Metadata**
- Fixes #[Link to Issue]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a duplicated word in the Quoter API documentation for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->